### PR TITLE
fix(trading-comp-your-score): Fix some YourScore styling bugs on Safari

### DIFF
--- a/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
+++ b/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
@@ -19,6 +19,8 @@ import NextRankBox from './NextRankBox'
 import { localiseTradingVolume } from '../../helpers'
 
 const TeamRankTextWrapper = styled(Flex)`
+  align-items: center;
+  justify-content: center;
   svg {
     width: 24px;
   }

--- a/src/views/TradingCompetition/components/YourScore/NextRankBox.tsx
+++ b/src/views/TradingCompetition/components/YourScore/NextRankBox.tsx
@@ -35,6 +35,7 @@ const MedalsWrapper = styled(Flex)`
 
 const ArrowWrapper = styled(Flex)`
   svg {
+    height: 10px;
     width: 10px;
     fill: ${({ theme }) => theme.colors.textSubtle};
   }


### PR DESCRIPTION
Some styles that are implicit in Chrome, aren't in Safari.

Before:
<img width="689" alt="Screenshot 2021-04-07 at 12 30 36" src="https://user-images.githubusercontent.com/79279477/113863754-f02de300-97a1-11eb-98fb-c0e124f066c3.png">

After:
<img width="739" alt="Screenshot 2021-04-07 at 12 43 04" src="https://user-images.githubusercontent.com/79279477/113863794-0176ef80-97a2-11eb-9258-ea020aaf3d0d.png">
