### PR TITLE
fix(trading-comp-rankings-fix): Add index values for ranking

### DIFF
--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -28,7 +28,7 @@ const Item = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; index?: number }> = ({ traderData, index }) => {
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; index: number }> = ({ traderData, index }) => {
   // reinstate 'rank' instead of index when rank is accurate
   const { address, volume, teamId } = traderData
 

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -28,8 +28,9 @@ const Item = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }) => {
-  const { rank, address, volume, teamId } = traderData
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; index }> = ({ traderData, index }) => {
+  // reinstate 'rank' instead of index when rank is accurate
+  const { address, volume, teamId } = traderData
 
   const icon = {
     1: <LeaderboardStorm />,
@@ -40,7 +41,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
   return (
     <Wrapper>
       <Item>
-        <Heading color="secondary">#{rank}</Heading>
+        <Heading color="secondary">#{index + 1}</Heading>
       </Item>
       <Item>
         <Text bold>${localiseTradingVolume(volume)}</Text>

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -28,7 +28,7 @@ const Item = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; index }> = ({ traderData, index }) => {
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; index?: number }> = ({ traderData, index }) => {
   // reinstate 'rank' instead of index when rank is accurate
   const { address, volume, teamId } = traderData
 

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -21,8 +21,8 @@ const TopTradersGrid: React.FC<{ data?: Array<LeaderboardDataItem> }> = ({ data 
   return (
     <Box>
       {data ? (
-        topFive.map((traderData) => {
-          return <GridItem key={traderData.address} traderData={traderData} />
+        topFive.map((traderData, index) => {
+          return <GridItem key={traderData.address} traderData={traderData} index={index} />
         })
       ) : (
         <SkeletonLoader />


### PR DESCRIPTION
Use index rather than API rank value for the # rank

Before (two #1 #1s)
<img width="556" alt="Screenshot 2021-04-07 at 09 36 21" src="https://user-images.githubusercontent.com/79279477/113836384-c0241700-9784-11eb-8aa1-1ee8f4b7e4ba.png">

After
<img width="554" alt="Screenshot 2021-04-07 at 09 36 16" src="https://user-images.githubusercontent.com/79279477/113836408-c5816180-9784-11eb-8334-fb85a9169042.png">


[ ] Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/master/CONTRIBUTING.md) first
[ ] If your PR is work in progress, open it as `draft`
[ ] Before requesting a review, all the checks need to pass
[ ] Explain what your PR does
