### PR TITLE
Update config objects accessing tokens.blk & tokens.btc 

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -649,7 +649,7 @@ const farms: FarmConfig[] = [
       97: '',
       56: '0xC743Dc05F03D25E1aF8eC5F8228f4BD25513c8d0',
     },
-    token: tokens.blk,
+    token: tokens.blink,
     quoteToken: tokens.wbnb,
   },
   {
@@ -769,7 +769,7 @@ const farms: FarmConfig[] = [
       97: '0xE66790075ad839978fEBa15D4d8bB2b415556a1D',
       56: '0x7561EEe90e24F3b348E1087A005F78B4c8453524',
     },
-    token: tokens.btc,
+    token: tokens.btcb,
     quoteToken: tokens.wbnb,
   },
   {

--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -879,7 +879,7 @@ const pools: PoolConfig[] = [
   {
     sousId: 18,
     stakingToken: tokens.cake,
-    earningToken: tokens.blk,
+    earningToken: tokens.blink,
     contractAddress: {
       97: '',
       56: '0x42Afc29b2dEa792974d1e9420696870f1Ca6d18b',
@@ -893,7 +893,7 @@ const pools: PoolConfig[] = [
   {
     sousId: 17,
     stakingToken: tokens.cake,
-    earningToken: tokens.blk,
+    earningToken: tokens.blink,
     contractAddress: {
       97: '',
       56: '0xBb2B66a2c7C2fFFB06EA60BeaD69741b3f5BF831',


### PR DESCRIPTION
- Following some recent changes to the `btc` & `blk` token config, we were getting compilation errors as our farms & pools configs were still accessing the old values
- This updates them to the new values - `btcb` & `blink`
