### PR TITLE
refactor(graphql): Change string literals to variables in gql requests

### DIFF
--- a/src/state/achievements/helpers.ts
+++ b/src/state/achievements/helpers.ts
@@ -16,11 +16,11 @@ const profileSubgraphApi = process.env.REACT_APP_SUBGRAPH_PROFILE
  */
 export const getUserPointIncreaseEvents = async (account: string): Promise<UserPointIncreaseEvent[]> => {
   try {
-    const data = await request(
+    const { user } = await request(
       profileSubgraphApi,
       gql`
-        {
-          user(id: "${account.toLowerCase()}") {
+        query($account: ID!) {
+          user(id: $account) {
             points {
               id
               campaignId
@@ -29,8 +29,12 @@ export const getUserPointIncreaseEvents = async (account: string): Promise<UserP
           }
         }
       `,
+      {
+        account: account.toLowerCase(),
+      },
     )
-    return data.user.points
+
+    return user.points
   } catch (error) {
     return null
   }

--- a/src/state/achievements/helpers.ts
+++ b/src/state/achievements/helpers.ts
@@ -19,7 +19,7 @@ export const getUserPointIncreaseEvents = async (account: string): Promise<UserP
     const { user } = await request(
       profileSubgraphApi,
       gql`
-        query($account: ID!) {
+        query getUserPointIncreaseEvents($account: ID!) {
           user(id: $account) {
             points {
               id


### PR DESCRIPTION
It is generally a bad practice to use string literals in queries / mutations as this doesn't properly secure the passed values.
This would also makes it easier to manage / re-use queries in the future.