### PR TITLE
feat(cake-api-price): Replace API price with Farms price for CAKE

### DIFF
--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -9,14 +9,17 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 
     const feeEndTime = lastDepositedTime + withdrawalFeePeriod
     const secondsRemainingCalc = feeEndTime - currentSeconds
     const doesUnstakingFeeApply = secondsRemainingCalc > 0
-    if (doesUnstakingFeeApply) {
-      setSecondsRemaining(secondsRemainingCalc)
-      setHasUnstakingFee(true)
-    }
     const tick = () => {
       setCurrentSeconds((prevSeconds) => prevSeconds + 1)
     }
     const timerInterval = setInterval(() => tick(), 1000)
+    if (doesUnstakingFeeApply) {
+      setSecondsRemaining(secondsRemainingCalc)
+      setHasUnstakingFee(true)
+    } else {
+      setHasUnstakingFee(false)
+      clearInterval(timerInterval)
+    }
     return () => clearInterval(timerInterval)
   }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining, currentSeconds])
 

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -142,17 +142,33 @@ export const useCakeVault = () => {
     },
   } = useSelector((state: State) => state.pools.cakeVault)
 
-  // TODO: Figure out why this needs to be memoised to prevent rerender loop within BountyCard effect
   const estimatedCakeBountyReward = useMemo(() => {
     return new BigNumber(estimatedCakeBountyRewardAsString)
   }, [estimatedCakeBountyRewardAsString])
 
