### PR TITLE
feat(apy-calculator): Allow APY calculator to handle performance fee deductions

### DIFF
--- a/src/__tests__/utils/compoundApyHelpers.test.ts
+++ b/src/__tests__/utils/compoundApyHelpers.test.ts
@@ -1,14 +1,16 @@
 import { tokenEarnedPerThousandDollarsCompounding, getRoi } from 'utils/compoundApyHelpers'
 
 it.each([
-  [{ numberOfDays: 1, farmApr: 365, tokenPrice: 1 }, 10],
-  [{ numberOfDays: 7, farmApr: 20, tokenPrice: 0.8 }, 4.8],
-  [{ numberOfDays: 40, farmApr: 212.21, tokenPrice: 1.2 }, 217.48],
-  [{ numberOfDays: 330, farmApr: 45.12, tokenPrice: 5 }, 100.67],
-  [{ numberOfDays: 365, farmApr: 100, tokenPrice: 0.2 }, 8572.84],
-  [{ numberOfDays: 365, farmApr: 20, tokenPrice: 1 }, 221.34],
-])('calculate cake earned with values %o', ({ numberOfDays, farmApr, tokenPrice }, expected) => {
-  expect(tokenEarnedPerThousandDollarsCompounding({ numberOfDays, farmApr, tokenPrice })).toEqual(expected)
+  [{ numberOfDays: 1, farmApr: 365, tokenPrice: 1, performanceFee: 20 }, 8],
+  [{ numberOfDays: 7, farmApr: 20, tokenPrice: 0.8, performanceFee: 1 }, 4.75],
+  [{ numberOfDays: 40, farmApr: 212.21, tokenPrice: 1.2, performanceFee: 2 }, 212.63],
+  [{ numberOfDays: 330, farmApr: 45.12, tokenPrice: 5, performanceFee: 5 }, 94.6],
+  [{ numberOfDays: 365, farmApr: 100, tokenPrice: 0.2, performanceFee: 0 }, 8572.84],
+  [{ numberOfDays: 365, farmApr: 20, tokenPrice: 1, performanceFee: 0 }, 221.34],
+])('calculate cake earned with values %o', ({ numberOfDays, farmApr, tokenPrice, performanceFee }, expected) => {
+  expect(tokenEarnedPerThousandDollarsCompounding({ numberOfDays, farmApr, tokenPrice, performanceFee })).toEqual(
+    expected,
+  )
 })
 
 it.each([

--- a/src/components/ApyCalculatorModal/index.tsx
+++ b/src/components/ApyCalculatorModal/index.tsx
@@ -164,7 +164,10 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
         </Text>
         {performanceFee && (
           <Text mt="14px" fontSize="12px" color="textSubtle">
-            {TranslateString(999, `All rates factor in this pool's ${performanceFee}% performance fee`)}
+            {TranslateString(
+              999,
+              `All estimated rates take into account this pool's ${performanceFee}% performance fee`,
+            )}
           </Text>
         )}
       </Box>

--- a/src/components/ApyCalculatorModal/index.tsx
+++ b/src/components/ApyCalculatorModal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Modal, Text, LinkExternal, Flex } from '@pancakeswap-libs/uikit'
+import { Modal, Text, LinkExternal, Flex, Box } from '@pancakeswap-libs/uikit'
 import useI18n from 'hooks/useI18n'
 import { tokenEarnedPerThousandDollarsCompounding, getRoi } from 'utils/compoundApyHelpers'
 
@@ -13,6 +13,7 @@ interface ApyCalculatorModalProps {
   earningTokenSymbol?: string
   roundingDecimals?: number
   compoundFrequency?: number
+  performanceFee?: number
 }
 
 const Grid = styled.div`
@@ -26,11 +27,6 @@ const GridItem = styled.div`
   margin-bottom: '10px';
 `
 
-const Description = styled(Text)`
-  max-width: 320px;
-  margin-bottom: 28px;
-`
-
 const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
   onDismiss,
   tokenPrice,
@@ -40,6 +36,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
   earningTokenSymbol = 'CAKE',
   roundingDecimals = 2,
   compoundFrequency = 1,
+  performanceFee = 0,
 }) => {
   const TranslateString = useI18n()
   const oneThousandDollarsWorthOfToken = 1000 / tokenPrice
@@ -50,6 +47,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
     tokenPrice,
     roundingDecimals,
     compoundFrequency,
+    performanceFee,
   })
   const tokenEarnedPerThousand7D = tokenEarnedPerThousandDollarsCompounding({
     numberOfDays: 7,
@@ -57,6 +55,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
     tokenPrice,
     roundingDecimals,
     compoundFrequency,
+    performanceFee,
   })
   const tokenEarnedPerThousand30D = tokenEarnedPerThousandDollarsCompounding({
     numberOfDays: 30,
@@ -64,6 +63,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
     tokenPrice,
     roundingDecimals,
     compoundFrequency,
+    performanceFee,
   })
   const tokenEarnedPerThousand365D = tokenEarnedPerThousandDollarsCompounding({
     numberOfDays: 365,
@@ -71,6 +71,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
     tokenPrice,
     roundingDecimals,
     compoundFrequency,
+    performanceFee,
   })
 
   return (
@@ -154,12 +155,19 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
           <Text>{tokenEarnedPerThousand365D}</Text>
         </GridItem>
       </Grid>
-      <Description fontSize="12px" color="textSubtle">
-        {TranslateString(
-          999,
-          `Calculated based on current rates. Compounding ${compoundFrequency.toLocaleString()}x daily. Rates are estimates provided for your convenience only, and by no means represent guaranteed returns.`,
+      <Box mb="28px" maxWidth="280px">
+        <Text fontSize="12px" color="textSubtle">
+          {TranslateString(
+            999,
+            `Calculated based on current rates. Compounding ${compoundFrequency.toLocaleString()}x daily. Rates are estimates provided for your convenience only, and by no means represent guaranteed returns.`,
+          )}
+        </Text>
+        {performanceFee && (
+          <Text mt="14px" fontSize="12px" color="textSubtle">
+            {TranslateString(999, `All rates factor in this pool's ${performanceFee}% performance fee`)}
+          </Text>
         )}
