### PR TITLE
fix(auth): Clear profile state on logout

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -13,8 +13,11 @@ import { ConnectorNames, connectorLocalStorageKey } from '@pancakeswap-libs/uiki
 import { useToast } from 'state/hooks'
 import { connectorsByName } from 'utils/web3React'
 import { setupNetwork } from 'utils/wallet'
+import { useDispatch } from 'react-redux'
+import { profileClear } from 'state/profile'
 
 const useAuth = () => {
+  const dispatch = useDispatch()
   const { activate, deactivate } = useWeb3React()
   const { toastError } = useToast()
 
@@ -51,7 +54,12 @@ const useAuth = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return { login, logout: deactivate }
+  const logout = useCallback(() => {
+    dispatch(profileClear())
+    deactivate()
+  }, [deactivate, dispatch])
+
+  return { login, logout }
 }
 
 export default useAuth

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,14 +10,14 @@ import {
   WalletConnectConnector,
 } from '@web3-react/walletconnect-connector'
 import { ConnectorNames, connectorLocalStorageKey } from '@pancakeswap-libs/uikit'
-import { useToast } from 'state/hooks'
 import { connectorsByName } from 'utils/web3React'
 import { setupNetwork } from 'utils/wallet'
-import { useDispatch } from 'react-redux'
+import { useToast } from 'state/hooks'
 import { profileClear } from 'state/profile'
+import { useAppDispatch } from 'state'
 
 const useAuth = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const { activate, deactivate } = useWeb3React()
   const { toastError } = useToast()
 

--- a/src/state/profile/index.tsx
+++ b/src/state/profile/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { ProfileState } from 'state/types'
+import type { AppDispatch } from 'state'
 import getProfile, { GetProfileResponse } from './getProfile'
 
 const initialState: ProfileState = {
@@ -17,7 +18,7 @@ export const profileSlice = createSlice({
     profileFetchStart: (state) => {
       state.isLoading = true
     },
-    profileFetchSucceeded: (state, action: PayloadAction<GetProfileResponse>) => {
+    profileFetchSucceeded: (_state, action: PayloadAction<GetProfileResponse>) => {
       const { profile, hasRegistered } = action.payload
 
       return {
@@ -31,6 +32,10 @@ export const profileSlice = createSlice({
       state.isLoading = false
       state.isInitialized = true
     },
+    profileClear: () => ({
+      ...initialState,
+      isLoading: false,
+    }),
     addPoints: (state, action: PayloadAction<number>) => {
       state.data.points += action.payload
     },
@@ -38,11 +43,17 @@ export const profileSlice = createSlice({
 })
 
 // Actions
-export const { profileFetchStart, profileFetchSucceeded, profileFetchFailed, addPoints } = profileSlice.actions
+export const {
+  profileFetchStart,
+  profileFetchSucceeded,
+  profileFetchFailed,
+  profileClear,
+  addPoints,
+} = profileSlice.actions
 
 // Thunks
 // TODO: this should be an AsyncThunk
-export const fetchProfile = (address: string) => async (dispatch) => {
+export const fetchProfile = (address: string) => async (dispatch: AppDispatch) => {
   try {
     dispatch(profileFetchStart())
     const response = await getProfile(address)


### PR DESCRIPTION
Currently user profile is not cleared from redux when `logout` action is called.
This causes things such as profile picture to remain in the navbar & edit profile button to remain on the profile page.