### PR TITLE
fix(predictions): Fetch user bets on load

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -11,7 +11,7 @@ import { getAddress } from 'utils/addressHelpers'
 import { getBalanceNumber } from 'utils/formatBalance'
 import useRefresh from 'hooks/useRefresh'
 import { fetchFarmsPublicDataAsync, fetchPoolsPublicDataAsync, fetchPoolsUserDataAsync, setBlock } from './actions'
-import { State, Farm, Pool, ProfileState, TeamsState, AchievementState, PriceState, FarmsState, Bet } from './types'
+import { State, Farm, Pool, ProfileState, TeamsState, AchievementState, PriceState, FarmsState } from './types'
 import { fetchProfile } from './profile'
 import { fetchTeam, fetchTeams } from './teams'
 import { fetchAchievements } from './achievements'
@@ -261,16 +261,6 @@ export const useGetMinBetAmount = () => {
   return useMemo(() => new BigNumber(minBetAmount), [minBetAmount])
 }
 
-export const useGetUserBetByRound = (id: string, account: string): Bet => {
-  const round = useGetRound(id)
-
-  if (!account) {
-    return undefined
-  }
-
-  return round.bets.find((bet) => bet.user.address.toLowerCase() === account.toLocaleLowerCase())
-}
-
 export const useGetIsFetchingHistory = () => {
   return useSelector((state: State) => state.predictions.isFetchingHistory)
 }
