### PR TITLE
refactor: Remove redundant divs on past lottery round

### DIFF
--- a/src/views/Lottery/components/PastLotteryRoundViewer/PastLotteryActions.tsx
+++ b/src/views/Lottery/components/PastLotteryRoundViewer/PastLotteryActions.tsx
@@ -45,14 +45,10 @@ const TicketCard: React.FC<{ contractLink?: string; lotteryNumber?: number }> = 
 
   return (
     <Wrapper>
-      <div>
-        <Button disabled={ticketsLength === 0} onClick={onPresentMyTickets} width="100%">
-          {TranslateString(432, 'View your tickets')}
-        </Button>
-      </div>
-      <div>
-        <ExternalLinkWrap href={contractLink}>{TranslateString(356, 'View on BscScan')}</ExternalLinkWrap>
-      </div>
+      <Button disabled={ticketsLength === 0} onClick={onPresentMyTickets} width="100%">
+        {TranslateString(432, 'View your tickets')}
+      </Button>
+      <ExternalLinkWrap href={contractLink}>{TranslateString(356, 'View on BscScan')}</ExternalLinkWrap>
     </Wrapper>
   )
 }


### PR DESCRIPTION
Before:
<img width="577" alt="Screenshot 2021-04-18 at 19 09 49" src="https://user-images.githubusercontent.com/2213635/115154147-aedae480-a079-11eb-9d7b-3f17e2a88a06.png">

After:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/2213635/115154133-9bc81480-a079-11eb-94fe-97de61d40e2b.png">
