### PR TITLE
fix: Web3 utf8ToHex must be called to allow hex-like usernames

### DIFF
--- a/src/views/Profile/ProfileCreation/UserName.tsx
+++ b/src/views/Profile/ProfileCreation/UserName.tsx
@@ -111,7 +111,10 @@ const UserName: React.FC = () => {
 
       const signature = library?.bnbSign
         ? (await library.bnbSign(account, userName))?.signature
-        : await web3.eth.personal.sign(userName, account, null) // Last param is the password, and is null to request a signature in the wallet
+        : // web3.utils.utf8ToHex("...") will not be called here on username if hex like string
+          // https://github.com/ChainSafe/web3.js/blob/5d027191c5cb7ffbcd44083528bdab19b4e14744/packages/web3-core-helpers/src/formatters.js#L225
+          // Last param is the password, and is null to request a signature in the wallet
+          await web3.eth.personal.sign(web3.utils.utf8ToHex(userName), account, null)
 
       const response = await fetch(`${profileApiUrl}/api/users/register`, {
         method: 'POST',


### PR DESCRIPTION
When a user registers a username, `web3.eth.personal.sign` does not call `web3.utils.utf8ToHex("...")` if hex like string is entered.
Code unit responsible for this in web3-core: https://github.com/ChainSafe/web3.js/blob/5d027191c5cb7ffbcd44083528bdab19b4e14744/packages/web3-core-helpers/src/formatters.js#L225

This will result in a message of `AAAAA` being signed if a user inputs `0x4141414141`

![image](https://user-images.githubusercontent.com/69803008/115356410-a1148480-a189-11eb-82c3-84f4796f0f60.png)
