### PR TITLE
chore: Rename unstaking fee related variables

### DIFF
--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -2,20 +2,20 @@ import { useEffect, useState } from 'react'
 
 const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 259200) => {
   const [secondsRemaining, setSecondsRemaining] = useState(null)
-  const [hasPerformanceFee, setHasPerformanceFee] = useState(false)
+  const [hasUnstakingFee, setHasUnstakingFee] = useState(false)
 
   useEffect(() => {
     const threeDaysFromDeposit = lastDepositedTime + withdrawalFeePeriod
     const now = Math.floor(Date.now() / 1000)
     const secondsRemainingCalc = threeDaysFromDeposit - now
-    const doesPerformanceFeeApply = secondsRemainingCalc > 0
-    if (doesPerformanceFeeApply) {
+    const doesUnstakingFeeApply = secondsRemainingCalc > 0
+    if (doesUnstakingFeeApply) {
       setSecondsRemaining(secondsRemainingCalc)
-      setHasPerformanceFee(true)
+      setHasUnstakingFee(true)
     }
   }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining])
 
-  return { hasPerformanceFee, secondsRemaining }
+  return { hasUnstakingFee, secondsRemaining }
 }
 
 export default useWithdrawalFeeTimer

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -33,12 +33,12 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
     { placement: 'bottom-start' },
   )
 
-  const { secondsRemaining, hasPerformanceFee } = useWithdrawalFeeTimer(
+  const { secondsRemaining, hasUnstakingFee } = useWithdrawalFeeTimer(
     parseInt(lastDepositedTime, 10),
     parseInt(withdrawalFeePeriod, 10),
   )
 
-  const shouldShowTimer = account && lastDepositedTime && hasPerformanceFee
+  const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
 
   return (
     <Flex alignItems="center" justifyContent="space-between">

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -52,7 +52,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
   const [pendingTx, setPendingTx] = useState(false)
   const [stakeAmount, setStakeAmount] = useState('')
   const [percent, setPercent] = useState(0)
-  const { hasPerformanceFee } = useWithdrawalFeeTimer(parseInt(userInfo.lastDepositedTime))
+  const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(userInfo.lastDepositedTime))
   const usdValueStaked = stakeAmount && formatNumber(new BigNumber(stakeAmount).times(stakingTokenPrice).toNumber())
 
   const handleStakeInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -202,7 +202,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
           MAX
         </StyledButton>
       </Flex>
-      {isRemovingStake && hasPerformanceFee && (
+      {isRemovingStake && hasUnstakingFee && (
         <FeeSummary
           stakingTokenSymbol={stakingToken.symbol}
           lastDepositedTime={userInfo.lastDepositedTime}


### PR DESCRIPTION
unstakingFee was mistakenly called performanceFee in some places.