### PR TITLE
chore(cake-vault-bounty): Reorganise vault bounty hook, Improve var names. Account check

### DIFF
--- a/src/hooks/cakeVault/useGetVaultBountyInfo.ts
+++ b/src/hooks/cakeVault/useGetVaultBountyInfo.ts
@@ -2,44 +2,32 @@ import { useState, useEffect } from 'react'
 import BigNumber from 'bignumber.js'
 import { useGetApiPrice } from 'state/hooks'
 import { useCakeVaultContract } from 'hooks/useContract'
-import { getFullDisplayBalance } from 'utils/formatBalance'
 import makeBatchRequest from 'utils/makeBatchRequest'
 import { getCakeAddress } from 'utils/addressHelpers'
 
 const useGetVaultBountyInfo = (refresh?: number) => {
   const cakeVaultContract = useCakeVaultContract()
-  const [estimatedCallBountyReward, setEstimatedCallBountyReward] = useState(null)
-  const [totalPendingCakeRewards, setTotalPendingCakeRewards] = useState(null)
-  const [dollarCallBountyToDisplay, setDollarBountyToDisplay] = useState(null)
-  const [cakeCallBountyToDisplay, setCakeBountyToDisplay] = useState(null)
+  const [estimatedDollarBountyReward, setEstimatedDollarBountyReward] = useState(null)
+  const [estimatedCakeBountyReward, setEstimatedCakeBountyReward] = useState(null)
+  const [totalPendingCakeHarvest, setTotalPendingCakeHarvest] = useState(null)
 
   const cakePrice = useGetApiPrice(getCakeAddress())
 
   useEffect(() => {
-    // Call contract to get estimated rewards
     const fetchRewards = async () => {
-      const [estimatedRewards, pendingCakeRewards] = await makeBatchRequest([
+      const [estimatedClaimableCakeReward, pendingTotalCakeHarvest] = await makeBatchRequest([
         cakeVaultContract.methods.calculateHarvestCakeRewards().call,
         cakeVaultContract.methods.calculateTotalPendingCakeRewards().call,
       ])
-      setEstimatedCallBountyReward(new BigNumber(estimatedRewards as string))
-      setTotalPendingCakeRewards(new BigNumber(pendingCakeRewards as string))
+      const dollarValueOfClaimableReward = new BigNumber(estimatedClaimableCakeReward as string).multipliedBy(cakePrice)
+      setEstimatedDollarBountyReward(dollarValueOfClaimableReward)
+      setEstimatedCakeBountyReward(new BigNumber(estimatedClaimableCakeReward as string))
+      setTotalPendingCakeHarvest(new BigNumber(pendingTotalCakeHarvest as string))
     }
     fetchRewards()
-  }, [cakeVaultContract, refresh])
+  }, [cakeVaultContract, cakePrice, refresh])
 
-  useEffect(() => {
-    // Convert estimated rewards to dollars and a cake display value
-    if (estimatedCallBountyReward && cakePrice) {
-      const dollarValueOfReward = estimatedCallBountyReward.multipliedBy(cakePrice)
-      const estimatedDollars = getFullDisplayBalance(dollarValueOfReward, 18, 2)
-      const estimatedCake = getFullDisplayBalance(estimatedCallBountyReward, 18, 3)
-      setDollarBountyToDisplay(estimatedDollars)
-      setCakeBountyToDisplay(estimatedCake)
-    }
-  }, [cakePrice, estimatedCallBountyReward])
-
-  return { estimatedCallBountyReward, dollarCallBountyToDisplay, cakeCallBountyToDisplay, totalPendingCakeRewards }
+  return { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest }
 }
 
 export default useGetVaultBountyInfo

--- a/src/hooks/cakeVault/useGetVaultBountyInfo.ts
+++ b/src/hooks/cakeVault/useGetVaultBountyInfo.ts
@@ -19,8 +19,12 @@ const useGetVaultBountyInfo = (refresh?: number) => {
         cakeVaultContract.methods.calculateHarvestCakeRewards().call,
         cakeVaultContract.methods.calculateTotalPendingCakeRewards().call,
       ])
