### PR TITLE
style(lottery): Legend colors incorrect in dark mode

### DIFF
--- a/src/views/Lottery/components/PastDrawsHistory/Legend.tsx
+++ b/src/views/Lottery/components/PastDrawsHistory/Legend.tsx
@@ -18,7 +18,7 @@ const Circle = styled.div<{ isPoolSize?: boolean }>`
   width: 20px;
   height: 20px;
   border-radius: 10px;
-  background-color: ${({ isPoolSize, theme }) => theme.colors[isPoolSize ? 'textSubtle' : 'primary']};
+  background-color: ${({ isPoolSize, theme }) => (isPoolSize ? '#7A6EAA' : theme.colors.primary)};
   margin-right: 6px;
 `
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/987947/118790555-2b89fa00-b896-11eb-9702-c886cd9bdfe9.png)
![image](https://user-images.githubusercontent.com/987947/118790577-317fdb00-b896-11eb-9699-298d5dc5c439.png)

After:
![image](https://user-images.githubusercontent.com/987947/118790607-3b094300-b896-11eb-8e86-5a06fdb7b28d.png)
![image](https://user-images.githubusercontent.com/987947/118790630-40ff2400-b896-11eb-9c6c-35579a9beedf.png)
