### PR TITLE
fix: Align lottery jackpot and staking card when no price or no cake winning available

### DIFF
--- a/src/views/Home/components/CakeHarvestBalance.tsx
+++ b/src/views/Home/components/CakeHarvestBalance.tsx
@@ -20,7 +20,8 @@ const CakeHarvestBalance = () => {
   const earningsSum = allEarnings.reduce((accum, earning) => {
     return accum + new BigNumber(earning).div(new BigNumber(10).pow(18)).toNumber()
   }, 0)
-  const earningsBusd = new BigNumber(earningsSum).multipliedBy(usePriceCakeBusd()).toNumber()
+  const cakePriceBusd = usePriceCakeBusd()
+  const earningsBusd = new BigNumber(earningsSum).multipliedBy(cakePriceBusd).toNumber()
 
   if (!account) {
     return (
@@ -33,7 +34,7 @@ const CakeHarvestBalance = () => {
   return (
     <Block>
       <CardValue value={earningsSum} lineHeight="1.5" />
-      <CardBusdValue value={earningsBusd} />
+      {!cakePriceBusd.eq(0) && <CardBusdValue value={earningsBusd} />}
     </Block>
   )
 }

--- a/src/views/Home/components/CakeWalletBalance.tsx
+++ b/src/views/Home/components/CakeWalletBalance.tsx
@@ -13,7 +13,8 @@ import CardBusdValue from './CardBusdValue'
 const CakeWalletBalance = () => {
   const TranslateString = useI18n()
   const cakeBalance = useTokenBalance(getCakeAddress())
-  const busdBalance = new BigNumber(getBalanceNumber(cakeBalance)).multipliedBy(usePriceCakeBusd()).toNumber()
+  const cakePriceBusd = usePriceCakeBusd()
+  const busdBalance = new BigNumber(getBalanceNumber(cakeBalance)).multipliedBy(cakePriceBusd).toNumber()
   const { account } = useWeb3React()
 
   if (!account) {
@@ -27,7 +28,7 @@ const CakeWalletBalance = () => {
   return (
     <>
       <CardValue value={getBalanceNumber(cakeBalance)} decimals={4} fontSize="24px" lineHeight="36px" />
-      <CardBusdValue value={busdBalance} />
+      {!cakePriceBusd.eq(0) ? <CardBusdValue value={busdBalance} /> : <br />}
     </>
   )
 }

--- a/src/views/Home/components/CakeWinnings.tsx
+++ b/src/views/Home/components/CakeWinnings.tsx
@@ -19,7 +19,8 @@ const CakeWinnings = () => {
   const { account } = useWeb3React()
   const { claimAmount } = useTotalClaim()
   const cakeAmount = getBalanceNumber(claimAmount)
-  const claimAmountBusd = new BigNumber(cakeAmount).multipliedBy(usePriceCakeBusd()).toNumber()
+  const cakePriceBusd = usePriceCakeBusd()
+  const claimAmountBusd = new BigNumber(cakeAmount).multipliedBy(cakePriceBusd).toNumber()
 
   if (!account) {
     return (
@@ -32,7 +33,7 @@ const CakeWinnings = () => {
   return (
     <Block>
       <CardValue value={cakeAmount} lineHeight="1.5" />
-      {claimAmountBusd !== 0 && <CardBusdValue value={claimAmountBusd} decimals={2} />}
+      {!cakePriceBusd.eq(0) && <CardBusdValue value={claimAmountBusd} decimals={2} />}
     </Block>
   )
 }

--- a/src/views/Home/components/LotteryJackpot.tsx
+++ b/src/views/Home/components/LotteryJackpot.tsx
@@ -14,14 +14,15 @@ const LotteryJackpot = () => {
   const lotteryPrizeAmountCake = balance.toLocaleString(undefined, {
     maximumFractionDigits: 2,
   })
-  const lotteryPrizeAmountBusd = new BigNumber(balance).multipliedBy(usePriceCakeBusd()).toNumber()
+  const cakePriceBusd = usePriceCakeBusd()
+  const lotteryPrizeAmountBusd = new BigNumber(balance).multipliedBy(cakePriceBusd).toNumber()
 
   return (
     <>
       <Text bold fontSize="24px" style={{ lineHeight: '1.5' }}>
         {TranslateString(999, `${lotteryPrizeAmountCake} CAKE`, { amount: lotteryPrizeAmountCake })}
       </Text>
-      {lotteryPrizeAmountBusd !== 0 && <CardBusdValue value={lotteryPrizeAmountBusd} />}
+      {!cakePriceBusd.eq(0) ? <CardBusdValue value={lotteryPrizeAmountBusd} /> : <br />}
     </>
   )
 }


### PR DESCRIPTION
- Fix height when no price available when no wallet connected

Before: 

<img width="1191" alt="Screenshot 2021-04-09 at 10 37 28" src="https://user-images.githubusercontent.com/2213635/114165997-7cb8dc80-992d-11eb-9568-ffc3b537baba.png">

After: 

<img width="1200" alt="Screenshot 2021-04-09 at 11 35 40" src="https://user-images.githubusercontent.com/2213635/114166080-90fcd980-992d-11eb-9b63-1f064942b65f.png">

- Fix height when no price available when wallet connected

Before:

<img width="1198" alt="Screenshot 2021-04-09 at 11 37 26" src="https://user-images.githubusercontent.com/2213635/114166373-edf88f80-992d-11eb-8e2f-30b6da613974.png">

After: 

<img width="1191" alt="Screenshot 2021-04-09 at 11 34 40" src="https://user-images.githubusercontent.com/2213635/114166201-b8ec3d00-992d-11eb-8199-3896037a6785.png">


- Fix cake busd price when available 

Before: 

<img width="1189" alt="Screenshot 2021-04-09 at 12 25 45" src="https://user-images.githubusercontent.com/2213635/114167086-cfdf5f00-992e-11eb-8127-ea656ebba501.png">

After: 

<img width="1190" alt="Screenshot 2021-04-09 at 11 56 14" src="https://user-images.githubusercontent.com/2213635/114167099-d372e600-992e-11eb-9f81-11434a749b8f.png">

 