### PR TITLE
fix: (farms) Disable cancel button on deposit and withdraw modals when pending confirmation

### DIFF
--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -50,7 +50,7 @@ const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, 
         inputTitle={TranslateString(1070, 'Stake')}
       />
       <ModalActions>
-        <Button variant="secondary" onClick={onDismiss} width="100%">
+        <Button variant="secondary" onClick={onDismiss} width="100%" disabled={pendingTx}>
           {TranslateString(462, 'Cancel')}
         </Button>
         <Button

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -48,7 +48,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
         inputTitle={TranslateString(588, 'Unstake')}
       />
       <ModalActions>
-        <Button variant="secondary" onClick={onDismiss} width="100%">
+        <Button variant="secondary" onClick={onDismiss} width="100%" disabled={pendingTx}>
           {TranslateString(462, 'Cancel')}
         </Button>
         <Button


### PR DESCRIPTION
If it is enabled it can be misunderstood from users to cancel the pending confirmation