### PR TITLE
fix: Cake price in webpage title shows 0 when loading fresh restart and added dependency to useEffect

### DIFF
--- a/src/hooks/useGetDocumentTitlePrice.ts
+++ b/src/hooks/useGetDocumentTitlePrice.ts
@@ -3,11 +3,16 @@ import { usePriceCakeBusd } from 'state/hooks'
 
 const useGetDocumentTitlePrice = () => {
   const cakePriceUsd = usePriceCakeBusd()
+
+  const cakePriceUsdString = cakePriceUsd.eq(0)
+    ? ''
+    : ` - $${cakePriceUsd.toNumber().toLocaleString(undefined, {
+        minimumFractionDigits: 3,
+        maximumFractionDigits: 3,
+      })}`
+
   useEffect(() => {
-    document.title = `PancakeSwap - $${Number(cakePriceUsd).toLocaleString(undefined, {
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    })}`
-  })
+    document.title = `PancakeSwap${cakePriceUsdString}`
+  }, [cakePriceUsdString])
 }
 export default useGetDocumentTitlePrice


### PR DESCRIPTION
Fixes #711 

And added dependency to useEffect regarding to 

https://github.com/pancakeswap/pancake-swap-interface/pull/295#discussion_r598396443