### PR TITLE
fix: Trading Competition styles for small devices

### DIFF
--- a/src/views/TradingCompetition/components/BattleBanner/index.tsx
+++ b/src/views/TradingCompetition/components/BattleBanner/index.tsx
@@ -44,7 +44,7 @@ const BattleBanner = () => {
       <ImageWrapper>
         <Image src={AllBunniesImage} alt="all the bunnies" width={1208} height={659} responsive />
       </ImageWrapper>
-      <StyledText mb="16px" color="textSubtle" fontWeight="bold">
+      <StyledText mb="16px" color="textSubtle" bold>
         {TranslateString(999, 'April')} 07—14, 2021
       </StyledText>
       <StyledHeading1Text>{TranslateString(999, 'Easter Battle')}</StyledHeading1Text>

--- a/src/views/TradingCompetition/components/ClaimModal/index.tsx
+++ b/src/views/TradingCompetition/components/ClaimModal/index.tsx
@@ -52,7 +52,7 @@ const ClaimModal: React.FC<CompetitionProps> = ({ onDismiss, onClaimSuccess, use
   return (
     <Modal title="Collect Winnings" onDismiss={onDismiss}>
       <Flex flexDirection="column" alignItems="center" maxWidth="400px">
-        <Text color="secondary" fontWeight={600} fontSize="16px">
+        <Text color="secondary" bold fontSize="16px">
           {TranslateString(999, 'Congratulations, you won')}
         </Text>
         <Flex mt="16px">

--- a/src/views/TradingCompetition/components/Countdown/ProgressStepper.tsx
+++ b/src/views/TradingCompetition/components/Countdown/ProgressStepper.tsx
@@ -9,11 +9,15 @@ const Wrapper = styled.div``
 
 const Spacer = styled.div<{ isPastSpacer?: boolean }>`
   margin: 12px 8px 0 8px;
-  width: 36px;
+  width: 28px;
   background-color: ${({ isPastSpacer, theme }) =>
     isPastSpacer ? theme.colors.textSubtle : theme.colors.textDisabled};
   height: 2px;
   border-radius: 4px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    width: 36px;
+  }
 `
 
 const ProgressStepper: React.FC<CountdownProps> = ({ steps, activeStepIndex }) => {

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -65,9 +65,6 @@ const StyledHeading = styled(Heading2Text)`
 `
 
 const StyledTimerText = styled(Text)`
-  color: #ffff;
-  font-weight: 600;
-  font-size: 16px;
   margin-right: 10px;
 
   ${({ theme }) => theme.mediaQueries.sm} {
@@ -82,7 +79,7 @@ const TimerHeadingComponent = ({ children }) => (
 )
 
 const TimerBodyComponent = ({ children }) => (
-  <StyledTimerText color="#ffff" fontWeight="600" fontSize="16px" mr="16px">
+  <StyledTimerText bold color="#ffff" fontSize="16px">
     {children}
   </StyledTimerText>
 )

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -16,9 +16,14 @@ const Wrapper = styled(Flex)`
   border: 1px solid #7645d9;
   box-sizing: border-box;
   border-radius: 0px 0px 24px 24px;
-  padding: 16px 24px;
+  padding: 16px 18px;
   margin: -30px auto 50px;
   justify-content: space-around;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    padding: 16px 24px;
+  }
+
   ${({ theme }) => theme.mediaQueries.xl} {
     flex-direction: column;
     margin: -38px 0 0 36px;
@@ -28,11 +33,20 @@ const Wrapper = styled(Flex)`
 const PocketWatchWrapper = styled(Flex)`
   align-items: center;
   justify-content: center;
-  margin-right: 24px;
+  margin-right: 12px;
 
   svg {
-    height: 64px;
-    width: 64px;
+    height: 48px;
+    width: 48px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-right: 24px;
+
+    svg {
+      height: 64px;
+      width: 64px;
+    }
   }
 
   ${({ theme }) => theme.mediaQueries.xl} {
@@ -43,7 +57,22 @@ const PocketWatchWrapper = styled(Flex)`
 
 const StyledHeading = styled(Heading2Text)`
   font-size: 24px;
-  margin-right: 4px;
+  margin-right: 2px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-right: 4px;
+  }
+`
+
+const StyledTimerText = styled(Text)`
+  color: #ffff;
+  font-weight: 600;
+  font-size: 16px;
+  margin-right: 10px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-right: 16px;
+  }
 `
 
 const TimerHeadingComponent = ({ children }) => (
@@ -53,9 +82,9 @@ const TimerHeadingComponent = ({ children }) => (
 )
 
 const TimerBodyComponent = ({ children }) => (
-  <Text color="#ffff" fontWeight="600" fontSize="16px" mr="16px">
+  <StyledTimerText color="#ffff" fontWeight="600" fontSize="16px" mr="16px">
     {children}
-  </Text>
+  </StyledTimerText>
 )
 
 const Countdown: React.FC<{ currentPhase: CompetitionPhaseProps }> = ({ currentPhase }) => {

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -64,14 +64,6 @@ const StyledHeading = styled(Heading2Text)`
   }
 `
 
-const StyledTimerText = styled(Text)`
-  margin-right: 10px;
-
-  ${({ theme }) => theme.mediaQueries.sm} {
-    margin-right: 16px;
-  }
-`
-
 const TimerHeadingComponent = ({ children }) => (
   <StyledHeading background={GOLDGRADIENT} fill>
     {children}
@@ -79,9 +71,9 @@ const TimerHeadingComponent = ({ children }) => (
 )
 
 const TimerBodyComponent = ({ children }) => (
-  <StyledTimerText bold color="#ffff" fontSize="16px">
+  <Text bold color="#ffff" fontSize="16px" mr={{ _: '10px', sm: '16px' }}>
     {children}
-  </StyledTimerText>
+  </Text>
 )
 
 const Countdown: React.FC<{ currentPhase: CompetitionPhaseProps }> = ({ currentPhase }) => {

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -71,7 +71,7 @@ const TimerHeadingComponent = ({ children }) => (
 )
 
 const TimerBodyComponent = ({ children }) => (
-  <Text bold color="#ffff" fontSize="16px" mr={{ _: '10px', sm: '16px' }}>
+  <Text bold color="#ffff" fontSize="16px" mr={{ _: '8px', sm: '16px' }}>
     {children}
   </Text>
 )

--- a/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
+++ b/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
@@ -166,9 +166,9 @@ const PrizesGrid = () => {
                   </BoldTd>
                   <Td>
                     <Flex alignItems="center" flexWrap="wrap" justifyContent="center" width="100%">
-                      {champion && <CrownIcon mr={{ sm: '2px', md: '4px' }} />}
-                      {teamPlayer && <TeamPlayerIcon mr={{ sm: '2px', md: '4px' }} />}
-                      <TrophyGoldIcon mr={{ sm: '2px', md: '4px' }} />
+                      {champion && <CrownIcon mr={{ _: '2px', md: '4px' }} />}
+                      {teamPlayer && <TeamPlayerIcon mr={{ _: '2px', md: '4px' }} />}
+                      <TrophyGoldIcon mr={{ _: '2px', md: '4px' }} />
                       <Text fontSize="12px" color="textSubtle">
                         {`+${getTotalAchievementPoints(row.achievements).toLocaleString(undefined, {
                           minimumFractionDigits: 0,

--- a/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
+++ b/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
@@ -79,7 +79,11 @@ const tierStyleMap = {
 
 const Td = styled.td`
   border-bottom: 2px solid ${({ theme }) => theme.colors.borderColor};
-  padding: 8px;
+  padding: 4px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    padding: 8px;
+  }
 `
 const BoldTd = styled(Td)`
   font-weight: 600;
@@ -96,8 +100,16 @@ const PrizeTable = styled.table`
 
   & > thead th {
     font-size: 12px;
-    padding: 16px;
+    padding: 16px 4px;
     text-transform: uppercase;
+
+    ${({ theme }) => theme.mediaQueries.xs} {
+      padding: 16px 8px;
+    }
+
+    ${({ theme }) => theme.mediaQueries.sm} {
+      padding: 16px;
+    }
   }
 `
 
@@ -154,9 +166,9 @@ const PrizesGrid = () => {
                   </BoldTd>
                   <Td>
                     <Flex alignItems="center" flexWrap="wrap" justifyContent="center" width="100%">
-                      {champion && <CrownIcon mr="4px" />}
-                      {teamPlayer && <TeamPlayerIcon mr="4px" />}
-                      <TrophyGoldIcon mr="4px" />
+                      {champion && <CrownIcon mr={{ sm: '2px', md: '4px' }} />}
+                      {teamPlayer && <TeamPlayerIcon mr={{ sm: '2px', md: '4px' }} />}
+                      <TrophyGoldIcon mr={{ sm: '2px', md: '4px' }} />
                       <Text fontSize="12px" color="textSubtle">
                         {`+${getTotalAchievementPoints(row.achievements).toLocaleString(undefined, {
                           minimumFractionDigits: 0,

--- a/src/views/TradingCompetition/components/RegisterModal/RegisterWithProfile.tsx
+++ b/src/views/TradingCompetition/components/RegisterModal/RegisterWithProfile.tsx
@@ -45,7 +45,7 @@ const RegisterWithProfile: React.FC<CompetitionProps> = ({ profile, onDismiss, o
     <>
       <Heading size="md" mb="24px">{`@${profile.username}`}</Heading>
       <Flex flexDirection="column">
-        <Text fontWeight="bold">
+        <Text bold>
           {TranslateString(
             999,
             'Registering for the competition will make your wallet address publicly visible on the leaderboard.',

--- a/src/views/TradingCompetition/components/Ribbon/index.tsx
+++ b/src/views/TradingCompetition/components/Ribbon/index.tsx
@@ -27,7 +27,7 @@ const TextWrapper = styled(Flex)`
   background-color: #7645d9;
 `
 
-const LaurelWrapper = styled.div<{ dir?: 'l' | 'r' }>`
+const LaurelWrapper = styled.div<{ dir?: 'left' | 'right' }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -35,7 +35,7 @@ const LaurelWrapper = styled.div<{ dir?: 'l' | 'r' }>`
   z-index: 2;
   top: 50%;
   transform: translate(0, -50%);
-  ${({ dir }) => (dir === 'l' ? `left: 0;` : `right: 0;`)}
+  ${({ dir }) => (dir === 'left' ? `left: 0;` : `right: 0;`)}
 
   svg {
     height: 20px;
@@ -51,7 +51,7 @@ const Ribbon: React.FC<RibbonProps> = ({ children, ribbonDirection }) => {
     return (
       <Wrapper ribbonDirection={ribbonDirection}>
         <RibbonDownLeftSide width="32px" />
-        <LaurelWrapper dir="l">
+        <LaurelWrapper dir="left">
           <LaurelLeftIcon />
         </LaurelWrapper>
         <div>
@@ -61,7 +61,7 @@ const Ribbon: React.FC<RibbonProps> = ({ children, ribbonDirection }) => {
         <TextWrapper>
           <Heading2Text p="0 30px">{children}</Heading2Text>
         </TextWrapper>
-        <LaurelWrapper dir="r">
+        <LaurelWrapper dir="right">
           <LaurelRightIcon />
         </LaurelWrapper>
         <RibbonDownRightSide width="32px" />
@@ -73,7 +73,7 @@ const Ribbon: React.FC<RibbonProps> = ({ children, ribbonDirection }) => {
     return (
       <Wrapper ribbonDirection={ribbonDirection}>
         <RibbonUpLeftSide width="32px" />
-        <LaurelWrapper dir="l">
+        <LaurelWrapper dir="left">
           <LaurelLeftIcon />
         </LaurelWrapper>
         <div>
@@ -83,7 +83,7 @@ const Ribbon: React.FC<RibbonProps> = ({ children, ribbonDirection }) => {
         <TextWrapper>
           <Heading2Text p="0 30px">{children}</Heading2Text>
         </TextWrapper>
-        <LaurelWrapper dir="r">
+        <LaurelWrapper dir="right">
           <LaurelRightIcon />
         </LaurelWrapper>
         <RibbonUpRightSide width="32px" />

--- a/src/views/TradingCompetition/components/Rules/FoldableText.tsx
+++ b/src/views/TradingCompetition/components/Rules/FoldableText.tsx
@@ -33,7 +33,7 @@ const FoldableText: React.FC<FoldableTextProps> = ({ title, children, ...props }
   return (
     <Wrapper {...props} flexDirection="column" onClick={() => setIsExpanded(!isExpanded)}>
       <Flex justifyContent="space-between">
-        <Text fontWeight="bold" mb="16px">
+        <Text bold mb="16px">
           {title}
         </Text>
         <StyledExpandableLabelWrapper>

--- a/src/views/TradingCompetition/components/Rules/FoldableText.tsx
+++ b/src/views/TradingCompetition/components/Rules/FoldableText.tsx
@@ -15,6 +15,7 @@ const StyledExpandableLabelWrapper = styled(Flex)`
   button {
     align-items: flex-start;
     justify-content: flex-start;
+    padding-right: 0;
   }
 `
 


### PR DESCRIPTION
- Fix the timer & prizes grid breaking out on smaller devices.
- Media queries added to reduce padding/margins at smaller sizes and make the page style correctly down to 320px
- *Note* Struggled to get overflow-x scrolling on the prize grid, so have just shrunk padding/margins. When less time-pressed with the trading comp components we can improve this.

Before (318 px):
<img width="403" alt="Screenshot 2021-04-06 at 11 32 38" src="https://user-images.githubusercontent.com/79279477/113697957-d7eb9480-96cb-11eb-89c7-d7dfad1896d6.png">
<img width="388" alt="Screenshot 2021-04-06 at 11 32 33" src="https://user-images.githubusercontent.com/79279477/113697962-d9b55800-96cb-11eb-98d3-3a6afaf31c60.png">


After (318 px):
<img width="408" alt="Screenshot 2021-04-06 at 11 32 10" src="https://user-images.githubusercontent.com/79279477/113697986-e20d9300-96cb-11eb-9560-c8e484ba5bf1.png">
<img width="393" alt="Screenshot 2021-04-06 at 11 31 59" src="https://user-images.githubusercontent.com/79279477/113697993-e33ec000-96cb-11eb-8cb4-455ec74d6789.png">