### PR TITLE
Feature/farm table improvements

### DIFF
--- a/src/hooks/useDelayedUnmount.ts
+++ b/src/hooks/useDelayedUnmount.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Use this hook when you want to animate something when it appears on the screen (e.g. when some prop set to true)
+ * but when its not on the screen you want it to be fully unmounted and not just hidden or height 0.
+ * This is especially useful when you have a table of 100s rows and each row has expandable element that appears on click.
+ * If you just set the expanding animation while keeping inactive elements mounted all those 100 elements will load the DOM,
+ * and if they all receive updates via props you're looking at 100 DOM updates for hidden elements.
+ * This hook "shows" element immediately when the isMounted is true
+ * but keeps element mounted for delayTime to let unmounting animation happen, after which you unmount element completely.
+ * delayTime should be the same as animation time in most cases.
+ */
+const useDelayedUnmount = (isMounted: boolean, delayTime: number) => {
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>
+    if (isMounted && !shouldRender) {
+      setShouldRender(true)
+    } else if (!isMounted && shouldRender) {
+      timeoutId = setTimeout(() => setShouldRender(false), delayTime)
+    }
+    return () => clearTimeout(timeoutId)
+  }, [isMounted, delayTime, shouldRender])
+  return shouldRender
+}
+
+export default useDelayedUnmount

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit'
+import BigNumber from 'bignumber.js'
 import farmsConfig from 'config/constants/farms'
 import isArchivedPid from 'utils/farmHelpers'
 import fetchFarms from './fetchFarms'
@@ -13,7 +14,17 @@ import { FarmsState, Farm } from '../types'
 
 const nonArchivedFarms = farmsConfig.filter(({ pid }) => !isArchivedPid(pid))
 
