### PR TITLE
fix: Collect winnings button pops up again after successful claim

### DIFF
--- a/src/views/Predictions/components/RoundCard/CollectWinningsOverlay.tsx
+++ b/src/views/Predictions/components/RoundCard/CollectWinningsOverlay.tsx
@@ -50,32 +50,38 @@ const CollectWinningsOverlay: React.FC<CollectWinningsOverlayProps> = ({
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const currentEpoch = useGetCurrentEpoch()
-  const [claimedLocal, setClaimedLocal] = useState(false)
 
   // Check if the wallet can collect the bet
   // We do it here because it is not guaranteed the bet info will be in the history
   useEffect(() => {
+    let isCancelled = false
+
     const fetchBet = async () => {
       const bets = await getBetHistory({ user: account.toLowerCase(), round: roundId, claimed: false })
+      if (!isCancelled) {
+        if (bets.length === 1) {
+          const [firstBetResponse] = bets
+          const bet = transformBetResponse(firstBetResponse)
 
-      if (bets.length === 1) {
-        const [firstBetResponse] = bets
-        const bet = transformBetResponse(firstBetResponse)
-
-        if (bet.position === bet.round.position) {
-          setState({
-            betId: bet.id,
-            epoch: bet.round.epoch,
-            payout: getPayout(bet),
-          })
+          if (bet.position === bet.round.position) {
+            setState({
+              betId: bet.id,
+              epoch: bet.round.epoch,
+              payout: getPayout(bet),
+            })
+          }
         }
       }
     }
 
-    if (account && hasEntered && !claimedLocal) {
+    if (account && hasEntered) {
       fetchBet()
     }
-  }, [account, roundId, hasEntered, currentEpoch, setState, claimedLocal])
+
+    return () => {
+      isCancelled = true
+    }
+  }, [account, roundId, hasEntered, currentEpoch, setState])
 
   if (!state.epoch) {
     return null
@@ -84,7 +90,6 @@ const CollectWinningsOverlay: React.FC<CollectWinningsOverlayProps> = ({
   const handleSuccess = async () => {
     dispatch(markBetAsCollected({ betId: state.betId, account }))
     setState({ betId: null, epoch: null, payout: 0 })
-    setClaimedLocal(true)
   }
 
   return (

--- a/src/views/Predictions/components/RoundCard/CollectWinningsOverlay.tsx
+++ b/src/views/Predictions/components/RoundCard/CollectWinningsOverlay.tsx
@@ -50,6 +50,7 @@ const CollectWinningsOverlay: React.FC<CollectWinningsOverlayProps> = ({
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const currentEpoch = useGetCurrentEpoch()
+  const [collectedSuccess, setCollectedSuccess] = useState(false)
 
   // Check if the wallet can collect the bet
   // We do it here because it is not guaranteed the bet info will be in the history
@@ -58,30 +59,28 @@ const CollectWinningsOverlay: React.FC<CollectWinningsOverlayProps> = ({
 
     const fetchBet = async () => {
       const bets = await getBetHistory({ user: account.toLowerCase(), round: roundId, claimed: false })
-      if (!isCancelled) {
-        if (bets.length === 1) {
-          const [firstBetResponse] = bets
-          const bet = transformBetResponse(firstBetResponse)
+      if (!isCancelled && bets.length === 1) {
+        const [firstBetResponse] = bets
+        const bet = transformBetResponse(firstBetResponse)
 
-          if (bet.position === bet.round.position) {
-            setState({
-              betId: bet.id,
-              epoch: bet.round.epoch,
-              payout: getPayout(bet),
-            })
-          }
+        if (bet.position === bet.round.position) {
+          setState({
+            betId: bet.id,
+            epoch: bet.round.epoch,
+            payout: getPayout(bet),
+          })
         }
       }
     }
 
-    if (account && hasEntered) {
+    if (account && hasEntered && !collectedSuccess) {
       fetchBet()
     }
 
     return () => {
       isCancelled = true
     }
-  }, [account, roundId, hasEntered, currentEpoch, setState])
+  }, [account, roundId, hasEntered, currentEpoch, setState, collectedSuccess])
 
   if (!state.epoch) {
     return null
@@ -90,6 +89,7 @@ const CollectWinningsOverlay: React.FC<CollectWinningsOverlayProps> = ({
   const handleSuccess = async () => {
     dispatch(markBetAsCollected({ betId: state.betId, account }))
     setState({ betId: null, epoch: null, payout: 0 })
+    setCollectedSuccess(true)
   }
 
   return (


### PR DESCRIPTION
Fixes #1094 

@hachiojidev I think I found the root cause of that issue. I tested it by mocking response of that request with big response times, and I was able reproduce it. As you can see the response times of that graph api requests (huge response times)

<img width="1637" alt="Screenshot 2021-05-06 at 16 36 04" src="https://user-images.githubusercontent.com/2213635/117323107-e5dd3280-ae8e-11eb-997c-fc5d9a9d5c1c.png">

We have to clean the stop the async response processing when useEffect function is cleaned up (in our case it happens after claiming the winnings and before re-rendering)

I keep the local collect state (just changed the name) to stop making further requests after successful collection

