### PR TITLE
chore(cake-vault): Remove unnecessary passing of account in the Cake Vault, instead fetch it from the provider

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
@@ -2,22 +2,22 @@ import React from 'react'
 import BigNumber from 'bignumber.js'
 import { Flex, Text } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useWeb3React } from '@web3-react/core'
 import RecentCakeProfitBalance from './RecentCakeProfitBalance'
 
 interface RecentCakeProfitRowProps {
-  account: string
   cakeAtLastUserAction: BigNumber
   userShares: BigNumber
   pricePerFullShare: BigNumber
 }
 
 const RecentCakeProfitCountdownRow: React.FC<RecentCakeProfitRowProps> = ({
-  account,
   cakeAtLastUserAction,
   userShares,
   pricePerFullShare,
 }) => {
   const { t } = useTranslation()
+  const { account } = useWeb3React()
   const shouldDisplayCakeProfit =
     account && cakeAtLastUserAction && cakeAtLastUserAction.gt(0) && userShares && userShares.gt(0)
 

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -1,23 +1,23 @@
 import React from 'react'
 import { Flex, Text, TooltipText, useTooltip } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useWeb3React } from '@web3-react/core'
 import useWithdrawalFeeTimer from 'hooks/cakeVault/useWithdrawalFeeTimer'
 import WithdrawalFeeTimer from './WithdrawalFeeTimer'
 
 interface UnstakingFeeCountdownRowProps {
-  account?: string
   withdrawalFee: string
   lastDepositedTime: string
   withdrawalFeePeriod?: string
 }
 
 const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
