### PR TITLE
feat: Save user profile and avatar to cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "canvas-confetti": "^1.3.3",
     "chart.js": "^2.9.4",
     "date-fns": "^2.17.0",
+    "js-cookie": "^2.2.1",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",
     "react": "^17.0.1",

--- a/src/state/profile/getProfile.ts
+++ b/src/state/profile/getProfile.ts
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie'
 import { getPancakeProfileAddress, getPancakeRabbitsAddress } from 'utils/addressHelpers'
 import pancakeProfileAbi from 'config/abi/pancakeProfile.json'
 import pancakeRabbitsAbi from 'config/abi/pancakeRabbits.json'
@@ -53,13 +54,14 @@ const getProfile = async (address: string): Promise<GetProfileResponse> => {
       const bunnyId = await rabbitContract.methods.getBunnyId(tokenId).call()
       nft = nfts.find((nftItem) => nftItem.bunnyId === Number(bunnyId))
 
-      // Save the preview image to local storage for the exchange
-      localStorage.setItem(
+      // Save the preview image in a cookie so it can be used on the exchange
+      Cookies.set(
         `profile_${address}`,
-        JSON.stringify({
+        {
           username,
           avatar: `https://pancakeswap.finance/images/nfts/${nft.images.sm}`,
-        }),
+        },
+        { domain: 'pancakeswap.finance', secure: true, expires: 30 },
       )
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9628,6 +9628,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 js-sha3@0.5.7, js-sha3@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"


### PR DESCRIPTION
The current implementation of getting the profile avatar and username to the exchange will not work with local storage. This PR updates the code to use a cookie.
