### PR TITLE
chore: Update BTCST decimals

### DIFF
--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -706,7 +706,7 @@ const pools: PoolConfig[] = [
     tokenPerBlock: '0.011574',
     sortOrder: 999,
     isFinished: true,
-    tokenDecimals: 18,
+    tokenDecimals: 17,
   },
   {
     sousId: 34,


### PR DESCRIPTION
BTCST are removing one decimal from their token
https://btcst.medium.com/btcst-redenomination-guide-for-exchange-and-wallet-partners-ad00eade8cec
