### PR TITLE
style(trading-competition-claim-modal): Fix alignment issue within claim modal on safari

### DIFF
--- a/src/views/TradingCompetition/components/ClaimModal/index.tsx
+++ b/src/views/TradingCompetition/components/ClaimModal/index.tsx
@@ -64,7 +64,7 @@ const ClaimModal: React.FC<CompetitionProps> = ({ onDismiss, onClaimSuccess, use
         <Text color="secondary" bold fontSize="16px">
           {TranslateString(999, 'Congratulations! You won')}:
         </Text>
-        <Flex mt="16px">
+        <Flex mt="16px" alignItems="center">
           {/* achievements */}
           <TrophyGoldIcon mr={[0, '4px']} />
           {champion && <CrownIcon mr={[0, '4px']} />}


### PR DESCRIPTION
Before:
![Image from iOS](https://user-images.githubusercontent.com/79279477/114688823-fde8e880-9d0c-11eb-9f6d-962beccc016a.jpg)

After:
<img width="459" alt="Screenshot 2021-04-14 at 10 29 55" src="https://user-images.githubusercontent.com/79279477/114688742-e9a4eb80-9d0c-11eb-9c49-32653f61969d.png">



