### PR TITLE
fix(pool): PoolCard height adjusting to siblings

### DIFF
--- a/src/views/Pools/components/Card.tsx
+++ b/src/views/Pools/components/Card.tsx
@@ -11,6 +11,7 @@ const Card = styled.div<{ isActive?: boolean; isFinished?: boolean }>`
       ? '0px 0px 0px 1px #0098A1, 0px 0px 4px 8px rgba(31, 199, 212, 0.4);'
       : '0px 2px 12px -8px rgba(25, 19, 38, 0.1), 0px 1px 1px rgba(25, 19, 38, 0.05)'};
   flex-direction: column;
+  align-self: baseline;
   position: relative;
 `
 


### PR DESCRIPTION
Currently when a `PoolCard` gets expanded it's siblings which are on the same row also grow to the same height.

**Before**
![image](https://user-images.githubusercontent.com/23725326/114752287-6c05cd80-9d56-11eb-9512-e740e4906dac.png)

**After**
![image](https://user-images.githubusercontent.com/23725326/114752142-4678c400-9d56-11eb-9d69-932052d2e466.png)
