### PR TITLE
feat: make Burned Balance value user friendly

### DIFF
--- a/src/views/Home/components/CakeStats.tsx
+++ b/src/views/Home/components/CakeStats.tsx
@@ -23,8 +23,8 @@ const Row = styled.div`
 const CakeStats = () => {
   const TranslateString = useI18n()
   const totalSupply = useTotalSupply()
-  const burnedBalance = useBurnedBalance(getCakeAddress())
-  const cakeSupply = totalSupply ? getBalanceNumber(totalSupply) - getBalanceNumber(burnedBalance) : 0
+  const burnedBalance = getBalanceNumber(useBurnedBalance(getCakeAddress()))
+  const cakeSupply = totalSupply ? getBalanceNumber(totalSupply) - burnedBalance : 0
 
   return (
     <StyledCakeStats>

--- a/src/views/Home/components/CakeStats.tsx
+++ b/src/views/Home/components/CakeStats.tsx
@@ -38,7 +38,7 @@ const CakeStats = () => {
         </Row>
         <Row>
           <Text fontSize="14px">{TranslateString(538, 'Total CAKE Burned')}</Text>
-          <CardValue fontSize="14px" value={getBalanceNumber(burnedBalance)} />
+          <CardValue fontSize="14px" decimals={0} value={burnedBalance} />
         </Row>
         <Row>
           <Text fontSize="14px">{TranslateString(540, 'New CAKE/block')}</Text>


### PR DESCRIPTION
Burned balance in cake stats shows value with decimals. We should show as same type that total supply does

I reviewed it and made the corrections