### PR TITLE
Styling improvements

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -41,6 +41,7 @@ const DropDownContainer = styled.div<{ isOpen: boolean; width: number; height: n
   border-radius: 16px;
   height: 40px;
   min-width: 136px;
+  user-select: none;
 
   ${({ theme }) => theme.mediaQueries.sm} {
     min-width: 168px;

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -35,7 +35,8 @@ const Hero = styled.div`
 const Cards = styled(BaseLayout)`
   align-items: stretch;
   justify-content: stretch;
-  margin-bottom: 32px;
+  margin-bottom: 24px;
+  grid-gap: 24px;
 
   & > div {
     grid-column: span 6;
@@ -49,6 +50,9 @@ const Cards = styled(BaseLayout)`
   }
 
   ${({ theme }) => theme.mediaQueries.lg} {
+    margin-bottom: 32px;
+    grid-gap: 32px;
+
     & > div {
       grid-column: span 6;
     }
@@ -57,7 +61,8 @@ const Cards = styled(BaseLayout)`
 
 const CTACards = styled(BaseLayout)`
   align-items: start;
-  margin-bottom: 32px;
+  margin-bottom: 24px;
+  grid-gap: 24px;
 
   & > div {
     grid-column: span 6;
@@ -70,6 +75,9 @@ const CTACards = styled(BaseLayout)`
   }
 
   ${({ theme }) => theme.mediaQueries.lg} {
+    margin-bottom: 32px;
+    grid-gap: 32px;
+
     & > div {
       grid-column: span 4;
     }

--- a/src/views/Lottery/components/YourPrizesCard/NoPrizesContent.tsx
+++ b/src/views/Lottery/components/YourPrizesCard/NoPrizesContent.tsx
@@ -12,6 +12,7 @@ const Wrapper = styled.div`
 const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
 `
 
 const StyledText = styled(Text)`

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -86,7 +86,7 @@ const AprRow: React.FC<AprRowProps> = ({
   return (
     <Flex alignItems="center" justifyContent="space-between">
       {tooltipVisible && tooltip}
-      <TooltipText ref={targetRef}>{isAutoVault ? t('APY') : t('APR')}:</TooltipText>
+      <TooltipText ref={targetRef}>{isAutoVault ? `${t('APY')}:` : `${t('APR')}:`}</TooltipText>
       {isFinished || !apr ? (
         <Skeleton width="82px" height="32px" />
       ) : (

--- a/src/views/Pools/components/PoolCard/CardFooter/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import BigNumber from 'bignumber.js'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
-import { Flex, CardFooter, ExpandableLabel, HelpIcon, useTooltip, Box } from '@pancakeswap/uikit'
+import { Flex, CardFooter, ExpandableLabel, HelpIcon, useTooltip } from '@pancakeswap/uikit'
 import { Pool } from 'state/types'
 import { CompoundingPoolTag, ManualPoolTag } from 'components/Tags'
 import ExpandedFooter from './ExpandedFooter'
@@ -41,9 +41,9 @@ const Footer: React.FC<FooterProps> = ({ pool, account, isAutoVault = false }) =
         <Flex alignItems="center">
           {isAutoVault ? <CompoundingPoolTag /> : <ManualPoolTag />}
           {tooltipVisible && tooltip}
-          <Box ref={targetRef}>
+          <Flex ref={targetRef}>
             <HelpIcon ml="4px" width="20px" height="20px" color="textSubtle" />
-          </Box>
+          </Flex>
         </Flex>
         <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
           {isExpanded ? t('Hide') : t('Details')}


### PR DESCRIPTION
Some small styling improvements.

- Help Icon on Pool Card (Flex instead of Box)
- Home cards - unify margin/gap on mobile (Large screens unaffected)
- Lottery - no prizes to collect alignment
- Selects - Prevent text / user selection
- TooltipText on Pool cards, ugly underline issue

## Help Icon
Before:
![image](https://user-images.githubusercontent.com/987947/118625989-c61d0700-b7ca-11eb-9d07-c17202479927.png)

After:
![image](https://user-images.githubusercontent.com/987947/118626077-d6cd7d00-b7ca-11eb-847d-120002f6a444.png)


## Home cards on mobile
Before:
![image](https://user-images.githubusercontent.com/987947/118626584-48a5c680-b7cb-11eb-8713-675bdb82a8c7.png)

After:
![image](https://user-images.githubusercontent.com/987947/118626595-4b082080-b7cb-11eb-9a20-1fafde7f607b.png)


## No prizes to collect
Before:
![image](https://user-images.githubusercontent.com/987947/118640401-3599f300-b7d9-11eb-95c5-92dddebba771.png)

After:
![image](https://user-images.githubusercontent.com/987947/118640414-392d7a00-b7d9-11eb-8f7e-be473fa74980.png)


## Select

Before:
![before](https://user-images.githubusercontent.com/987947/118641747-d3da8880-b7da-11eb-898e-368f0560950f.gif)

After:
![after](https://user-images.githubusercontent.com/987947/118641752-d6d57900-b7da-11eb-822b-37b4081dca4c.gif)

## TooltipText

Before:
![image](https://user-images.githubusercontent.com/987947/118642846-1d77a300-b7dc-11eb-9cf3-76ca932d8db8.png)

After:
![image](https://user-images.githubusercontent.com/987947/118642870-223c5700-b7dc-11eb-99a2-935987650a75.png)