### PR TITLE
fix: Missing margin lottery won card

### DIFF
--- a/src/views/Lottery/components/YourPrizesCard/index.tsx
+++ b/src/views/Lottery/components/YourPrizesCard/index.tsx
@@ -7,21 +7,24 @@ import PrizesWonContent from './PrizesWonContent'
 import NoPrizesContent from './NoPrizesContent'
 
 const StyledCard = styled(Card)`
+  margin-top: 16px;
+
+  ${(props) => `
+    ${props.theme.mediaQueries.sm} {
+      margin-top: 24px;
+    }
+  
+    ${props.theme.mediaQueries.lg} {
+      margin-top: 32px;
+    }
+`}
+
   ${(props) =>
     props.isDisabled
-      ? `  
-        margin-top: 16px;
+      ? `
         background-color: unset;
         box-shadow: unset;
         border: 1px solid ${props.theme.colors.textDisabled};
-
-        ${props.theme.mediaQueries.sm} {
-          margin-top: 24px;
-        }
-
-        ${props.theme.mediaQueries.lg} {
-          margin-top: 32px;
-        }
         `
       : ``}
 `

--- a/src/views/Lottery/components/YourPrizesCard/index.tsx
+++ b/src/views/Lottery/components/YourPrizesCard/index.tsx
@@ -9,6 +9,14 @@ import NoPrizesContent from './NoPrizesContent'
 const StyledCard = styled(Card)`
   margin-top: 16px;
 
+  ${({ theme }) => theme.mediaQueries.sm} {
+    margin-top: 24px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    margin-top: 32px;
+  }
+
   ${(props) => `
     ${props.theme.mediaQueries.sm} {
       margin-top: 24px;

--- a/src/views/Lottery/components/YourPrizesCard/index.tsx
+++ b/src/views/Lottery/components/YourPrizesCard/index.tsx
@@ -17,16 +17,6 @@ const StyledCard = styled(Card)`
     margin-top: 32px;
   }
 
-  ${(props) => `
-    ${props.theme.mediaQueries.sm} {
-      margin-top: 24px;
-    }
-  
-    ${props.theme.mediaQueries.lg} {
-      margin-top: 32px;
-    }
-`}
-
   ${(props) =>
     props.isDisabled
       ? `


### PR DESCRIPTION
Fixes #869 

**Ipad:**

<img width="50%" height="50%" src="https://user-images.githubusercontent.com/2213635/114545913-d3d7ed80-9c5c-11eb-9a0b-138442185d73.png">

**Android:**

<img width="50%"  height="50%"  src="https://user-images.githubusercontent.com/2213635/114545916-d4708400-9c5c-11eb-9b96-e395c2db6abd.png">

**Iphone:**

<img width="50%"  height="50%"  src="https://user-images.githubusercontent.com/2213635/114545918-d5091a80-9c5c-11eb-8adc-1c160f7e5837.png">

**Desktop:**

<img width="50%"  height="50%"  src="https://user-images.githubusercontent.com/2213635/114545958-e2260980-9c5c-11eb-8885-92f1f46cdc21.png">
