### PR TITLE
fix: Pool card shows compounding when click harvest

### DIFF
--- a/src/views/Pools/components/PoolCard.tsx
+++ b/src/views/Pools/components/PoolCard.tsx
@@ -145,7 +145,7 @@ const PoolCard: React.FC<HarvestProps> = ({ pool }) => {
             {sousId === 0 && account && harvest && (
               <HarvestButton
                 disabled={!earnings.toNumber() || pendingTx}
-                text={pendingTx ? TranslateString(999, 'Compounding') : TranslateString(704, 'Compound')}
+                text={TranslateString(704, 'Compound')}
                 onClick={onPresentCompound}
               />
             )}


### PR DESCRIPTION
We were using a ternary operator to check if there is a `pendingTx`, if so we'd set the `text` of the button to be "Compounding", however, when compounding we don't really use `pendingTx` and for that reason we were displaying "Compounding" when actually harvesting.

In this PR that logic is removed, and the button remains with the "Compound" text when harvesting.

Closes #893