### PR TITLE
Fix pool "stacked only switch" UI in dark theme

### DIFF
--- a/src/views/Pools/components/PoolTabButtons.tsx
+++ b/src/views/Pools/components/PoolTabButtons.tsx
@@ -44,9 +44,7 @@ const PoolTabButtons = ({ stakedOnly, setStakedOnly, hasStakeInFinishedPools }) 
         </ButtonMenu>
         <Flex mt={['4px', null, 0, null]} ml={[0, null, '24px', null]} justifyContent="center" alignItems="center">
           <Toggle scale="sm" checked={stakedOnly} onChange={() => setStakedOnly((prev) => !prev)} />
-          <Text ml="8px" color={`${stakedOnly ? 'body' : 'textDisabled'}`}>
-            {TranslateString(999, 'Staked only')}
-          </Text>
+          <Text ml="8px">{TranslateString(999, 'Staked only')}</Text>
         </Flex>
       </Flex>
       <Flex ml="24px" alignItems="center" justifyContent="flex-end">


### PR DESCRIPTION
**Environment:**
Device and OS: Any
Browser: Any
Reproducibility rate: 100%

**Steps to reproduce:**
1. Set theme to dark
2. Go to the Pool view
3. Click on stacked only switch

**Actual result:**
![Actual](https://user-images.githubusercontent.com/6993911/116676443-465c0380-a9a7-11eb-9970-e917f69be276.png)

**Expected result:**
![Expected](https://user-images.githubusercontent.com/6993911/116676457-4956f400-a9a7-11eb-919c-88c371e4c011.png)
