### PR TITLE
fix: Update balance in set position card after claim

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -102,7 +102,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
     if (account) {
       fetchBalance()
     }
-  }, [account, fastRefresh, setBnbBalance, web3.eth])
+  }, [account, fastRefresh, setBnbBalance, web3])
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (evt) => {
     const newValue = evt.target.value


### PR DESCRIPTION
Fixes #1154 

Could be an another top up that's why we should refresh the balance continuously regardless of claim happened or not.