### PR TITLE
fix: (IFO) ~Infinity LP shown when price is being loaded in Achivements

### DIFF
--- a/src/views/Ifos/components/IfoFoldableCard/Achievement.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/Achievement.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Flex, LinkExternal, Image, Text, PrizeIcon } from '@pancakeswap/uikit'
+import { Flex, LinkExternal, Image, Text, PrizeIcon, Skeleton } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { PublicIfoData } from 'hooks/ifo/types'
 import { Ifo } from 'config/constants/types'
@@ -53,9 +53,13 @@ const Achievement: React.FC<Props> = ({ ifo, publicIfoData }) => {
               <Text color="textSubtle">{publicIfoData.numberPoints}</Text>
             </Flex>
           </Flex>
-          <Text color="textSubtle" fontSize="12px">
-            {t('Commit ~%amount% LP in total to earn!', { amount: minLpForAchievement.toFixed(3) })}
-          </Text>
+          {publicIfoData.currencyPriceInUSD.gt(0) ? (
+            <Text color="textSubtle" fontSize="12px">
+              {t('Commit ~%amount% LP in total to earn!', { amount: minLpForAchievement.toFixed(3) })}
+            </Text>
+          ) : (
+            <Skeleton minHeight={18} width={80} />
+          )}
         </Flex>
       </Flex>
       <StyledLinkExternal href={ifo.articleUrl}>


### PR DESCRIPTION
Issue: 

<img width="329" alt="Screenshot 2021-05-19 at 21 28 26" src="https://user-images.githubusercontent.com/2213635/118874533-4dfa3280-b8eb-11eb-9e55-10d5382a573a.png">
