### PR TITLE
Fixed typo

### DIFF
--- a/src/config/constants/contracts.ts
+++ b/src/config/constants/contracts.ts
@@ -15,7 +15,7 @@ export default {
     97: '0x8175c10383511b3a1C68f9dB222dc14A19CC950e',
     56: '0x5e74094Cd416f55179DBd0E45b1a8ED030e396A1',
   },
-  mulltiCall: {
+  multiCall: {
     56: '0x1ee38d535d541c55c9dae27b12edf090c608e6fb',
     97: '0x67ADCB4dF3931b0C5Da724058ADC2174a9844412',
   },

--- a/src/utils/addressHelpers.ts
+++ b/src/utils/addressHelpers.ts
@@ -15,7 +15,7 @@ export const getMasterChefAddress = () => {
   return getAddress(addresses.masterChef)
 }
 export const getMulticallAddress = () => {
-  return getAddress(addresses.mulltiCall)
+  return getAddress(addresses.multiCall)
 }
 export const getWbnbAddress = () => {
   return getAddress(tokens.wbnb.address)


### PR DESCRIPTION
There was a typo `mullticall` that was fixed to `multicall` 
