### PR TITLE
fix: Farm table stake lp button not showing when 0

### DIFF
--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -82,7 +82,7 @@ const Staked: React.FunctionComponent<FarmWithStakedValue> = ({ pid, lpSymbol, l
   }
 
   if (isApproved) {
-    if (stakedBalance) {
+    if (stakedBalance.gt(0)) {
       return (
         <ActionContainer>
           <ActionTitles>


### PR DESCRIPTION
Fixes #901 

Before:

![image](https://user-images.githubusercontent.com/2213635/114861991-4a582500-9dee-11eb-997c-65ae6f7a7f8c.png)

After:

<img width="444" alt="Screenshot 2021-04-15 at 13 29 41" src="https://user-images.githubusercontent.com/2213635/114862407-c9e5f400-9dee-11eb-8739-1a55c0cca70f.png">
