### PR TITLE
refactor: (earn asset card) Move asset list to constant since pools configuration is constant

### DIFF
--- a/src/views/Home/components/EarnAssetCard.tsx
+++ b/src/views/Home/components/EarnAssetCard.tsx
@@ -19,12 +19,13 @@ const StyledFarmStakingCard = styled(Card)`
 const CardMidContent = styled(Heading).attrs({ size: 'xl' })`
   line-height: 44px;
 `
-const EarnAssetCard = () => {
-  const activeNonCakePools = pools.filter((pool) => !pool.isFinished && !pool.earningToken.symbol.includes('CAKE'))
-  const latestPools: Pool[] = orderBy(activeNonCakePools, ['sortOrder', 'pid'], ['desc', 'desc']).slice(0, 3)
-  // Always include CAKE
-  const assets = ['CAKE', ...latestPools.map((pool) => pool.earningToken.symbol)].join(', ')
 
+const activeNonCakePools = pools.filter((pool) => !pool.isFinished && !pool.earningToken.symbol.includes('CAKE'))
+const latestPools: Pool[] = orderBy(activeNonCakePools, ['sortOrder', 'pid'], ['desc', 'desc']).slice(0, 3)
+// Always include CAKE
+const assets = ['CAKE', ...latestPools.map((pool) => pool.earningToken.symbol)].join(', ')
+
+const EarnAssetCard = () => {
   return (
     <StyledFarmStakingCard>
       <CardBody>


### PR DESCRIPTION
No need to do the computation on every render