### PR TITLE
fix: Cake winnings section Locked when no wallet and remove cake prize in dollar when 0

### DIFF
--- a/src/views/Home/components/CakeWinnings.tsx
+++ b/src/views/Home/components/CakeWinnings.tsx
@@ -32,11 +32,7 @@ const CakeWinnings = () => {
   return (
     <Block>
       <CardValue value={cakeAmount} lineHeight="1.5" />
-      {claimAmountBusd !== 0 ? (
-        <CardBusdValue value={claimAmountBusd} decimals={2} />
-      ) : (
-        <Skeleton animation="pulse" variant="rect" height="44px" />
-      )}
+      {claimAmountBusd !== 0 && <CardBusdValue value={claimAmountBusd} decimals={2} />}
     </Block>
   )
 }

--- a/src/views/Home/components/CakeWinnings.tsx
+++ b/src/views/Home/components/CakeWinnings.tsx
@@ -2,24 +2,41 @@ import React from 'react'
 import { useTotalClaim } from 'hooks/useTickets'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { usePriceCakeBusd } from 'state/hooks'
+import { Skeleton, Text } from '@pancakeswap-libs/uikit'
+import { useWeb3React } from '@web3-react/core'
 import { BigNumber } from 'bignumber.js'
 import styled from 'styled-components'
 import CardValue from './CardValue'
 import CardBusdValue from './CardBusdValue'
+import useI18n from '../../../hooks/useI18n'
 
 const Block = styled.div`
   margin-bottom: 24px;
- }
 `
+
 const CakeWinnings = () => {
+  const TranslateString = useI18n()
+  const { account } = useWeb3React()
   const { claimAmount } = useTotalClaim()
   const cakeAmount = getBalanceNumber(claimAmount)
   const claimAmountBusd = new BigNumber(cakeAmount).multipliedBy(usePriceCakeBusd()).toNumber()
 
+  if (!account) {
+    return (
+      <Text color="textDisabled" style={{ lineHeight: '76px' }}>
+        {TranslateString(298, 'Locked')}
+      </Text>
+    )
+  }
+
   return (
     <Block>
       <CardValue value={cakeAmount} lineHeight="1.5" />
-      <CardBusdValue value={claimAmountBusd} decimals={2} />
+      {claimAmountBusd !== 0 ? (
+        <CardBusdValue value={claimAmountBusd} decimals={2} />
+      ) : (
+        <Skeleton animation="pulse" variant="rect" height="44px" />
+      )}
     </Block>
   )
 }

--- a/src/views/Home/components/CakeWinnings.tsx
+++ b/src/views/Home/components/CakeWinnings.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { useTotalClaim } from 'hooks/useTickets'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { usePriceCakeBusd } from 'state/hooks'
-import { Skeleton, Text } from '@pancakeswap-libs/uikit'
+import { Text } from '@pancakeswap-libs/uikit'
 import { useWeb3React } from '@web3-react/core'
 import { BigNumber } from 'bignumber.js'
 import styled from 'styled-components'
+import useI18n from 'hooks/useI18n'
 import CardValue from './CardValue'
 import CardBusdValue from './CardBusdValue'
-import useI18n from '../../../hooks/useI18n'
 
 const Block = styled.div`
   margin-bottom: 24px;

--- a/src/views/Home/components/LotteryCard.tsx
+++ b/src/views/Home/components/LotteryCard.tsx
@@ -45,7 +45,7 @@ const Actions = styled.div`
   }
 `
 
-const FarmedStakingCard = () => {
+const LotteryCard = () => {
   const { account } = useWeb3React()
   const lotteryHasDrawn = useGetLotteryHasDrawn()
   const [requesteClaim, setRequestedClaim] = useState(false)
@@ -124,4 +124,4 @@ const FarmedStakingCard = () => {
   )
 }
 
-export default FarmedStakingCard
+export default LotteryCard

--- a/src/views/Home/components/LotteryCard.tsx
+++ b/src/views/Home/components/LotteryCard.tsx
@@ -13,9 +13,9 @@ import BuyModal from 'views/Lottery/components/TicketCard/BuyTicketModal'
 import { useLotteryAllowance } from 'hooks/useAllowance'
 import { useApproval } from 'hooks/useApproval'
 import PurchaseWarningModal from 'views/Lottery/components/TicketCard/PurchaseWarningModal'
+import UnlockButton from 'components/UnlockButton'
 import CakeWinnings from './CakeWinnings'
 import LotteryJackpot from './LotteryJackpot'
-import UnlockButton from '../../../components/UnlockButton'
 
 const StyledLotteryCard = styled(Card)`
   background-image: url('/images/ticket-bg.svg');

--- a/src/views/Home/components/LotteryJackpot.tsx
+++ b/src/views/Home/components/LotteryJackpot.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Skeleton, Text } from '@pancakeswap-libs/uikit'
+import { Text } from '@pancakeswap-libs/uikit'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { useTotalRewards } from 'hooks/useTickets'
 import useI18n from 'hooks/useI18n'
@@ -19,7 +19,7 @@ const LotteryJackpot = () => {
   return (
     <>
       <Text bold fontSize="24px" style={{ lineHeight: '1.5' }}>
-        {lotteryPrizeAmountCake} {TranslateString(999, 'CAKE')}
+        {TranslateString(999, `${lotteryPrizeAmountCake} CAKE`, { amount: lotteryPrizeAmountCake })}
       </Text>
       {lotteryPrizeAmountBusd !== 0 && <CardBusdValue value={lotteryPrizeAmountBusd} />}
     </>

--- a/src/views/Home/components/LotteryJackpot.tsx
+++ b/src/views/Home/components/LotteryJackpot.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text } from '@pancakeswap-libs/uikit'
+import { Skeleton, Text } from '@pancakeswap-libs/uikit'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { useTotalRewards } from 'hooks/useTickets'
 import useI18n from 'hooks/useI18n'
@@ -11,7 +11,7 @@ const LotteryJackpot = () => {
   const TranslateString = useI18n()
   const lotteryPrizeAmount = useTotalRewards()
   const balance = getBalanceNumber(lotteryPrizeAmount)
-  const lotteryPrizeAmoutCake = balance.toLocaleString(undefined, {
+  const lotteryPrizeAmountCake = balance.toLocaleString(undefined, {
     maximumFractionDigits: 2,
   })
   const lotteryPrizeAmountBusd = new BigNumber(balance).multipliedBy(usePriceCakeBusd()).toNumber()
@@ -19,9 +19,9 @@ const LotteryJackpot = () => {
   return (
     <>
       <Text bold fontSize="24px" style={{ lineHeight: '1.5' }}>
-        {lotteryPrizeAmoutCake} {TranslateString(999, 'CAKE')}
+        {lotteryPrizeAmountCake} {TranslateString(999, 'CAKE')}
       </Text>
-      <CardBusdValue value={lotteryPrizeAmountBusd} />
+      {lotteryPrizeAmountBusd !== 0 && <CardBusdValue value={lotteryPrizeAmountBusd} />}
     </>
   )
 }


### PR DESCRIPTION
Cake winnings section shows 0 when no wallet connected

<img width="585" alt="image" src="https://user-images.githubusercontent.com/2213635/112201946-1a639a80-8c11-11eb-84dd-fb255d2fdd5a.png">

Look like this when no wallet connected and cake price is loading

<img width="1640" alt="image" src="https://user-images.githubusercontent.com/2213635/112201612-b9d45d80-8c10-11eb-8e8e-997772a94ede.png">