-      const dollarValueOfClaimableReward = new BigNumber(estimatedClaimableCakeReward as string).multipliedBy(cakePrice)
-      setEstimatedDollarBountyReward(dollarValueOfClaimableReward)
+      if (cakePrice) {
+        const dollarValueOfClaimableReward = new BigNumber(estimatedClaimableCakeReward as string).multipliedBy(
+          cakePrice,
+        )
+        setEstimatedDollarBountyReward(dollarValueOfClaimableReward)
+      }
       setEstimatedCakeBountyReward(new BigNumber(estimatedClaimableCakeReward as string))
       setTotalPendingCakeHarvest(new BigNumber(pendingTotalCakeHarvest as string))
     }

--- a/src/hooks/cakeVault/useGetVaultBountyInfo.ts
+++ b/src/hooks/cakeVault/useGetVaultBountyInfo.ts
@@ -2,10 +2,12 @@ import { useState, useEffect } from 'react'
 import BigNumber from 'bignumber.js'
 import { useGetApiPrice } from 'state/hooks'
 import { useCakeVaultContract } from 'hooks/useContract'
+import useRefresh from 'hooks/useRefresh'
 import makeBatchRequest from 'utils/makeBatchRequest'
 import { getCakeAddress } from 'utils/addressHelpers'
 
-const useGetVaultBountyInfo = (refresh?: number) => {
+const useGetVaultBountyInfo = () => {
+  const { fastRefresh } = useRefresh()
   const cakeVaultContract = useCakeVaultContract()
   const [estimatedDollarBountyReward, setEstimatedDollarBountyReward] = useState(null)
   const [estimatedCakeBountyReward, setEstimatedCakeBountyReward] = useState(null)
@@ -29,7 +31,7 @@ const useGetVaultBountyInfo = (refresh?: number) => {
       setTotalPendingCakeHarvest(new BigNumber(pendingTotalCakeHarvest as string))
     }
     fetchRewards()
-  }, [cakeVaultContract, cakePrice, refresh])
+  }, [cakeVaultContract, cakePrice, fastRefresh])
 
   return { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest }
 }

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -14,7 +14,6 @@ import {
   useTooltip,
 } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
-import useRefresh from 'hooks/useRefresh'
 import useGetVaultFees from 'hooks/cakeVault/useGetVaultFees'
 import { getFullDisplayBalance } from 'utils/formatBalance'
 import useGetVaultBountyInfo from 'hooks/cakeVault/useGetVaultBountyInfo'
