### PR TITLE
fix: Past pools with BNB token

### DIFF
--- a/src/views/Pools/components/CardFooter.tsx
+++ b/src/views/Pools/components/CardFooter.tsx
@@ -144,12 +144,14 @@ const CardFooter: React.FC<Props> = ({
               <Balance fontSize="14px" isDisabled={isFinished} value={blocksRemaining} decimals={0} />
             </Row>
           )}
-          <Flex mb="4px">
-            <TokenLink onClick={() => registerToken(tokenAddress, tokenName, tokenDecimals, imageSrc)}>
-              Add {tokenName} to Metamask
-            </TokenLink>
-            <MetamaskIcon height={15} width={15} ml="4px" />
-          </Flex>
+          {tokenAddress && (
+            <Flex mb="4px">
+              <TokenLink onClick={() => registerToken(tokenAddress, tokenName, tokenDecimals, imageSrc)}>
+                Add {tokenName} to Metamask
+              </TokenLink>
+              <MetamaskIcon height={15} width={15} ml="4px" />
+            </Flex>
+          )}
           <TokenLink href={projectLink} target="_blank">
             {TranslateString(412, 'View project site')}
           </TokenLink>

--- a/src/views/Pools/components/PoolCard.tsx
+++ b/src/views/Pools/components/PoolCard.tsx
@@ -46,10 +46,11 @@ const PoolCard: React.FC<HarvestProps> = ({ pool }) => {
     userData,
     stakingLimit,
   } = pool
+
   // Pools using native BNB behave differently than pools using a token
   const isBnbPool = poolCategory === PoolCategory.BINANCE
   const TranslateString = useI18n()
-  const stakingTokenContract = useERC20(getAddress(stakingToken.address))
+  const stakingTokenContract = useERC20(stakingToken.address ? getAddress(stakingToken.address) : '')
   const { account } = useWeb3React()
   const { onApprove } = useSousApprove(stakingTokenContract, sousId)
   const { onStake } = useSousStake(sousId, isBnbPool)
@@ -213,7 +214,7 @@ const PoolCard: React.FC<HarvestProps> = ({ pool }) => {
         isFinished={isFinished}
         poolCategory={poolCategory}
         tokenName={earningToken.symbol}
-        tokenAddress={getAddress(earningToken.address)}
+        tokenAddress={earningToken.address ? getAddress(earningToken.address) : ''}
         tokenDecimals={earningToken.decimals}
       />
     </Card>


### PR DESCRIPTION
BNB doesn't have an address , which break some pools after the token list rework
