### PR TITLE
fix: (bounty) Add unlock wallet button bounty modal when no wallet connected

### DIFF
--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -8,6 +8,8 @@ import { useCakeVaultContract } from 'hooks/useContract'
 import { getFullDisplayBalance } from 'utils/formatBalance'
 import useTheme from 'hooks/useTheme'
 import useToast from 'hooks/useToast'
+import UnlockButton from '../../../components/UnlockButton'
+import { ActionContent } from '../../Farms/components/FarmTable/Actions/styles'
 
 interface BountyModalProps {
   cakeCallBountyToDisplay: string
@@ -104,14 +106,18 @@ const BountyModal: React.FC<BountyModalProps> = ({
           {callFeeAsDecimal}%
         </Text>
       </Flex>
-      <Button
-        isLoading={pendingTx}
-        endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
-        onClick={handleConfirmClick}
-        mb="28px"
-      >
-        {TranslateString(464, 'Confirm')}
-      </Button>
+      {!account ? (
+        <UnlockButton width="100%" />
+      ) : (
+        <Button
+          isLoading={pendingTx}
+          endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
+          onClick={handleConfirmClick}
+          mb="28px"
+        >
+          {TranslateString(464, 'Confirm')}
+        </Button>
+      )}
       <Flex ref={targetRef} justifyContent="center" alignItems="center">
         <Text fontSize="16px" bold color="textSubtle" mr="4px">
           {TranslateString(999, "What's this?")}


### PR DESCRIPTION
Because it causes an error when user clicks confirm without wallet

Before: 

<img width="336" src="https://user-images.githubusercontent.com/2213635/116677527-9ab3b300-a9a8-11eb-9e13-38483bba3a26.png">

After:

<img width="336"  src="https://user-images.githubusercontent.com/2213635/116677549-a1dac100-a9a8-11eb-865f-5c73a9d5c1b8.png">
