### PR TITLE
Farm Archived tab

### DIFF
--- a/src/state/farms/fetchFarmUser.ts
+++ b/src/state/farms/fetchFarmUser.ts
@@ -2,13 +2,13 @@ import BigNumber from 'bignumber.js'
 import erc20ABI from 'config/abi/erc20.json'
 import masterchefABI from 'config/abi/masterchef.json'
 import multicall from 'utils/multicall'
-import farmsConfig from 'config/constants/farms'
 import { getAddress, getMasterChefAddress } from 'utils/addressHelpers'
+import { FarmConfig } from 'config/constants/types'
 
-export const fetchFarmUserAllowances = async (account: string) => {
+export const fetchFarmUserAllowances = async (account: string, farmsToFetch: FarmConfig[]) => {
   const masterChefAddress = getMasterChefAddress()
 
-  const calls = farmsConfig.map((farm) => {
+  const calls = farmsToFetch.map((farm) => {
     const lpContractAddress = getAddress(farm.lpAddresses)
     return { address: lpContractAddress, name: 'allowance', params: [account, masterChefAddress] }
   })
@@ -20,8 +20,8 @@ export const fetchFarmUserAllowances = async (account: string) => {
   return parsedLpAllowances
 }
 
-export const fetchFarmUserTokenBalances = async (account: string) => {
-  const calls = farmsConfig.map((farm) => {
+export const fetchFarmUserTokenBalances = async (account: string, farmsToFetch: FarmConfig[]) => {
+  const calls = farmsToFetch.map((farm) => {
     const lpContractAddress = getAddress(farm.lpAddresses)
     return {
       address: lpContractAddress,
@@ -37,10 +37,10 @@ export const fetchFarmUserTokenBalances = async (account: string) => {
   return parsedTokenBalances
 }
 
-export const fetchFarmUserStakedBalances = async (account: string) => {
+export const fetchFarmUserStakedBalances = async (account: string, farmsToFetch: FarmConfig[]) => {
   const masterChefAddress = getMasterChefAddress()
 
-  const calls = farmsConfig.map((farm) => {
+  const calls = farmsToFetch.map((farm) => {
     return {
       address: masterChefAddress,
       name: 'userInfo',
@@ -55,10 +55,10 @@ export const fetchFarmUserStakedBalances = async (account: string) => {
   return parsedStakedBalances
 }
 
-export const fetchFarmUserEarnings = async (account: string) => {
+export const fetchFarmUserEarnings = async (account: string, farmsToFetch: FarmConfig[]) => {
   const masterChefAddress = getMasterChefAddress()
 
-  const calls = farmsConfig.map((farm) => {
+  const calls = farmsToFetch.map((farm) => {
     return {
       address: masterChefAddress,
       name: 'pendingCake',

--- a/src/state/farms/fetchFarms.ts
+++ b/src/state/farms/fetchFarms.ts
@@ -3,11 +3,11 @@ import erc20 from 'config/abi/erc20.json'
 import masterchefABI from 'config/abi/masterchef.json'
 import multicall from 'utils/multicall'
 import { getAddress, getMasterChefAddress } from 'utils/addressHelpers'
-import farmsConfig from 'config/constants/farms'
+import { FarmConfig } from 'config/constants/types'
 
-const fetchFarms = async () => {
+const fetchFarms = async (farmsToFetch: FarmConfig[]) => {
   const data = await Promise.all(
-    farmsConfig.map(async (farmConfig) => {
+    farmsToFetch.map(async (farmConfig) => {
       const lpAddress = getAddress(farmConfig.lpAddresses)
       const calls = [
         // Balance of token in the LP contract

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -29,7 +29,8 @@ export const farmsSlice = createSlice({
     setFarmUserData: (state, action) => {
       const { arrayOfUserDataObjects } = action.payload
       arrayOfUserDataObjects.forEach((userDataEl) => {
-        const { index } = userDataEl
+        const { pid } = userDataEl
+        const index = state.data.findIndex((farm) => farm.pid === pid)
         state.data[index] = { ...state.data[index], userData: userDataEl }
       })
     },
@@ -60,7 +61,7 @@ export const fetchFarmUserDataAsync = (account: string) => async (dispatch, getS
 
   const arrayOfUserDataObjects = userFarmAllowances.map((farmAllowance, index) => {
     return {
-      index,
+      pid: farmsToFetch[index].pid,
       allowance: userFarmAllowances[index],
       tokenBalance: userFarmTokenBalances[index],
       stakedBalance: userStakedBalances[index],

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit'
 import farmsConfig from 'config/constants/farms'
+import isArchivedPid from 'utils/farmHelpers'
 import fetchFarms from './fetchFarms'
 import {
   fetchFarmUserEarnings,
@@ -10,7 +11,9 @@ import {
 } from './fetchFarmUser'
 import { FarmsState, Farm } from '../types'
 
-const initialState: FarmsState = { data: [...farmsConfig] }
+const nonArchivedFarms = farmsConfig.filter(({ pid }) => !isArchivedPid(pid))
+
+const initialState: FarmsState = { data: [...farmsConfig], loadArchivedFarmsData: false }
 
 export const farmsSlice = createSlice({
   name: 'Farms',
@@ -30,22 +33,30 @@ export const farmsSlice = createSlice({
         state.data[index] = { ...state.data[index], userData: userDataEl }
       })
     },
+    setLoadArchivedFarmsData: (state, action) => {
+      const loadArchivedFarmsData = action.payload
+      state.loadArchivedFarmsData = loadArchivedFarmsData
+    },
   },
 })
 
 // Actions
-export const { setFarmsPublicData, setFarmUserData } = farmsSlice.actions
+export const { setFarmsPublicData, setFarmUserData, setLoadArchivedFarmsData } = farmsSlice.actions
 
 // Thunks
-export const fetchFarmsPublicDataAsync = () => async (dispatch) => {
-  const farms = await fetchFarms()
+export const fetchFarmsPublicDataAsync = () => async (dispatch, getState) => {
+  const fetchArchived = getState().farms.loadArchivedFarmsData
+  const farmsToFetch = fetchArchived ? farmsConfig : nonArchivedFarms
+  const farms = await fetchFarms(farmsToFetch)
   dispatch(setFarmsPublicData(farms))
 }
-export const fetchFarmUserDataAsync = (account) => async (dispatch) => {
-  const userFarmAllowances = await fetchFarmUserAllowances(account)
-  const userFarmTokenBalances = await fetchFarmUserTokenBalances(account)
-  const userStakedBalances = await fetchFarmUserStakedBalances(account)
-  const userFarmEarnings = await fetchFarmUserEarnings(account)
+export const fetchFarmUserDataAsync = (account: string) => async (dispatch, getState) => {
+  const fetchArchived = getState().farms.loadArchivedFarmsData
+  const farmsToFetch = fetchArchived ? farmsConfig : nonArchivedFarms
+  const userFarmAllowances = await fetchFarmUserAllowances(account, farmsToFetch)
+  const userFarmTokenBalances = await fetchFarmUserTokenBalances(account, farmsToFetch)
+  const userStakedBalances = await fetchFarmUserStakedBalances(account, farmsToFetch)
+  const userFarmEarnings = await fetchFarmUserEarnings(account, farmsToFetch)
 
   const arrayOfUserDataObjects = userFarmAllowances.map((farmAllowance, index) => {
     return {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -20,7 +20,7 @@ import {
   clear as clearToast,
   setBlock,
 } from './actions'
-import { State, Farm, Pool, ProfileState, TeamsState, AchievementState, PriceState } from './types'
+import { State, Farm, FarmsState, Pool, ProfileState, TeamsState, AchievementState, PriceState } from './types'
 import { fetchProfile } from './profile'
 import { fetchTeam, fetchTeams } from './teams'
 import { fetchAchievements } from './achievements'
@@ -48,8 +48,8 @@ export const useFetchPublicData = () => {
 
 // Farms
 
-export const useFarms = (): Farm[] => {
-  const farms = useSelector((state: State) => state.farms.data)
+export const useFarms = (): FarmsState => {
+  const farms = useSelector((state: State) => state.farms)
   return farms
 }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -60,6 +60,7 @@ export interface ToastsState {
 
 export interface FarmsState {
   data: Farm[]
+  loadArchivedFarmsData: boolean
 }
 
 export interface PoolsState {

--- a/src/utils/farmHelpers.ts
+++ b/src/utils/farmHelpers.ts
@@ -1,0 +1,6 @@
+const ARCHIVED_FARMS_START_PID = 139
+const ARCHIVED_FARMS_END_PID = 250
+
+const isArchivedPid = (pid: number) => pid >= ARCHIVED_FARMS_START_PID && pid <= ARCHIVED_FARMS_END_PID
+
+export default isArchivedPid

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -19,7 +19,7 @@ import { orderBy } from 'lodash'
 import { getAddress } from 'utils/addressHelpers'
 import isArchivedPid from 'utils/farmHelpers'
 import PageHeader from 'components/PageHeader'
-import { setLoadArchivedFarmsData } from 'state/farms'
+import { fetchFarmsPublicDataAsync, setLoadArchivedFarmsData } from 'state/farms'
 import FarmCard, { FarmWithStakedValue } from './components/FarmCard/FarmCard'
 import Table from './components/FarmTable/FarmTable'
 import FarmTabButtons from './components/FarmTabButtons'
@@ -132,8 +132,18 @@ const Farms: React.FC = () => {
   }, [isActive])
 
   useEffect(() => {
+    // Makes the main scheduled fetching to request archived farms data
     dispatch(setLoadArchivedFarmsData(isArchived))
-  }, [isArchived, dispatch])
+
+    // Immediately request data for archived farms so users don't have to wait
+    // 60 seconds for public data and 10 seconds for user data
+    if (isArchived) {
+      dispatch(fetchFarmsPublicDataAsync())
+      if (account) {
+        dispatch(fetchFarmUserDataAsync(account))
+      }
+    }
+  }, [isArchived, dispatch, account])
 
   const activeFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier !== '0X' && !isArchivedPid(farm.pid))
   const inactiveFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X' && !isArchivedPid(farm.pid))

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -342,6 +342,11 @@ const Farms: React.FC = () => {
               <FarmCard key={farm.pid} farm={farm} cakePrice={cakePrice} account={account} removed />
             ))}
           </Route>
+          <Route exact path={`${path}/archived`}>
+            {farmsStakedMemoized.map((farm) => (
+              <FarmCard key={farm.pid} farm={farm} cakePrice={cakePrice} account={account} removed />
+            ))}
+          </Route>
         </FlexLayout>
       </div>
     )

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -369,7 +369,10 @@ const Farms: React.FC = () => {
               <Toggle checked={stakedOnly} onChange={() => setStakedOnly(!stakedOnly)} scale="sm" />
               <Text> {TranslateString(1116, 'Staked only')}</Text>
             </ToggleWrapper>
-            <FarmTabButtons hasStakeInFinishedFarms={stakedInactiveFarms.length > 0} />
+            <FarmTabButtons
+              hasStakeInFinishedFarms={stakedInactiveFarms.length > 0}
+              hasStakeInArchivedFarms={stakedArchivedFarms.length > 0}
+            />
           </ViewControls>
           <FilterContainer>
             <LabelWrapper>

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -280,7 +280,7 @@ const Farms: React.FC = () => {
       },
       farm: {
         image: farm.lpSymbol.split(' ')[0].toLocaleLowerCase(),
-        label: lpLabel + farm.pid.toString(),
+        label: lpLabel,
         pid: farm.pid,
       },
       earned: {

--- a/src/views/Farms/components/FarmTabButtons/index.tsx
+++ b/src/views/Farms/components/FarmTabButtons/index.tsx
@@ -6,9 +6,10 @@ import useI18n from 'hooks/useI18n'
 
 interface FarmTabButtonsProps {
   hasStakeInFinishedFarms: boolean
+  hasStakeInArchivedFarms: boolean
 }
 
-const FarmTabButtons: React.FC<FarmTabButtonsProps> = ({ hasStakeInFinishedFarms }) => {
+const FarmTabButtons: React.FC<FarmTabButtonsProps> = ({ hasStakeInFinishedFarms, hasStakeInArchivedFarms }) => {
   const { url } = useRouteMatch()
   const location = useLocation()
   const TranslateString = useI18n()
@@ -40,9 +41,11 @@ const FarmTabButtons: React.FC<FarmTabButtonsProps> = ({ hasStakeInFinishedFarms
             {TranslateString(388, 'Finished')}
           </ButtonMenuItem>
         </NotificationDot>
-        <ButtonMenuItem as={Link} to={`${url}/archived`}>
-          {TranslateString(999, 'Archived')}
-        </ButtonMenuItem>
+        <NotificationDot show={hasStakeInArchivedFarms}>
+          <ButtonMenuItem as={Link} to={`${url}/archived`}>
+            {TranslateString(999, 'Archived')}
+          </ButtonMenuItem>
+        </NotificationDot>
       </ButtonMenu>
     </Wrapper>
   )

--- a/src/views/Farms/components/FarmTabButtons/index.tsx
+++ b/src/views/Farms/components/FarmTabButtons/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useRouteMatch, Link } from 'react-router-dom'
+import { useLocation, Link, useRouteMatch } from 'react-router-dom'
 import { ButtonMenu, ButtonMenuItem, NotificationDot } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 
@@ -9,12 +9,29 @@ interface FarmTabButtonsProps {
 }
 
 const FarmTabButtons: React.FC<FarmTabButtonsProps> = ({ hasStakeInFinishedFarms }) => {
-  const { url, isExact } = useRouteMatch()
+  const { url } = useRouteMatch()
+  const location = useLocation()
   const TranslateString = useI18n()
+
+  let activeIndex
+  switch (location.pathname) {
+    case '/farms':
+      activeIndex = 0
+      break
+    case '/farms/history':
+      activeIndex = 1
+      break
+    case '/farms/archived':
+      activeIndex = 2
+      break
+    default:
+      activeIndex = 0
+      break
+  }
 
   return (
     <Wrapper>
-      <ButtonMenu activeIndex={isExact ? 0 : 1} scale="sm" variant="subtle">
+      <ButtonMenu activeIndex={activeIndex} scale="sm" variant="subtle">
         <ButtonMenuItem as={Link} to={`${url}`}>
           {TranslateString(1198, 'Live')}
         </ButtonMenuItem>
@@ -23,6 +40,9 @@ const FarmTabButtons: React.FC<FarmTabButtonsProps> = ({ hasStakeInFinishedFarms
             {TranslateString(388, 'Finished')}
           </ButtonMenuItem>
         </NotificationDot>
+        <ButtonMenuItem as={Link} to={`${url}/archived`}>
+          {TranslateString(999, 'Archived')}
+        </ButtonMenuItem>
       </ButtonMenu>
     </Wrapper>
   )

--- a/src/views/Home/components/EarnAPRCard.tsx
+++ b/src/views/Home/components/EarnAPRCard.tsx
@@ -24,7 +24,7 @@ const CardMidContent = styled(Heading).attrs({ size: 'xl' })`
 `
 const EarnAPRCard = () => {
   const TranslateString = useI18n()
-  const farmsLP = useFarms()
+  const { data: farmsLP } = useFarms()
   const prices = useGetApiPrices()
   const cakePrice = usePriceCakeBusd()
 


### PR DESCRIPTION
New tab in Farms page for Archived farms.
Fetching logic slightly reworked so it doesn't fetch data for archived pools unless you're looking at them.