### PR TITLE
chore: Remove unused types

### DIFF
--- a/src/views/Ifos/components/IfoCard/MetaLabel.tsx
+++ b/src/views/Ifos/components/IfoCard/MetaLabel.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { Box, BoxProps, Text } from '@pancakeswap-libs/uikit'
 
-type MetaLabel = BoxProps
-
 const MetaLabel: React.FC<BoxProps> = ({ children, ...props }) => {
   return (
     <Box minHeight="18px" {...props}>

--- a/src/views/Profile/ProfileCreation/TeamSelection.tsx
+++ b/src/views/Profile/ProfileCreation/TeamSelection.tsx
@@ -7,12 +7,6 @@ import SelectionCard from '../components/SelectionCard'
 import NextStepButton from '../components/NextStepButton'
 import useProfileCreation from './contexts/hook'
 
-interface Team {
-  name: string
-  description: string
-  isJoinable: boolean
-}
-
 const Team: React.FC = () => {
   const { teamId: currentTeamId, actions } = useProfileCreation()
   const TranslateString = useI18n()


### PR DESCRIPTION
The `MetaLabel` and `Team` types that are removed in this PR are defined but not used. Moreover, they also have the same name as the React components. Luckily TS compiler is able to figure out to export React component on the last line and not the type, so nothing is broken, but better to clean it up.