### PR TITLE
fix: Wrong Until ticket sale progress when no wallet connected

### DIFF
--- a/src/hooks/useGetLotteryHasDrawn.ts
+++ b/src/hooks/useGetLotteryHasDrawn.ts
@@ -10,11 +10,10 @@ import { getLotteryStatus } from 'utils/lotteryUtils'
  */
 const useGetLotteryHasDrawn = () => {
   const [lotteryHasDrawn, setLotteryHasDrawn] = useState(true)
-  const { account } = useWeb3React()
   const lotteryContract = useLottery()
 
   useEffect(() => {
-    if (account && lotteryContract) {
+    if (lotteryContract) {
       const fetchLotteryStatus = async () => {
         const state = await getLotteryStatus(lotteryContract)
         setLotteryHasDrawn(state)
@@ -22,7 +21,7 @@ const useGetLotteryHasDrawn = () => {
 
       fetchLotteryStatus()
     }
-  }, [account, lotteryContract])
+  }, [lotteryContract])
 
   return lotteryHasDrawn
 }

--- a/src/hooks/useGetLotteryHasDrawn.ts
+++ b/src/hooks/useGetLotteryHasDrawn.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useWeb3React } from '@web3-react/core'
 import { useLottery } from 'hooks/useContract'
 import { getLotteryStatus } from 'utils/lotteryUtils'
 


### PR DESCRIPTION
Until ticket sale progress always shown and countdown from 1 hour repeatedly till end of lottery draw when no wallet connected

![644E2ABE-3A20-4F3C-905D-60274CC6A55D](https://user-images.githubusercontent.com/2213635/113503094-ffa5f580-952f-11eb-9f7c-a0de0f4fb924.jpeg)
