### PR TITLE
fix: Fix walletconnect qr code problems and make wallet errors human readable

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -30,7 +30,7 @@ const useAuth = () => {
         } else {
           window.localStorage.removeItem(connectorLocalStorageKey)
           if (error instanceof NoEthereumProviderError || error instanceof NoBscProviderError) {
-            toastError('Provider Error', `No provider was found`)
+            toastError('Provider Error', 'No provider was found')
           } else if (
             error instanceof UserRejectedRequestErrorInjected ||
             error instanceof UserRejectedRequestErrorWalletConnect
@@ -39,7 +39,7 @@ const useAuth = () => {
               const walletConnector = connector as WalletConnectConnector
               walletConnector.walletConnectProvider = null
             }
-            toastError('Authorization Error', `Please authorize to access your account`)
+            toastError('Authorization Error', 'Please authorize to access your account')
           } else {
             toastError(error.name, error.message)
           }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -36,7 +36,8 @@ const useAuth = () => {
             error instanceof UserRejectedRequestErrorWalletConnect
           ) {
             if (connector instanceof WalletConnectConnector) {
-              (connector as WalletConnectConnector).walletConnectProvider = null
+              const walletConnector = connector as WalletConnectConnector
+              walletConnector.walletConnectProvider = null
             }
             toastError('Authorization Error', `Please authorize to access your account`)
           } else {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,12 @@
 import { useCallback } from 'react'
 import { useWeb3React, UnsupportedChainIdError } from '@web3-react/core'
-import { ConnectorNames } from '@pancakeswap-libs/uikit'
+import { NoBscProviderError } from '@binance-chain/bsc-connector'
+import {
+  NoEthereumProviderError,
+  UserRejectedRequestError as UserRejectedRequestErrorInjected
+} from '@web3-react/injected-connector'
+import { UserRejectedRequestError as UserRejectedRequestErrorWalletConnect } from '@web3-react/walletconnect-connector'
+import { ConnectorNames, connectorLocalStorageKey } from '@pancakeswap-libs/uikit'
 import { useToast } from 'state/hooks'
 import { connectorsByName } from 'utils/web3React'
 import { setupNetwork } from 'utils/wallet'
@@ -19,7 +25,20 @@ const useAuth = () => {
             activate(connector)
           }
         } else {
-          toastError(error.name, error.message)
+          window.localStorage.removeItem(connectorLocalStorageKey)
+          if (
+            error instanceof NoEthereumProviderError || 
+            error instanceof NoBscProviderError
+          ) {
+            toastError('Provider Error', `No provider was found`)
+          } else if (
+            error instanceof UserRejectedRequestErrorInjected ||
+            error instanceof UserRejectedRequestErrorWalletConnect
+          ) {
+            toastError('Authorization Error', `Please authorize to access your account`)
+          } else {
+            toastError(error.name, error.message)
+          }
         }
       })
     } else {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,7 +5,7 @@ import {
   NoEthereumProviderError,
   UserRejectedRequestError as UserRejectedRequestErrorInjected
 } from '@web3-react/injected-connector'
-import { UserRejectedRequestError as UserRejectedRequestErrorWalletConnect } from '@web3-react/walletconnect-connector'
+import { UserRejectedRequestError as UserRejectedRequestErrorWalletConnect, WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import { ConnectorNames, connectorLocalStorageKey } from '@pancakeswap-libs/uikit'
 import { useToast } from 'state/hooks'
 import { connectorsByName } from 'utils/web3React'
@@ -35,6 +35,9 @@ const useAuth = () => {
             error instanceof UserRejectedRequestErrorInjected ||
             error instanceof UserRejectedRequestErrorWalletConnect
           ) {
+            if (connector instanceof WalletConnectConnector) {
+              (connector as WalletConnectConnector).walletConnectProvider = null
+            }
             toastError('Authorization Error', `Please authorize to access your account`)
           } else {
             toastError(error.name, error.message)

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,9 +3,12 @@ import { useWeb3React, UnsupportedChainIdError } from '@web3-react/core'
 import { NoBscProviderError } from '@binance-chain/bsc-connector'
 import {
   NoEthereumProviderError,
-  UserRejectedRequestError as UserRejectedRequestErrorInjected
+  UserRejectedRequestError as UserRejectedRequestErrorInjected,
 } from '@web3-react/injected-connector'
-import { UserRejectedRequestError as UserRejectedRequestErrorWalletConnect, WalletConnectConnector } from '@web3-react/walletconnect-connector'
+import {
+  UserRejectedRequestError as UserRejectedRequestErrorWalletConnect,
+  WalletConnectConnector,
+} from '@web3-react/walletconnect-connector'
 import { ConnectorNames, connectorLocalStorageKey } from '@pancakeswap-libs/uikit'
 import { useToast } from 'state/hooks'
 import { connectorsByName } from 'utils/web3React'
@@ -26,10 +29,7 @@ const useAuth = () => {
           }
         } else {
           window.localStorage.removeItem(connectorLocalStorageKey)
-          if (
-            error instanceof NoEthereumProviderError || 
-            error instanceof NoBscProviderError
-          ) {
+          if (error instanceof NoEthereumProviderError || error instanceof NoBscProviderError) {
             toastError('Provider Error', `No provider was found`)
           } else if (
             error instanceof UserRejectedRequestErrorInjected ||


### PR DESCRIPTION
PR contains:

Fixes #594 , fixes #622 , fixes #633

- fix(walletconnect): Fix qr code shown after restart when selecting wallet connect and rejecting it
- fix(walletconnect): Fix qr code not shown again after rejecting it
- feature(wallet errors): Make wallet errors human readable

<img width="430" alt="image" src="https://user-images.githubusercontent.com/2213635/110521983-b620e100-8110-11eb-8cb1-f1ddbd094704.png">

<img width="451" alt="image" src="https://user-images.githubusercontent.com/2213635/110522084-d0f35580-8110-11eb-84aa-62a1c92644de.png">
