### PR TITLE
fix: specific section is not displayed in Prediction page

### DIFF
--- a/src/views/Predictions/Mobile.tsx
+++ b/src/views/Predictions/Mobile.tsx
@@ -21,7 +21,7 @@ const StyledMobile = styled.div`
   height: 100%;
   max-height: 100%;
 
-  ${({ theme }) => theme.mediaQueries.lg} {
+  ${({ theme }) => theme.mediaQueries.xl} {
     display: none;
   }
 `

--- a/src/views/Predictions/index.tsx
+++ b/src/views/Predictions/index.tsx
@@ -34,7 +34,7 @@ const Predictions = () => {
   const isChartPaneOpen = useIsChartPaneOpen()
   const dispatch = useAppDispatch()
   const initialBlock = useInitialBlock()
-  const isDesktop = isXl || false
+  const isDesktop = isXl
   const handleAcceptRiskSuccess = () => setHasAcceptedRisk(true)
   const handleAcceptChart = () => setHasAcceptedChart(true)
   const [onPresentRiskDisclaimer] = useModal(<RiskDisclaimer onSuccess={handleAcceptRiskSuccess} />, false)

--- a/src/views/Predictions/index.tsx
+++ b/src/views/Predictions/index.tsx
@@ -27,14 +27,14 @@ import ChartDisclaimer from './components/ChartDisclaimer'
 const FUTURE_ROUND_COUNT = 2 // the number of rounds in the future to show
 
 const Predictions = () => {
-  const { isLg, isXl } = useMatchBreakpoints()
+  const { isXl } = useMatchBreakpoints()
   const [hasAcceptedRisk, setHasAcceptedRisk] = usePersistState(false, 'pancake_predictions_accepted_risk')
   const [hasAcceptedChart, setHasAcceptedChart] = usePersistState(false, 'pancake_predictions_chart')
   const status = useGetPredictionsStatus()
   const isChartPaneOpen = useIsChartPaneOpen()
   const dispatch = useAppDispatch()
   const initialBlock = useInitialBlock()
-  const isDesktop = isLg || isXl
+  const isDesktop = isXl || false
   const handleAcceptRiskSuccess = () => setHasAcceptedRisk(true)
   const handleAcceptChart = () => setHasAcceptedChart(true)
   const [onPresentRiskDisclaimer] = useModal(<RiskDisclaimer onSuccess={handleAcceptRiskSuccess} />, false)


### PR DESCRIPTION
The screen is not displayed when the width is 853 to 967.

![issue](https://user-images.githubusercontent.com/49149450/117582796-b9e7d880-b13e-11eb-934d-691f35da5027.png)
