### PR TITLE
Feat/farms infinite scroll

### DIFF
--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -97,6 +97,7 @@ const StyledImage = styled(Image)`
   margin-right: auto;
   margin-top: 58px;
 `
+const NUMBER_OF_FARMS_VISIBLE = 12
 
 const Farms: React.FC = () => {
   const { path } = useRouteMatch()
@@ -163,8 +164,8 @@ const Farms: React.FC = () => {
 
   const loadMoreRef = useRef<HTMLDivElement>(null)
 
-  const [numberOfItemsToShow, setNumberOfItemsToShow] = useState(12)
-  const [observerIsSet, setObserverIsSet] = useState<boolean>()
+  const [numberOfFarmsVisible, setNumberOfFarmsVisible] = useState(NUMBER_OF_FARMS_VISIBLE)
+  const [observerIsSet, setObserverIsSet] = useState(false)
 
   const farmsStakedMemoized = useMemo(() => {
     let farmsStaked = []
@@ -194,7 +195,7 @@ const Farms: React.FC = () => {
       farmsStaked = stakedOnly ? farmsList(stakedInactiveFarms) : farmsList(inactiveFarms)
     }
 
-    return sortFarms(farmsStaked).slice(0, numberOfItemsToShow)
+    return sortFarms(farmsStaked).slice(0, numberOfFarmsVisible)
   }, [
     sortOption,
     activeFarms,
@@ -204,25 +205,23 @@ const Farms: React.FC = () => {
     stakedInactiveFarms,
     stakedOnly,
     stakedOnlyFarms,
-    numberOfItemsToShow,
+    numberOfFarmsVisible,
   ])
 
   useEffect(() => {
-    const options = {
-      rootMargin: '0px',
-      threshold: 1,
-    }
-
-    const callbackFunction = (entries) => {
+    const showMoreFarms = (entries) => {
       const [entry] = entries
       if (entry.isIntersecting) {
-        setNumberOfItemsToShow((currentlyShowing) => currentlyShowing + 12)
+        setNumberOfFarmsVisible((farmsCurrentlyVisible) => farmsCurrentlyVisible + NUMBER_OF_FARMS_VISIBLE)
       }
     }
 
     if (!observerIsSet) {
-      const newObserver = new IntersectionObserver(callbackFunction, options)
-      newObserver.observe(loadMoreRef.current)
+      const loadMoreObserver = new IntersectionObserver(showMoreFarms, {
+        rootMargin: '0px',
+        threshold: 1,
+      })
+      loadMoreObserver.observe(loadMoreRef.current)
       setObserverIsSet(true)
     }
   }, [farmsStakedMemoized, observerIsSet])


### PR DESCRIPTION
As @memoyil mentioned in the [pagination PR](https://github.com/pancakeswap/pancake-frontend/pull/855), instead of adding pagination, an infinite scroll would be a better and more universal solution (can be applied to both the card and the table view).

I've created it using an Intersection Observer, and added the observed ref right after the Table. That way, the Table stays it's own component, only shows what is passed to it, and doesn't have to worry about whether it should infinitely scroll or not.

I picked 12 as a number of initially loaded rows/cards, mostly because of how the card view changes on smaller screens. That way, the last row rendered will always be "full".

There was also a type mismatch on the liquidity prop, so I took the liberty of fixing that.

Here's how the change looks like on larger screens:

https://user-images.githubusercontent.com/9339019/114942405-c9784800-9e44-11eb-9085-1228689c6647.mp4

And here's how the change looks like on smaller screens:

https://user-images.githubusercontent.com/9339019/114942457-d9902780-9e44-11eb-80b1-969399b968f7.mp4


Please let me know what you think.