@@ -282,6 +272,20 @@ export const useGetHistory = () => {
 export const useGetHistoryByAccount = (account: string) => {
   const bets = useGetHistory()
   return bets ? bets[account] : []
+}
+
+export const useGetBetByRoundId = (account: string, roundId: string) => {
+  const bets = useSelector((state: State) => state.predictions.bets)
+
+  if (!bets[account]) {
+    return null
+  }
+
+  if (!bets[account][roundId]) {
+    return null
+  }
+
+  return bets[account][roundId]
 }
 
 // Collectibles

--- a/src/state/predictions/helpers.ts
+++ b/src/state/predictions/helpers.ts
@@ -221,7 +221,7 @@ type BetHistoryWhereClause = Record<string, string | number | boolean>
 
 export const getBetHistory = async (
   where: BetHistoryWhereClause = {},
-  first = 100,
+  first = 1000,
   skip = 0,
 ): Promise<BetResponse[]> => {
   const response = await request(

--- a/src/state/predictions/helpers.ts
+++ b/src/state/predictions/helpers.ts
@@ -172,12 +172,6 @@ export const getMarketData = async (): Promise<{
       query getMarketData {
         rounds(first: 5, orderBy: epoch, orderDirection: desc) {
           ${getRoundBaseFields()}
-          bets(first: 1000) {
-            ${getBetBaseFields()}
-            user {
-              ${getUserBaseFields()}
-            }
-          }
         }
         market(id: 1) {
           id

--- a/src/state/predictions/index.ts
+++ b/src/state/predictions/index.ts
@@ -90,12 +90,8 @@ export const predictionsSlice = createSlice({
     initialize: (state, action: PayloadAction<PredictionsState>) => {
       return action.payload
     },
-    updateMarketData: (
-      state,
-      action: PayloadAction<{ marketData: { rounds: Round[]; market: Market }; account?: string }>,
-    ) => {
-      const { marketData, account } = action.payload
-      const { rounds, market } = marketData
+    updateMarketData: (state, action: PayloadAction<{ rounds: Round[]; market: Market }>) => {
+      const { rounds, market } = action.payload
       const newRoundData = makeRoundData(rounds)
       const incomingCurrentRound = maxBy(rounds, 'epoch')
 
@@ -107,31 +103,6 @@ export const predictionsSlice = createSlice({
         )
 
         newRoundData[futureRound.id] = futureRound
-      }
-
-      // For each round, loop through the bets and save them to the bets namespace
-      // if they match the current account
-      if (account) {
-        const betData = rounds.reduce((accum, polledRound) => {
-          const userBet = polledRound.bets.find((bet) => bet.user.address.toLowerCase() === account.toLowerCase())
-
-          if (userBet) {
-            return {
-              ...accum,
-              [polledRound.id]: userBet,
-            }
-          }
-
-          return accum
-        }, {})
-
-        state.bets = {
-          ...state.bets,
-          [account]: {
-            ...state.bets[account],
-            ...betData,
-          },
-        }
       }
 
       state.currentEpoch = incomingCurrentRound.epoch

--- a/src/state/predictions/index.ts
+++ b/src/state/predictions/index.ts
@@ -125,6 +125,20 @@ export const predictionsSlice = createSlice({
         }
       }
     },
+    markPositionAsEntered: (
+      state,
+      action: PayloadAction<{ account: string; roundId: string; partialBet: Partial<Bet> }>,
+    ) => {
+      const { account, roundId, partialBet } = action.payload
+
+      state.bets = {
+        ...state.bets,
+        [account]: {
+          ...state.bets[account],
+          [roundId]: partialBet,
+        },
+      }
+    },
   },
   extraReducers: (builder) => {
     // Get round bet
@@ -176,6 +190,7 @@ export const {
   updateMarketData,
   markBetAsCollected,
   setPredictionStatus,
+  markPositionAsEntered,
 } = predictionsSlice.actions
 
 export default predictionsSlice.reducer

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -217,8 +217,14 @@ export interface RoundData {
   [key: string]: Round
 }
 
-export interface BetData {
+export interface HistoryData {
   [key: string]: Bet[]
+}
+
+export interface BetData {
+  [key: string]: {
+    [key: string]: Bet
+  }
 }
 
 export enum HistoryFilter {
@@ -240,7 +246,8 @@ export interface PredictionsState {
   bufferBlocks: number
   minBetAmount: string
   rounds: RoundData
-  history: BetData
+  history: HistoryData
+  bets: BetData
 }
 
 // Global state

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -223,7 +223,7 @@ export interface HistoryData {
 
 export interface BetData {
   [key: string]: {
-    [key: string]: Bet
+    [key: string]: Partial<Bet>
   }
 }
 

--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -34,7 +34,7 @@ interface SetPositionCardProps {
   position: BetPosition
   togglePosition: () => void
   onBack: () => void
-  onSuccess: () => Promise<void>
+  onSuccess: (decimalValue: BigNumber, hash: string) => Promise<void>
 }
 
 const dust = new BigNumber(0.01).times(new BigNumber(10).pow(18))
@@ -131,9 +131,9 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
       .once('sending', () => {
         setIsTxPending(true)
       })
-      .once('receipt', async () => {
+      .once('receipt', async (result) => {
         setIsTxPending(false)
-        await onSuccess()
+        onSuccess(decimalValue, result.transactionHash as string)
       })
       .once('error', (error) => {
         const errorMsg = TranslateString(999, 'An error occurred, unable to enter your position')

--- a/src/views/Predictions/hooks/usePollRoundData.ts
+++ b/src/views/Predictions/hooks/usePollRoundData.ts
@@ -14,7 +14,7 @@ const usePollRoundData = () => {
     const timer = setInterval(async () => {
       const marketData = await getMarketData()
 
-      dispatch(updateMarketData(marketData))
+      dispatch(updateMarketData({ marketData, account }))
     }, POLL_TIME_IN_SECONDS * 1000)
 
     return () => {

--- a/src/views/Predictions/hooks/usePollRoundData.ts
+++ b/src/views/Predictions/hooks/usePollRoundData.ts
@@ -14,7 +14,7 @@ const usePollRoundData = () => {
     const timer = setInterval(async () => {
       const marketData = await getMarketData()
 
-      dispatch(updateMarketData({ marketData, account }))
+      dispatch(updateMarketData(marketData))
     }, POLL_TIME_IN_SECONDS * 1000)
 
     return () => {

--- a/src/views/Predictions/index.tsx
+++ b/src/views/Predictions/index.tsx
@@ -69,6 +69,7 @@ const Predictions = () => {
             currentRoundStartBlockNumber: currentRoundStartBlock,
             rounds: roundData,
             history: {},
+            bets: {},
           }),
         )
       } else {


### PR DESCRIPTION
`<RoundCard />` now makes a fetch on initial load for the user's bets. This will ensure that the entered tag always shows even if a round has greater than 1,000 bets.

