### PR TITLE
fix(pool-card-stake-actions): Use correct token for decimalisation in stakedTokenBalance

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
@@ -37,7 +37,7 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   const convertedLimit = getDecimalAmount(new BigNumber(stakingLimit), earningToken.decimals)
   const stakingMax =
     stakingLimit && stakingTokenBalance.isGreaterThan(convertedLimit) ? convertedLimit : stakingTokenBalance
-  const stakedTokenBalance = getBalanceNumber(stakedBalance, earningToken.decimals)
+  const stakedTokenBalance = getBalanceNumber(stakedBalance, stakingToken.decimals)
   const stakedTokenDollarBalance = getBalanceNumber(
     stakedBalance.multipliedBy(stakingTokenPrice),
     stakingToken.decimals,


### PR DESCRIPTION
Use the correct token decimal value for the `stakedTokenBalance`

<img width="394" alt="Screenshot 2021-05-10 at 08 24 54" src="https://user-images.githubusercontent.com/79279477/117621191-3d1e2400-b169-11eb-9dd8-2f9b87a0245f.png">

<img width="389" alt="Screenshot 2021-05-10 at 08 29 11" src="https://user-images.githubusercontent.com/79279477/117621771-d9e0c180-b169-11eb-9d21-2eee14f314fd.png">
