### PR TITLE
fix: Liquidity type mismatch

### DIFF
--- a/src/views/Farms/components/FarmTable/Liquidity.tsx
+++ b/src/views/Farms/components/FarmTable/Liquidity.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import styled from 'styled-components'
 import { HelpIcon, Text, useTooltip } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
+import BigNumber from 'bignumber.js'
 
 const ReferenceElement = styled.div`
   display: inline-block;
 `
 
 export interface LiquidityProps {
-  liquidity: number
+  liquidity: BigNumber
 }
 
 const LiquidityWrapper = styled.div`


### PR DESCRIPTION
Once wrapping the code in the `useMemo`, in [this PR](https://github.com/pancakeswap/pancake-frontend/pull/909), the TS compiler started throwing a type mismatch error in `Farms.tsx`, on line `230`.

It is caused because `LiquidityProps.liquidity` is of type `number`, while the `FarmsWithStakedValue.liquidity` is of type `BigNumber`.