-  account = true,
   withdrawalFee,
   lastDepositedTime,
   withdrawalFeePeriod = '259200',
 }) => {
   const { t } = useTranslation()
+  const { account } = useWeb3React()
   const feeAsDecimal = parseInt(withdrawalFee) / 100 || '-'
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     <>

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
@@ -15,7 +15,6 @@ interface HasStakeActionProps {
   stakingTokenPrice: number
   userInfo: VaultUser
   pricePerFullShare: BigNumber
-  account: string
   vaultFees: VaultFees
   setLastUpdated: () => void
 }
@@ -26,7 +25,6 @@ const HasSharesActions: React.FC<HasStakeActionProps> = ({
   stakingTokenPrice,
   userInfo,
   pricePerFullShare,
-  account,
   vaultFees,
   setLastUpdated,
 }) => {
@@ -41,7 +39,6 @@ const HasSharesActions: React.FC<HasStakeActionProps> = ({
 
   const [onPresentStake] = useModal(
     <VaultStakeModal
-      account={account}
       stakingMax={stakingTokenBalance}
       pool={pool}
       userInfo={userInfo}
@@ -52,7 +49,6 @@ const HasSharesActions: React.FC<HasStakeActionProps> = ({
 
   const [onPresentUnstake] = useModal(
     <VaultStakeModal
-      account={account}
       stakingMax={cakeAsBigNumber}
       pool={pool}
       stakingTokenPrice={stakingTokenPrice}

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultApprovalAction.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultApprovalAction.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Button, AutoRenewIcon, Skeleton } from '@pancakeswap-libs/uikit'
+import { useWeb3React } from '@web3-react/core'
 import { ethers } from 'ethers'
 import { useTranslation } from 'contexts/Localization'
 import { useCake, useCakeVaultContract } from 'hooks/useContract'
@@ -8,12 +9,12 @@ import { Pool } from 'state/types'
 
 interface ApprovalActionProps {
   pool: Pool
-  account: string
   setLastUpdated: () => void
   isLoading?: boolean
 }
 
-const ApprovalAction: React.FC<ApprovalActionProps> = ({ pool, account, isLoading = false, setLastUpdated }) => {
+const ApprovalAction: React.FC<ApprovalActionProps> = ({ pool, isLoading = false, setLastUpdated }) => {
+  const { account } = useWeb3React()
   const { stakingToken } = pool
   const cakeVaultContract = useCakeVaultContract()
   const cakeContract = useCake()

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
@@ -17,7 +17,6 @@ interface VaultStakeActionsProps {
   accountHasSharesStaked: boolean
   pricePerFullShare: BigNumber
   isLoading?: boolean
-  account: string
   vaultFees: VaultFees
   setLastUpdated: () => void
 }
@@ -30,7 +29,6 @@ const VaultStakeActions: React.FC<VaultStakeActionsProps> = ({
   accountHasSharesStaked,
   pricePerFullShare,
   isLoading = false,
-  account,
   vaultFees,
   setLastUpdated,
 }) => {
@@ -39,7 +37,6 @@ const VaultStakeActions: React.FC<VaultStakeActionsProps> = ({
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
   const [onPresentStake] = useModal(
     <VaultStakeModal
-      account={account}
       stakingMax={stakingTokenBalance}
       stakingTokenPrice={stakingTokenPrice}
       userInfo={userInfo}
@@ -56,7 +53,6 @@ const VaultStakeActions: React.FC<VaultStakeActionsProps> = ({
         stakingTokenPrice={stakingTokenPrice}
         userInfo={userInfo}
         pricePerFullShare={pricePerFullShare}
-        account={account}
         setLastUpdated={setLastUpdated}
         vaultFees={vaultFees}
       />

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Flex, Text, Box } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useWeb3React } from '@web3-react/core'
 import { useCake, useCakeVaultContract } from 'hooks/useContract'
 import { VaultFees } from 'hooks/cakeVault/useGetVaultFees'
 import { Pool } from 'state/types'
@@ -20,7 +21,6 @@ const CakeVaultCardActions: React.FC<{
   pricePerFullShare: BigNumber
   stakingTokenPrice: number
   accountHasSharesStaked: boolean
-  account: string
   lastUpdated: number
   vaultFees: VaultFees
   isLoading: boolean
@@ -31,12 +31,12 @@ const CakeVaultCardActions: React.FC<{
   pricePerFullShare,
   stakingTokenPrice,
   accountHasSharesStaked,
-  account,
   lastUpdated,
   vaultFees,
   isLoading,
   setLastUpdated,
 }) => {
+  const { account } = useWeb3React()
   const { stakingToken, userData } = pool
   const [isVaultApproved, setIsVaultApproved] = useState(false)
   const cakeContract = useCake()
@@ -89,11 +89,10 @@ const CakeVaultCardActions: React.FC<{
             userInfo={userInfo}
             pricePerFullShare={pricePerFullShare}
             accountHasSharesStaked={accountHasSharesStaked}
-            account={account}
             setLastUpdated={setLastUpdated}
           />
         ) : (
-          <VaultApprovalAction pool={pool} account={account} isLoading={isLoading} setLastUpdated={setLastUpdated} />
+          <VaultApprovalAction pool={pool} isLoading={isLoading} setLastUpdated={setLastUpdated} />
         )}
       </Flex>
     </Flex>

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Modal, Text, Flex, Image, Button, Slider, BalanceInput, AutoRenewIcon } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useWeb3React } from '@web3-react/core'
 import { BASE_EXCHANGE_URL } from 'config'
 import { useCakeVaultContract } from 'hooks/useContract'
 import useTheme from 'hooks/useTheme'
@@ -19,7 +20,6 @@ interface VaultStakeModalProps {
   pool: Pool
   stakingMax: BigNumber
   stakingTokenPrice: number
-  account: string
   userInfo: VaultUser
   isRemovingStake?: boolean
   pricePerFullShare?: BigNumber
@@ -37,13 +37,13 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
   stakingMax,
   stakingTokenPrice,
   pricePerFullShare,
-  account,
   userInfo,
   isRemovingStake = false,
   vaultFees,
   onDismiss,
   setLastUpdated,
 }) => {
+  const { account } = useWeb3React()
   const { stakingToken } = pool
   const cakeVaultContract = useCakeVaultContract()
   const { t } = useTranslation()

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Box, CardBody, Flex, Text } from '@pancakeswap-libs/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useWeb3React } from '@web3-react/core'
 import UnlockButton from 'components/UnlockButton'
 import { getAddress } from 'utils/addressHelpers'
 import { useGetApiPrice } from 'state/hooks'
@@ -22,8 +23,9 @@ const StyledCardBody = styled(CardBody)<{ isLoading: boolean }>`
   min-height: ${({ isLoading }) => (isLoading ? '0' : '254px')};
 `
 
-const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) => {
+const CakeVaultCard: React.FC<{ pool: Pool }> = ({ pool }) => {
   const { t } = useTranslation()
+  const { account } = useWeb3React()
   const { lastUpdated, setLastUpdated } = useLastUpdated()
   const userInfo = useGetVaultUserInfo(lastUpdated)
   const vaultFees = useGetVaultFees()
@@ -49,7 +51,6 @@ const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, accoun
         />
         <Box mt="24px">
           <RecentCakeProfitRow
-            account={account}
             cakeAtLastUserAction={userInfo.cakeAtLastUserAction}
             userShares={userInfo.shares}
             pricePerFullShare={pricePerFullShare}
@@ -57,7 +58,6 @@ const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, accoun
         </Box>
         <Box mt="8px">
           <UnstakingFeeCountdownRow
-            account={account}
             withdrawalFee={vaultFees.withdrawalFee}
             withdrawalFeePeriod={vaultFees.withdrawalFeePeriod}
             lastDepositedTime={accountHasSharesStaked && userInfo.lastDepositedTime}
@@ -72,7 +72,6 @@ const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, accoun
               vaultFees={vaultFees}
               stakingTokenPrice={stakingTokenPrice}
               accountHasSharesStaked={accountHasSharesStaked}
-              account={account}
               lastUpdated={lastUpdated}
               setLastUpdated={setLastUpdated}
               isLoading={isLoading}

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -68,7 +68,7 @@ const Pools: React.FC = () => {
         <FlexLayout>
           <Route exact path={`${path}`}>
             <>
-              <CakeVaultCard pool={cakePoolData} account={account} />
+              <CakeVaultCard pool={cakePoolData} />
               {stakedOnly
                 ? orderBy(stakedOnlyPools, ['sortOrder']).map((pool) => (
                     <PoolCard key={pool.sousId} pool={pool} account={account} />


### PR DESCRIPTION
- Triggered by fixing the incorrect assigning of an account string's default to `true` - https://github.com/pancakeswap/pancake-frontend/blob/bec23a0b7e9674e015d88ddcbd780d6ca5ac14af/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx#L26
- Initially the cake vault followed the same pattern as the pool cards - use a single function call within `pools/index.tsx` to get `account`, and then pass it down to all components that required it.
- While this may provide a tiny bit of optimisation to the pool cards (where every function that is called, is called 60 times) - it is unnecessary in the vaults and complicates things.