### PR TITLE
fix(fee-countdown-row): Conditional for handling fee row if a user's fee time has expired

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -39,16 +39,22 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
   )
 
   const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
+  // Hide the fee countdown row if a user has made a deposit, but has no fee
+  const hideFeeRow = lastDepositedTime && !hasUnstakingFee
 
   return (
-    <Flex alignItems="center" justifyContent="space-between">
-      {tooltipVisible && tooltip}
-      <TooltipText ref={targetRef} small>
-        {parseInt(withdrawalFee) / 100 || '-'}%{' '}
-        {shouldShowTimer ? t('unstaking fee until') : t('unstaking fee if withdrawn within 72h')}
-      </TooltipText>
-      {shouldShowTimer && <WithdrawalFeeTimer secondsRemaining={secondsRemaining} />}
-    </Flex>
+    <>
+      {hideFeeRow ? null : (
+        <Flex alignItems="center" justifyContent="space-between">
+          {tooltipVisible && tooltip}
+          <TooltipText ref={targetRef} small>
+            {parseInt(withdrawalFee) / 100 || '-'}%{' '}
+            {shouldShowTimer ? t('unstaking fee until') : t('unstaking fee if withdrawn within 72h')}
+          </TooltipText>
+          {shouldShowTimer && <WithdrawalFeeTimer secondsRemaining={secondsRemaining} />}
+        </Flex>
+      )}
+    </>
   )
 }
 

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -38,9 +38,11 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
     parseInt(withdrawalFeePeriod, 10),
   )
 
-  const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
   // Hide the fee countdown row if a user has made a deposit, but has no fee
   const hideFeeRow = lastDepositedTime && !hasUnstakingFee
+
+  // Show the timer if a user is connected, has deposited, and has an unstaking fee
+  const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
 
   return (
     <>

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -39,13 +39,13 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
   )
 
   // The user has made a deposit, but has no fee
-  const feeTimeExpired = lastDepositedTime && !hasUnstakingFee
+  const noFeeToPay = lastDepositedTime && !hasUnstakingFee
 
   // Show the timer if a user is connected, has deposited, and has an unstaking fee
   const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
 
   const getRowText = () => {
-    if (feeTimeExpired) {
+    if (noFeeToPay) {
       return t('unstaking fee')
     }
     if (shouldShowTimer) {
@@ -58,7 +58,7 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
     <Flex alignItems="center" justifyContent="space-between">
       {tooltipVisible && tooltip}
       <TooltipText ref={targetRef} small>
-        {feeTimeExpired ? '0' : feeAsDecimal}% {getRowText()}
+        {noFeeToPay ? '0' : feeAsDecimal}% {getRowText()}
       </TooltipText>
       {shouldShowTimer && <WithdrawalFeeTimer secondsRemaining={secondsRemaining} />}
     </Flex>

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -38,25 +38,30 @@ const UnstakingFeeCountdownRow: React.FC<UnstakingFeeCountdownRowProps> = ({
     parseInt(withdrawalFeePeriod, 10),
   )
 
-  // Hide the fee countdown row if a user has made a deposit, but has no fee
-  const hideFeeRow = lastDepositedTime && !hasUnstakingFee
+  // The user has made a deposit, but has no fee
+  const feeTimeExpired = lastDepositedTime && !hasUnstakingFee
 
   // Show the timer if a user is connected, has deposited, and has an unstaking fee
   const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee
 
+  const getRowText = () => {
+    if (feeTimeExpired) {
+      return t('unstaking fee')
+    }
+    if (shouldShowTimer) {
+      return t('unstaking fee until')
+    }
+    return t('unstaking fee if withdrawn within 72h')
+  }
+
   return (
-    <>
-      {hideFeeRow ? null : (
-        <Flex alignItems="center" justifyContent="space-between">
-          {tooltipVisible && tooltip}
-          <TooltipText ref={targetRef} small>
-            {parseInt(withdrawalFee) / 100 || '-'}%{' '}
-            {shouldShowTimer ? t('unstaking fee until') : t('unstaking fee if withdrawn within 72h')}
-          </TooltipText>
-          {shouldShowTimer && <WithdrawalFeeTimer secondsRemaining={secondsRemaining} />}
-        </Flex>
-      )}
-    </>
+    <Flex alignItems="center" justifyContent="space-between">
+      {tooltipVisible && tooltip}
+      <TooltipText ref={targetRef} small>
+        {feeTimeExpired ? '0' : feeAsDecimal}% {getRowText()}
+      </TooltipText>
+      {shouldShowTimer && <WithdrawalFeeTimer secondsRemaining={secondsRemaining} />}
+    </Flex>
   )
 }
 


### PR DESCRIPTION
Condition for when a user has deposited to the vault but no longer has a withdrawal fee (i.e. 72 hrs has passed since depositing).

- If a user has made a deposit to the CAKE vault (`lastDepositedTime` is true), but doesn't have a fee to pay (`hasUnstakingFee` is false): then show a 0% staking fee
- The impacts both the card, and the withdrawal modal

Staked, no fee
<img width="344" alt="Screenshot 2021-05-04 at 15 05 12" src="https://user-images.githubusercontent.com/79279477/117015991-28b1d580-acea-11eb-93e0-f059dd9d035c.png">


Staked, has fee
<img width="336" alt="Screenshot 2021-05-04 at 13 44 32" src="https://user-images.githubusercontent.com/79279477/117005341-09617b00-acdf-11eb-8822-bc146c124c8d.png">

Not staked
<img width="346" alt="Screenshot 2021-05-04 at 13 45 25" src="https://user-images.githubusercontent.com/79279477/117005369-141c1000-acdf-11eb-824f-252e0daec326.png">
