### PR TITLE
chore: Replace ETH by BNB in swap urls

### DIFF
--- a/src/utils/getLiquidityUrlPathParts.ts
+++ b/src/utils/getLiquidityUrlPathParts.ts
@@ -1,9 +1,8 @@
 // Constructing the two forward-slash-separated parts of the 'Add Liquidity' URL
 // Each part of the url represents a different side of the LP pair.
-// In the URL, using the quote token 'BNB' is represented by 'ETH'
-const getLiquidityUrlPathParts = ({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses }) => {
+const getLiquidityUrlPathParts = ({ quoteTokenAdresses, tokenAddresses }) => {
   const chainId = process.env.REACT_APP_CHAIN_ID
-  const firstPart = quoteTokenSymbol === 'BNB' ? 'ETH' : quoteTokenAdresses[chainId]
+  const firstPart = quoteTokenAdresses[chainId]
   const secondPart = tokenAddresses[chainId]
   return `${firstPart}/${secondPart}`
 }

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -130,8 +130,8 @@ const FarmCard: React.FC<FarmCardProps> = ({ farm, removed, cakePrice, bnbPrice,
   const farmAPY =
     farm.apy && farm.apy.times(new BigNumber(100)).toNumber().toLocaleString('en-US', { maximumFractionDigits: 2 })
 
-  const { quoteTokenAdresses, quoteTokenSymbol, tokenAddresses } = farm
-  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
+  const { quoteTokenAdresses, tokenAddresses } = farm
+  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, tokenAddresses })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
 
   return (

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -104,9 +104,9 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
   const farm = details
 
   const TranslateString = useI18n()
-  const { quoteTokenAdresses, quoteTokenSymbol, tokenAddresses, tokenSymbol, dual } = farm
+  const { quoteTokenAdresses, tokenAddresses, tokenSymbol, dual } = farm
   const lpLabel = farm.lpSymbol && farm.lpSymbol.toUpperCase().replace('PANCAKE', '')
-  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
+  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, tokenAddresses })
   const lpAddress = farm.lpAddresses[process.env.REACT_APP_CHAIN_ID]
   const bsc = `https://bscscan.com/address/${lpAddress}`
   const info = `https://pancakeswap.info/pair/${lpAddress}`

--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -28,7 +28,6 @@ const Staked: React.FunctionComponent<FarmWithStakedValue> = ({
   lpSymbol,
   lpAddresses,
   quoteTokenAdresses,
-  quoteTokenSymbol,
   tokenAddresses,
 }) => {
   const TranslateString = useI18n()
@@ -42,7 +41,7 @@ const Staked: React.FunctionComponent<FarmWithStakedValue> = ({
   const isApproved = account && allowance && allowance.isGreaterThan(0)
 
   const lpAddress = lpAddresses[process.env.REACT_APP_CHAIN_ID]
-  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
+  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, tokenAddresses })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
   const rawStakedBalance = getBalanceNumber(stakedBalance)
   const displayBalance = rawStakedBalance.toLocaleString()

--- a/src/views/Farms/components/FarmTable/Apr.tsx
+++ b/src/views/Farms/components/FarmTable/Apr.tsx
@@ -45,14 +45,13 @@ const Apr: React.FC<AprProps> = ({
   value,
   lpLabel,
   quoteTokenAdresses,
-  quoteTokenSymbol,
   tokenAddresses,
   cakePrice,
   originalValue,
   hideButton = false,
 }) => {
   const TranslateString = useI18n()
-  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, quoteTokenSymbol, tokenAddresses })
+  const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAdresses, tokenAddresses })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
   return (
     <Container>

--- a/src/views/Ifos/ComingSoon.tsx
+++ b/src/views/Ifos/ComingSoon.tsx
@@ -63,7 +63,7 @@ const ComingSoon = () => {
               )}
             </Text>
             <Text mb={3}>
-              <LiquidityLink href="https://exchange.pancakeswap.finance/#/add/ETH/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82">
+              <LiquidityLink href="https://exchange.pancakeswap.finance/#/add/BNB/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82">
                 {TranslateString(506, 'Get CAKE-BNB LP >')}
               </LiquidityLink>
             </Text>

--- a/src/views/Ifos/CurrentIfo.tsx
+++ b/src/views/Ifos/CurrentIfo.tsx
@@ -55,7 +55,7 @@ const Ifo = () => {
             <LinkExternal href="https://exchange.pancakeswap.finance/#/swap" mr="16px">
               {TranslateString(1060, 'Buy CAKE')}
             </LinkExternal>
-            <LinkExternal href="https://exchange.pancakeswap.finance/#/add/ETH/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82">
+            <LinkExternal href="https://exchange.pancakeswap.finance/#/add/BNB/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82">
               {TranslateString(1062, 'Get LP tokens')}
             </LinkExternal>
           </Flex>

--- a/src/views/Ifos/components/IfoCard/ContributeModal.tsx
+++ b/src/views/Ifos/components/IfoCard/ContributeModal.tsx
@@ -86,7 +86,7 @@ const ContributeModal: React.FC<Props> = ({ currency, contract, currencyAddress,
           onConfirm={handleConfirm}
         />
         <LinkExternal
-          href="https://exchange.pancakeswap.finance/#/add/ETH/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82"
+          href="https://exchange.pancakeswap.finance/#/add/BNB/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82"
           style={{ margin: '16px auto 0' }}
         >
           {`Get ${currency}`}


### PR DESCRIPTION
Remove ETH in swap urls.
To be release at the same time as https://github.com/pancakeswap/pancake-swap-interface/pull/234.