### PR TITLE
fix: (farms) Earned cake usd price 0 when price is loading

### DIFF
--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -51,7 +51,7 @@ const HarvestAction: React.FunctionComponent<FarmWithStakedValue> = ({ pid, user
       <ActionContent>
         <div>
           <Earned>{displayBalance}</Earned>
-          <Staked>~{countUp}USD</Staked>
+          {countUp > 0 && <Staked>~{countUp}USD</Staked>}
         </div>
         <Button
           disabled={!earnings || pendingTx || !account}


### PR DESCRIPTION
Fixes #920 

When price is loading: 

![image](https://user-images.githubusercontent.com/2213635/115115474-f3d91b00-9f94-11eb-88bb-4d1cc36ac9f1.png)

After loaded

<img width="720" alt="Screenshot 2021-04-17 at 15 52 16" src="https://user-images.githubusercontent.com/2213635/115115482-f76ca200-9f94-11eb-8ed5-b84e7a01a74d.png">
