### PR TITLE
fix(auth): Eager connect not working with bsc extension

### DIFF
--- a/src/hooks/useEagerConnect.ts
+++ b/src/hooks/useEagerConnect.ts
@@ -2,16 +2,38 @@ import { useEffect } from 'react'
 import { connectorLocalStorageKey, ConnectorNames } from '@pancakeswap-libs/uikit'
 import useAuth from 'hooks/useAuth'
 
+const _binanceChainListener = async () =>
+  new Promise<void>((resolve) =>
+    Object.defineProperty(window, 'BinanceChain', {
+      get() {
+        return this.bsc
+      },
+      set(bsc) {
+        this.bsc = bsc
+
+        resolve()
+      },
+    }),
+  )
+
 const useEagerConnect = () => {
   const { login } = useAuth()
 
   useEffect(() => {
     const connectorId = window.localStorage.getItem(connectorLocalStorageKey) as ConnectorNames
 
-    // Disable eager connect for BSC Wallet. Currently the BSC Wallet extension does not inject BinanceChain
-    // into the Window object in time causing it to throw an error
-    // TODO: Figure out an elegant way to listen for when the BinanceChain object is ready
-    if (connectorId && connectorId !== ConnectorNames.BSC) {
+    if (connectorId) {
+      const isConnectorBinanceChain = connectorId === ConnectorNames.BSC
+      const isBinanceChainDefined = Reflect.has(window, 'BinanceChain')
+
+      // Currently BSC extension doesn't always inject in time.
+      // We must check to see if it exists, and if not, wait for it before proceeding.
+      if (isConnectorBinanceChain && !isBinanceChainDefined) {
+        _binanceChainListener().then(() => login(connectorId))
+
+        return
+      }
+
       login(connectorId)
     }
   }, [login])


### PR DESCRIPTION
Fixes Binance Chain Wallet not working with eager connect, requiring users to re-authenticate on every refresh.

This fix defines `BinanceChain` property on window with a getter & setter so that we get notified once the extension has initialized and we can proceed with login.