### PR TITLE
fix: Sort by APR not sorting high APR properly

### DIFF
--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -142,7 +142,7 @@ const Farms: React.FC = () => {
   const sortFarms = (farms: FarmWithStakedValue[]): FarmWithStakedValue[] => {
     switch (sortOption) {
       case 'apr':
-        return orderBy(farms, (farm: FarmWithStakedValue) => Number(farm.apy), 'desc')
+        return orderBy(farms, (farm: FarmWithStakedValue) => farm.apy.toNumber(), 'desc')
       case 'multiplier':
         return orderBy(farms, (farm: FarmWithStakedValue) => Number(farm.multiplier.slice(0, -1)), 'desc')
       case 'earned':

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -142,7 +142,7 @@ const Farms: React.FC = () => {
   const sortFarms = (farms: FarmWithStakedValue[]): FarmWithStakedValue[] => {
     switch (sortOption) {
       case 'apr':
-        return orderBy(farms, 'apy', 'desc')
+        return orderBy(farms, (farm: FarmWithStakedValue) => Number(farm.apy), 'desc')
       case 'multiplier':
         return orderBy(farms, (farm: FarmWithStakedValue) => Number(farm.multiplier.slice(0, -1)), 'desc')
       case 'earned':


### PR DESCRIPTION
In Farms table sort by APR does not sort farms with more than 1000 APR properly.
Currently in master it gets shoved below farms with 200% APR due to the way how lodash's orderBy works with BigNumber.js numbers.
You can see contrived example in sandbox here - https://codesandbox.io/s/c1kgz
This PR fixes ordering so farms with >1000% APR come on top.

Fixes #650 

**Current master (note BUX-BNB)**
![Screenshot 2021-03-12 at 11 43 17](https://user-images.githubusercontent.com/24019688/110925381-c95bc880-832b-11eb-882e-257d91a90cbb.png)

**This PR**
![Screenshot 2021-03-12 at 11 43 40](https://user-images.githubusercontent.com/24019688/110925440-dc6e9880-832b-11eb-9d55-555eff65ba21.png)
