### PR TITLE
fix: Fix dom key warning

### DIFF
--- a/src/views/TradingCompetition/components/BattleBanner/index.tsx
+++ b/src/views/TradingCompetition/components/BattleBanner/index.tsx
@@ -48,7 +48,7 @@ const BattleBanner = () => {
         {TranslateString(999, 'April')} 07—14, 2021
       </StyledText>
       <StyledHeading1Text>{TranslateString(999, 'Easter Battle')}</StyledHeading1Text>
-      <StyledHeading2Text background={GOLDGRADIENT} fill>
+      <StyledHeading2Text background={GOLDGRADIENT} $fill>
         {TranslateString(999, '$200,000 in Prizes!')}
       </StyledHeading2Text>
       <StyledHeading size="md" color="inputSecondary" mt="16px">

--- a/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
+++ b/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
@@ -54,19 +54,16 @@ export const Heading1Text = styled(HeadingUi)<HeadingProps>`
   ${(props) => sharedStyles(props)}
 `
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const Heading2Text = styled(HeadingUi)<HeadingProps>`
   ${({ theme }) => H2SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const VisuallyHiddenHeading1Text = styled(HeadingUi)`
   ${({ theme }) => H1SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const VisuallyHiddenHeading2Text = styled(HeadingUi)`
   ${({ theme }) => H2SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}

--- a/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
+++ b/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
@@ -47,25 +47,27 @@ interface HeadingProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Heading1Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)<HeadingProps>`
+const HeadingUi = ({ textColor, background, fill, ...props }) => <Heading {...props} />
+
+export const Heading1Text = styled(HeadingUi)<HeadingProps>`
   ${({ theme }) => H1SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Heading2Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)<HeadingProps>`
+export const Heading2Text = styled(HeadingUi)<HeadingProps>`
   ${({ theme }) => H2SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const VisuallyHiddenHeading1Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)`
+export const VisuallyHiddenHeading1Text = styled(HeadingUi)`
   ${({ theme }) => H1SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const VisuallyHiddenHeading2Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)`
+export const VisuallyHiddenHeading2Text = styled(HeadingUi)`
   ${({ theme }) => H2SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `

--- a/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
+++ b/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
@@ -1,6 +1,5 @@
 import { Heading } from '@pancakeswap-libs/uikit'
 import styled, { DefaultTheme } from 'styled-components'
-import React from 'react'
 
 const H1SizeStyles = (theme: DefaultTheme) => `
   font-size: 48px;
@@ -28,7 +27,7 @@ const sharedStyles = (props: HeadingProps) => `
   background-clip: text;
   -webkit-background-clip: text;
   ${
-    props.fill
+    props.$fill
       ? `-webkit-text-fill-color: transparent;`
       : `-webkit-text-stroke: 4px transparent;
        text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);`
@@ -43,28 +42,25 @@ const sharedVisiblyHiddenStyles = `
 interface HeadingProps {
   textColor?: string
   background?: string
-  fill?: boolean
+  $fill?: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const HeadingUi = ({ textColor, background, fill, ...props }) => <Heading {...props} />
-
-export const Heading1Text = styled(HeadingUi)<HeadingProps>`
+export const Heading1Text = styled(Heading)<HeadingProps>`
   ${({ theme }) => H1SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
-export const Heading2Text = styled(HeadingUi)<HeadingProps>`
+export const Heading2Text = styled(Heading)<HeadingProps>`
   ${({ theme }) => H2SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
-export const VisuallyHiddenHeading1Text = styled(HeadingUi)`
+export const VisuallyHiddenHeading1Text = styled(Heading)`
   ${({ theme }) => H1SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `
 
-export const VisuallyHiddenHeading2Text = styled(HeadingUi)`
+export const VisuallyHiddenHeading2Text = styled(Heading)`
   ${({ theme }) => H2SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `

--- a/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
+++ b/src/views/TradingCompetition/components/CompetitionHeadingText.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@pancakeswap-libs/uikit'
 import styled, { DefaultTheme } from 'styled-components'
+import React from 'react'
 
 const H1SizeStyles = (theme: DefaultTheme) => `
   font-size: 48px;
@@ -45,22 +46,26 @@ interface HeadingProps {
   fill?: boolean
 }
 
-export const Heading1Text = styled(Heading)<HeadingProps>`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Heading1Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)<HeadingProps>`
   ${({ theme }) => H1SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
-export const Heading2Text = styled(Heading)<HeadingProps>`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Heading2Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)<HeadingProps>`
   ${({ theme }) => H2SizeStyles(theme)}
   ${(props) => sharedStyles(props)}
 `
 
-export const VisuallyHiddenHeading1Text = styled(Heading)`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const VisuallyHiddenHeading1Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)`
   ${({ theme }) => H1SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `
 
-export const VisuallyHiddenHeading2Text = styled(Heading)`
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const VisuallyHiddenHeading2Text = styled(({ textColor, background, fill, ...props }) => <Heading {...props} />)`
   ${({ theme }) => H2SizeStyles(theme)}
   ${sharedVisiblyHiddenStyles}
 `

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -65,7 +65,7 @@ const StyledHeading = styled(Heading2Text)`
 `
 
 const TimerHeadingComponent = ({ children }) => (
-  <StyledHeading background={GOLDGRADIENT} fill>
+  <StyledHeading background={GOLDGRADIENT} $fill>
     {children}
   </StyledHeading>
 )

--- a/src/views/TradingCompetition/components/LeadInBanner/index.tsx
+++ b/src/views/TradingCompetition/components/LeadInBanner/index.tsx
@@ -60,7 +60,7 @@ const LeadInBanner = () => {
           </LaurelWrapper>
           <Box px={['8px', '16px', null, '0']}>
             <Header>{TranslateString(999, 'Easter Battle')}</Header>
-            <SubHeader background={GOLDGRADIENT} fill>
+            <SubHeader background={GOLDGRADIENT} $fill>
               {TranslateString(999, '$200,000 in Prizes!')}
             </SubHeader>
             <LearnMoreLink id="hp-learn-more-cta" to="/competition">

--- a/src/views/TradingCompetition/components/PreviewComponents/PreviewBattleBanner.tsx
+++ b/src/views/TradingCompetition/components/PreviewComponents/PreviewBattleBanner.tsx
@@ -30,7 +30,7 @@ const BattleBanner = () => {
         <Image src={AllBunniesImage} alt="all the bunnies" width={1208} height={659} responsive />
       </ImageWrapper>
       <StyledHeading1Text>{TranslateString(999, 'Easter Battle')}</StyledHeading1Text>
-      <StyledHeading2Text background="linear-gradient(180deg, #FFD800 0%, #EB8C00 100%)" fill>
+      <StyledHeading2Text background="linear-gradient(180deg, #FFD800 0%, #EB8C00 100%)" $fill>
         {TranslateString(999, '$200,000 in Prizes!')}
       </StyledHeading2Text>
       <StyledHeading size="md" color="inputSecondary" mt="16px">


### PR DESCRIPTION
`Warning: Received `true` for a non-boolean attribute `fill`. If you want to write it to the DOM, pass a string instead: fill="true" or fill={value.toString()}. h2 O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 LeadInBanner@http://localhost:3000/static/js/0.chunk.js:256:88 Home@http://localhost:3000/static/js/11.chunk.js:760:88 Route@http://localhost:3000/static/js/vendors~main.chunk.js:199424:29 Switch@http://localhost:3000/static/js/vendors~main.chunk.js:199626:29 Suspense SuspenseWithChunkError@http://localhost:3000/static/js/main.chunk.js:2201:5 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 div O@http://localhost:3000/static/js/vendors~main.chunk.js:214520:6 Menu@http://localhost:3000/static/js/vendors~main.chunk.js:34938:17 Menu@http://localhost:3000/static/js/main.chunk.js:1432:76 Router@http://localhost:3000/static/js/vendors~main.chunk.js:199059:30 App@http://localhost:3000/static/js/main.chunk.js:86:58 ModalProvider@http://localhost:3000/static/js/vendors~main.chunk.js:33457:18 RefreshContextProvider@http://localhost:3000/static/js/main.chunk.js:9153:32 LanguageContextProvider@http://localhost:3000/static/js/main.chunk.js:8868:33 Ge@http://localhost:3000/static/js/vendors~main.chunk.js:214431:67 ThemeContextProvider@http://localhost:3000/static/js/main.chunk.js:9304:30 r@http://localhost:3000/static/js/vendors~main.chunk.js:195714:19 Provider@http://localhost:3000/static/js/vendors~main.chunk.js:196295:15 Web3ReactProvider@http://localhost:3000/static/js/vendors~main.chunk.js:39344:22 Providers@http://localhost:3000/static/js/main.chunk.js:454:19`