### PR TITLE
Chore/Replace api prices with farm prices

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -149,16 +149,6 @@ const farms: FarmConfig[] = [
     quoteToken: tokens.wbnb,
   },
   {
-    pid: 372,
-    lpSymbol: 'KUN-QSD LP',
-    lpAddresses: {
-      97: '',
-      56: '0x4eafbf68a2d50291ffd163d4e00ad0f040aae707',
-    },
-    token: tokens.kun,
-    quoteToken: tokens.qsd,
-  },
-  {
     pid: 373,
     lpSymbol: 'KUN-BUSD LP',
     lpAddresses: {
@@ -167,6 +157,16 @@ const farms: FarmConfig[] = [
     },
     token: tokens.kun,
     quoteToken: tokens.busd,
+  },
+  {
+    pid: 372,
+    lpSymbol: 'KUN-QSD LP',
+    lpAddresses: {
+      97: '',
+      56: '0x4eafbf68a2d50291ffd163d4e00ad0f040aae707',
+    },
+    token: tokens.kun,
+    quoteToken: tokens.qsd,
   },
   {
     pid: 371,

--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -149,16 +149,6 @@ const farms: FarmConfig[] = [
     quoteToken: tokens.wbnb,
   },
   {
-    pid: 373,
-    lpSymbol: 'KUN-BUSD LP',
-    lpAddresses: {
-      97: '',
-      56: '0xea61020e5a128d2bec67d48f7cfbe3408db7e391',
-    },
-    token: tokens.kun,
-    quoteToken: tokens.busd,
-  },
-  {
     pid: 372,
     lpSymbol: 'KUN-QSD LP',
     lpAddresses: {
@@ -167,6 +157,16 @@ const farms: FarmConfig[] = [
     },
     token: tokens.kun,
     quoteToken: tokens.qsd,
+  },
+  {
+    pid: 373,
+    lpSymbol: 'KUN-BUSD LP',
+    lpAddresses: {
+      97: '',
+      56: '0xea61020e5a128d2bec67d48f7cfbe3408db7e391',
+    },
+    token: tokens.kun,
+    quoteToken: tokens.busd,
   },
   {
     pid: 371,

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -108,9 +108,6 @@ export const useTokenPriceBusd = (pid: number): BigNumber => {
   // we find the pBTC farm, pBTC - BNB
   // from the BNB - pBTC BUSD price, we can get the PNT - BUSD price
 
-  if (!quoteTokenFarm) {
-    debugger // eslint-disable-line
-  }
   if (quoteTokenFarm.quoteToken.symbol === 'wBNB') {
     const quoteTokenInBusd = bnbPriceBusd.gt(0) && bnbPriceBusd.times(quoteTokenFarm.tokenPriceVsQuote)
     return farm.tokenPriceVsQuote ? new BigNumber(farm.tokenPriceVsQuote).times(quoteTokenInBusd) : BIG_ZERO

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -91,7 +91,7 @@ export const useFarmFromTokenSymbol = (tokenSymbol: string, preferredQuoteTokens
 export const useTokenPriceBusd = (pid: number): BigNumber => {
   const farm = useFarmFromPid(pid)
   const bnbPriceBusd = usePriceBnbBusd()
-  const quoteTokenFarm = useFarmFromTokenSymbol(farm.token.symbol)
+  const quoteTokenFarm = useFarmFromTokenSymbol(farm.quoteToken.symbol)
 
   if (farm.quoteToken.symbol === 'BUSD') {
     return farm.tokenPriceVsQuote ? new BigNumber(farm.tokenPriceVsQuote) : BIG_ZERO

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -83,6 +83,9 @@ export const useFarmUser = (pid) => {
 
 export const useFarmFromTokenSymbol = (tokenSymbol: string): Farm => {
   const farm = useSelector((state: State) => state.farms.data.find((f) => f.token.symbol === tokenSymbol))
+  // if (tokenSymbol === 'pBTC') {
+  //   debugger //eslint-disable-line
+  // }
   return farm
 }
 
@@ -100,7 +103,9 @@ export const useTokenPriceBusd = (pid: number): BigNumber => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     quoteTokenPriceBusd = usePriceBnbBusd()
     tokenPriceBusd = quoteTokenPriceBusd.gt(0) && quoteTokenPriceBusd.times(farm.tokenPriceVsQuote)
-  } else {
+  } else if (farm.quoteToken.symbol === 'pBTC') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const tokenFarm = useFarmFromTokenSymbol(farm.quoteToken.symbol)
     debugger // eslint-disable-line
   }
 

--- a/src/utils/farmsPriceHelpers.ts
+++ b/src/utils/farmsPriceHelpers.ts
@@ -1,0 +1,12 @@
+import { Farm } from 'state/types'
+
+export const filterFarmsByQuoteToken = (farms: Farm[], preferredQuoteTokens: string[] = ['BUSD', 'wBNB']): Farm => {
+  const preferredFarm = farms.find((farm) => {
+    return preferredQuoteTokens.some((quoteToken) => {
+      return farm.quoteToken.symbol === quoteToken
+    })
+  })
+  return preferredFarm || farms[0]
+}
+
+export default filterFarmsByQuoteToken

--- a/src/utils/farmsPriceHelpers.ts
+++ b/src/utils/farmsPriceHelpers.ts
@@ -1,5 +1,11 @@
 import { Farm } from 'state/types'
 
+/**
+ * Returns the first farm with a quote token that matches from an array of preferred quote tokens
+ * @param farms Array of farms
+ * @param preferredQuoteTokens Array of preferred quote tokens
+ * @returns A preferred farm, if found - or the first element of the farms array
+ */
 export const filterFarmsByQuoteToken = (farms: Farm[], preferredQuoteTokens: string[] = ['BUSD', 'wBNB']): Farm => {
   const preferredFarm = farms.find((farm) => {
     return preferredQuoteTokens.some((quoteToken) => {

--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -80,7 +80,6 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
     <Action>
       <Flex>
         <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
-          {/* TODO: Is there a way to get a dynamic value here from useFarmFromSymbol? */}
           CAKE
         </Text>
         <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -4,7 +4,7 @@ import { Box, CardBody, Flex, Text } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useWeb3React } from '@web3-react/core'
 import UnlockButton from 'components/UnlockButton'
-import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
+import { useCakeVault } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from '../PoolCard/AprRow'
 import { StyledCard, StyledCardInner } from '../PoolCard/StyledCard'
@@ -33,7 +33,6 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
   //   Estimate & manual for now. 288 = once every 5 mins. We can change once we have a better sense of this
   const timesCompoundedDaily = 288
   const accountHasSharesStaked = userShares && userShares.gt(0)
-  const cakePriceBusd = usePriceCakeBusd()
   const isLoading = !pool.userData || isVaultUserDataLoading
   const performanceFeeAsDecimal = performanceFee && performanceFee / 100
 
@@ -54,7 +53,6 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
         <StyledCardBody isLoading={isLoading}>
           <AprRow
             pool={pool}
-            stakingTokenPrice={cakePriceBusd.toNumber()}
             isAutoVault
             compoundFrequency={timesCompoundedDaily}
             performanceFee={performanceFeeAsDecimal}

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -5,7 +5,7 @@ import { getBalanceNumber } from 'utils/formatBalance'
 import { getPoolApr } from 'utils/apr'
 import { getAddress } from 'utils/addressHelpers'
 import { tokenEarnedPerThousandDollarsCompounding, getRoi } from 'utils/compoundApyHelpers'
-import { useGetApiPrice } from 'state/hooks'
+import { useFarmFromTokenSymbol, useGetApiPrice, useTokenPriceBusd } from 'state/hooks'
 import Balance from 'components/Balance'
 import ApyCalculatorModal from 'components/ApyCalculatorModal'
 import { Pool } from 'state/types'
@@ -35,7 +35,16 @@ const AprRow: React.FC<AprRowProps> = ({
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, { placement: 'bottom-end' })
 
+  const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
   const earningTokenPrice = useGetApiPrice(earningToken.address ? getAddress(earningToken.address) : '')
+  const earningTokenFarmPrice = useTokenPriceBusd(earningTokenFarm.pid)
+
+  console.log(
+    earningToken.symbol,
+    ' ',
+    earningTokenFarmPrice && earningTokenFarmPrice.gt(0) && earningTokenFarmPrice.toNumber(),
+  )
+
   const apr = getPoolApr(
     stakingTokenPrice,
     earningTokenPrice,

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -35,9 +35,10 @@ const AprRow: React.FC<AprRowProps> = ({
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, { placement: 'bottom-end' })
 
-  const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
   const earningTokenPrice = useGetApiPrice(earningToken.address ? getAddress(earningToken.address) : '')
+  const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
   const earningTokenFarmPrice = useTokenPriceBusd(earningTokenFarm.pid)
+  const earningTokenFarmPriceAsNumber = earningTokenFarmPrice && earningTokenFarmPrice.toNumber()
 
   console.log(
     earningToken.symbol,
@@ -47,7 +48,7 @@ const AprRow: React.FC<AprRowProps> = ({
 
   const apr = getPoolApr(
     stakingTokenPrice,
-    earningTokenPrice,
+    earningTokenFarmPriceAsNumber,
     getBalanceNumber(totalStaked, stakingToken.decimals),
     parseFloat(tokenPerBlock),
   )

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { getPoolApr } from 'utils/apr'
 import { tokenEarnedPerThousandDollarsCompounding, getRoi } from 'utils/compoundApyHelpers'
-import { useFarmFromTokenSymbol, useTokenPriceBusd } from 'state/hooks'
+import { useBusdPriceFromToken } from 'state/hooks'
 import Balance from 'components/Balance'
 import ApyCalculatorModal from 'components/ApyCalculatorModal'
 import { Pool } from 'state/types'
@@ -27,12 +27,10 @@ const AprRow: React.FC<AprRowProps> = ({ pool, isAutoVault = false, compoundFreq
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, { placement: 'bottom-end' })
 
-  const earningTokenFarmForPriceCalc = useFarmFromTokenSymbol(earningToken.symbol)
-  const earningTokenPrice = useTokenPriceBusd(earningTokenFarmForPriceCalc.pid)
+  const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
   const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()
 
-  const stakingTokenFarmForPriceCalc = useFarmFromTokenSymbol(stakingToken.symbol)
-  const stakingTokenPrice = useTokenPriceBusd(stakingTokenFarmForPriceCalc.pid)
+  const stakingTokenPrice = useBusdPriceFromToken(stakingToken.symbol)
   const stakingTokenPriceAsNumber = stakingTokenPrice && stakingTokenPrice.toNumber()
 
   const apr = getPoolApr(

--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js'
 import { Token } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'
 import { getFullDisplayBalance, getBalanceNumber, formatNumber } from 'utils/formatBalance'
-import { useFarmFromTokenSymbol, useTokenPriceBusd } from 'state/hooks'
+import { useBusdPriceFromToken } from 'state/hooks'
 import Balance from 'components/Balance'
 import CollectModal from '../Modals/CollectModal'
 
@@ -24,11 +24,8 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   isLoading = false,
 }) => {
   const { t } = useTranslation()
-
-  const earningTokenFarmForPriceCalc = useFarmFromTokenSymbol(earningToken.symbol)
-  const earningTokenPrice = useTokenPriceBusd(earningTokenFarmForPriceCalc.pid)
+  const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
   const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()
-
   const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
   const earningTokenDollarBalance = getBalanceNumber(
     earnings.multipliedBy(earningTokenPriceAsNumber),

--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -24,15 +24,17 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   isLoading = false,
 }) => {
   const { t } = useTranslation()
+  const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
+  const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
+
   const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
   const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()
-  const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
   const earningTokenDollarBalance =
     earningTokenPriceAsNumber &&
     getBalanceNumber(earnings.multipliedBy(earningTokenPriceAsNumber), earningToken.decimals)
+  const earningsDollarValue = earningTokenDollarBalance && formatNumber(earningTokenDollarBalance)
+
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
-  const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
-  const earningsDollarValue = formatNumber(earningTokenDollarBalance)
   const hasEarnings = earnings.toNumber() > 0
   const isCompoundPool = sousId === 0
 

--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -2,10 +2,9 @@ import React from 'react'
 import { Flex, Text, Button, Heading, useModal, Skeleton } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { Token } from 'config/constants/types'
-import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
 import { getFullDisplayBalance, getBalanceNumber, formatNumber } from 'utils/formatBalance'
-import { useGetApiPrice } from 'state/hooks'
+import { useFarmFromTokenSymbol, useTokenPriceBusd } from 'state/hooks'
 import Balance from 'components/Balance'
 import CollectModal from '../Modals/CollectModal'
 
@@ -25,9 +24,16 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   isLoading = false,
 }) => {
   const { t } = useTranslation()
-  const earningTokenPrice = useGetApiPrice(earningToken.address ? getAddress(earningToken.address) : '')
+
+  const earningTokenFarmForPriceCalc = useFarmFromTokenSymbol(earningToken.symbol)
+  const earningTokenPrice = useTokenPriceBusd(earningTokenFarmForPriceCalc.pid)
+  const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()
+
   const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
-  const earningTokenDollarBalance = getBalanceNumber(earnings.multipliedBy(earningTokenPrice), earningToken.decimals)
+  const earningTokenDollarBalance = getBalanceNumber(
+    earnings.multipliedBy(earningTokenPriceAsNumber),
+    earningToken.decimals,
+  )
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
   const earningsDollarValue = formatNumber(earningTokenDollarBalance)

--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -27,10 +27,9 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
   const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()
   const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
-  const earningTokenDollarBalance = getBalanceNumber(
-    earnings.multipliedBy(earningTokenPriceAsNumber),
-    earningToken.decimals,
-  )
+  const earningTokenDollarBalance =
+    earningTokenPriceAsNumber &&
+    getBalanceNumber(earnings.multipliedBy(earningTokenPriceAsNumber), earningToken.decimals)
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
   const earningsDollarValue = formatNumber(earningTokenDollarBalance)

--- a/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { Pool } from 'state/types'
-import { useFarmFromTokenSymbol, useTokenPriceBusd } from 'state/hooks'
+import { useBusdPriceFromToken } from 'state/hooks'
 import Balance from 'components/Balance'
 import NotEnoughTokensModal from '../Modals/NotEnoughTokensModal'
 import StakeModal from '../Modals/StakeModal'
@@ -29,14 +29,12 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   const { stakingToken, stakingLimit, isFinished, userData } = pool
   const { t } = useTranslation()
   const stakedTokenBalance = getBalanceNumber(stakedBalance, stakingToken.decimals)
-  const stakingTokenFarmForPriceCalc = useFarmFromTokenSymbol(stakingToken.symbol)
-  const stakingTokenPrice = useTokenPriceBusd(stakingTokenFarmForPriceCalc.pid)
+  const stakingTokenPrice = useBusdPriceFromToken(stakingToken.symbol)
   const stakingTokenPriceAsNumber = stakingTokenPrice && stakingTokenPrice.toNumber()
+  const stakedTokenDollarBalance =
+    stakingTokenPriceAsNumber &&
+    getBalanceNumber(stakedBalance.multipliedBy(stakingTokenPriceAsNumber), stakingToken.decimals)
 
-  const stakedTokenDollarBalance = getBalanceNumber(
-    stakedBalance.multipliedBy(stakingTokenPriceAsNumber),
-    stakingToken.decimals,
-  )
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
 
   const [onPresentStake] = useModal(

--- a/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { Pool } from 'state/types'
+import { useFarmFromTokenSymbol, useTokenPriceBusd } from 'state/hooks'
 import Balance from 'components/Balance'
 import NotEnoughTokensModal from '../Modals/NotEnoughTokensModal'
 import StakeModal from '../Modals/StakeModal'
@@ -11,7 +12,6 @@ import StakeModal from '../Modals/StakeModal'
 interface StakeActionsProps {
   pool: Pool
   stakingTokenBalance: BigNumber
-  stakingTokenPrice: number
   stakedBalance: BigNumber
   isBnbPool: boolean
   isStaked: ConstrainBoolean
@@ -21,7 +21,6 @@ interface StakeActionsProps {
 const StakeAction: React.FC<StakeActionsProps> = ({
   pool,
   stakingTokenBalance,
-  stakingTokenPrice,
   stakedBalance,
   isBnbPool,
   isStaked,
@@ -30,8 +29,12 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   const { stakingToken, stakingLimit, isFinished, userData } = pool
   const { t } = useTranslation()
   const stakedTokenBalance = getBalanceNumber(stakedBalance, stakingToken.decimals)
+  const stakingTokenFarmForPriceCalc = useFarmFromTokenSymbol(stakingToken.symbol)
+  const stakingTokenPrice = useTokenPriceBusd(stakingTokenFarmForPriceCalc.pid)
+  const stakingTokenPriceAsNumber = stakingTokenPrice && stakingTokenPrice.toNumber()
+
   const stakedTokenDollarBalance = getBalanceNumber(
-    stakedBalance.multipliedBy(stakingTokenPrice),
+    stakedBalance.multipliedBy(stakingTokenPriceAsNumber),
     stakingToken.decimals,
   )
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
@@ -41,7 +44,7 @@ const StakeAction: React.FC<StakeActionsProps> = ({
       isBnbPool={isBnbPool}
       pool={pool}
       stakingTokenBalance={stakingTokenBalance}
-      stakingTokenPrice={stakingTokenPrice}
+      stakingTokenPrice={stakingTokenPriceAsNumber}
     />,
   )
 
@@ -50,7 +53,7 @@ const StakeAction: React.FC<StakeActionsProps> = ({
       stakingTokenBalance={stakingTokenBalance}
       isBnbPool={isBnbPool}
       pool={pool}
-      stakingTokenPrice={stakingTokenPrice}
+      stakingTokenPrice={stakingTokenPriceAsNumber}
       isRemovingStake
     />,
   )

--- a/src/views/Pools/components/PoolCard/CardActions/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/index.tsx
@@ -17,10 +17,9 @@ const InlineText = styled(Text)`
 interface CardActionsProps {
   pool: Pool
   stakedBalance: BigNumber
-  stakingTokenPrice: number
 }
 
-const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance, stakingTokenPrice }) => {
+const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
   const { sousId, stakingToken, earningToken, harvest, poolCategory, userData } = pool
   // Pools using native BNB behave differently than pools using a token
   const isBnbPool = poolCategory === PoolCategory.BINANCE
@@ -69,7 +68,6 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance, stakingT
             isLoading={isLoading}
             pool={pool}
             stakingTokenBalance={stakingTokenBalance}
-            stakingTokenPrice={stakingTokenPrice}
             stakedBalance={stakedBalance}
             isBnbPool={isBnbPool}
             isStaked={isStaked}

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -3,9 +3,8 @@ import React from 'react'
 import { CardBody, Flex, Text, CardRibbon } from '@pancakeswap/uikit'
 import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
-import { getAddress } from 'utils/addressHelpers'
 import { BIG_ZERO } from 'utils/bigNumber'
-import { useFarmFromTokenSymbol, useGetApiPrice } from 'state/hooks'
+import { useFarmFromTokenSymbol } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from './AprRow'
 import { StyledCard, StyledCardInner } from './StyledCard'
@@ -18,7 +17,6 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
   const { t } = useTranslation()
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
   const accountHasStakedBalance = stakedBalance.gt(0)
-  const stakingTokenPrice = useGetApiPrice(stakingToken.address ? getAddress(stakingToken.address) : '')
   const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
 
   return (
@@ -34,10 +32,11 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
           isFinished={isFinished && sousId !== 0}
         />
         <CardBody>
-          {earningTokenFarm && <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />}
+          {earningTokenFarm && <AprRow pool={pool} />}
+
           <Flex mt="24px" flexDirection="column">
             {account ? (
-              <CardActions pool={pool} stakedBalance={stakedBalance} stakingTokenPrice={stakingTokenPrice} />
+              <CardActions pool={pool} stakedBalance={stakedBalance} />
             ) : (
               <>
                 <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -4,7 +4,6 @@ import { CardBody, Flex, Text, CardRibbon } from '@pancakeswap/uikit'
 import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
 import { BIG_ZERO } from 'utils/bigNumber'
-import { useFarmFromTokenSymbol } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from './AprRow'
 import { StyledCard, StyledCardInner } from './StyledCard'
@@ -17,7 +16,6 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
   const { t } = useTranslation()
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
   const accountHasStakedBalance = stakedBalance.gt(0)
-  const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
 
   return (
     <StyledCard
@@ -32,8 +30,7 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
           isFinished={isFinished && sousId !== 0}
         />
         <CardBody>
-          {earningTokenFarm && <AprRow pool={pool} />}
-
+          <AprRow pool={pool} />
           <Flex mt="24px" flexDirection="column">
             {account ? (
               <CardActions pool={pool} stakedBalance={stakedBalance} />

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -5,7 +5,7 @@ import UnlockButton from 'components/UnlockButton'
 import { useTranslation } from 'contexts/Localization'
 import { getAddress } from 'utils/addressHelpers'
 import { BIG_ZERO } from 'utils/bigNumber'
-import { useGetApiPrice } from 'state/hooks'
+import { useFarmFromTokenSymbol, useGetApiPrice } from 'state/hooks'
 import { Pool } from 'state/types'
 import AprRow from './AprRow'
 import { StyledCard, StyledCardInner } from './StyledCard'
@@ -19,6 +19,7 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
   const accountHasStakedBalance = stakedBalance.gt(0)
   const stakingTokenPrice = useGetApiPrice(stakingToken.address ? getAddress(stakingToken.address) : '')
+  const earningTokenFarm = useFarmFromTokenSymbol(earningToken.symbol)
 
   return (
     <StyledCard
@@ -33,7 +34,7 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
           isFinished={isFinished && sousId !== 0}
         />
         <CardBody>
-          <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />
+          {earningTokenFarm && <AprRow pool={pool} stakingTokenPrice={stakingTokenPrice} />}
           <Flex mt="24px" flexDirection="column">
             {account ? (
               <CardActions pool={pool} stakedBalance={stakedBalance} stakingTokenPrice={stakingTokenPrice} />


### PR DESCRIPTION
Preview: https://farm-pools-prices.netlify.app/pools

### Replace API price data with LP price data for:

**Pools**
- APR / APY balances & calculation modals
- Staked/earned $ values
- Staking/unstaking modal $ values

**IFO**
- LP token price

-------

**To do in next PR:**
- Farms
- Possible optimisations of using the hooks to store price in state and then access them in unified way across farms & pools