### PR TITLE
feat: Make links in farm pair dropdown menu more descriptive

### DIFF
--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -123,7 +123,7 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
       <InfoContainer>
         <StakeContainer>
           <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
-            {TranslateString(999, 'Get ${lpLabel}', { name: lpLabel })}
+            {TranslateString(999, `Get ${lpLabel}`, { name: lpLabel })}
           </StyledLinkExternal>
         </StakeContainer>
         <StyledLink href={bsc} external>

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -43,17 +43,6 @@ const StyledLink = styled(Link)`
   margin-top: 8px;
 `
 
-const StakeContainer = styled.div`
-  color: ${({ theme }) => theme.colors.text};
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-
-  ${({ theme }) => theme.mediaQueries.sm} {
-    justify-content: flex-start;
-  }
-`
-
 const TagsContainer = styled.div`
   display: flex;
   align-items: center;
@@ -111,7 +100,6 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
 
   const TranslateString = useI18n()
   const { quoteTokenAdresses, quoteTokenSymbol, tokenAddresses, tokenSymbol, dual } = farm
-  const lpLabel = farm.lpSymbol && farm.lpSymbol.toUpperCase().replace('PANCAKE', '')
   const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
   const lpAddress = farm.lpAddresses[process.env.REACT_APP_CHAIN_ID]
   const bsc = `https://bscscan.com/address/${lpAddress}`
@@ -121,22 +109,19 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
   return (
     <Container>
       <InfoContainer>
-        <StakeContainer>
-          Stake:
-          <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
-            {lpLabel}
-          </StyledLinkExternal>
-        </StakeContainer>
-        <StyledLink href={bsc} external>
-          {TranslateString(999, 'BscScan')}
-        </StyledLink>
-        <StyledLink href={info} external>
-          {TranslateString(999, 'Info site')}
-        </StyledLink>
         <TagsContainer>
           {isCommunityFarm ? <CommunityTag /> : <CoreTag />}
           {dual ? <DualTag /> : null}
         </TagsContainer>
+        <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
+          {TranslateString(999, 'Provide Liquidity')}
+        </StyledLinkExternal>
+        <StyledLink href={bsc} external>
+          {TranslateString(999, 'View Contract')}
+        </StyledLink>
+        <StyledLink href={info} external>
+          {TranslateString(999, 'See Pair Info')}
+        </StyledLink>
       </InfoContainer>
       <ValueContainer>
         <ValueWrapper>

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -123,7 +123,7 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
       <InfoContainer>
         <StakeContainer>
           <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
-            Get {lpLabel}
+            {TranslateString(999, 'Get ${lpLabel}', { name: lpLabel })}
           </StyledLinkExternal>
         </StakeContainer>
         <StyledLink href={bsc} external>

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -43,6 +43,17 @@ const StyledLink = styled(Link)`
   margin-top: 8px;
 `
 
+const StakeContainer = styled.div`
+  color: ${({ theme }) => theme.colors.text};
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    justify-content: flex-start;
+  }
+`
+
 const TagsContainer = styled.div`
   display: flex;
   align-items: center;
@@ -100,6 +111,7 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
 
   const TranslateString = useI18n()
   const { quoteTokenAdresses, quoteTokenSymbol, tokenAddresses, tokenSymbol, dual } = farm
+  const lpLabel = farm.lpSymbol && farm.lpSymbol.toUpperCase().replace('PANCAKE', '')
   const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
   const lpAddress = farm.lpAddresses[process.env.REACT_APP_CHAIN_ID]
   const bsc = `https://bscscan.com/address/${lpAddress}`
@@ -109,19 +121,21 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
   return (
     <Container>
       <InfoContainer>
-        <TagsContainer>
-          {isCommunityFarm ? <CommunityTag /> : <CoreTag />}
-          {dual ? <DualTag /> : null}
-        </TagsContainer>
-        <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
-          {TranslateString(999, 'Provide Liquidity')}
-        </StyledLinkExternal>
+        <StakeContainer>
+          <StyledLinkExternal href={`https://exchange.pancakeswap.finance/#/add/${liquidityUrlPathParts}`}>
+            Get {lpLabel}
+          </StyledLinkExternal>
+        </StakeContainer>
         <StyledLink href={bsc} external>
           {TranslateString(999, 'View Contract')}
         </StyledLink>
         <StyledLink href={info} external>
           {TranslateString(999, 'See Pair Info')}
         </StyledLink>
+        <TagsContainer>
+          {isCommunityFarm ? <CommunityTag /> : <CoreTag />}
+          {dual ? <DualTag /> : null}
+        </TagsContainer>
       </InfoContainer>
       <ValueContainer>
         <ValueWrapper>


### PR DESCRIPTION
The new detail menu would look like this

<img width="328" alt="Screenshot 2021-03-04 at 02 14 32" src="https://user-images.githubusercontent.com/2213635/109895833-3918e600-7c90-11eb-8b06-0701f26e08b4.png">
