### PR TITLE
fix: Show last lottery results instead of first in past draws when wallet is not connected

### DIFF
--- a/src/views/Lottery/Lottery.tsx
+++ b/src/views/Lottery/Lottery.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { ButtonMenu, ButtonMenuItem } from '@pancakeswap-libs/uikit'
-import { useWeb3React } from '@web3-react/core'
 import PastLotteryDataContext from 'contexts/PastLotteryDataContext'
 import { getLotteryIssueIndex } from 'utils/lotteryUtils'
 import useI18n from 'hooks/useI18n'
@@ -22,7 +21,6 @@ const Wrapper = styled.div`
 
 const Lottery: React.FC = () => {
   const lotteryContract = useLottery()
-  const { account } = useWeb3React()
   const TranslateString = useI18n()
   const [activeIndex, setActiveIndex] = useState(0)
   const [historyData, setHistoryData] = useState([])
@@ -48,10 +46,10 @@ const Lottery: React.FC = () => {
       setMostRecentLotteryNumber(previousLotteryNumber)
     }
 
-    if (account && lotteryContract) {
+    if (lotteryContract) {
       getInitialLotteryIndex()
     }
-  }, [account, lotteryContract])
+  }, [lotteryContract])
 
   const handleClick = (index) => {
     setActiveIndex(index)


### PR DESCRIPTION
Fixes #631 
