### PR TITLE
feat(withdrawal-fee-timer): Make vault timer update per second that passes

### DIFF
--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -6,14 +6,6 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 
   const [currentSeconds, setCurrentSeconds] = useState(Math.floor(Date.now() / 1000))
 
   useEffect(() => {
-    const tick = () => {
-      setCurrentSeconds((prevSeconds) => prevSeconds + 1)
-    }
-    const timerInterval = setInterval(() => tick(), 1000)
-    return () => clearInterval(timerInterval)
-  }, [])
-
-  useEffect(() => {
     const feeEndTime = lastDepositedTime + withdrawalFeePeriod
     const secondsRemainingCalc = feeEndTime - currentSeconds
     const doesUnstakingFeeApply = secondsRemainingCalc > 0
@@ -21,6 +13,11 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 
       setSecondsRemaining(secondsRemainingCalc)
       setHasUnstakingFee(true)
     }
+    const tick = () => {
+      setCurrentSeconds((prevSeconds) => prevSeconds + 1)
+    }
+    const timerInterval = setInterval(() => tick(), 1000)
+    return () => clearInterval(timerInterval)
   }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining, currentSeconds])
 
   return { hasUnstakingFee, secondsRemaining }

--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -3,17 +3,25 @@ import { useEffect, useState } from 'react'
 const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 259200) => {
   const [secondsRemaining, setSecondsRemaining] = useState(null)
   const [hasUnstakingFee, setHasUnstakingFee] = useState(false)
+  const [currentSeconds, setCurrentSeconds] = useState(Math.floor(Date.now() / 1000))
 
   useEffect(() => {
-    const threeDaysFromDeposit = lastDepositedTime + withdrawalFeePeriod
-    const now = Math.floor(Date.now() / 1000)
-    const secondsRemainingCalc = threeDaysFromDeposit - now
+    const tick = () => {
+      setCurrentSeconds((prevSeconds) => prevSeconds + 1)
+    }
+    const timerInterval = setInterval(() => tick(), 1000)
+    return () => clearInterval(timerInterval)
+  }, [])
+
+  useEffect(() => {
+    const feeEndTime = lastDepositedTime + withdrawalFeePeriod
+    const secondsRemainingCalc = feeEndTime - currentSeconds
     const doesUnstakingFeeApply = secondsRemainingCalc > 0
     if (doesUnstakingFeeApply) {
       setSecondsRemaining(secondsRemainingCalc)
       setHasUnstakingFee(true)
     }
-  }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining])
+  }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining, currentSeconds])
 
   return { hasUnstakingFee, secondsRemaining }
 }


### PR DESCRIPTION
Previously, the Vault withdrawal fee timer would fetch the seconds remaining once on component mount, now it sets an interval that updates the `currentSeconds` value every 1000ms, meaning the timer will count down as the user sits on the page.

<img width="350" alt="Screenshot 2021-05-07 at 13 27 38" src="https://user-images.githubusercontent.com/79279477/117449524-03b2a200-af38-11eb-98f6-4f001d55e41d.png">