-const initialState: FarmsState = { data: [...farmsConfig], loadArchivedFarmsData: false }
+const noAccountFarmConfig = farmsConfig.map((farm) => ({
+  ...farm,
+  userData: {
+    allowance: '0',
+    tokenBalance: '0',
+    stakedBalance: '0',
+    earnings: '0',
+  },
+}))
+
+const initialState: FarmsState = { data: noAccountFarmConfig, loadArchivedFarmsData: false }
 
 export const farmsSlice = createSlice({
   name: 'Farms',

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit'
-import BigNumber from 'bignumber.js'
 import farmsConfig from 'config/constants/farms'
 import isArchivedPid from 'utils/farmHelpers'
 import fetchFarms from './fetchFarms'

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -24,7 +24,7 @@ const noAccountFarmConfig = farmsConfig.map((farm) => ({
   },
 }))
 
-const initialState: FarmsState = { data: noAccountFarmConfig, loadArchivedFarmsData: false }
+const initialState: FarmsState = { data: noAccountFarmConfig, loadArchivedFarmsData: false, userDataLoaded: false }
 
 export const farmsSlice = createSlice({
   name: 'Farms',
@@ -44,6 +44,7 @@ export const farmsSlice = createSlice({
         const index = state.data.findIndex((farm) => farm.pid === pid)
         state.data[index] = { ...state.data[index], userData: userDataEl }
       })
+      state.userDataLoaded = true
     },
     setLoadArchivedFarmsData: (state, action) => {
       const loadArchivedFarmsData = action.payload

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -61,6 +61,7 @@ export interface ToastsState {
 export interface FarmsState {
   data: Farm[]
   loadArchivedFarmsData: boolean
+  userDataLoaded: boolean
 }
 
 export interface PoolsState {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -20,10 +20,10 @@ export interface Farm extends FarmConfig {
   tokenPriceVsQuote?: BigNumber
   poolWeight?: BigNumber
   userData?: {
-    allowance: BigNumber
-    tokenBalance: BigNumber
-    stakedBalance: BigNumber
-    earnings: BigNumber
+    allowance: string
+    tokenBalance: string
+    stakedBalance: string
+    earnings: string
   }
 }
 

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -107,7 +107,7 @@ const Farms: React.FC = () => {
   const { path } = useRouteMatch()
   const { pathname } = useLocation()
   const TranslateString = useI18n()
-  const { data: farmsLP } = useFarms()
+  const { data: farmsLP, userDataLoaded } = useFarms()
   const cakePrice = usePriceCakeBusd()
   const [query, setQuery] = useState('')
   const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, 'pancake_farm_view')
@@ -126,6 +126,11 @@ const Farms: React.FC = () => {
   const isArchived = pathname.includes('archived')
   const isInactive = pathname.includes('history')
   const isActive = !isInactive && !isArchived
+
+  // Users with no wallet connected should see 0 as Earned amount
+  // Connected users should see loading indicator until first userData has loaded
+  const userDataReady = !account || (!!account && userDataLoaded)
+
   const [stakedOnly, setStakedOnly] = useState(!isActive)
   useEffect(() => {
     setStakedOnly(!isActive)
@@ -284,7 +289,7 @@ const Farms: React.FC = () => {
         pid: farm.pid,
       },
       earned: {
-        earnings: farm.userData ? getBalanceNumber(new BigNumber(farm.userData.earnings)) : null,
+        earnings: getBalanceNumber(new BigNumber(farm.userData.earnings)),
         pid: farm.pid,
       },
       liquidity: {
@@ -326,7 +331,7 @@ const Farms: React.FC = () => {
         sortable: column.sortable,
       }))
 
-      return <Table data={rowData} columns={columns} />
+      return <Table data={rowData} columns={columns} userDataReady={userDataReady} />
     }
 
     return (

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { keyframes, css } from 'styled-components'
 import useI18n from 'hooks/useI18n'
 import { LinkExternal, Text } from '@pancakeswap-libs/uikit'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
@@ -18,9 +18,37 @@ export interface ActionPanelProps {
   liquidity: LiquidityProps
   details: FarmWithStakedValue
   userDataReady: boolean
+  expanded: boolean
 }
 
-const Container = styled.div`
+const expandAnimation = keyframes`
+  from {
+    max-height: 0px;
+  }
+  to {
+    max-height: 500px;
+  }
+`
+
+const collapseAnimation = keyframes`
+  from {
+    max-height: 500px;
+  }
+  to {
+    max-height: 0px;
+  }
+`
+
+const Container = styled.div<{ expanded }>`
+  animation: ${({ expanded }) =>
+    expanded
+      ? css`
+          ${expandAnimation} 300ms linear forwards
+        `
+      : css`
+          ${collapseAnimation} 300ms linear forwards
+        `};
+  overflow: hidden;
   background: ${({ theme }) => theme.colors.background};
   display: flex;
   width: 100%;
@@ -106,6 +134,7 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({
   multiplier,
   liquidity,
   userDataReady,
+  expanded,
 }) => {
   const farm = details
 
@@ -122,7 +151,7 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({
   const info = `https://pancakeswap.info/pair/${lpAddress}`
 
   return (
-    <Container>
+    <Container expanded={expanded}>
       <InfoContainer>
         {isActive && (
           <StakeContainer>

--- a/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -17,6 +17,7 @@ export interface ActionPanelProps {
   multiplier: MultiplierProps
   liquidity: LiquidityProps
   details: FarmWithStakedValue
+  userDataReady: boolean
 }
 
 const Container = styled.div`
@@ -99,7 +100,13 @@ const ValueWrapper = styled.div`
   margin: 4px 0px;
 `
 
-const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, multiplier, liquidity }) => {
+const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({
+  details,
+  apr,
+  multiplier,
+  liquidity,
+  userDataReady,
+}) => {
   const farm = details
 
   const TranslateString = useI18n()
@@ -146,8 +153,8 @@ const ActionPanel: React.FunctionComponent<ActionPanelProps> = ({ details, apr, 
         </ValueWrapper>
       </ValueContainer>
       <ActionContainer>
-        <HarvestAction {...farm} />
-        <StakedAction {...farm} />
+        <HarvestAction {...farm} userDataReady={userDataReady} />
+        <StakedAction {...farm} userDataReady={userDataReady} />
       </ActionContainer>
     </Container>
   )

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react'
-import { useWeb3React } from '@web3-react/core'
-import { Button } from '@pancakeswap-libs/uikit'
+import { Button, Skeleton } from '@pancakeswap-libs/uikit'
 import BigNumber from 'bignumber.js'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
 import { getBalanceNumber } from 'utils/formatBalance'
@@ -11,15 +10,19 @@ import { useCountUp } from 'react-countup'
 
 import { ActionContainer, ActionTitles, Title, Subtle, ActionContent, Earned, Staked } from './styles'
 
-const HarvestAction: React.FunctionComponent<FarmWithStakedValue> = ({ pid, userData }) => {
-  const { account } = useWeb3React()
-  const earningsBigNumber = userData && account ? new BigNumber(userData.earnings) : null
-  const cakePrice = usePriceCakeBusd()
-  let earnings = null
-  let earningsBusd = 0
-  let displayBalance = '?'
+interface HarvestActionProps extends FarmWithStakedValue {
+  userDataReady: boolean
+}
 
-  if (earningsBigNumber) {
+const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userData, userDataReady }) => {
+  const earningsBigNumber = new BigNumber(userData.earnings)
+  const cakePrice = usePriceCakeBusd()
+  let earnings = 0
+  let earningsBusd = 0
+  let displayBalance = userDataReady ? earnings.toLocaleString() : <Skeleton width={60} />
+
+  // If user didn't connect wallet default abalance will be 0
+  if (!earningsBigNumber.isZero()) {
     earnings = getBalanceNumber(earningsBigNumber)
     earningsBusd = new BigNumber(earnings).multipliedBy(cakePrice).toNumber()
     displayBalance = earnings.toLocaleString()
@@ -42,6 +45,10 @@ const HarvestAction: React.FunctionComponent<FarmWithStakedValue> = ({ pid, user
     updateValue.current(earningsBusd)
   }, [earningsBusd, updateValue])
 
+  // Harvesting is disabled if
+  // 1. Wallet is not connected (earningsBigNumber.isZero() === true, earnings remains null)
+  // 2. Wallet is connected but we're waiting for the userData
+  // 3. There is pending transaction
   return (
     <ActionContainer>
       <ActionTitles>
@@ -54,7 +61,7 @@ const HarvestAction: React.FunctionComponent<FarmWithStakedValue> = ({ pid, user
           {countUp > 0 && <Staked>~{countUp}USD</Staked>}
         </div>
         <Button
-          disabled={!earnings || pendingTx || !account}
+          disabled={!earnings || pendingTx || !userDataReady}
           onClick={async () => {
             setPendingTx(true)
             await onReward()

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -45,10 +45,6 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
     updateValue.current(earningsBusd)
   }, [earningsBusd, updateValue])
 
-  // Harvesting is disabled if
-  // 1. Wallet is not connected (earningsBigNumber.isZero() === true, earnings remains null)
-  // 2. Wallet is connected but we're waiting for the userData
-  // 3. There is pending transaction
   return (
     <ActionContainer>
       <ActionTitles>

--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
-import { Button, useModal, IconButton, AddIcon, MinusIcon } from '@pancakeswap-libs/uikit'
+import { Button, useModal, IconButton, AddIcon, MinusIcon, Skeleton } from '@pancakeswap-libs/uikit'
 import { useLocation } from 'react-router-dom'
 import UnlockButton from 'components/UnlockButton'
 import { useWeb3React } from '@web3-react/core'
@@ -24,7 +24,18 @@ const IconButtonWrapper = styled.div`
   display: flex;
 `
 
-const Staked: React.FunctionComponent<FarmWithStakedValue> = ({ pid, lpSymbol, lpAddresses, quoteToken, token }) => {
+interface StackedActionProps extends FarmWithStakedValue {
+  userDataReady: boolean
+}
+
+const Staked: React.FunctionComponent<StackedActionProps> = ({
+  pid,
+  lpSymbol,
+  lpAddresses,
+  quoteToken,
+  token,
+  userDataReady,
+}) => {
   const TranslateString = useI18n()
   const { account } = useWeb3React()
   const [requestedApproval, setRequestedApproval] = useState(false)
@@ -123,6 +134,19 @@ const Staked: React.FunctionComponent<FarmWithStakedValue> = ({ pid, lpSymbol, l
           >
             {TranslateString(999, 'Stake LP')}
           </Button>
+        </ActionContent>
+      </ActionContainer>
+    )
+  }
+
+  if (!userDataReady) {
+    return (
+      <ActionContainer>
+        <ActionTitles>
+          <Subtle>{TranslateString(999, 'START FARMING')}</Subtle>
+        </ActionTitles>
+        <ActionContent>
+          <Skeleton width={180} marginBottom={28} marginTop={14} />
         </ActionContent>
       </ActionContainer>
     )

--- a/src/views/Farms/components/FarmTable/Apr.tsx
+++ b/src/views/Farms/components/FarmTable/Apr.tsx
@@ -5,7 +5,7 @@ import { Address } from 'config/constants/types'
 import BigNumber from 'bignumber.js'
 import { BASE_ADD_LIQUIDITY_URL } from 'config'
 import getLiquidityUrlPathParts from 'utils/getLiquidityUrlPathParts'
-import useI18n from 'hooks/useI18n'
+import { Skeleton } from '@pancakeswap-libs/uikit'
 
 export interface AprProps {
   value: string
@@ -49,7 +49,6 @@ const Apr: React.FC<AprProps> = ({
   originalValue,
   hideButton = false,
 }) => {
-  const TranslateString = useI18n()
   const liquidityUrlPathParts = getLiquidityUrlPathParts({ quoteTokenAddress, tokenAddress })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
 
@@ -63,7 +62,9 @@ const Apr: React.FC<AprProps> = ({
           )}
         </>
       ) : (
-        <AprWrapper>{TranslateString(656, 'Loading...')}</AprWrapper>
+        <AprWrapper>
+          <Skeleton width={60} />
+        </AprWrapper>
       )}
     </Container>
   ) : (

--- a/src/views/Farms/components/FarmTable/Earned.tsx
+++ b/src/views/Farms/components/FarmTable/Earned.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useWeb3React } from '@web3-react/core'
+import { Skeleton } from '@pancakeswap-libs/uikit'
 
 export interface EarnedProps {
   earnings: number
   pid: number
+}
+
+interface EarnedPropsWithLoading extends EarnedProps {
+  userDataReady: boolean
 }
 
 const Amount = styled.span<{ earned: number }>`
@@ -13,12 +17,15 @@ const Amount = styled.span<{ earned: number }>`
   align-items: center;
 `
 
-const Earned: React.FunctionComponent<EarnedProps> = ({ earnings }) => {
-  const { account } = useWeb3React()
-  const amountEarned = account ? earnings : null
-
-  const displayBalance = amountEarned ? amountEarned.toLocaleString() : '?'
-  return <Amount earned={amountEarned}>{displayBalance}</Amount>
+const Earned: React.FunctionComponent<EarnedPropsWithLoading> = ({ earnings, userDataReady }) => {
+  if (userDataReady) {
+    return <Amount earned={earnings}>{earnings.toLocaleString()}</Amount>
+  }
+  return (
+    <Amount earned={0}>
+      <Skeleton width={60} />
+    </Amount>
+  )
 }
 
 export default Earned

--- a/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -8,6 +8,7 @@ import Row, { RowProps } from './Row'
 export interface ITableProps {
   data: RowProps[]
   columns: ColumnType<RowProps>[]
+  userDataReady: boolean
   sortColumn?: string
 }
 
@@ -59,7 +60,7 @@ const ScrollButtonContainer = styled.div`
 const FarmTable: React.FC<ITableProps> = (props) => {
   const tableWrapperEl = useRef<HTMLDivElement>(null)
   const TranslateString = useI18n()
-  const { data, columns } = props
+  const { data, columns, userDataReady } = props
 
   const { rows } = useTable(columns, data, { sortable: true, sortColumn: 'farm' })
 
@@ -76,7 +77,7 @@ const FarmTable: React.FC<ITableProps> = (props) => {
           <StyledTable>
             <TableBody>
               {rows.map((row) => {
-                return <Row {...row.original} key={`table-row-${row.id}`} />
+                return <Row {...row.original} userDataReady={userDataReady} key={`table-row-${row.id}`} />
               })}
             </TableBody>
           </StyledTable>

--- a/src/views/Farms/components/FarmTable/Liquidity.tsx
+++ b/src/views/Farms/components/FarmTable/Liquidity.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { HelpIcon, Text, useTooltip } from '@pancakeswap-libs/uikit'
+import { HelpIcon, Text, Skeleton, useTooltip } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import BigNumber from 'bignumber.js'
 
@@ -30,9 +30,11 @@ const Container = styled.div`
 `
 
 const Liquidity: React.FunctionComponent<LiquidityProps> = ({ liquidity }) => {
-  const displayLiquidity = liquidity
-    ? `$${Number(liquidity).toLocaleString(undefined, { maximumFractionDigits: 0 })}`
-    : '-'
+  const displayLiquidity = liquidity ? (
+    `$${Number(liquidity).toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+  ) : (
+    <Skeleton width={60} />
+  )
   const TranslateString = useI18n()
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     TranslateString(999, 'The total value of the funds in this farm’s liquidity pool'),

--- a/src/views/Farms/components/FarmTable/Multiplier.tsx
+++ b/src/views/Farms/components/FarmTable/Multiplier.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { HelpIcon, useTooltip } from '@pancakeswap-libs/uikit'
+import { HelpIcon, Skeleton, useTooltip } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 
 const ReferenceElement = styled.div`
@@ -29,7 +29,7 @@ const Container = styled.div`
 `
 
 const Multiplier: React.FunctionComponent<MultiplierProps> = ({ multiplier }) => {
-  const displayMultiplier = multiplier ? multiplier.toLowerCase() : '-'
+  const displayMultiplier = multiplier ? multiplier.toLowerCase() : <Skeleton width={30} />
   const TranslateString = useI18n()
   const tooltipContent = (
     <div>

--- a/src/views/Farms/components/FarmTable/Row.tsx
+++ b/src/views/Farms/components/FarmTable/Row.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
 import { useMatchBreakpoints } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
+import useDelayedUnmount from 'hooks/useDelayedUnmount'
 import { useFarmUser } from 'state/hooks'
 
 import Apr, { AprProps } from './Apr'
@@ -70,15 +71,16 @@ const FarmMobileCell = styled.td`
 const Row: React.FunctionComponent<RowPropsWithLoading> = (props) => {
   const { details, userDataReady } = props
   const hasStakedAmount = !!useFarmUser(details.pid).stakedBalance.toNumber()
-  const [actionPanelToggled, setActionPanelToggled] = useState(hasStakedAmount)
+  const [actionPanelExpanded, setActionPanelExpanded] = useState(hasStakedAmount)
+  const shouldRenderChild = useDelayedUnmount(actionPanelExpanded, 300)
   const TranslateString = useI18n()
 
   const toggleActionPanel = () => {
-    setActionPanelToggled(!actionPanelToggled)
+    setActionPanelExpanded(!actionPanelExpanded)
   }
 
   useEffect(() => {
-    setActionPanelToggled(hasStakedAmount)
+    setActionPanelExpanded(hasStakedAmount)
   }, [hasStakedAmount])
 
   const { isXl, isXs } = useMatchBreakpoints()
@@ -103,7 +105,7 @@ const Row: React.FunctionComponent<RowPropsWithLoading> = (props) => {
                   <td key={key}>
                     <CellInner>
                       <CellLayout>
-                        <Details actionPanelToggled={actionPanelToggled} />
+                        <Details actionPanelToggled={actionPanelExpanded} />
                       </CellLayout>
                     </CellInner>
                   </td>
@@ -162,7 +164,7 @@ const Row: React.FunctionComponent<RowPropsWithLoading> = (props) => {
         <td>
           <CellInner>
             <CellLayout>
-              <Details actionPanelToggled={actionPanelToggled} />
+              <Details actionPanelToggled={actionPanelExpanded} />
             </CellLayout>
           </CellInner>
         </td>
@@ -173,10 +175,10 @@ const Row: React.FunctionComponent<RowPropsWithLoading> = (props) => {
   return (
     <>
       {handleRenderRow()}
-      {actionPanelToggled && details && (
+      {shouldRenderChild && (
         <tr>
           <td colSpan={6}>
-            <ActionPanel {...props} />
+            <ActionPanel {...props} expanded={actionPanelExpanded} />
           </td>
         </tr>
       )}

--- a/src/views/Farms/components/FarmTable/Row.tsx
+++ b/src/views/Farms/components/FarmTable/Row.tsx
@@ -24,6 +24,10 @@ export interface RowProps {
   details: FarmWithStakedValue
 }
 
+interface RowPropsWithLoading extends RowProps {
+  userDataReady: boolean
+}
+
 const cells = {
   apr: Apr,
   farm: Farm,
@@ -63,8 +67,8 @@ const FarmMobileCell = styled.td`
   padding-top: 24px;
 `
 
-const Row: React.FunctionComponent<RowProps> = (props) => {
-  const { details } = props
+const Row: React.FunctionComponent<RowPropsWithLoading> = (props) => {
+  const { details, userDataReady } = props
   const hasStakedAmount = !!useFarmUser(details.pid).stakedBalance.toNumber()
   const [actionPanelToggled, setActionPanelToggled] = useState(hasStakedAmount)
   const TranslateString = useI18n()
@@ -121,7 +125,7 @@ const Row: React.FunctionComponent<RowProps> = (props) => {
                       <CellLayout
                         label={TranslateString(tableSchema[columnIndex].translationId, tableSchema[columnIndex].label)}
                       >
-                        {React.createElement(cells[key], props[key])}
+                        {React.createElement(cells[key], { ...props[key], userDataReady })}
                       </CellLayout>
                     </CellInner>
                   </td>
@@ -145,7 +149,7 @@ const Row: React.FunctionComponent<RowProps> = (props) => {
           <tr>
             <EarnedMobileCell>
               <CellLayout label={TranslateString(1072, 'Earned')}>
-                <Earned {...props.earned} />
+                <Earned {...props.earned} userDataReady={userDataReady} />
               </CellLayout>
             </EarnedMobileCell>
             <AprMobileCell>

--- a/src/views/Farms/components/FarmTable/Row.tsx
+++ b/src/views/Farms/components/FarmTable/Row.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
 import { useMatchBreakpoints } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
+import { useFarmUser } from 'state/hooks'
 
 import Apr, { AprProps } from './Apr'
 import Farm, { FarmProps } from './Farm'
@@ -64,12 +65,17 @@ const FarmMobileCell = styled.td`
 
 const Row: React.FunctionComponent<RowProps> = (props) => {
   const { details } = props
-  const [actionPanelToggled, setActionPanelToggled] = useState(false)
+  const hasStakedAmount = !!useFarmUser(details.pid).stakedBalance.toNumber()
+  const [actionPanelToggled, setActionPanelToggled] = useState(hasStakedAmount)
   const TranslateString = useI18n()
 
   const toggleActionPanel = () => {
     setActionPanelToggled(!actionPanelToggled)
   }
+
+  useEffect(() => {
+    setActionPanelToggled(hasStakedAmount)
+  }, [hasStakedAmount])
 
   const { isXl, isXs } = useMatchBreakpoints()
 


### PR DESCRIPTION
This PR:
- Shows loading `<Skeleton />` instead of `?` or `Loading...`
- Expand farms with staked LP tokens by default
- Adds expanding animation

Some small additions in this PR:
- Redux's `farms` reducer now has `userDataLoaded` boolean to track when initial farm data for user is loaded. This doesn't need to be `isLoading` since we don't want to show loaders every time data is updated (now every 10 seconds)
- Fixes types for `farm.userData` from `BigNumber` to `string` - it always have been strings, it's just a chunk of our Redux logic doesn't have types defined so TS didn't complain.
- Added useDelayedUnmount hook to help with performance of table animations (read more about it in the docstring)


https://user-images.githubusercontent.com/81824236/115714228-8f94cd80-a37f-11eb-9c7b-7626c773bc07.mp4

