### PR TITLE
fix: improve error handling when loading translations

### DIFF
--- a/src/contexts/Localisation/languageContext.tsx
+++ b/src/contexts/Localisation/languageContext.tsx
@@ -60,14 +60,15 @@ const LanguageContextProvider = ({ children }) => {
       fetchTranslationsForSelectedLanguage(selectedLanguage)
         .then((translationApiResponse) => {
           if (translationApiResponse.data.length < 1) {
-            setTranslations(['error'])
+            setTranslations([])
           } else {
             setTranslations(translationApiResponse.data)
           }
         })
         .then(() => setTranslatedLanguage(selectedLanguage))
-        .catch(() => {
-          setTranslations(['error'])
+        .catch((e) => {
+          setTranslations([])
+          console.error('Error while loading translations', e)
         })
     }
   }, [selectedLanguage, setTranslations])

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -10,6 +10,10 @@ const useI18n = () => {
   const { translations } = useContext(TranslationsContext)
 
   return (translationId: number, fallback: string, data: ContextData = {}) => {
+    if (translations.length === 0) {
+      return fallback
+    }
+
     const foundTranslation = translations.find((translation) => {
       return translation.data.stringId === translationId
     })


### PR DESCRIPTION
When first starting up the project i got the following error:

![Screenshot from 2021-02-14 14-02-47](https://user-images.githubusercontent.com/376155/107869896-5eef6e00-6ece-11eb-9345-754df7d0e77f.png)

Change the value when an error is encountered while loading crowdin translations to an empty array to prevent errors in code that doesn't handle the 'error' string value