### PR TITLE
Feature: Top Traders - Top 20

### DIFF
--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -84,7 +84,7 @@ const VolumeText = styled(Text)`
   }
 `
 
-const IconWrapper = styled(Flex)`
+const TeamImageWrapper = styled(Flex)`
   ${({ theme }) => theme.mediaQueries.xl} {
     position: absolute;
     right: 0;
@@ -92,7 +92,10 @@ const IconWrapper = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.ReactNode[] }> = ({ traderData, icons }) => {
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; teamImages?: React.ReactNode[] }> = ({
+  traderData,
+  teamImages,
+}) => {
   const { address, volume, teamId, rank } = traderData
 
   return (
@@ -114,7 +117,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.React
           </Text>
         </Flex>
       </VolumeAddressWrapper>
-      <IconWrapper justifyContent="flex-end">{icons[teamId - 1]}</IconWrapper>
+      <TeamImageWrapper justifyContent="flex-end">{teamImages[teamId - 1]}</TeamImageWrapper>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -8,24 +8,24 @@ import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../
 const Wrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr) 3fr;
+  grid-gap: 8px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
   svg {
     height: 44px;
     width: auto;
   }
-`
-
-const Item = styled(Flex)`
-  align-items: center;
-  justify-content: center;
-  /* 
-  ${({ theme }) => theme.mediaQueries.xs} {
-    min-width: 40px;
-  }
 
   ${({ theme }) => theme.mediaQueries.sm} {
-    min-width: 80px;
-  } */
+    grid-gap: 16px;
+  }
+`
+
+const RankItem = styled(Flex)`
+  margin-left: 8px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-left: 16px;
+  }
 `
 
 const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }) => {
@@ -39,21 +39,21 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
 
   return (
     <Wrapper>
-      <Item>
-        <Text mx="16px" fontSize="16px" bold color="secondary">
+      <RankItem alignItems="center" justifyContent="flex-start">
+        <Text fontSize="16px" bold color="secondary">
           #{rank}
         </Text>
-      </Item>
-      <Item>
-        <Text fontSize="12px" mr="16px" bold>
+      </RankItem>
+      <Flex alignItems="center" justifyContent="flex-start">
+        <Text fontSize="12px" bold>
           ${localiseTradingVolume(volume)}
         </Text>
-      </Item>
-      <Item>
-        <Text color="primary" mr="16px" fontSize="12px">
+      </Flex>
+      <Flex alignItems="center" justifyContent="flex-start">
+        <Text color="primary" fontSize="12px">
           {accountEllipsis(address)}
         </Text>
-      </Item>
+      </Flex>
       <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
     </Wrapper>
   )

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Heading, Text, Flex } from '@pancakeswap-libs/uikit'
+import { Text, Flex } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
@@ -7,10 +7,10 @@ import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../
 
 const Wrapper = styled.div`
   display: grid;
