### PR TITLE
refactor: Hide "Add to MetaMask" if no MetaMask in scope

### DIFF
--- a/src/views/Pools/components/CardFooter.tsx
+++ b/src/views/Pools/components/CardFooter.tsx
@@ -105,7 +105,7 @@ const CardFooter: React.FC<Props> = ({
 
   const imageSrc = `${BASE_URL}/images/tokens/${tokenName.toLowerCase()}.png`
 
-  const isMetaMaskInScope = !!Reflect.get(window, 'ethereum')?.isMetaMask
+  const isMetaMaskInScope = !!(window as WindowChain).ethereum?.isMetaMask
 
   return (
     <StyledFooter isFinished={isFinished}>

--- a/src/views/Pools/components/CardFooter.tsx
+++ b/src/views/Pools/components/CardFooter.tsx
@@ -105,6 +105,8 @@ const CardFooter: React.FC<Props> = ({
 
   const imageSrc = `${BASE_URL}/images/tokens/${tokenName.toLowerCase()}.png`
 
+  const isMetaMaskInScope = !!Reflect.get(window, 'ethereum')?.isMetaMask
+
   return (
     <StyledFooter isFinished={isFinished}>
       <Row>
@@ -144,10 +146,10 @@ const CardFooter: React.FC<Props> = ({
               <Balance fontSize="14px" isDisabled={isFinished} value={blocksRemaining} decimals={0} />
             </Row>
           )}
-          {tokenAddress && (
+          {isMetaMaskInScope && tokenAddress && (
             <Flex mb="4px">
               <TokenLink onClick={() => registerToken(tokenAddress, tokenName, tokenDecimals, imageSrc)}>
-                Add {tokenName} to Metamask
+                Add {tokenName} to MetaMask
               </TokenLink>
               <MetamaskIcon height={15} width={15} ml="4px" />
             </Flex>


### PR DESCRIPTION
In pools there's an option on each card to add that card's token to MetaMask.
Currently this option is still available if there's no MetaMask extension installed, in such cases clicking it will result in errors in console.