### PR TITLE
fix: Add extra space to ticket symbol and remove redundant div

### DIFF
--- a/src/components/TicketInput/TicketInput.tsx
+++ b/src/components/TicketInput/TicketInput.tsx
@@ -20,13 +20,12 @@ const TicketInput: React.FC<TokenInputProps> = ({ max, symbol, availableSymbol, 
       <Flex alignItems="center">
         <Input type="number" inputMode="numeric" min="0" onChange={onChange} placeholder="0" value={value} />
         <StyledTokenAdornmentWrapper>
+          <StyledSpacer />
           <StyledTokenSymbol>{symbol}</StyledTokenSymbol>
           <StyledSpacer />
-          <div>
-            <Button size="sm" onClick={onSelectMax}>
-              {TranslateString(452, 'Max')}
-            </Button>
-          </div>
+          <Button size="sm" onClick={onSelectMax}>
+            {TranslateString(452, 'Max')}
+          </Button>
         </StyledTokenAdornmentWrapper>
       </Flex>
       <StyledMaxText>{TranslateString(454, `${max.toLocaleString()} ${availableSymbol} Available`)}</StyledMaxText>


### PR DESCRIPTION
Before:

<img src="https://user-images.githubusercontent.com/2213635/115025787-0cc4cc00-9ec2-11eb-94f7-723bca84bd1f.png" width="30%" height="30%"> 
<img src="https://user-images.githubusercontent.com/2213635/115025789-0cc4cc00-9ec2-11eb-8df2-7bd7e62f43ca.png" width="30%" height="30%"> 
<img width="635" src="https://user-images.githubusercontent.com/2213635/115026181-7a70f800-9ec2-11eb-88de-58c156ef0ea5.png">

After:

<img src="https://user-images.githubusercontent.com/2213635/115026243-8ceb3180-9ec2-11eb-9cef-f989e4c9d531.png" width="30%" height="30%"> 

<img src="https://user-images.githubusercontent.com/2213635/115026245-8d83c800-9ec2-11eb-96a9-4f817342edb0.png" width="30%" height="30%">

<img width="628" src="https://user-images.githubusercontent.com/2213635/115026218-878de700-9ec2-11eb-9cd8-7ef54d23012d.png">