-  const totalShares = new BigNumber(totalSharesAsString)
-  const pricePerFullShare = new BigNumber(pricePerFullShareAsString)
-  const totalPendingCakeHarvest = new BigNumber(totalPendingCakeHarvestAsString)
-  const totalCakeInVault = new BigNumber(totalCakeInVaultAsString)
-  const userShares = new BigNumber(userSharesAsString)
-  const cakeAtLastUserAction = new BigNumber(cakeAtLastUserActionAsString)
+  const totalPendingCakeHarvest = useMemo(() => {
+    return new BigNumber(totalPendingCakeHarvestAsString)
+  }, [totalPendingCakeHarvestAsString])
+
+  const totalShares = useMemo(() => {
+    return new BigNumber(totalSharesAsString)
+  }, [totalSharesAsString])
+
+  const pricePerFullShare = useMemo(() => {
+    return new BigNumber(pricePerFullShareAsString)
+  }, [pricePerFullShareAsString])
+
+  const totalCakeInVault = useMemo(() => {
+    return new BigNumber(totalCakeInVaultAsString)
+  }, [totalCakeInVaultAsString])
+
+  const userShares = useMemo(() => {
+    return new BigNumber(userSharesAsString)
+  }, [userSharesAsString])
+
+  const cakeAtLastUserAction = useMemo(() => {
+    return new BigNumber(cakeAtLastUserActionAsString)
+  }, [cakeAtLastUserActionAsString])
 
   return {
     totalShares,

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
 import styled from 'styled-components'
 import {
@@ -16,8 +16,7 @@ import {
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
-import { getCakeAddress } from 'utils/addressHelpers'
-import { useCakeVault, useGetApiPrice } from 'state/hooks'
+import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
 import Balance from 'components/Balance'
 import BountyModal from './BountyModal'
 
@@ -30,21 +29,17 @@ const StyledCard = styled(Card)`
 
 const BountyCard = () => {
   const { t } = useTranslation()
-  const [estimatedDollarBountyReward, setEstimatedDollarBountyReward] = useState(null)
   const {
     estimatedCakeBountyReward,
     totalPendingCakeHarvest,
     fees: { callFee },
   } = useCakeVault()
+  const cakePriceBusd = usePriceCakeBusd()
+  const cakePriceBusdAsNumber = cakePriceBusd.toNumber()
 
-  const cakePrice = useGetApiPrice(getCakeAddress())
-
-  useEffect(() => {
-    if (cakePrice && estimatedCakeBountyReward) {
-      const dollarValueofClaimableReward = new BigNumber(estimatedCakeBountyReward).multipliedBy(cakePrice)
-      setEstimatedDollarBountyReward(dollarValueofClaimableReward)
-    }
-  }, [cakePrice, estimatedCakeBountyReward])
+  const estimatedDollarBountyReward = useMemo(() => {
+    return new BigNumber(estimatedCakeBountyReward).multipliedBy(cakePriceBusdAsNumber)
+  }, [cakePriceBusdAsNumber, estimatedCakeBountyReward])
 
   const hasFetchedDollarBounty = estimatedDollarBountyReward && estimatedDollarBountyReward.gte(0)
   const hasFetchedCakeBounty = estimatedCakeBountyReward && estimatedCakeBountyReward.gte(0)

--- a/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import { Flex, Text } from '@pancakeswap/uikit'
 import { useWeb3React } from '@web3-react/core'
 import { useTranslation } from 'contexts/Localization'
-import { useCakeVault, useGetApiPrice } from 'state/hooks'
+import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
 import { getBalanceNumber } from 'utils/formatBalance'
-import { getCakeAddress } from 'utils/addressHelpers'
 import { convertSharesToCake } from 'views/Pools/helpers'
 import RecentCakeProfitBalance from './RecentCakeProfitBalance'
 
@@ -12,18 +11,16 @@ const RecentCakeProfitCountdownRow = () => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const {
+    pricePerFullShare,
     userData: { cakeAtLastUserAction, userShares, lastUserActionTime },
   } = useCakeVault()
   const shouldDisplayCakeProfit =
     account && cakeAtLastUserAction && cakeAtLastUserAction.gt(0) && userShares && userShares.gt(0)
-
-  const { pricePerFullShare } = useCakeVault()
   const currentSharesAsCake = convertSharesToCake(userShares, pricePerFullShare)
   const cakeProfit = currentSharesAsCake.cakeAsBigNumber.minus(cakeAtLastUserAction)
   const cakeToDisplay = cakeProfit.gte(0) ? getBalanceNumber(cakeProfit, 18) : 0
-
-  const cakePrice = useGetApiPrice(getCakeAddress())
-  const dollarValueOfCake = cakeProfit.times(cakePrice)
+  const cakePriceBusd = usePriceCakeBusd()
+  const dollarValueOfCake = cakeProfit.times(cakePriceBusd)
   const dollarValueToDisplay = dollarValueOfCake.gte(0) ? getBalanceNumber(dollarValueOfCake, 18) : 0
 
   const lastActionInMs = lastUserActionTime && parseInt(lastUserActionTime) * 1000

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
@@ -10,7 +10,6 @@ import HasSharesActions from './HasSharesActions'
 interface VaultStakeActionsProps {
   pool: Pool
   stakingTokenBalance: BigNumber
-  stakingTokenPrice: number
   accountHasSharesStaked: boolean
   isLoading?: boolean
 }
@@ -18,20 +17,17 @@ interface VaultStakeActionsProps {
 const VaultStakeActions: React.FC<VaultStakeActionsProps> = ({
   pool,
   stakingTokenBalance,
-  stakingTokenPrice,
   accountHasSharesStaked,
   isLoading = false,
 }) => {
   const { stakingToken } = pool
   const { t } = useTranslation()
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
-  const [onPresentStake] = useModal(
-    <VaultStakeModal stakingMax={stakingTokenBalance} stakingTokenPrice={stakingTokenPrice} pool={pool} />,
-  )
+  const [onPresentStake] = useModal(<VaultStakeModal stakingMax={stakingTokenBalance} pool={pool} />)
 
   const renderStakeAction = () => {
     return accountHasSharesStaked ? (
-      <HasSharesActions pool={pool} stakingTokenBalance={stakingTokenBalance} stakingTokenPrice={stakingTokenPrice} />
+      <HasSharesActions pool={pool} stakingTokenBalance={stakingTokenBalance} />
     ) : (
       <Button onClick={stakingTokenBalance.gt(0) ? onPresentStake : onPresentTokenRequired}>{t('Stake')}</Button>
     )

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
@@ -17,10 +17,9 @@ const InlineText = styled(Text)`
 
 const CakeVaultCardActions: React.FC<{
   pool: Pool
-  stakingTokenPrice: number
   accountHasSharesStaked: boolean
   isLoading: boolean
-}> = ({ pool, stakingTokenPrice, accountHasSharesStaked, isLoading }) => {
+}> = ({ pool, accountHasSharesStaked, isLoading }) => {
   const { account } = useWeb3React()
   const { stakingToken, userData } = pool
   const { lastUpdated, setLastUpdated } = useLastUpdated()
@@ -70,7 +69,6 @@ const CakeVaultCardActions: React.FC<{
             isLoading={isLoading}
             pool={pool}
             stakingTokenBalance={stakingTokenBalance}
-            stakingTokenPrice={stakingTokenPrice}
             accountHasSharesStaked={accountHasSharesStaked}
           />
         ) : (

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -6,7 +6,7 @@ import { useWeb3React } from '@web3-react/core'
 import { BASE_EXCHANGE_URL } from 'config'
 import { useAppDispatch } from 'state'
 import { BIG_TEN } from 'utils/bigNumber'
-import { useCakeVault } from 'state/hooks'
+import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
 import { useCakeVaultContract } from 'hooks/useContract'
 import useTheme from 'hooks/useTheme'
 import useWithdrawalFeeTimer from 'hooks/cakeVault/useWithdrawalFeeTimer'
@@ -21,7 +21,6 @@ import FeeSummary from './FeeSummary'
 interface VaultStakeModalProps {
   pool: Pool
   stakingMax: BigNumber
-  stakingTokenPrice: number
   isRemovingStake?: boolean
   onDismiss?: () => void
 }
@@ -30,13 +29,7 @@ const StyledButton = styled(Button)`
   flex-grow: 1;
 `
 
-const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
-  pool,
-  stakingMax,
-  stakingTokenPrice,
-  isRemovingStake = false,
-  onDismiss,
-}) => {
+const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isRemovingStake = false, onDismiss }) => {
   const dispatch = useAppDispatch()
   const { stakingToken } = pool
   const { account } = useWeb3React()
@@ -52,7 +45,8 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
   const [stakeAmount, setStakeAmount] = useState('')
   const [percent, setPercent] = useState(0)
   const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(lastDepositedTime))
-  const usdValueStaked = stakeAmount && formatNumber(new BigNumber(stakeAmount).times(stakingTokenPrice).toNumber())
+  const cakePriceBusd = usePriceCakeBusd()
+  const usdValueStaked = stakeAmount && formatNumber(new BigNumber(stakeAmount).times(cakePriceBusd).toNumber())
 
   const handleStakeInputChange = (input: string) => {
     if (input) {

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -4,8 +4,7 @@ import { Box, CardBody, Flex, Text } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useWeb3React } from '@web3-react/core'
 import UnlockButton from 'components/UnlockButton'
-import { getAddress } from 'utils/addressHelpers'
-import { useCakeVault, useGetApiPrice } from 'state/hooks'
+import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from '../PoolCard/AprRow'
 import { StyledCard, StyledCardInner } from '../PoolCard/StyledCard'
@@ -31,11 +30,10 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
     userData: { userShares, isLoading: isVaultUserDataLoading },
     fees: { performanceFee },
   } = useCakeVault()
-  const { stakingToken } = pool
   //   Estimate & manual for now. 288 = once every 5 mins. We can change once we have a better sense of this
   const timesCompoundedDaily = 288
   const accountHasSharesStaked = userShares && userShares.gt(0)
-  const stakingTokenPrice = useGetApiPrice(stakingToken.address ? getAddress(stakingToken.address) : '')
+  const cakePriceBusd = usePriceCakeBusd()
   const isLoading = !pool.userData || isVaultUserDataLoading
   const performanceFeeAsDecimal = performanceFee && performanceFee / 100
 
@@ -56,7 +54,7 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
         <StyledCardBody isLoading={isLoading}>
           <AprRow
             pool={pool}
-            stakingTokenPrice={stakingTokenPrice}
+            stakingTokenPrice={cakePriceBusd.toNumber()}
             isAutoVault
             compoundFrequency={timesCompoundedDaily}
             performanceFee={performanceFeeAsDecimal}
@@ -69,12 +67,7 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
           </Box>
           <Flex mt="24px" flexDirection="column">
             {account ? (
-              <VaultCardActions
-                pool={pool}
-                stakingTokenPrice={stakingTokenPrice}
-                accountHasSharesStaked={accountHasSharesStaked}
-                isLoading={isLoading}
-              />
+              <VaultCardActions pool={pool} accountHasSharesStaked={accountHasSharesStaked} isLoading={isLoading} />
             ) : (
               <>
                 <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>


### PR DESCRIPTION
PR is doing a couple of things 
- Replace any instances where `useGetApiPrice` is being used to access the price of CAKE, and replace it with `usePriceCakeBusd`
- Clear timer for `useWithdrawalFeeTimer` when `doesUnstakingFeeApply` is false, to prevent unnecessary re-renders
- useMemo to wrap the returns of all BigNumbers within the `useCakeVault`. If one of the return values was used as a useEffect/Memo dependency, then it would trigger a re-render as it is a new class instance with a different reference
