### PR TITLE
refactor: Use balanced number instead of full one for readability in buy ticket modal

### DIFF
--- a/src/views/Lottery/components/TicketCard/BuyTicketModal.tsx
+++ b/src/views/Lottery/components/TicketCard/BuyTicketModal.tsx
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { Button, Modal } from '@pancakeswap-libs/uikit'
-import { getFullDisplayBalance } from 'utils/formatBalance'
+import { getBalanceNumber, getFullDisplayBalance } from 'utils/formatBalance'
 import TicketInput from 'components/TicketInput'
 import ModalActions from 'components/ModalActions'
 import { useMultiBuyLottery, useMaxNumber } from 'hooks/useBuyLottery'
@@ -22,7 +22,7 @@ const BuyTicketModal: React.FC<BuyTicketModalProps> = ({ max, onDismiss }) => {
   const [, setRequestedBuy] = useState(false)
   const TranslateString = useI18n()
   const fullBalance = useMemo(() => {
-    return getFullDisplayBalance(max)
+    return getBalanceNumber(max)
   }, [max])
 
   const maxTickets = useMemo(() => {


### PR DESCRIPTION
Before: 

<img width="639" alt="Screenshot 2021-04-12 at 16 22 16" src="https://user-images.githubusercontent.com/2213635/114426202-1d233100-9bba-11eb-90d7-50a2c20482a5.png">

<img width="648" alt="Screenshot 2021-04-12 at 18 08 03" src="https://user-images.githubusercontent.com/2213635/114426215-21e7e500-9bba-11eb-98fc-00cf7fbc9e2e.png">


After: 

<img width="635" alt="Screenshot 2021-04-12 at 16 25 42" src="https://user-images.githubusercontent.com/2213635/114426234-26ac9900-9bba-11eb-99dd-5da91fd7031c.png">

<img width="634" alt="Screenshot 2021-04-12 at 16 23 00" src="https://user-images.githubusercontent.com/2213635/114426229-257b6c00-9bba-11eb-82ee-693ff5df2683.png">
