### PR TITLE
feat(farm/pool): Add WATCH

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -33,6 +33,22 @@ const farms: FarmConfig[] = [
     quoteTokenAdresses: contracts.wbnb,
   },
   {
+    pid: 84,
+    lpSymbol: 'WATCH-BNB LP',
+    lpAddresses: {
+      97: '',
+      56: '0xdc6c130299e53acd2cc2d291fa10552ca2198a6b',
+    },
+    tokenSymbol: 'WATCH',
+    tokenAddresses: {
+      97: '',
+      56: '0x7a9f28eb62c791422aa23ceae1da9c847cbec9b0',
+    },
+    quoteTokenSymbol: QuoteToken.BNB,
+    quoteTokenAdresses: contracts.wbnb,
+    isCommunity: false,
+  },
+  {
     pid: 83,
     lpSymbol: 'xMARK-BUSD LP',
     lpAddresses: {

--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -19,6 +19,23 @@ const pools: PoolConfig[] = [
     tokenDecimals: 18,
   },
   {
+    sousId: 60,
+    tokenName: 'WATCH',
+    stakingTokenName: QuoteToken.CAKE,
+    stakingTokenAddress: '0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82',
+    contractAddress: {
+      97: '',
+      56: '0xC58954199E268505fa3D3Cb0A00b7207af8C2D1d',
+    },
+    poolCategory: PoolCategory.CORE,
+    projectLink: 'https://yieldwatch.net/',
+    harvest: true,
+    tokenPerBlock: '0.3472',
+    sortOrder: 999,
+    isFinished: false,
+    tokenDecimals: 18,
+  },
+  {
     sousId: 59,
     tokenName: 'xMARK',
     stakingTokenName: QuoteToken.CAKE,


### PR DESCRIPTION
Farm
Stake WATCH-BNB LP Tokens, Earn CAKE
2x CAKE rewards for the first 48 hours and then 1x CAKE rewards after that.
Start block: 5382600 (March 4th 6PM SGT)
WATCH-BNB LP Token Address: 0xdc6c130299e53acd2cc2d291fa10552ca2198a6b
Syrup Pool
Stake CAKE, Earn WATCH
Total Pool Tokens: 600,000 WATCH
Distribution duration: 60 days
Start block: 5382600 (March 4th 6PM SGT)
Finish block: 7110600 (May 3rd 6PM SGT)
Token rewards per block: 0.3472 WATCH
WATCH Token Contract: https://bscscan.com/token/0x7a9f28eb62c791422aa23ceae1da9c847cbec9b0