### PR TITLE
fix: Apr check when number is 0 and simplify apr component

### DIFF
--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -208,7 +208,7 @@ const Farms: React.FC = () => {
 
     const row: RowProps = {
       apr: {
-        value: farm.apy && farm.apy.toLocaleString('en-US', { maximumFractionDigits: 2 }),
+        value: Number.isFinite(farm.apy) ? farm.apy.toLocaleString('en-US', { maximumFractionDigits: 2 }) : null,
         multiplier: farm.multiplier,
         lpLabel,
         tokenAddress,

--- a/src/views/Farms/components/FarmTable/Apr.tsx
+++ b/src/views/Farms/components/FarmTable/Apr.tsx
@@ -53,22 +53,18 @@ const Apr: React.FC<AprProps> = ({
   const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAddress, tokenAddress })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
 
-  return originalValue !== 0 ? (
+  return (
     <Container>
-      {originalValue ? (
+      {Number.isFinite(originalValue) ? (
         <>
           <AprWrapper>{value}%</AprWrapper>
-          {!hideButton && (
+          {!hideButton && originalValue !== 0 && (
             <ApyButton lpLabel={lpLabel} cakePrice={cakePrice} apy={originalValue} addLiquidityUrl={addLiquidityUrl} />
           )}
         </>
       ) : (
         <AprWrapper>{TranslateString(656, 'Loading...')}</AprWrapper>
       )}
-    </Container>
-  ) : (
-    <Container>
-      <AprWrapper>{originalValue}%</AprWrapper>
     </Container>
   )
 }


### PR DESCRIPTION
Fixed When apr is 0 (when farm is finished) it fails in apr value check and returns itself which ends up in the runtime row apr value type is number instead of string which might cause problem in the future

Fixed Apr component uses originalValue when 0 instead of value as well.