### PR TITLE
fix: Unapproved pool does not show enable button

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/index.tsx
@@ -17,16 +17,10 @@ const InlineText = styled(Text)`
 interface CardActionsProps {
   pool: Pool
   stakedBalance: BigNumber
-  accountHasStakedBalance: boolean
   stakingTokenPrice: number
 }
 
-const CardActions: React.FC<CardActionsProps> = ({
-  pool,
-  stakedBalance,
-  accountHasStakedBalance,
-  stakingTokenPrice,
-}) => {
+const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance, stakingTokenPrice }) => {
   const { sousId, stakingToken, earningToken, harvest, poolCategory, userData } = pool
   // Pools using native BNB behave differently than pools using a token
   const isBnbPool = poolCategory === PoolCategory.BINANCE
@@ -34,7 +28,7 @@ const CardActions: React.FC<CardActionsProps> = ({
   const allowance = userData?.allowance ? new BigNumber(userData.allowance) : BIG_ZERO
   const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO
   const earnings = userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO
-  const needsApproval = !accountHasStakedBalance && !allowance.gt(0) && !isBnbPool
+  const needsApproval = !allowance.gt(0) && !isBnbPool
   const isStaked = stakedBalance.gt(0)
   const isLoading = !userData
 

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -35,12 +35,7 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
         <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />
         <Flex mt="24px" flexDirection="column">
           {account ? (
-            <CardActions
-              pool={pool}
-              stakedBalance={stakedBalance}
-              stakingTokenPrice={stakingTokenPrice}
-              accountHasStakedBalance={accountHasStakedBalance}
-            />
+            <CardActions pool={pool} stakedBalance={stakedBalance} stakingTokenPrice={stakingTokenPrice} />
           ) : (
             <>
               <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>


### PR DESCRIPTION
If user unapproved a pool (e.g. using https://app.unrekt.info/) the pool will not show Enable button (and you'll get failed transaction if you'd try to stake more CAKE). The check for staked balance seems to be not needed at all here.