### PR TITLE
refactor: Interopolate even when missing key

### DIFF
--- a/src/contexts/Localization/Provider.tsx
+++ b/src/contexts/Localization/Provider.tsx
@@ -78,12 +78,7 @@ export const LanguageProvider: React.FC = ({ children }) => {
       const translationSet = languageMap.has(currentLanguage.code)
         ? languageMap.get(currentLanguage.code)
         : languageMap.get(EN.code)
-      const translatedText = translationSet[key]
-
-      if (!translatedText) {
-        return key
-      }
-
+      const translatedText = translationSet[key] || key
       const includesVariable = translatedText.includes('%')
 
       if (includesVariable) {


### PR DESCRIPTION
Before if the key was not in the translation file it would return the key without interpolation. Now it still interpolates the key even if it is not found.
