### PR TITLE
feat(teams): Route structure (wip)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ const Lottery = lazy(() => import('./views/Lottery'))
 const Ifos = lazy(() => import('./views/Ifos'))
 const NotFound = lazy(() => import('./views/NotFound'))
 const Nft = lazy(() => import('./views/Nft'))
+const Teams = lazy(() => import('./views/Teams'))
+const Profile = lazy(() => import('./views/Teams/Profile'))
 
 // This config is required for number formating
 BigNumber.config({
@@ -63,6 +65,12 @@ const App: React.FC = () => {
             </Route>
             <Route path="/nft">
               <Nft />
+            </Route>
+            <Route exact path="/teams">
+              <Teams />
+            </Route>
+            <Route path="/teams/profile">
+              <Profile />
             </Route>
             {/* Redirect */}
             <Route path="/staking">

--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -41,6 +41,11 @@ const config: MenuEntry[] = [
     href: '/nft',
   },
   {
+    label: 'Teams & Profile',
+    icon: 'NftIcon',
+    href: '/teams',
+  },
+  {
     label: 'Info',
     icon: 'InfoIcon',
     items: [

--- a/src/views/Teams/Profile/index.tsx
+++ b/src/views/Teams/Profile/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import ProfileCreation from '../ProfileCreation'
+
+const hasProfile = false
+
+const Profile = () => {
+  if (!hasProfile) {
+    return <ProfileCreation />
+  }
+
+  return <div>Profile</div>
+}
+
+export default Profile

--- a/src/views/Teams/ProfileCreation/index.tsx
+++ b/src/views/Teams/ProfileCreation/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const ProfileCreation = () => {
-  return <div />
+  return <div>ProfileCreation</div>
 }
 
 export default ProfileCreation

--- a/src/views/Teams/components/NoProfileCard.tsx
+++ b/src/views/Teams/components/NoProfileCard.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Button, Card, CardBody, Flex, Heading, Text } from '@pancakeswap-libs/uikit'
+import useI18n from 'hooks/useI18n'
+import { Link } from 'react-router-dom'
+
+const NoProfileCard = () => {
+  const TranslateString = useI18n()
+
+  return (
+    <Card mb="32px" isActive>
+      <CardBody>
+        <Flex
+          alignItems={['start', null, 'center']}
+          justifyContent={['start', null, 'space-between']}
+          flexDirection={['column', null, 'row']}
+        >
+          <div>
+            <Heading size="lg" mb="8px">
+              {TranslateString(999, "You haven't set up your profile yet!")}
+            </Heading>
+            <Text>
+              {TranslateString(999, 'You can do this at any time by clicking on your profile picture in the menu')}
+            </Text>
+          </div>
+          <Button as={Link} to="/teams/profile" mt={['16px', null, 0]}>
+            {TranslateString(999, 'Set up now')}
+          </Button>
+        </Flex>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default NoProfileCard

--- a/src/views/Teams/index.tsx
+++ b/src/views/Teams/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Heading, Text } from '@pancakeswap-libs/uikit'
+import Page from 'components/layout/Page'
+import useI18n from 'hooks/useI18n'
+import NoProfileCard from './components/NoProfileCard'
+
+const hasProfile = false
+
+const Teams = () => {
+  const TranslateString = useI18n()
+
+  return (
+    <Page>
+      {!hasProfile && <NoProfileCard />}
+      <Heading size="xxl" color="secondary">
+        {TranslateString(999, 'Teams & Profiles')}
+      </Heading>
+      <Text bold>
+        {TranslateString(
+          999,
+          'Show off your stats and collectibles with your unique profile. Team features will be revealed soon!',
+        )}
+      </Text>
+    </Page>
+  )
+}
+
+export default Teams


### PR DESCRIPTION
Structure for profiles

`/teams` - main landing page
`/teams/profile` - user's profile page, renders creation screen if doesn't exist
