### PR TITLE
fix: Position of info icon in calculating card

### DIFF
--- a/src/views/Predictions/components/RoundCard/CalculatingCard.tsx
+++ b/src/views/Predictions/components/RoundCard/CalculatingCard.tsx
@@ -36,11 +36,9 @@ const CalculatingCard: React.FC<CalculatingCardProps> = ({ round }) => {
           <RoundResultBox>
             <Flex alignItems="center" justifyContent="center" flexDirection="column">
               <Spinner size={96} />
-              <Flex mt="8px">
-                <span ref={targetRef}>
-                  <TooltipText>{t('Calculating')}</TooltipText>
-                  <InfoIcon />
-                </span>
+              <Flex mt="8px" ref={targetRef}>
+                <TooltipText>{t('Calculating')}</TooltipText>
+                <InfoIcon ml="4px" />
               </Flex>
             </Flex>
           </RoundResultBox>


### PR DESCRIPTION
Before:

<img width="318" alt="Screenshot 2021-05-14 at 22 52 50" src="https://user-images.githubusercontent.com/2213635/118330222-bf12a200-b507-11eb-8b42-5e7366260273.png">


After: 

<img width="314" alt="Screenshot 2021-05-14 at 22 52 22" src="https://user-images.githubusercontent.com/2213635/118330177-ae622c00-b507-11eb-9031-0d077581bda0.png">
