### PR TITLE
fix(cake-vault-withdrawal): Increase withdrawAll threshold - make it trigger more easily

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -74,8 +74,8 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
   const handleWithdrawal = async (convertedStakeAmount: BigNumber) => {
     setPendingTx(true)
     const shareStakeToWithdraw = convertCakeToShares(convertedStakeAmount, pricePerFullShare)
-    // trigger withdrawAll function if the withdrawal will leave 0.000000000000200000 CAKE or less
-    const triggerWithdrawAllThreshold = new BigNumber(200000)
+    // trigger withdrawAll function if the withdrawal will leave 0.000001 CAKE or less
+    const triggerWithdrawAllThreshold = new BigNumber(1000000000000)
     const sharesRemaining = userInfo.shares.minus(shareStakeToWithdraw.sharesAsBigNumber)
     const isWithdrawingAll = sharesRemaining.lte(triggerWithdrawAllThreshold)
 


### PR DESCRIPTION
I recently tested a 100% withdrawal transaction, and it didn't call the `withdrawAll` contract call, leaving some dust in the vault

<img width="387" alt="Screenshot 2021-05-06 at 14 19 40" src="https://user-images.githubusercontent.com/79279477/117308517-832d6c00-ae79-11eb-9b3d-8637e4e8a6e3.png">

Transaction confirms `withdraw` was called, not `withdrawAll` https://bscscan.com/tx/0x2d74d9d962c6264a9fb560abe94bdc4bec410fa32473cd9a97dd276f59204a0f

This PR modifies the threshold at which a `withdrawAll` call will be triggered:

From
> withdrawAll if `0.0000000000002` or fewer CAKE would remain in the vault

to
> withdrawAll if `0.000001` or fewer CAKE would remain in the vault