### PR TITLE
style(lottery): Two loading indicators

### DIFF
--- a/src/views/Lottery/components/PastDrawsHistory/HistoryChart.tsx
+++ b/src/views/Lottery/components/PastDrawsHistory/HistoryChart.tsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense, useContext, useMemo } from 'react'
 import styled from 'styled-components'
-import { Text } from '@pancakeswap/uikit'
+import { Flex, Text } from '@pancakeswap/uikit'
 import PastLotteryDataContext from 'contexts/PastLotteryDataContext'
 import { useTranslation } from 'contexts/Localization'
 import useTheme from 'hooks/useTheme'
@@ -148,7 +148,13 @@ const HistoryChart: React.FC<HistoryChartProps> = ({ showLast }) => {
         </InnerWrapper>
       )}
       {!historyError && historyData.length > 1 ? (
-        <Suspense fallback={<div>{t('Loading...')}</div>}>
+        <Suspense
+          fallback={
+            <Flex justifyContent="center">
+              <Loading />
+            </Flex>
+          }
+        >
           {showLast === 50 || showLast === 100 ? (
             <Bar data={chartData(t)} options={options} />
           ) : (


### PR DESCRIPTION
The lottery history chart.js had two loading indicators, the loading spinner and a text, now only one loading indicator is used.

Before lottery history is ready:
![image](https://user-images.githubusercontent.com/987947/118796351-d3ee8d00-b89b-11eb-8c64-090d649ac5be.png)

Before chart.js is ready (also appeared when changing the "last" value in dropdown):
![image](https://user-images.githubusercontent.com/987947/118796463-ee286b00-b89b-11eb-9dc2-4f7aac9d4cf0.png)

Before:
![before_load](https://user-images.githubusercontent.com/987947/118796548-00a2a480-b89c-11eb-85c5-954d999e1442.gif)

After:
![after_load](https://user-images.githubusercontent.com/987947/118796571-04cec200-b89c-11eb-857d-7c5dd47e3cdc.gif)
