### PR TITLE
feat(build): Enable deploy previews based on branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  [context.deploy-preview]
+    ignore = "if [[ $HEAD == feature/* ]]; then exit 1; else exit 0; fi"


### PR DESCRIPTION
Adds a config for Netlify to auto-cancel builds if the branch name does not start with `feature/`. This will enable us to keep PR deploy previews on for only PR's we want a preview.