### PR TITLE
fix: (prediction) Slider cannot be set to max by sliding it to the right

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -209,6 +209,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
           max={maxBalance}
           value={valueAsBn.lte(maxBalance) ? valueAsBn.toNumber() : 0}
           onValueChanged={handleSliderChange}
+          step={0.000000000000001}
           valueLabel={account ? percentageDisplay : ''}
           disabled={!account || isTxPending}
           mb="4px"


### PR DESCRIPTION
This could be bug in input range component. Which you can test it via this code


https://www.w3schools.com/html/tryit.asp?filename=tryhtml_input_range

put this to input 

`<input type="range" id="vol" name="vol" min="0" max="0.1259255862692049"  step="any">`

I set step to 15 decimal digits, which input type range rounds it to 15 from 16 after some point that affects max value check.



