### PR TITLE
fix: No 'approve' state on the dashboard lottery modal. Fixes #310

### DIFF
--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react"
+import { useLotteryApprove } from "./useApprove"
+
+export const useApproval = (onPresentApprove: () => void) => {
+  const [requestedApproval, setRequestedApproval] = useState(false)
+  const { onApprove } = useLotteryApprove()
+
+  const handleApprove = useCallback(async () => {
+    try {
+      setRequestedApproval(true)
+      const txHash = await onApprove()
+      // user rejected tx or didn't go thru
+      if (!txHash) {
+        setRequestedApproval(false)
+      }
+      onPresentApprove()
+    } catch (e) {
+      console.error(e)
+    }
+  }, [onApprove, onPresentApprove])
+
+  return { handleApprove, requestedApproval }
+}
+
+export default useApproval

--- a/src/views/Home/components/LotteryCard.tsx
+++ b/src/views/Home/components/LotteryCard.tsx
@@ -10,7 +10,7 @@ import { useMultiClaimLottery } from 'hooks/useBuyLottery'
 import { useTotalClaim } from 'hooks/useTickets'
 import BuyModal from 'views/Lottery/components/TicketCard/BuyTicketModal'
 import { useLotteryAllowance } from 'hooks/useAllowance'
-import { useLotteryApprove } from 'hooks/useApprove'
+import { useApproval } from 'hooks/useApproval'
 import PurchaseWarningModal from 'views/Lottery/components/TicketCard/PurchaseWarningModal'
 import CakeWinnings from './CakeWinnings'
 import LotteryJackpot from './LotteryJackpot'
@@ -48,26 +48,11 @@ const FarmedStakingCard = () => {
   const [requesteClaim, setRequestedClaim] = useState(false)
   const TranslateString = useI18n()
   const allowance = useLotteryAllowance()
-  const { onApprove } = useLotteryApprove()
   const [onPresentApprove] = useModal(<PurchaseWarningModal />)
-  const [requestedApproval, setRequestedApproval] = useState(false)
   const { claimAmount } = useTotalClaim()
   const { onMultiClaim } = useMultiClaimLottery()
   const cakeBalance = useTokenBalance(getCakeAddress())
-
-  const handleApprove = useCallback(async () => {
-    try {
-      setRequestedApproval(true)
-      const txHash = await onApprove()
-      // user rejected tx or didn't go thru
-      if (!txHash) {
-        setRequestedApproval(false)
-      }
-      onPresentApprove()
-    } catch (e) {
-      console.error(e)
-    }
-  }, [onApprove, onPresentApprove])
+  const { handleApprove, requestedApproval } = useApproval(onPresentApprove)
 
   const handleClaim = useCallback(async () => {
     try {

--- a/src/views/Lottery/components/TicketCard/TicketActions.tsx
+++ b/src/views/Lottery/components/TicketCard/TicketActions.tsx
@@ -1,13 +1,13 @@
-import React, { useCallback, useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { Button, useModal } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import useGetLotteryHasDrawn from 'hooks/useGetLotteryHasDrawn'
 import { useLotteryAllowance } from 'hooks/useAllowance'
-import { useLotteryApprove } from 'hooks/useApprove'
 import useTickets from 'hooks/useTickets'
 import useTokenBalance from 'hooks/useTokenBalance'
 import { getCakeAddress } from 'utils/addressHelpers'
+import { useApproval } from 'hooks/useApproval'
 import BuyTicketModal from './BuyTicketModal'
 import MyTicketsModal from './UserTicketsModal'
 import PurchaseWarningModal from './PurchaseWarningModal'
@@ -23,32 +23,16 @@ const CardActions = styled.div`
 `
 
 const TicketCard: React.FC = () => {
-  const [requestedApproval, setRequestedApproval] = useState(false)
   const TranslateString = useI18n()
   const allowance = useLotteryAllowance()
-  const { onApprove } = useLotteryApprove()
   const lotteryHasDrawn = useGetLotteryHasDrawn()
   const cakeBalance = useTokenBalance(getCakeAddress())
-
   const tickets = useTickets()
   const ticketsLength = tickets.length
   const [onPresentMyTickets] = useModal(<MyTicketsModal myTicketNumbers={tickets} from="buy" />)
   const [onPresentApprove] = useModal(<PurchaseWarningModal />)
   const [onPresentBuy] = useModal(<BuyTicketModal max={cakeBalance} tokenName="CAKE" />)
-
-  const handleApprove = useCallback(async () => {
-    try {
-      setRequestedApproval(true)
-      const txHash = await onApprove()
-      // user rejected tx or didn't go thru
-      if (!txHash) {
-        setRequestedApproval(false)
-      }
-      onPresentApprove()
-    } catch (e) {
-      console.error(e)
-    }
-  }, [onApprove, onPresentApprove])
+  const { handleApprove, requestedApproval } = useApproval(onPresentApprove)
 
   const renderLotteryTicketButtons = () => {
     if (!allowance.toNumber()) {


### PR DESCRIPTION
Fixes https://github.com/pancakeswap/pancake-frontend/issues/310

Adds the approve state so that the"Approve" button is shown instead of the "Buy tickets". I've duplicated the logic of `src/views/Lottery/components/TicketCard/TicketActions.tsx` as I'm not yet too familiar with the codebase.