### PR TITLE
feat: make Burned Balance value user friendly

### DIFF
--- a/src/views/Home/components/CakeStats.tsx
+++ b/src/views/Home/components/CakeStats.tsx
@@ -23,8 +23,8 @@ const Row = styled.div`
 const CakeStats = () => {
   const TranslateString = useI18n()
   const totalSupply = useTotalSupply()
-  const burnedBalance = useBurnedBalance(getCakeAddress())
-  const cakeSupply = totalSupply ? getBalanceNumber(totalSupply) - getBalanceNumber(burnedBalance) : 0
+  const burnedBalance = getBalanceNumber(useBurnedBalance(getCakeAddress()))
+  const cakeSupply = totalSupply ? getBalanceNumber(totalSupply) - burnedBalance : 0
 
   return (
     <StyledCakeStats>


### PR DESCRIPTION
Burned balance in cake stats shows value with decimals. We should show as same type that total supply does