### PR TITLE
fix: (pools) Zero with decimals shown in amount when bunny slider moved back to zero

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -72,11 +72,10 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
       const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
       const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
       setStakeAmount(amountToStake)
-      setPercent(sliderPercent)
     } else {
       setStakeAmount('')
-      setPercent(0)
     }
+    setPercent(sliderPercent)
   }
 
   const handleWithdrawal = async (convertedStakeAmount: BigNumber) => {

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -68,10 +68,15 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
   }
 
   const handleChangePercent = (sliderPercent: number) => {
-    const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
-    const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
-    setStakeAmount(amountToStake)
-    setPercent(sliderPercent)
+    if (sliderPercent > 0) {
+      const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
+      const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
+      setStakeAmount(amountToStake)
+      setPercent(sliderPercent)
+    } else {
+      setStakeAmount('')
+      setPercent(0)
+    }
   }
 
   const handleWithdrawal = async (convertedStakeAmount: BigNumber) => {

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -63,11 +63,10 @@ const StakeModal: React.FC<StakeModalProps> = ({
       const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
       const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
       setStakeAmount(amountToStake)
-      setPercent(sliderPercent)
     } else {
       setStakeAmount('')
-      setPercent(0)
     }
+    setPercent(sliderPercent)
   }
 
   const handleConfirmClick = async () => {

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -59,10 +59,15 @@ const StakeModal: React.FC<StakeModalProps> = ({
   }
 
   const handleChangePercent = (sliderPercent: number) => {
-    const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
-    const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
-    setStakeAmount(amountToStake)
-    setPercent(sliderPercent)
+    if (sliderPercent > 0) {
+      const percentageOfStakingMax = stakingMax.dividedBy(100).multipliedBy(sliderPercent)
+      const amountToStake = getFullDisplayBalance(percentageOfStakingMax, stakingToken.decimals, stakingToken.decimals)
+      setStakeAmount(amountToStake)
+      setPercent(sliderPercent)
+    } else {
+      setStakeAmount('')
+      setPercent(0)
+    }
   }
 
   const handleConfirmClick = async () => {


### PR DESCRIPTION
Before: 

<img width="318" alt="Screenshot 2021-05-11 at 12 53 37" src="https://user-images.githubusercontent.com/2213635/117809406-6ec4e700-b25e-11eb-9fa7-89b594d11f81.png">

After: 

<img width="308" alt="Screenshot 2021-05-11 at 13 36 56" src="https://user-images.githubusercontent.com/2213635/117809418-708eaa80-b25e-11eb-90f9-38386ec365f0.png">
