### PR TITLE
fix(collectibles): Dollop identifier

### DIFF
--- a/src/config/constants/nfts.ts
+++ b/src/config/constants/nfts.ts
@@ -212,7 +212,7 @@ const Nfts: Nft[] = [
       blur: 'dollop-blur.png',
     },
     sortOrder: 999,
-    identifier: 'dollup',
+    identifier: 'dollop',
     type: NftType.PANCAKE,
     variationId: 6,
   },


### PR DESCRIPTION
Fix 'Dollop' collectible not showing as `In Wallet` because of identifier typo.

```
$ getTokenIdAndData TypeError: Cannot read property ‘identifier’ of undefined
```