### PR TITLE
refactor(predictions): Remove payout row from expired cards

### DIFF
--- a/src/views/Predictions/components/History/BetDetails.tsx
+++ b/src/views/Predictions/components/History/BetDetails.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components'
 import { Bet } from 'state/types'
 import { useTranslation } from 'contexts/Localization'
 import { Flex, Text, Link, Heading } from '@pancakeswap-libs/uikit'
-import { RoundResult } from '../RoundResult'
+import { getMultiplier } from '../../helpers'
+import { PayoutRow, RoundResult } from '../RoundResult'
 import BetResult, { Result } from './BetResult'
 
 interface BetDetailsProps {
@@ -19,6 +20,9 @@ const StyledBetDetails = styled.div`
 
 const BetDetails: React.FC<BetDetailsProps> = ({ bet, result }) => {
   const { t } = useTranslation()
+  const { totalAmount, bullAmount, bearAmount } = bet.round
+  const bullMultiplier = getMultiplier(totalAmount, bullAmount)
+  const bearMultiplier = getMultiplier(totalAmount, bearAmount)
 
   return (
     <StyledBetDetails>
@@ -31,7 +35,10 @@ const BetDetails: React.FC<BetDetailsProps> = ({ bet, result }) => {
       )}
       {result !== Result.LIVE && <BetResult bet={bet} result={result} />}
       <Heading mb="8px">{t('Round History')}</Heading>
-      <RoundResult round={bet.round} mb="24px" />
+      <RoundResult round={bet.round} mb="24px">
+        <PayoutRow positionLabel={t('Up')} multiplier={bullMultiplier} amount={bullAmount} />
+        <PayoutRow positionLabel={t('Down')} multiplier={bearMultiplier} amount={bearAmount} />
+      </RoundResult>
       <Flex alignItems="center" justifyContent="space-between" mb="8px">
         <Text>{t('Opening Block')}</Text>
         <Link href={`https://bscscan.com/block/${bet.round.lockBlock}`} external>

--- a/src/views/Predictions/components/RoundResult/RoundResult.tsx
+++ b/src/views/Predictions/components/RoundResult/RoundResult.tsx
@@ -2,22 +2,20 @@ import React from 'react'
 import { BoxProps, Flex, Text } from '@pancakeswap-libs/uikit'
 import { BetPosition, Round } from 'state/types'
 import { useTranslation } from 'contexts/Localization'
-import { formatUsd, getMultiplier } from '../../helpers'
+import { formatUsd } from '../../helpers'
 import PositionTag from '../PositionTag'
-import { LockPriceRow, PayoutRow, PrizePoolRow, RoundResultBox } from './styles'
+import { LockPriceRow, PrizePoolRow, RoundResultBox } from './styles'
 
 interface RoundResultProps extends BoxProps {
   round: Round
 }
 
-const RoundResult: React.FC<RoundResultProps> = ({ round, ...props }) => {
-  const { lockPrice, closePrice, totalAmount, bullAmount, bearAmount } = round
+const RoundResult: React.FC<RoundResultProps> = ({ round, children, ...props }) => {
+  const { lockPrice, closePrice, totalAmount } = round
   const betPosition = closePrice > lockPrice ? BetPosition.BULL : BetPosition.BEAR
   const isPositionUp = betPosition === BetPosition.BULL
   const { t } = useTranslation()
   const priceDifference = closePrice - lockPrice
-  const bullMultiplier = getMultiplier(totalAmount, bullAmount)
-  const bearMultiplier = getMultiplier(totalAmount, bearAmount)
 
   return (
     <RoundResultBox betPosition={betPosition} {...props}>
@@ -38,8 +36,7 @@ const RoundResult: React.FC<RoundResultProps> = ({ round, ...props }) => {
       )}
       {lockPrice && <LockPriceRow lockPrice={lockPrice} />}
       <PrizePoolRow totalAmount={totalAmount} />
-      <PayoutRow positionLabel={t('Up')} multiplier={bullMultiplier} amount={round.bullAmount} />
-      <PayoutRow positionLabel={t('Down')} multiplier={bearMultiplier} amount={round.bearAmount} />
+      {children}
     </RoundResultBox>
   )
 }


### PR DESCRIPTION
Removes the payout rows from the expired round card and only show them in the history.
