### PR TITLE
fix: specific section is not displayed in Prediction page

### DIFF
--- a/src/views/Predictions/index.tsx
+++ b/src/views/Predictions/index.tsx
@@ -27,14 +27,14 @@ import ChartDisclaimer from './components/ChartDisclaimer'
 const FUTURE_ROUND_COUNT = 2 // the number of rounds in the future to show
 
 const Predictions = () => {
-  const { isLg, isXl } = useMatchBreakpoints()
+  const { isMd, isLg, isXl } = useMatchBreakpoints()
   const [hasAcceptedRisk, setHasAcceptedRisk] = usePersistState(false, 'pancake_predictions_accepted_risk')
   const [hasAcceptedChart, setHasAcceptedChart] = usePersistState(false, 'pancake_predictions_chart')
   const status = useGetPredictionsStatus()
   const isChartPaneOpen = useIsChartPaneOpen()
   const dispatch = useAppDispatch()
   const initialBlock = useInitialBlock()
-  const isDesktop = isLg || isXl
+  const isDesktop = (isMd && isLg) || isXl
   const handleAcceptRiskSuccess = () => setHasAcceptedRisk(true)
   const handleAcceptChart = () => setHasAcceptedChart(true)
   const [onPresentRiskDisclaimer] = useModal(<RiskDisclaimer onSuccess={handleAcceptRiskSuccess} />, false)


### PR DESCRIPTION
The screen is not displayed when the width is 853 to 967.

![issue](https://user-images.githubusercontent.com/49149450/117498190-71041880-afb4-11eb-9f4b-ceb006d60441.png)