### PR TITLE
feat(pools): Staked only toggle now works for finished pools

### DIFF
--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -154,7 +154,7 @@ const pools: PoolConfig[] = [
     harvest: true,
     sortOrder: 999,
     tokenPerBlock: '0.4861',
-    isFinished: false,
+    isFinished: true,
   },
   {
     sousId: 128,
@@ -322,7 +322,7 @@ const pools: PoolConfig[] = [
     harvest: true,
     sortOrder: 999,
     tokenPerBlock: '0.009837',
-    isFinished: false,
+    isFinished: true,
   },
   {
     sousId: 116,


### PR DESCRIPTION
- Create a new pools data array - `stakedOnlyFinishedPools`. Shown when the 'Staked only' toggle is active
- change `ramp` (sousId `129`) to finished in config
- change `dexe` (sousId `117`) to finished in config
- We'll be less reliant on these config changes for finished pools when Memoyil's PR  is in https://github.com/pancakeswap/pancake-frontend/pull/1036