-  grid-template-columns: auto repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr) 3fr;
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
   svg {
-    height: 80px;
+    height: 44px;
     width: auto;
   }
 `
@@ -18,14 +18,14 @@ const Wrapper = styled.div`
 const Item = styled(Flex)`
   align-items: center;
   justify-content: center;
-
+  /* 
   ${({ theme }) => theme.mediaQueries.xs} {
     min-width: 40px;
   }
 
   ${({ theme }) => theme.mediaQueries.sm} {
     min-width: 80px;
-  }
+  } */
 `
 
 const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }) => {
@@ -40,15 +40,21 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
   return (
     <Wrapper>
       <Item>
-        <Heading color="secondary">#{rank}</Heading>
+        <Text mx="16px" fontSize="16px" bold color="secondary">
+          #{rank}
+        </Text>
       </Item>
       <Item>
-        <Text bold>${localiseTradingVolume(volume)}</Text>
+        <Text fontSize="12px" mr="16px" bold>
+          ${localiseTradingVolume(volume)}
+        </Text>
       </Item>
       <Item>
-        <Text color="primary">{accountEllipsis(address)}</Text>
+        <Text color="primary" mr="16px" fontSize="12px">
+          {accountEllipsis(address)}
+        </Text>
       </Item>
-      {icon[teamId]}
+      <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -6,12 +6,13 @@ import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
 import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const Wrapper = styled.div`
+  position: relative;
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
   display: grid;
   grid-gap: 8px;
   grid-template-columns: 1fr 4fr auto;
 
-  /* Specific styles for between 576 - 852px where the expanded wrapper shows as a three-column grid */
+  /* Between 576 - 852px - the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     grid-gap: 4px;
     grid-template-columns: auto 1fr auto;
@@ -20,6 +21,12 @@ const Wrapper = styled.div`
   ${({ theme }) => theme.mediaQueries.md} {
     grid-gap: 16px;
     grid-template-columns: 1fr 4fr auto;
+  }
+
+  /* Above 1080px - the expanded wrapper shows as a three-column grid. */
+  ${({ theme }) => theme.mediaQueries.xl} {
+    grid-template-columns: auto 1fr;
+    min-height: 44px;
   }
 
   svg {
@@ -44,7 +51,7 @@ const VolumeAddressWrapper = styled(Box)`
   display: grid;
   grid-template-columns: 1fr 2fr;
 
-  /* Between 576 - 852px the expanded wrapper shows as a three-column grid and these elements are stacked */
+  /* Between 576 - 852px - the expanded wrapper shows as a three-column grid and these elements are stacked */
   ${({ theme }) => theme.mediaQueries.sm} {
     display: flex;
     flex-direction: column;
@@ -53,18 +60,36 @@ const VolumeAddressWrapper = styled(Box)`
   ${({ theme }) => theme.mediaQueries.md} {
     display: grid;
   }
+
+  /* Above 1080px - the expanded wrapper shows as a three-column grid and these elements are stacked */
+  ${({ theme }) => theme.mediaQueries.sm} {
+    display: flex;
+  }
 `
 
 const VolumeText = styled(Text)`
   margin-right: 8px;
 
-  /* Specific style for between 576 - 852px where the expanded wrapper shows as a three-column grid */
+  /* Between 576 - 852px the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     margin-right: 0;
   }
 
   ${({ theme }) => theme.mediaQueries.md} {
     margin-right: 16px;
+  }
+
+  /* Above 1080px - the expanded wrapper shows as a three-column grid */
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-right: 0;
+  }
+`
+
+const IconWrapper = styled(Flex)`
+  ${({ theme }) => theme.mediaQueries.xl} {
+    position: absolute;
+    right: 0;
+    bottom: 0;
   }
 `
 
@@ -96,7 +121,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
           </Text>
         </Flex>
       </VolumeAddressWrapper>
-      <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
+      <IconWrapper justifyContent="flex-end">{icon[teamId]}</IconWrapper>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -1,30 +1,66 @@
 import React from 'react'
-import { Text, Flex } from '@pancakeswap-libs/uikit'
+import { Text, Flex, Box } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
 import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const Wrapper = styled.div`
-  display: grid;
-  grid-template-columns: repeat(3, 1fr) 3fr;
-  grid-gap: 8px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: 1fr 4fr auto;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    grid-gap: 4px;
+    grid-template-columns: auto 1fr auto;
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    grid-gap: 16px;
+    grid-template-columns: 1fr 4fr auto;
+  }
+
   svg {
     height: 44px;
     width: auto;
   }
-
-  ${({ theme }) => theme.mediaQueries.sm} {
-    grid-gap: 16px;
-  }
 `
 
 const RankItem = styled(Flex)`
-  margin-left: 8px;
+  margin-left: 4px;
+
+  ${({ theme }) => theme.mediaQueries.xs} {
+    margin-left: 8px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    margin-left: 16px;
+  }
+`
+
+const VolumeAddressWrapper = styled(Box)`
+  display: grid;
+  grid-template-columns: 1fr 2fr;
 
   ${({ theme }) => theme.mediaQueries.sm} {
-    margin-left: 16px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    grid-template-columns: 1fr 2fr;
+    display: grid;
+  }
+`
+
+const VolumeText = styled(Text)`
+  margin-right: 8px;
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-right: 0;
+  }
+  ${({ theme }) => theme.mediaQueries.md} {
+    margin-right: 16px;
   }
 `
 
@@ -44,16 +80,18 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
           #{rank}
         </Text>
       </RankItem>
-      <Flex alignItems="center" justifyContent="flex-start">
-        <Text fontSize="12px" bold>
-          ${localiseTradingVolume(volume)}
-        </Text>
-      </Flex>
-      <Flex alignItems="center" justifyContent="flex-start">
-        <Text color="primary" fontSize="12px">
-          {accountEllipsis(address)}
-        </Text>
-      </Flex>
+      <VolumeAddressWrapper>
+        <Flex alignItems="center" justifyContent="flex-start">
+          <VolumeText fontSize="12px" bold>
+            ${localiseTradingVolume(volume)}
+          </VolumeText>
+        </Flex>
+        <Flex alignItems="center" justifyContent="flex-start">
+          <Text color="primary" fontSize="12px">
+            {accountEllipsis(address)}
+          </Text>
+        </Flex>
+      </VolumeAddressWrapper>
       <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
     </Wrapper>
   )

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -3,7 +3,6 @@ import { Text, Flex, Box } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
-import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const Wrapper = styled.div`
   position: relative;
