### PR TITLE
fix: Remove arrows underneath lottery past draws search button

### DIFF
--- a/src/views/Lottery/components/PastLotteryRoundViewer/PastLotterySearcher.tsx
+++ b/src/views/Lottery/components/PastLotteryRoundViewer/PastLotterySearcher.tsx
@@ -15,6 +15,18 @@ const Wrapper = styled.div`
 const SearchWrapper = styled.div`
   position: relative;
 `
+const InputWrapper = styled.div`
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+`
 
 const ButtonWrapper = styled.div`
   position: absolute;
@@ -48,13 +60,15 @@ const PastLotterySearcher: React.FC<PastLotterySearcherProps> = ({ initialLotter
       <Text>{TranslateString(742, 'Select lottery number:')}</Text>
       <form onSubmit={handleSubmit}>
         <SearchWrapper>
-          <Input
-            value={lotteryNumber}
-            type="number"
-            isWarning={isError}
-            max={initialLotteryNumber}
-            onChange={handleChange}
-          />
+          <InputWrapper>
+            <Input
+              value={lotteryNumber}
+              type="number"
+              isWarning={isError}
+              max={initialLotteryNumber}
+              onChange={handleChange}
+            />
+          </InputWrapper>
           <ButtonWrapper>
             <Button type="submit" scale="sm" disabled={isError}>
               {TranslateString(744, 'Search')}

--- a/src/views/Lottery/components/PastLotteryRoundViewer/PastLotterySearcher.tsx
+++ b/src/views/Lottery/components/PastLotteryRoundViewer/PastLotterySearcher.tsx
@@ -16,7 +16,6 @@ const SearchWrapper = styled.div`
   position: relative;
 `
 const InputWrapper = styled.div`
-  input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;


### PR DESCRIPTION
Fixes #655

Before:

<img width="585" alt="image" src="https://user-images.githubusercontent.com/2213635/111031878-05655b00-840a-11eb-818e-2d53d0079c3e.png">

After: 

<img width="598" alt="image" src="https://user-images.githubusercontent.com/2213635/111031925-2e85eb80-840a-11eb-9850-120da71c61ba.png">

