### PR TITLE
fix: Set minimal gas limit @ 200k

### DIFF
--- a/src/utils/callHelpers.ts
+++ b/src/utils/callHelpers.ts
@@ -11,7 +11,7 @@ export const stake = async (masterChefContract, pid, amount, account) => {
   if (pid === 0) {
     return masterChefContract.methods
       .enterStaking(new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-      .send({ from: account })
+      .send({ from: account, gas: 200000 })
       .on('transactionHash', (tx) => {
         return tx.transactionHash
       })
@@ -19,7 +19,7 @@ export const stake = async (masterChefContract, pid, amount, account) => {
 
   return masterChefContract.methods
     .deposit(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -28,7 +28,7 @@ export const stake = async (masterChefContract, pid, amount, account) => {
 export const sousStake = async (sousChefContract, amount, account) => {
   return sousChefContract.methods
     .deposit(new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -37,7 +37,7 @@ export const sousStake = async (sousChefContract, amount, account) => {
 export const sousStakeBnb = async (sousChefContract, amount, account) => {
   return sousChefContract.methods
     .deposit()
-    .send({ from: account, value: new BigNumber(amount).times(new BigNumber(10).pow(18)).toString() })
+    .send({ from: account, gas: 200000, value: new BigNumber(amount).times(new BigNumber(10).pow(18)).toString() })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -47,14 +47,15 @@ export const unstake = async (masterChefContract, pid, amount, account) => {
   if (pid === 0) {
     return masterChefContract.methods
       .leaveStaking(new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-      .send({ from: account })
+      .send({ from: account, gas: 200000 })
       .on('transactionHash', (tx) => {
         return tx.transactionHash
       })
   }
+
   return masterChefContract.methods
     .withdraw(pid, new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -78,9 +79,10 @@ export const sousUnstake = async (sousChefContract, amount, account) => {
         return tx.transactionHash
       })
   }
+
   return sousChefContract.methods
     .withdraw(new BigNumber(amount).times(new BigNumber(10).pow(18)).toString())
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -99,14 +101,15 @@ export const harvest = async (masterChefContract, pid, account) => {
   if (pid === 0) {
     return masterChefContract.methods
       .leaveStaking('0')
-      .send({ from: account })
+      .send({ from: account, gas: 200000 })
       .on('transactionHash', (tx) => {
         return tx.transactionHash
       })
   }
+
   return masterChefContract.methods
     .deposit(pid, '0')
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -115,7 +118,7 @@ export const harvest = async (masterChefContract, pid, account) => {
 export const soushHarvest = async (sousChefContract, account) => {
   return sousChefContract.methods
     .deposit('0')
-    .send({ from: account })
+    .send({ from: account, gas: 200000 })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })
@@ -124,7 +127,7 @@ export const soushHarvest = async (sousChefContract, account) => {
 export const soushHarvestBnb = async (sousChefContract, account) => {
   return sousChefContract.methods
     .deposit()
-    .send({ from: account, value: new BigNumber(0) })
+    .send({ from: account, gas: 200000, value: new BigNumber(0) })
     .on('transactionHash', (tx) => {
       return tx.transactionHash
     })


### PR DESCRIPTION
Following reports from the community, a lot of users are experiencing lower estimated gas limit than used by contract call by their wallet resulting in multiple failed transactions, and as such wasting BNB. They need bump the gas limit in their wallet on each transaction to ensure it will not fail. Along this, users of Binance Chain wallet are not allowed to tweak their gas price and gas limit settings.
This will enhance the user experience.

> Note: Gas Price not affected as it's a node consensus on the BSC, and value is fetched by the wallet at each transaction via the connected node.

This is covering most use-cases:
- Harvest
- Compound
- Stake
- Unstake

 Approve and Emergency Withdraw still use the default estimated gas limit by the wallet.

Documentation: https://web3js.readthedocs.io/en/v1.3.1/web3-eth-contract.html#methods-mymethod-send