@@ -33,10 +32,7 @@ const InlineText = styled(Text)`
 
 const BountyCard = () => {
   const { t } = useTranslation()
-  const { fastRefresh } = useRefresh()
-  const { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest } = useGetVaultBountyInfo(
-    fastRefresh,
-  )
+  const { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest } = useGetVaultBountyInfo()
   const { callFee } = useGetVaultFees()
   const [bounties, setBounties] = useState({
     modalCakeBountyToDisplay: '',

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import {
   Card,
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from 'contexts/Localization'
 import useRefresh from 'hooks/useRefresh'
 import useGetVaultFees from 'hooks/cakeVault/useGetVaultFees'
+import { getFullDisplayBalance } from 'utils/formatBalance'
 import useGetVaultBountyInfo from 'hooks/cakeVault/useGetVaultBountyInfo'
 import BountyModal from './BountyModal'
 
@@ -33,28 +34,44 @@ const InlineText = styled(Text)`
 const BountyCard = () => {
   const { t } = useTranslation()
   const { fastRefresh } = useRefresh()
-  const { dollarCallBountyToDisplay, cakeCallBountyToDisplay, totalPendingCakeRewards } = useGetVaultBountyInfo(
+  const { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest } = useGetVaultBountyInfo(
     fastRefresh,
   )
   const TooltipComponent = () => (
-    <Box>
-      <Box mb="16px">{`${t(`This bounty is given as a reward for providing a service to other users.`)}`}</Box>
-      <Box mb="16px">
+    <>
+      <Text mb="16px">{`${t(`This bounty is given as a reward for providing a service to other users.`)}`}</Text>
+      <Text mb="16px">
         {t(
           'Whenever you successfully claim the bounty, you’re also helping out by activating the Auto CAKE Pool’s compounding function for everyone.',
         )}
-      </Box>
-      <Box style={{ fontWeight: 'bold' }}>
+      </Text>
+      <Text style={{ fontWeight: 'bold' }}>
         {t(`Auto-Compound Bounty: %fee%% of all Auto CAKE pool users’ pending yield`, { fee: callFee / 100 })}
-      </Box>
-    </Box>
+      </Text>
+    </>
   )
   const { callFee } = useGetVaultFees()
+  const [bounties, setBounties] = useState({
+    modalCakeBountyToDisplay: '',
+    cardCakeBountyToDisplay: '',
+    dollarBountyToDisplay: '',
+  })
+
+  useEffect(() => {
+    if (estimatedCakeBountyReward && estimatedDollarBountyReward && totalPendingCakeHarvest) {
+      setBounties({
+        modalCakeBountyToDisplay: getFullDisplayBalance(estimatedCakeBountyReward, 18, 5),
+        cardCakeBountyToDisplay: getFullDisplayBalance(estimatedCakeBountyReward, 18, 3),
+        dollarBountyToDisplay: getFullDisplayBalance(estimatedDollarBountyReward, 18, 2),
+      })
+    }
+  }, [estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest])
+
   const [onPresentBountyModal] = useModal(
     <BountyModal
-      cakeCallBountyToDisplay={cakeCallBountyToDisplay}
-      dollarCallBountyToDisplay={dollarCallBountyToDisplay}
-      totalPendingCakeRewards={totalPendingCakeRewards}
+      cakeBountyToDisplay={bounties.modalCakeBountyToDisplay}
+      dollarBountyToDisplay={bounties.dollarBountyToDisplay}
+      totalPendingCakeHarvest={totalPendingCakeHarvest}
       callFee={callFee}
       TooltipComponent={TooltipComponent}
     />,
@@ -82,13 +99,17 @@ const BountyCard = () => {
           </Flex>
           <Flex alignItems="center" justifyContent="space-between">
             <Flex flexDirection="column" mr="12px">
-              <Heading>{cakeCallBountyToDisplay || <Skeleton height={20} width={96} mb="2px" />}</Heading>
+              <Heading>{bounties.cardCakeBountyToDisplay || <Skeleton height={20} width={96} mb="2px" />}</Heading>
               <InlineText fontSize="12px" color="textSubtle">
-                {dollarCallBountyToDisplay ? `~ ${dollarCallBountyToDisplay} USD` : <Skeleton height={16} width={62} />}
+                {bounties.dollarBountyToDisplay ? (
+                  `~ ${bounties.dollarBountyToDisplay} USD`
+                ) : (
+                  <Skeleton height={16} width={62} />
+                )}
               </InlineText>
             </Flex>
             <Button
-              disabled={!dollarCallBountyToDisplay || !cakeCallBountyToDisplay || !callFee}
+              disabled={!bounties.dollarBountyToDisplay || !bounties.cardCakeBountyToDisplay || !callFee}
               onClick={onPresentBountyModal}
               scale="sm"
             >

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -37,19 +37,6 @@ const BountyCard = () => {
   const { estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest } = useGetVaultBountyInfo(
     fastRefresh,
   )
-  const TooltipComponent = () => (
-    <>
-      <Text mb="16px">{`${t(`This bounty is given as a reward for providing a service to other users.`)}`}</Text>
-      <Text mb="16px">
-        {t(
-          'Whenever you successfully claim the bounty, you’re also helping out by activating the Auto CAKE Pool’s compounding function for everyone.',
-        )}
-      </Text>
-      <Text style={{ fontWeight: 'bold' }}>
-        {t(`Auto-Compound Bounty: %fee%% of all Auto CAKE pool users’ pending yield`, { fee: callFee / 100 })}
-      </Text>
-    </>
-  )
   const { callFee } = useGetVaultFees()
   const [bounties, setBounties] = useState({
     modalCakeBountyToDisplay: '',
@@ -66,6 +53,20 @@ const BountyCard = () => {
       })
     }
   }, [estimatedCakeBountyReward, estimatedDollarBountyReward, totalPendingCakeHarvest])
+
+  const TooltipComponent = () => (
+    <>
+      <Text mb="16px">{`${t(`This bounty is given as a reward for providing a service to other users.`)}`}</Text>
+      <Text mb="16px">
+        {t(
+          'Whenever you successfully claim the bounty, you’re also helping out by activating the Auto CAKE Pool’s compounding function for everyone.',
+        )}
+      </Text>
+      <Text style={{ fontWeight: 'bold' }}>
+        {t(`Auto-Compound Bounty: %fee%% of all Auto CAKE pool users’ pending yield`, { fee: callFee / 100 })}
+      </Text>
+    </>
+  )
 
   const [onPresentBountyModal] = useModal(
     <BountyModal

--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -3,16 +3,17 @@ import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
 import { Modal, Text, Flex, Button, HelpIcon, AutoRenewIcon, useTooltip } from '@pancakeswap-libs/uikit'
-import { useCakeVaultContract } from 'hooks/useContract'
 import { getFullDisplayBalance } from 'utils/formatBalance'
+import { useCakeVaultContract } from 'hooks/useContract'
 import useTheme from 'hooks/useTheme'
 import useToast from 'hooks/useToast'
 import { useTranslation } from 'contexts/Localization'
+import UnlockButton from 'components/UnlockButton'
 
 interface BountyModalProps {
-  cakeCallBountyToDisplay: string
-  dollarCallBountyToDisplay: string
-  totalPendingCakeRewards: BigNumber
+  cakeBountyToDisplay: string
+  dollarBountyToDisplay: string
+  totalPendingCakeHarvest: BigNumber
   callFee: number
   onDismiss?: () => void
   TooltipComponent: React.ElementType
@@ -26,9 +27,9 @@ const Divider = styled.div`
 `
 
 const BountyModal: React.FC<BountyModalProps> = ({
-  cakeCallBountyToDisplay,
-  dollarCallBountyToDisplay,
-  totalPendingCakeRewards,
+  cakeBountyToDisplay,
+  dollarBountyToDisplay,
+  totalPendingCakeHarvest,
   callFee,
   onDismiss,
   TooltipComponent,
@@ -40,7 +41,7 @@ const BountyModal: React.FC<BountyModalProps> = ({
   const cakeVaultContract = useCakeVaultContract()
   const [pendingTx, setPendingTx] = useState(false)
   const callFeeAsDecimal = callFee / 100
-  const totalYieldToDisplay = getFullDisplayBalance(totalPendingCakeRewards, 18, 3)
+  const totalYieldToDisplay = getFullDisplayBalance(totalPendingCakeHarvest, 18, 3)
   const { targetRef, tooltip, tooltipVisible } = useTooltip(<TooltipComponent />, {
     placement: 'bottom',
     tooltipPadding: { right: 15 },
@@ -74,9 +75,9 @@ const BountyModal: React.FC<BountyModalProps> = ({
       <Flex alignItems="flex-start" justifyContent="space-between">
         <Text>{t("You'll claim")}</Text>
         <Flex flexDirection="column">
-          <Text bold>{cakeCallBountyToDisplay} CAKE</Text>
+          <Text bold>{cakeBountyToDisplay} CAKE</Text>
           <Text fontSize="12px" color="textSubtle">
-            ~ {dollarCallBountyToDisplay} USD
+            ~ {dollarBountyToDisplay} USD
           </Text>
         </Flex>
       </Flex>
@@ -97,14 +98,18 @@ const BountyModal: React.FC<BountyModalProps> = ({
           {callFeeAsDecimal}%
         </Text>
       </Flex>
-      <Button
-        isLoading={pendingTx}
-        endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
-        onClick={handleConfirmClick}
-        mb="28px"
-      >
-        {t('Confirm')}
-      </Button>
+      {account ? (
+        <Button
+          isLoading={pendingTx}
+          endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
+          onClick={handleConfirmClick}
+          mb="28px"
+        >
+          {t('Confirm')}
+        </Button>
+      ) : (
+        <UnlockButton mb="28px" />
+      )}
       <Flex justifyContent="center" alignItems="center">
         <Text fontSize="16px" bold color="textSubtle" mr="4px">
           {t("What's this?")}


### PR DESCRIPTION
- Reorganise vault bounty hook to no longer convert the contract responses into string display balances
- Improve var names. Fewer 'magic numbers'
- Add ternary to check user account is connected on the confirm button