### PR TITLE
fix: Prevent EasterEgg bunnies reposition on rerenders

### DIFF
--- a/src/components/EasterEgg/EasterEgg.tsx
+++ b/src/components/EasterEgg/EasterEgg.tsx
@@ -16,4 +16,4 @@ const EasterEgg: React.FC<FallingBunniesProps> = (props) => {
   return null
 }
 
-export default EasterEgg
+export default React.memo(EasterEgg)


### PR DESCRIPTION
Currently FallingBunnies use random position for bunnies. so RefreshContextProvider make the EasterEgg component rerender then it changes bunnies position in the middle of animation and it's not nice.