### PR TITLE
fix(trading-comp-zero-vol): Add catches for zero vol users

### DIFF
--- a/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
+++ b/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
@@ -149,7 +149,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({ hasRegistered, account, profil
       {shouldShowUserRanks && (
         <RanksWrapper>
           <Flex>
-            {volume !== 0 ? (
+            {volume > 0 ? (
               <UserRankBox
                 flex="1"
                 title={TranslateString(1222, 'Rank in team').toUpperCase()}

--- a/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
+++ b/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
@@ -9,6 +9,7 @@ import {
   MedalPurpleIcon,
   MedalSilverIcon,
   MedalTealIcon,
+  BlockIcon,
 } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
 import useI18n from 'hooks/useI18n'
@@ -70,8 +71,8 @@ const CardUserInfo: React.FC<YourScoreProps> = ({ hasRegistered, account, profil
       }
     }
     return {
-      current: null,
-      next: null,
+      current: <BlockIcon />,
+      next: <MedalTealIcon />,
     }
   }
 
@@ -107,8 +108,8 @@ const CardUserInfo: React.FC<YourScoreProps> = ({ hasRegistered, account, profil
       }
     }
     return {
-      color: null,
-      rank: null,
+      color: '',
+      rank: 500,
     }
   }
 
@@ -148,23 +149,25 @@ const CardUserInfo: React.FC<YourScoreProps> = ({ hasRegistered, account, profil
       {shouldShowUserRanks && (
         <RanksWrapper>
           <Flex>
-            <UserRankBox
-              flex="1"
-              title={TranslateString(1222, 'Rank in team').toUpperCase()}
-              footer={`${TranslateString(999, `#${userLeaderboardInformation && global.toLocaleString()} Overall`)}`}
-              mr="8px"
-            >
-              {!userLeaderboardInformation ? (
-                <Skeleton height="26px" width="110px" />
-              ) : (
-                <TeamRankTextWrapper>
-                  <Heading textAlign="center" size="lg" mr="8px">
-                    #{team}
-                  </Heading>
-                  {medal.current}
-                </TeamRankTextWrapper>
-              )}
-            </UserRankBox>
+            {volume !== 0 ? (
+              <UserRankBox
+                flex="1"
+                title={TranslateString(1222, 'Rank in team').toUpperCase()}
+                footer={`${TranslateString(999, `#${userLeaderboardInformation && global.toLocaleString()} Overall`)}`}
+                mr="8px"
+              >
+                {!userLeaderboardInformation ? (
+                  <Skeleton height="26px" width="110px" />
+                ) : (
+                  <TeamRankTextWrapper>
+                    <Heading textAlign="center" size="lg" mr="8px">
+                      #{team}
+                    </Heading>
+                    {medal.current}
+                  </TeamRankTextWrapper>
+                )}
+              </UserRankBox>
+            ) : null}
             <UserRankBox
               flex="1"
               title={TranslateString(1224, 'Your volume').toUpperCase()}


### PR DESCRIPTION
UI catch for users with 0 volume

<img width="580" alt="Screenshot 2021-04-07 at 09 16 13" src="https://user-images.githubusercontent.com/79279477/113833758-f3b17200-9781-11eb-832f-b35e01a8aed0.png">


[ ] Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/master/CONTRIBUTING.md) first
[ ] If your PR is work in progress, open it as `draft`
[ ] Before requesting a review, all the checks need to pass
[ ] Explain what your PR does
