### PR TITLE
fix: Add margin to farm controls on small screens

### DIFF
--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -35,11 +35,13 @@ const ControlContainer = styled.div`
 
   justify-content: space-between;
   flex-direction: column;
+  margin-bottom: 32px;
 
   ${({ theme }) => theme.mediaQueries.sm} {
     flex-direction: row;
     flex-wrap: wrap;
     padding: 16px 32px;
+    margin-bottom: 0;
   }
 `
 


### PR DESCRIPTION
I noticed that there is practically no margin separating the content of the farm cards, from the control, on smaller screen (mobile devices), so I added some margins there.

Here's how it looked like before:
![Screenshot from 2021-04-21 12-03-44](https://user-images.githubusercontent.com/9339019/115536475-1e2f1f00-a29a-11eb-8446-f6543e954a8b.png)

And here's how it looks like in the PR:
![Screenshot from 2021-04-21 12-04-03](https://user-images.githubusercontent.com/9339019/115536493-22f3d300-a29a-11eb-8a0c-0d0b63ac53e9.png)

I chose `32px`, because to be consistent with the margins between the cards. 
Let me know what you think.