### PR TITLE
chore: Update Profile API endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_PROFILE = https://pancake-profile-api.vercel.app
+REACT_APP_API_PROFILE = https://profile.pancakeswap.com

--- a/src/config/constants/ifo.ts
+++ b/src/config/constants/ifo.ts
@@ -114,7 +114,7 @@ const ifos: Ifo[] = [
     currencyAddress: '0xA527a61703D82139F8a06Bc30097cC9CAA2df5A6',
     tokenDecimals: 6,
     releaseBlockNumber: 3279767,
-  },  
+  },
 ]
 
 export default ifos

--- a/src/state/profile/getProfile.ts
+++ b/src/state/profile/getProfile.ts
@@ -19,7 +19,7 @@ export interface GetProfileResponse {
 
 const getUsername = async (address: string): Promise<string> => {
   try {
-    const response = await fetch(`${profileApi}/api/users?address=${address}`)
+    const response = await fetch(`${profileApi}/api/users/${address}`)
 
     if (!response.ok) {
       return ''

--- a/src/views/Profile/ProfileCreation/UserName.tsx
+++ b/src/views/Profile/ProfileCreation/UserName.tsx
@@ -83,7 +83,7 @@ const UserName: React.FC = () => {
   const checkUsernameValidity = debounce(async (value: string) => {
     try {
       setIsLoading(true)
-      const res = await fetch(`${profileApiUrl}/api/users/valid?username=${value}`)
+      const res = await fetch(`${profileApiUrl}/api/users/valid/${value}`)
 
       if (res.ok) {
         setIsValid(true)
@@ -144,7 +144,7 @@ const UserName: React.FC = () => {
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const response = await fetch(`${profileApiUrl}/api/users?address=${account}`)
+        const response = await fetch(`${profileApiUrl}/api/users/${account}`)
         const data = await response.json()
 
         if (response.ok) {


### PR DESCRIPTION
- Cleaner URL syntax
- Use official domain name

> Note: This is ready to be deployed as-is. Legacy and new URL's syntax are both supported by the API in production.