### PR TITLE
perf: add debounce to search farm

### DIFF
--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -341,7 +341,7 @@ const Farms: React.FC = () => {
             </LabelWrapper>
             <LabelWrapper style={{ marginLeft: 16 }}>
               <Text>SEARCH</Text>
-              <SearchInput onChange={handleChangeQuery} value={query} />
+              <SearchInput onChange={handleChangeQuery} />
             </LabelWrapper>
           </FilterContainer>
         </ControlContainer>

--- a/src/views/Farms/components/SearchInput.tsx
+++ b/src/views/Farms/components/SearchInput.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useMemo } from 'react'
 import { Input } from '@pancakeswap-libs/uikit'
 import styled from 'styled-components'
+import debounce from 'lodash/debounce'
 
 const StyledInput = styled(Input)`
   border-radius: 16px;
@@ -18,20 +19,28 @@ const InputWrapper = styled.div`
 const Container = styled.div<{ toggled: boolean }>``
 
 interface Props {
-  value: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-const SearchInput: React.FC<Props> = ({ value, onChange }) => {
+const SearchInput: React.FC<Props> = ({ onChange: onChangeCallback }) => {
   const [toggled, setToggled] = useState(false)
-  const inputEl = useRef(null)
+  const [searchText, setSearchText] = useState('')
+
+  const debouncedOnChange = useMemo(
+    () => debounce((e: React.ChangeEvent<HTMLInputElement>) => onChangeCallback(e), 500),
+    [onChangeCallback],
+  )
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchText(e.target.value)
+    debouncedOnChange(e)
+  }
 
   return (
     <Container toggled={toggled}>
       <InputWrapper>
         <StyledInput
-          ref={inputEl}
-          value={value}
+          value={searchText}
           onChange={onChange}
           placeholder="Search farms"
           onBlur={() => setToggled(false)}


### PR DESCRIPTION
**Every time I search farms, it’s very slow because it renders every characters while typing. So, I have improved it by adding debounce (Lodash already exists) to search farm**   

before adding debounce it for used **304 ms render time**

![Screenshot from 2021-04-17 17-26-08](https://user-images.githubusercontent.com/8810501/115114331-ea61aa00-9fb8-11eb-8461-141f663b6956.png)

after adding debounce it used just **1.5 ms render time (faster almost 300x )**

![Screenshot from 2021-04-17 17-26-24](https://user-images.githubusercontent.com/8810501/115114651-a4a5e100-9fba-11eb-95ea-5c0345eb0585.png)


I hope you review my PR