@@ -93,14 +92,8 @@ const IconWrapper = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }) => {
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.ReactNode[] }> = ({ traderData, icons }) => {
   const { address, volume, teamId, rank } = traderData
-
-  const icon = {
-    1: <LeaderboardStorm />,
-    2: <LeaderboardFlippers />,
-    3: <LeaderboardCakers />,
-  }
 
   return (
     <Wrapper>
@@ -121,7 +114,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
           </Text>
         </Flex>
       </VolumeAddressWrapper>
-      <IconWrapper justifyContent="flex-end">{icon[teamId]}</IconWrapper>
+      <IconWrapper justifyContent="flex-end">{icons[teamId - 1]}</IconWrapper>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -11,6 +11,7 @@ const Wrapper = styled.div`
   grid-gap: 8px;
   grid-template-columns: 1fr 4fr auto;
 
+  /* Specific styles for between 576 - 852px where the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     grid-gap: 4px;
     grid-template-columns: auto 1fr auto;
@@ -43,22 +44,25 @@ const VolumeAddressWrapper = styled(Box)`
   display: grid;
   grid-template-columns: 1fr 2fr;
 
+  /* Between 576 - 852px the expanded wrapper shows as a three-column grid and these elements are stacked */
   ${({ theme }) => theme.mediaQueries.sm} {
     display: flex;
     flex-direction: column;
   }
 
   ${({ theme }) => theme.mediaQueries.md} {
-    grid-template-columns: 1fr 2fr;
     display: grid;
   }
 `
 
 const VolumeText = styled(Text)`
   margin-right: 8px;
+
+  /* Specific style for between 576 - 852px where the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     margin-right: 0;
   }
+
   ${({ theme }) => theme.mediaQueries.md} {
     margin-right: 16px;
   }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/ExpandedGridItem.tsx
@@ -34,18 +34,6 @@ const Wrapper = styled.div`
   }
 `
 
-const RankItem = styled(Flex)`
-  margin-left: 4px;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    margin-left: 8px;
-  }
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    margin-left: 16px;
-  }
-`
-
 const VolumeAddressWrapper = styled(Box)`
   display: grid;
   grid-template-columns: 1fr 2fr;
@@ -92,19 +80,19 @@ const TeamImageWrapper = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; teamImages?: React.ReactNode[] }> = ({
-  traderData,
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; teamImages: React.ReactNode[] }> = ({
+  traderData = { address: '', volume: 0, teamId: 0, rank: 0 },
   teamImages,
 }) => {
   const { address, volume, teamId, rank } = traderData
 
   return (
     <Wrapper>
-      <RankItem alignItems="center" justifyContent="flex-start">
+      <Flex ml={['4px', '8px', '16px']} alignItems="center" justifyContent="flex-start">
         <Text fontSize="16px" bold color="secondary">
           #{rank}
         </Text>
-      </RankItem>
+      </Flex>
       <VolumeAddressWrapper>
         <Flex alignItems="center" justifyContent="flex-start">
           <VolumeText fontSize="12px" bold>

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -5,7 +5,7 @@ import { LeaderboardDataItem } from '../../../types'
 import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
 
 const Wrapper = styled.div`
-  overflow-x: hidden;
+  position: relative;
   display: grid;
   grid-template-columns: auto repeat(3, 1fr);
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
@@ -37,8 +37,10 @@ const Wrapper = styled.div`
     }
   }
 
+  /* Between 968 - 1080px the team image is absolute positioned so it becomes a 3-column grid */
   ${({ theme }) => theme.mediaQueries.lg} {
-    grid-template-columns: auto repeat(2, 1fr) auto;
+    grid-template-columns: auto auto 1fr;
+    min-height: 72px;
   }
 
   ${({ theme }) => theme.mediaQueries.xl} {
@@ -58,7 +60,23 @@ const RankItem = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.ReactNode[] }> = ({ traderData, icons }) => {
+const TeamImageWrapper = styled(Flex)`
+  /* Between 968 - 1080px the grid is narrow so absolute position the team image */
+  ${({ theme }) => theme.mediaQueries.lg} {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+  }
+
+  ${({ theme }) => theme.mediaQueries.xl} {
+    position: relative;
+  }
+`
+
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; teamImages?: React.ReactNode[] }> = ({
+  traderData,
+  teamImages,
+}) => {
   const { address, volume, teamId, rank } = traderData
 
   return (
@@ -72,7 +90,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.React
       <Flex alignItems="center" justifyContent="flex-start">
         <Text color="primary">{accountEllipsis(address)}</Text>
       </Flex>
-      <Flex justifyContent="flex-end">{icons[teamId - 1]}</Flex>
+      <TeamImageWrapper justifyContent="flex-end">{teamImages[teamId - 1]}</TeamImageWrapper>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -6,24 +6,38 @@ import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
 import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const Wrapper = styled.div`
+  overflow-x: hidden;
   display: grid;
   grid-template-columns: auto repeat(3, 1fr);
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
-  grid-gap: 8px;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    grid-template-columns: repeat(4, 1fr);
-    grid-gap: 16px;
+  grid-gap: 4px;
+  svg {
+    height: 55px;
+    width: auto;
   }
 
-  svg {
-    height: 80px;
-    width: auto;
+  ${({ theme }) => theme.mediaQueries.xs} {
+    grid-gap: 8px;
+    svg {
+      height: 70px;
+    }
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    grid-template-columns: repeat(4, 1fr);
+    grid-gap: 16px;
+    svg {
+      height: 75px;
+    }
   }
 `
 
 const RankItem = styled(Flex)`
-  margin-left: 8px;
+  margin-left: 4px;
+
+  ${({ theme }) => theme.mediaQueries.xs} {
+    margin-left: 8px;
+  }
 
   ${({ theme }) => theme.mediaQueries.sm} {
     margin-left: 16px;
@@ -50,7 +64,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
       <Flex alignItems="center" justifyContent="flex-start">
         <Text color="primary">{accountEllipsis(address)}</Text>
       </Flex>
-      {icon[teamId]}
+      <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -38,6 +38,10 @@ const Wrapper = styled.div`
     }
   }
 
+  ${({ theme }) => theme.mediaQueries.lg} {
+    grid-template-columns: auto repeat(2, 1fr) auto;
+  }
+
   ${({ theme }) => theme.mediaQueries.xl} {
     grid-template-columns: repeat(4, 1fr);
   }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -11,6 +11,7 @@ const Wrapper = styled.div`
   grid-template-columns: auto repeat(3, 1fr);
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
   grid-gap: 4px;
+
   svg {
     height: 55px;
     width: auto;
@@ -18,17 +19,27 @@ const Wrapper = styled.div`
 
   ${({ theme }) => theme.mediaQueries.xs} {
     grid-gap: 8px;
+
     svg {
-      height: 70px;
+      height: 65px;
     }
   }
 
-  ${({ theme }) => theme.mediaQueries.md} {
+  ${({ theme }) => theme.mediaQueries.sm} {
     grid-template-columns: repeat(4, 1fr);
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    grid-template-columns: auto repeat(3, 1fr);
     grid-gap: 16px;
+
     svg {
-      height: 75px;
+      height: 72px;
     }
+  }
+
+  ${({ theme }) => theme.mediaQueries.xl} {
+    grid-template-columns: repeat(4, 1fr);
   }
 `
 

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -3,7 +3,6 @@ import { Heading, Text, Flex } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import { localiseTradingVolume, accountEllipsis } from '../../../helpers'
-import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const Wrapper = styled.div`
   overflow-x: hidden;
@@ -59,14 +58,8 @@ const RankItem = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }) => {
+const GridItem: React.FC<{ traderData?: LeaderboardDataItem; icons?: React.ReactNode[] }> = ({ traderData, icons }) => {
   const { address, volume, teamId, rank } = traderData
-
-  const icon = {
-    1: <LeaderboardStorm />,
-    2: <LeaderboardFlippers />,
-    3: <LeaderboardCakers />,
-  }
 
   return (
     <Wrapper>
@@ -79,7 +72,7 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
       <Flex alignItems="center" justifyContent="flex-start">
         <Text color="primary">{accountEllipsis(address)}</Text>
       </Flex>
-      <Flex justifyContent="flex-end">{icon[teamId]}</Flex>
+      <Flex justifyContent="flex-end">{icons[teamId - 1]}</Flex>
     </Wrapper>
   )
 }

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -9,22 +9,24 @@ const Wrapper = styled.div`
   display: grid;
   grid-template-columns: auto repeat(3, 1fr);
   border-bottom: 1px solid ${({ theme }) => theme.colors.textDisabled};
+  grid-gap: 8px;
+
+  ${({ theme }) => theme.mediaQueries.xs} {
+    grid-template-columns: repeat(4, 1fr);
+    grid-gap: 16px;
+  }
+
   svg {
     height: 80px;
     width: auto;
   }
 `
 
-const Item = styled(Flex)`
-  align-items: center;
-  justify-content: center;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    min-width: 40px;
-  }
+const RankItem = styled(Flex)`
+  margin-left: 8px;
 
   ${({ theme }) => theme.mediaQueries.sm} {
-    min-width: 80px;
+    margin-left: 16px;
   }
 `
 
@@ -39,15 +41,15 @@ const GridItem: React.FC<{ traderData?: LeaderboardDataItem }> = ({ traderData }
 
   return (
     <Wrapper>
-      <Item>
+      <RankItem alignItems="center" justifyContent="flex-start">
         <Heading color="secondary">#{rank}</Heading>
-      </Item>
-      <Item>
+      </RankItem>
+      <Flex alignItems="center" justifyContent="flex-start">
         <Text bold>${localiseTradingVolume(volume)}</Text>
-      </Item>
-      <Item>
+      </Flex>
+      <Flex alignItems="center" justifyContent="flex-start">
         <Text color="primary">{accountEllipsis(address)}</Text>
-      </Item>
+      </Flex>
       {icon[teamId]}
     </Wrapper>
   )

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/GridItem.tsx
@@ -48,18 +48,6 @@ const Wrapper = styled.div`
   }
 `
 
-const RankItem = styled(Flex)`
-  margin-left: 4px;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    margin-left: 8px;
-  }
-
-  ${({ theme }) => theme.mediaQueries.sm} {
-    margin-left: 16px;
-  }
-`
-
 const TeamImageWrapper = styled(Flex)`
   /* Between 968 - 1080px the grid is narrow so absolute position the team image */
   ${({ theme }) => theme.mediaQueries.lg} {
@@ -73,17 +61,17 @@ const TeamImageWrapper = styled(Flex)`
   }
 `
 
-const GridItem: React.FC<{ traderData?: LeaderboardDataItem; teamImages?: React.ReactNode[] }> = ({
-  traderData,
-  teamImages,
-}) => {
+const GridItem: React.FC<{
+  traderData?: LeaderboardDataItem
+  teamImages: React.ReactNode[]
+}> = ({ traderData = { address: '', volume: 0, teamId: 0, rank: 0 }, teamImages }) => {
   const { address, volume, teamId, rank } = traderData
 
   return (
     <Wrapper>
-      <RankItem alignItems="center" justifyContent="flex-start">
+      <Flex ml={['4px', '8px', '16px']} alignItems="center" justifyContent="flex-start">
         <Heading color="secondary">#{rank}</Heading>
-      </RankItem>
+      </Flex>
       <Flex alignItems="center" justifyContent="flex-start">
         <Text bold>${localiseTradingVolume(volume)}</Text>
       </Flex>

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -18,7 +18,7 @@ const SkeletonLoader = () => {
 }
 
 const ExpandedWrapper = styled.div`
-  /* Between 576 - 852px the expanded wrapper shows as a three-column grid */
+  /* Between 576 - 852px - the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     display: grid;
     grid-template-rows: repeat(5, 1fr);
@@ -27,6 +27,11 @@ const ExpandedWrapper = styled.div`
 
   ${({ theme }) => theme.mediaQueries.md} {
     display: block;
+  }
+
+  /* Above 1080px - it should again show as a three-column grid */
+  ${({ theme }) => theme.mediaQueries.xl} {
+    display: grid;
   }
 `
 

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -18,6 +18,7 @@ const SkeletonLoader = () => {
 }
 
 const ExpandedWrapper = styled.div`
+  /* Between 576 - 852px the expanded wrapper shows as a three-column grid */
   ${({ theme }) => theme.mediaQueries.sm} {
     display: grid;
     grid-template-rows: repeat(5, 1fr);

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import GridItem from './GridItem'
 import ExpandedGridItem from './ExpandedGridItem'
+import { LeaderboardStorm, LeaderboardFlippers, LeaderboardCakers } from '../../../svgs'
 
 const SkeletonLoader = () => {
   return (
@@ -38,18 +39,19 @@ const ExpandedWrapper = styled.div`
 const TopTradersGrid: React.FC<{ data?: LeaderboardDataItem[]; isExpanded: boolean }> = ({ data, isExpanded }) => {
   const topFive = data && data.slice(0, 5)
   const nextTwenty = data && data.slice(5, 20)
+  const icons = [<LeaderboardStorm />, <LeaderboardFlippers />, <LeaderboardCakers />]
 
   return (
     <Box>
       {data ? (
         <>
           {topFive.map((traderData) => {
-            return <GridItem key={traderData.address} traderData={traderData} />
+            return <GridItem key={traderData.address} traderData={traderData} icons={icons} />
           })}
           {isExpanded && (
             <ExpandedWrapper>
               {nextTwenty.map((traderData) => {
-                return <ExpandedGridItem key={traderData.address} traderData={traderData} />
+                return <ExpandedGridItem key={traderData.address} traderData={traderData} icons={icons} />
               })}
             </ExpandedWrapper>
           )}

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -39,19 +39,19 @@ const ExpandedWrapper = styled.div`
 const TopTradersGrid: React.FC<{ data?: LeaderboardDataItem[]; isExpanded: boolean }> = ({ data, isExpanded }) => {
   const topFive = data && data.slice(0, 5)
   const nextTwenty = data && data.slice(5, 20)
-  const icons = [<LeaderboardStorm />, <LeaderboardFlippers />, <LeaderboardCakers />]
+  const teamImages = [<LeaderboardStorm />, <LeaderboardFlippers />, <LeaderboardCakers />]
 
   return (
     <Box>
       {data ? (
         <>
           {topFive.map((traderData) => {
-            return <GridItem key={traderData.address} traderData={traderData} icons={icons} />
+            return <GridItem key={traderData.address} traderData={traderData} teamImages={teamImages} />
           })}
           {isExpanded && (
             <ExpandedWrapper>
               {nextTwenty.map((traderData) => {
-                return <ExpandedGridItem key={traderData.address} traderData={traderData} icons={icons} />
+                return <ExpandedGridItem key={traderData.address} traderData={traderData} teamImages={teamImages} />
               })}
             </ExpandedWrapper>
           )}

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Box, Skeleton } from '@pancakeswap-libs/uikit'
+import styled from 'styled-components'
 import { LeaderboardDataItem } from '../../../types'
 import GridItem from './GridItem'
+import ExpandedGridItem from './ExpandedGridItem'
 
 const SkeletonLoader = () => {
   return (
@@ -15,15 +17,27 @@ const SkeletonLoader = () => {
   )
 }
 
-const TopTradersGrid: React.FC<{ data?: Array<LeaderboardDataItem> }> = ({ data }) => {
+const ExpandedWrapper = styled.div``
+
+const TopTradersGrid: React.FC<{ data?: LeaderboardDataItem[]; isExpanded: boolean }> = ({ data, isExpanded }) => {
   const topFive = data && data.slice(0, 5)
+  const nextTwenty = data && data.slice(5, 20)
 
   return (
     <Box>
       {data ? (
-        topFive.map((traderData, index) => {
-          return <GridItem key={traderData.address} traderData={traderData} index={index} />
-        })
+        <>
+          {topFive.map((traderData) => {
+            return <GridItem key={traderData.address} traderData={traderData} />
+          })}
+          {isExpanded && (
+            <ExpandedWrapper>
+              {nextTwenty.map((traderData) => {
+                return <ExpandedGridItem key={traderData.address} traderData={traderData} />
+              })}
+            </ExpandedWrapper>
+          )}
+        </>
       ) : (
         <SkeletonLoader />
       )}

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/TopTradersGrid.tsx
@@ -17,7 +17,17 @@ const SkeletonLoader = () => {
   )
 }
 
-const ExpandedWrapper = styled.div``
+const ExpandedWrapper = styled.div`
+  ${({ theme }) => theme.mediaQueries.sm} {
+    display: grid;
+    grid-template-rows: repeat(5, 1fr);
+    grid-auto-flow: column;
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    display: block;
+  }
+`
 
 const TopTradersGrid: React.FC<{ data?: LeaderboardDataItem[]; isExpanded: boolean }> = ({ data, isExpanded }) => {
   const topFive = data && data.slice(0, 5)

--- a/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
@@ -1,5 +1,16 @@
 import React, { useState, useEffect } from 'react'
-import { Card, CardFooter, CardHeader, Heading, Text, TabMenu, Tab, Box } from '@pancakeswap-libs/uikit'
+import {
+  Card,
+  CardFooter,
+  CardHeader,
+  Heading,
+  Text,
+  TabMenu,
+  Tab,
+  Box,
+  Flex,
+  ExpandableLabel,
+} from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import { TeamRanksProps } from '../../../types'
 import TopTradersGrid from './TopTradersGrid'
@@ -13,6 +24,7 @@ const TopTradersCard: React.FC<TeamRanksProps> = ({
 }) => {
   const TranslateString = useI18n()
   const [activeTab, setActiveTab] = useState(0)
+  const [isExpanded, setIsExpanded] = useState(false)
   const [topTradersGridData, setTopTradersGridData] = useState(null)
   const handleItemClick = (index: number) => setActiveTab(index)
   const tabs = [`${TranslateString(408, 'Total')}`, 'Storm', 'Flippers', 'Cakers']
@@ -65,9 +77,15 @@ const TopTradersCard: React.FC<TeamRanksProps> = ({
               return <Tab key={tabText}>{tabText}</Tab>
             })}
           </TabMenu>
-          <TopTradersGrid data={topTradersGridData} />
+          <TopTradersGrid data={topTradersGridData} isExpanded={isExpanded} />
         </Box>
-        <CardFooter />
+        <CardFooter p="0px">
+          <Flex alignItems="center" justifyContent="center">
+            <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
+              {isExpanded ? TranslateString(1066, 'Hide') : TranslateString(999, 'Show More')}
+            </ExpandableLabel>
+          </Flex>
+        </CardFooter>
       </Box>
     </Card>
   )


### PR DESCRIPTION
Expand the Top Traders section to show the next 15 traders on `ExpandableLabel` click

- Between **576 - 852px** (where the card has the full-screen) and again above **1080px**, the expanded wrapper shows as a three-column grid.
- Above & below those values, it renders as a block element.
- Resulting in lots of media queries to make this work across screen sizes.

Preview https://elegant-payne-0f0170.netlify.app/competition

### Below 576 - 1 column
<img width="408" alt="Screenshot 2021-04-08 at 13 25 54" src="https://user-images.githubusercontent.com/79279477/114026292-fc7f7200-986d-11eb-81bd-83cf02e636ff.png">

### 576 - 852px - 3 column
![Screenshot 2021-04-08 at 12 33 42](https://user-images.githubusercontent.com/79279477/114019839-cd193700-9866-11eb-9207-c0e3d75a9a31.png)

### 852 - 1080 - 1 column
![Screenshot 2021-04-08 at 12 33 59](https://user-images.githubusercontent.com/79279477/114019853-d1ddeb00-9866-11eb-9e1e-1b7d560eb2c8.png)

### Above 1080 - 3 column
![Screenshot 2021-04-08 at 12 34 10](https://user-images.githubusercontent.com/79279477/114019875-d73b3580-9866-11eb-82b8-afb1b37764e1.png)
