### PR TITLE
feat(pool-cards): Add new bg gradient style to pool cards and accent farm card

### DIFF
--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -43,10 +43,10 @@ const StyledCardAccent = styled.div`
   z-index: -1;
 `
 
-const FCard = styled.div`
+const FCard = styled.div<{ isPromotedFarm: boolean }>`
   align-self: baseline;
   background: ${(props) => props.theme.card.background};
-  border-radius: 31px;
+  border-radius: ${({ theme, isPromotedFarm }) => (isPromotedFarm ? '31px' : theme.radii.card)};
   box-shadow: 0px 1px 4px rgba(25, 19, 38, 0.15);
   display: flex;
   flex-direction: column;
@@ -100,10 +100,11 @@ const FarmCard: React.FC<FarmCardProps> = ({ farm, removed, cakePrice, account }
   })
   const addLiquidityUrl = `${BASE_ADD_LIQUIDITY_URL}/${liquidityUrlPathParts}`
   const lpAddress = farm.lpAddresses[process.env.REACT_APP_CHAIN_ID]
+  const isPromotedFarm = farm.token.symbol === 'CAKE'
 
   return (
-    <FCard>
-      {farm.token.symbol === 'CAKE' && <StyledCardAccent />}
+    <FCard isPromotedFarm={isPromotedFarm}>
+      {isPromotedFarm && <StyledCardAccent />}
       <CardHeading
         lpLabel={lpLabel}
         multiplier={farm.multiplier}

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -18,50 +18,36 @@ export interface FarmWithStakedValue extends Farm {
   liquidity?: BigNumber
 }
 
-const RainbowLight = keyframes`
-	0% {
-		background-position: 0% 50%;
-	}
-	50% {
-		background-position: 100% 50%;
-	}
-	100% {
-		background-position: 0% 50%;
-	}
+const AccentGradient = keyframes`
+    0% {
+      background-position: 47% 0%;
+    }
+    50% {
+      background-position: 54% 100%;
+    }
+    100% {
+      background-position: 47% 0%;
+    }
 `
 
 const StyledCardAccent = styled.div`
-  background: linear-gradient(
-    45deg,
-    rgba(255, 0, 0, 1) 0%,
-    rgba(255, 154, 0, 1) 10%,
-    rgba(208, 222, 33, 1) 20%,
-    rgba(79, 220, 74, 1) 30%,
-    rgba(63, 218, 216, 1) 40%,
-    rgba(47, 201, 226, 1) 50%,
-    rgba(28, 127, 238, 1) 60%,
-    rgba(95, 21, 242, 1) 70%,
-    rgba(186, 12, 248, 1) 80%,
-    rgba(251, 7, 217, 1) 90%,
-    rgba(255, 0, 0, 1) 100%
-  );
-  background-size: 300% 300%;
-  animation: ${RainbowLight} 2s linear infinite;
+  background: ${({ theme }) => `linear-gradient(180deg, ${theme.colors.primaryBright}, ${theme.colors.secondary})`};
+  background-size: 400% 400%;
+  animation: ${AccentGradient} 2s linear infinite;
   border-radius: 32px;
-  filter: blur(6px);
   position: absolute;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
+  top: -1px;
+  right: -1px;
+  bottom: -3px;
+  left: -1px;
   z-index: -1;
 `
 
 const FCard = styled.div`
   align-self: baseline;
   background: ${(props) => props.theme.card.background};
-  border-radius: 32px;
-  box-shadow: 0px 2px 12px -8px rgba(25, 19, 38, 0.1), 0px 1px 1px rgba(25, 19, 38, 0.05);
+  border-radius: 31px;
+  box-shadow: 0px 1px 4px rgba(25, 19, 38, 0.15);
   display: flex;
   flex-direction: column;
   justify-content: space-around;

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -20,13 +20,13 @@ export interface FarmWithStakedValue extends Farm {
 
 const AccentGradient = keyframes`  
   0% {
-    background-position: 47% 0%;
+    background-position: 50% 0%;
   }
   50% {
-    background-position: 54% 100%;
+    background-position: 50% 100%;
   }
   100% {
-    background-position: 47% 0%;
+    background-position: 50% 0%;
   }
 `
 

--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -18,16 +18,16 @@ export interface FarmWithStakedValue extends Farm {
   liquidity?: BigNumber
 }
 
-const AccentGradient = keyframes`
-    0% {
-      background-position: 47% 0%;
-    }
-    50% {
-      background-position: 54% 100%;
-    }
-    100% {
-      background-position: 47% 0%;
-    }
+const AccentGradient = keyframes`  
+  0% {
+    background-position: 47% 0%;
+  }
+  50% {
+    background-position: 54% 100%;
+  }
+  100% {
+    background-position: 47% 0%;
+  }
 `
 
 const StyledCardAccent = styled.div`

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -12,7 +12,7 @@ import useGetVaultSharesInfo from 'hooks/cakeVault/useGetVaultSharesInfo'
 import useGetVaultFees from 'hooks/cakeVault/useGetVaultFees'
 import { Pool } from 'state/types'
 import AprRow from '../PoolCard/AprRow'
-import StyledCard from '../PoolCard/StyledCard'
+import { StyledCard, StyledCardInner } from '../PoolCard/StyledCard'
 import CardFooter from '../PoolCard/CardFooter'
 import StyledCardHeader from '../PoolCard/StyledCardHeader'
 import VaultCardActions from './VaultCardActions'
@@ -48,60 +48,67 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
   }
 
   return (
-    <StyledCard isStaking={accountHasSharesStaked}>
-      <StyledCardHeader isAutoVault earningTokenSymbol="CAKE" stakingTokenSymbol="CAKE" />
-      <StyledCardBody isLoading={isLoading}>
-        <AprRow
-          pool={pool}
-          stakingTokenPrice={stakingTokenPrice}
+    <StyledCard isPromotedPool>
+      <StyledCardInner>
+        <StyledCardHeader
+          isStaking={accountHasSharesStaked}
           isAutoVault
-          compoundFrequency={timesCompoundedDaily}
-          performanceFee={performanceFeeAsDecimal}
+          earningTokenSymbol="CAKE"
+          stakingTokenSymbol="CAKE"
         />
-        <Box mt="24px">
-          <RecentCakeProfitRow
-            cakeAtLastUserAction={userInfo.cakeAtLastUserAction}
-            userShares={userInfo.shares}
-            pricePerFullShare={pricePerFullShare}
+        <StyledCardBody isLoading={isLoading}>
+          <AprRow
+            pool={pool}
+            stakingTokenPrice={stakingTokenPrice}
+            isAutoVault
+            compoundFrequency={timesCompoundedDaily}
+            performanceFee={performanceFeeAsDecimal}
           />
-        </Box>
-        <Box mt="8px">
-          <UnstakingFeeCountdownRow
-            withdrawalFee={vaultFees.withdrawalFee}
-            withdrawalFeePeriod={vaultFees.withdrawalFeePeriod}
-            lastDepositedTime={accountHasSharesStaked && userInfo.lastDepositedTime}
-          />
-        </Box>
-        <Flex mt="24px" flexDirection="column">
-          {account ? (
-            <VaultCardActions
-              pool={pool}
-              userInfo={userInfo}
+          <Box mt="24px">
+            <RecentCakeProfitRow
+              cakeAtLastUserAction={userInfo.cakeAtLastUserAction}
+              userShares={userInfo.shares}
               pricePerFullShare={pricePerFullShare}
-              vaultFees={vaultFees}
-              stakingTokenPrice={stakingTokenPrice}
-              accountHasSharesStaked={accountHasSharesStaked}
-              lastUpdated={lastUpdated}
-              setLastUpdated={setLastUpdated}
-              isLoading={isLoading}
             />
-          ) : (
-            <>
-              <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
-                {t('Start earning')}
-              </Text>
-              <UnlockButton />
-            </>
-          )}
-        </Flex>
-      </StyledCardBody>
-      <CardFooter
-        pool={pool}
-        account={account}
-        performanceFee={vaultFees.performanceFee}
-        isAutoVault
-        totalCakeInVault={totalCakeInVault}
-      />
+          </Box>
+          <Box mt="8px">
+            <UnstakingFeeCountdownRow
+              withdrawalFee={vaultFees.withdrawalFee}
+              withdrawalFeePeriod={vaultFees.withdrawalFeePeriod}
+              lastDepositedTime={accountHasSharesStaked && userInfo.lastDepositedTime}
+            />
+          </Box>
+          <Flex mt="24px" flexDirection="column">
+            {account ? (
+              <VaultCardActions
+                pool={pool}
+                userInfo={userInfo}
+                pricePerFullShare={pricePerFullShare}
+                vaultFees={vaultFees}
+                stakingTokenPrice={stakingTokenPrice}
+                accountHasSharesStaked={accountHasSharesStaked}
+                lastUpdated={lastUpdated}
+                setLastUpdated={setLastUpdated}
+                isLoading={isLoading}
+              />
+            ) : (
+              <>
+                <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
+                  {t('Start earning')}
+                </Text>
+                <UnlockButton />
+              </>
+            )}
+          </Flex>
+        </StyledCardBody>
+        <CardFooter
+          pool={pool}
+          account={account}
+          performanceFee={vaultFees.performanceFee}
+          isAutoVault
+          totalCakeInVault={totalCakeInVault}
+        />
+      </StyledCardInner>
     </StyledCard>
   )
 }

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -49,8 +49,9 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
 
   return (
     <StyledCard isPromotedPool>
-      <StyledCardInner>
+      <StyledCardInner isPromotedPool>
         <StyledCardHeader
+          isPromotedPool
           isStaking={accountHasSharesStaked}
           isAutoVault
           earningTokenSymbol="CAKE"

--- a/src/views/Pools/components/PoolCard/StyledCard.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCard.tsx
@@ -2,15 +2,15 @@ import styled, { css, keyframes } from 'styled-components'
 import { Card, Box } from '@pancakeswap/uikit'
 
 const PromotedGradient = keyframes`
-    0% {
-      background-position: 47% 0%;
-    }
-    50% {
-      background-position: 54% 100%;
-    }
-    100% {
-      background-position: 47% 0%;
-    }
+  0% {
+    background-position: 47% 0%;
+  }
+  50% {
+    background-position: 54% 100%;
+  }
+  100% {
+    background-position: 47% 0%;
+  }
 `
 
 export const StyledCard = styled(Card)<{ isPromotedPool?: boolean; isFinished?: boolean }>`

--- a/src/views/Pools/components/PoolCard/StyledCard.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCard.tsx
@@ -38,9 +38,9 @@ export const StyledCard = styled(Card)<{ isPromotedPool?: boolean; isFinished?: 
   }
 `
 
-export const StyledCardInner = styled(Box)`
-  background: ${(props) => props.theme.card.background};
-  border-radius: 31px;
+export const StyledCardInner = styled(Box)<{ isPromotedPool?: boolean }>`
+  background: ${({ theme }) => theme.card.background};
+  border-radius: ${({ isPromotedPool, theme }) => (isPromotedPool ? '31px' : theme.radii.card)};
 `
 
 export default StyledCard

--- a/src/views/Pools/components/PoolCard/StyledCard.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCard.tsx
@@ -3,13 +3,13 @@ import { Card, Box } from '@pancakeswap/uikit'
 
 const PromotedGradient = keyframes`
   0% {
-    background-position: 47% 0%;
+    background-position: 50% 0%;
   }
   50% {
-    background-position: 54% 100%;
+    background-position: 50% 100%;
   }
   100% {
-    background-position: 47% 0%;
+    background-position: 50% 0%;
   }
 `
 

--- a/src/views/Pools/components/PoolCard/StyledCard.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCard.tsx
@@ -1,24 +1,46 @@
-import styled from 'styled-components'
-import { Card } from '@pancakeswap/uikit'
+import styled, { css, keyframes } from 'styled-components'
+import { Card, Box } from '@pancakeswap/uikit'
 
-const StyledCard = styled(Card)<{ isStaking?: boolean; isFinished?: boolean }>`
+const PromotedGradient = keyframes`
+    0% {
+      background-position: 47% 0%;
+    }
+    50% {
+      background-position: 54% 100%;
+    }
+    100% {
+      background-position: 47% 0%;
+    }
+`
+
+export const StyledCard = styled(Card)<{ isPromotedPool?: boolean; isFinished?: boolean }>`
   max-width: 352px;
   margin: 0 8px 24px;
-  background: ${(props) => props.theme.card.background};
-  border-radius: 32px;
   display: flex;
-  color: ${({ isFinished, theme }) => theme.colors[isFinished ? 'textDisabled' : 'secondary']};
-  box-shadow: ${({ isStaking }) =>
-    isStaking
-      ? '0px 0px 0px 2px #53DEE9;'
-      : '0px 2px 12px -8px rgba(25, 19, 38, 0.1), 0px 1px 1px rgba(25, 19, 38, 0.05)'};
   flex-direction: column;
   align-self: baseline;
   position: relative;
+  color: ${({ isFinished, theme }) => theme.colors[isFinished ? 'textDisabled' : 'secondary']};
+  box-shadow: 0px 1px 4px rgba(25, 19, 38, 0.15);
+
+  ${({ isPromotedPool, theme }) =>
+    isPromotedPool
+      ? css`
+          background: linear-gradient(180deg, ${theme.colors.primaryBright}, ${theme.colors.secondary});
+          padding: 1px 1px 3px 1px;
+          background-size: 400% 400%;
+          animation: ${PromotedGradient} 3s ease infinite;
+        `
+      : `background: ${(props) => props.theme.card.background};`}
 
   ${({ theme }) => theme.mediaQueries.sm} {
     margin: 0 12px 46px;
   }
+`
+
+export const StyledCardInner = styled(Box)`
+  background: ${(props) => props.theme.card.background};
+  border-radius: 31px;
 `
 
 export default StyledCard

--- a/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
@@ -3,10 +3,11 @@ import { CardHeader, Heading, Text, Flex, Image } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 
-const Wrapper = styled(CardHeader)<{ isFinished?: boolean; background?: string }>`
+const Wrapper = styled(CardHeader)<{ isFinished?: boolean; background?: string; isPromotedPool?: boolean }>`
   background: ${({ isFinished, background, theme }) =>
     isFinished ? theme.colors.backgroundDisabled : theme.colors.gradients[background]};
-  border-radius: 31px 31px 0 0;
+  border-radius: ${({ theme, isPromotedPool }) =>
+    isPromotedPool ? '31px 31px 0 0' : `${theme.radii.card} ${theme.radii.card} 0 0`};
 `
 
 const StyledCardHeader: React.FC<{
@@ -15,7 +16,15 @@ const StyledCardHeader: React.FC<{
   isAutoVault?: boolean
   isFinished?: boolean
   isStaking?: boolean
-}> = ({ earningTokenSymbol, stakingTokenSymbol, isFinished = false, isAutoVault = false, isStaking = false }) => {
+  isPromotedPool?: boolean
+}> = ({
+  earningTokenSymbol,
+  stakingTokenSymbol,
+  isFinished = false,
+  isAutoVault = false,
+  isStaking = false,
+  isPromotedPool = false,
+}) => {
   const { t } = useTranslation()
   const poolImageSrc = isAutoVault
     ? `cake-cakevault.svg`
@@ -47,7 +56,7 @@ const StyledCardHeader: React.FC<{
   }
 
   return (
-    <Wrapper isFinished={isFinished} background={background}>
+    <Wrapper isPromotedPool={isPromotedPool} isFinished={isFinished} background={background}>
       <Flex alignItems="center" justifyContent="space-between">
         <Flex flexDirection="column">
           <Heading color={isFinished ? 'textDisabled' : 'body'} size="lg">

--- a/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'contexts/Localization'
 const Wrapper = styled(CardHeader)<{ isFinished?: boolean; background?: string }>`
   background: ${({ isFinished, background, theme }) =>
     isFinished ? theme.colors.backgroundDisabled : theme.colors.gradients[background]};
+  border-radius: 31px 31px 0 0;
 `
 
 const StyledCardHeader: React.FC<{
@@ -13,13 +14,14 @@ const StyledCardHeader: React.FC<{
   stakingTokenSymbol: string
   isAutoVault?: boolean
   isFinished?: boolean
-}> = ({ earningTokenSymbol, stakingTokenSymbol, isFinished = false, isAutoVault = false }) => {
+  isStaking?: boolean
+}> = ({ earningTokenSymbol, stakingTokenSymbol, isFinished = false, isAutoVault = false, isStaking = false }) => {
   const { t } = useTranslation()
   const poolImageSrc = isAutoVault
     ? `cake-cakevault.svg`
     : `${earningTokenSymbol}-${stakingTokenSymbol}.svg`.toLocaleLowerCase()
   const isCakePool = earningTokenSymbol === 'CAKE' && stakingTokenSymbol === 'CAKE'
-  const background = isCakePool ? 'bubblegum' : 'cardHeader'
+  const background = isStaking ? 'bubblegum' : 'cardHeader'
 
   const getHeadingPrefix = () => {
     if (isAutoVault) {

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -8,7 +8,7 @@ import { BIG_ZERO } from 'utils/bigNumber'
 import { useGetApiPrice } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from './AprRow'
-import StyledCard from './StyledCard'
+import { StyledCard, StyledCardInner } from './StyledCard'
 import CardFooter from './CardFooter'
 import StyledCardHeader from './StyledCardHeader'
 import CardActions from './CardActions'
@@ -22,31 +22,33 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
 
   return (
     <StyledCard
-      isStaking={!isFinished && accountHasStakedBalance}
       isFinished={isFinished && sousId !== 0}
       ribbon={isFinished && <CardRibbon variantColor="textDisabled" text={`${t('Finished')}`} />}
     >
-      <StyledCardHeader
-        earningTokenSymbol={earningToken.symbol}
-        stakingTokenSymbol={stakingToken.symbol}
-        isFinished={isFinished && sousId !== 0}
-      />
-      <CardBody>
-        <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />
-        <Flex mt="24px" flexDirection="column">
-          {account ? (
-            <CardActions pool={pool} stakedBalance={stakedBalance} stakingTokenPrice={stakingTokenPrice} />
-          ) : (
-            <>
-              <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
-                {t('Start earning')}
-              </Text>
-              <UnlockButton />
-            </>
-          )}
-        </Flex>
-      </CardBody>
-      <CardFooter pool={pool} account={account} />
+      <StyledCardInner>
+        <StyledCardHeader
+          isStaking={accountHasStakedBalance}
+          earningTokenSymbol={earningToken.symbol}
+          stakingTokenSymbol={stakingToken.symbol}
+          isFinished={isFinished && sousId !== 0}
+        />
+        <CardBody>
+          <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />
+          <Flex mt="24px" flexDirection="column">
+            {account ? (
+              <CardActions pool={pool} stakedBalance={stakedBalance} stakingTokenPrice={stakingTokenPrice} />
+            ) : (
+              <>
+                <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
+                  {t('Start earning')}
+                </Text>
+                <UnlockButton />
+              </>
+            )}
+          </Flex>
+        </CardBody>
+        <CardFooter pool={pool} account={account} />
+      </StyledCardInner>
     </StyledCard>
   )
 }


### PR DESCRIPTION
- Shiny animated gradient for promoted pools (currently just auto CAKE) and CAKE - BNB farm
<img width="1176" alt="Screenshot 2021-05-10 at 15 47 25" src="https://user-images.githubusercontent.com/79279477/117684271-bdb24400-b1ac-11eb-8219-3180c12eab71.png">

- Change card header logic to be bubblegum gradient when staked
<img width="391" alt="Screenshot 2021-05-10 at 15 46 54" src="https://user-images.githubusercontent.com/79279477/117684478-efc3a600-b1ac-11eb-8d58-344734208b6e.png">

and cardHeader gradient when not
<img width="383" alt="Screenshot 2021-05-10 at 15 46 59" src="https://user-images.githubusercontent.com/79279477/117684528-fd792b80-b1ac-11eb-98fe-e33e39c7a78c.png">

