### PR TITLE
fix: Fix addAchievements in achievements reducer

### DIFF
--- a/src/state/achievements/index.ts
+++ b/src/state/achievements/index.ts
@@ -18,7 +18,7 @@ export const achievementSlice = createSlice({
       state.data.push(action.payload)
     },
     addAchievements: (state, action: PayloadAction<Achievement[]>) => {
-      state.data.concat(action.payload)
+      state.data = [...state.data, ...action.payload]
     },
     setAchievements: (state, action: PayloadAction<Achievement[]>) => {
       state.data = action.payload


### PR DESCRIPTION
Found a bug in the achievements reducer (`state/achievements/index.ts`). `.concat` returns new array and does not change the existing array, so it didn't affect the state at all.
Right now only `addAchievement` is used. `addAchievements`, `setAchievements` and `clearAchievements` are not used anywhere in the code, so there is no bug in prod. However as I understand the competition will give multiple achievements to users so it might be used soon.

I've made a quick demo UI to test it:

You can try it yourself, here is a [branch](https://github.com/Chef-Cheems/pancake-frontend/tree/feature/test-achievement-broken) on my fork (on top of current develop)

https://user-images.githubusercontent.com/81824236/113603526-bbf4de00-964c-11eb-9c6a-f95f8485798c.mp4

And here is the same testing UI on top of this PR's fix. If you wanna test yourself - here's the [branch](https://github.com/Chef-Cheems/pancake-frontend/tree/feature/test-achievement-fixed)

https://user-images.githubusercontent.com/81824236/113603845-1db54800-964d-11eb-9fdb-c955fbdfb4ab.mp4