### PR TITLE
fix: Token address casing

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -209,7 +209,7 @@ export const useGetApiPrice = (address: string) => {
     return null
   }
 
-  return prices[address]
+  return prices[address.toLowerCase()]
 }
 
 export const usePriceCakeBusd = (): BigNumber => {


### PR DESCRIPTION
Fix issue with token address casing not matching, and resulting in some APR's values missing for farms/pools.

<img width="1152" alt="pools" src="https://user-images.githubusercontent.com/74599990/114871289-6f9e6080-9df9-11eb-8453-af030eb36bfe.png">