-      </Description>
+      </Box>
       <Flex justifyContent="center">
         <LinkExternal href={linkHref}>{linkLabel}</LinkExternal>
       </Flex>

--- a/src/utils/compoundApyHelpers.ts
+++ b/src/utils/compoundApyHelpers.ts
@@ -4,11 +4,20 @@ export const tokenEarnedPerThousandDollarsCompounding = ({
   tokenPrice,
   roundingDecimals = 2,
   compoundFrequency = 1,
+  performanceFee = 0,
 }) => {
   // Everything here is worked out relative to a year, with the asset compounding at the compoundFrequency rate. 1 = once per day
   const timesCompounded = 365 * compoundFrequency
   // We use decimal values rather than % in the math for both APY and the number of days being calculates as a proportion of the year
-  const aprAsDecimal = farmApr / 100
+  let aprAsDecimal = farmApr / 100
+
+  if (performanceFee) {
+    // Reduce the APR by the % performance fee
+    const feeRelativeToApr = (farmApr / 100) * performanceFee
+    const aprAfterFee = farmApr - feeRelativeToApr
+    aprAsDecimal = aprAfterFee / 100
+  }
+
   const daysAsDecimalOfYear = numberOfDays / 365
   // Calculate the starting TOKEN balance with a dollar balance of $1000.
   const principal = 1000 / tokenPrice

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -34,6 +34,7 @@ const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, accoun
   const accountHasSharesStaked = userInfo.shares && userInfo.shares.gt(0)
   const stakingTokenPrice = useGetApiPrice(stakingToken.address ? getAddress(stakingToken.address) : '')
   const isLoading = !pool.userData || !userInfo.shares
+  const performanceFeeAsDecimal = vaultFees.performanceFee && parseInt(vaultFees.performanceFee, 10) / 100
 
   return (
     <StyledCard isStaking={accountHasSharesStaked}>
@@ -44,6 +45,7 @@ const CakeVaultCard: React.FC<{ pool: Pool; account: string }> = ({ pool, accoun
           stakingTokenPrice={stakingTokenPrice}
           isAutoVault
           compoundFrequency={timesCompoundedDaily}
+          performanceFee={performanceFeeAsDecimal}
         />
         <Box mt="24px">
           <RecentCakeProfitRow

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -16,9 +16,16 @@ interface AprRowProps {
   stakingTokenPrice: number
   isAutoVault?: boolean
   compoundFrequency?: number
+  performanceFee?: number
 }
 
-const AprRow: React.FC<AprRowProps> = ({ pool, stakingTokenPrice, isAutoVault = false, compoundFrequency = 1 }) => {
+const AprRow: React.FC<AprRowProps> = ({
+  pool,
+  stakingTokenPrice,
+  isAutoVault = false,
+  compoundFrequency = 1,
+  performanceFee = 0,
+}) => {
   const TranslateString = useI18n()
   const { stakingToken, earningToken, totalStaked, isFinished, tokenPerBlock } = pool
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
@@ -50,6 +57,7 @@ const AprRow: React.FC<AprRowProps> = ({ pool, stakingTokenPrice, isAutoVault = 
         tokenPrice: earningTokenPrice,
         roundingDecimals,
         compoundFrequency,
+        performanceFee,
       })
       return getRoi({
         amountEarned: tokenEarnedPerThousand365D,
@@ -72,6 +80,7 @@ const AprRow: React.FC<AprRowProps> = ({ pool, stakingTokenPrice, isAutoVault = 
       earningTokenSymbol={earningToken.symbol}
       roundingDecimals={isHighValueToken ? 4 : 2}
       compoundFrequency={compoundFrequency}
+      performanceFee={performanceFee}
     />,
   )
 


### PR DESCRIPTION
- Add APR 'fee' logic to our APY helper
- Slight UI changes, adding an explainer when a performance fee _is_ modifying the APY/APR calc
- Update tests

<img width="361" alt="Screenshot 2021-04-30 at 14 45 51" src="https://user-images.githubusercontent.com/79279477/116703993-cf346880-a9c2-11eb-84df-513914ec6409.png">