### PR TITLE
Fix/Auto vault fee timer display conditions fix

### DIFF
--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -1,6 +1,7 @@
+import BigNumber from 'bignumber.js'
 import { useEffect, useState } from 'react'
 
-const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 259200) => {
+const useWithdrawalFeeTimer = (lastDepositedTime: number, userShares: BigNumber, withdrawalFeePeriod = 259200) => {
   const [secondsRemaining, setSecondsRemaining] = useState(null)
   const [hasUnstakingFee, setHasUnstakingFee] = useState(false)
   const [currentSeconds, setCurrentSeconds] = useState(Math.floor(Date.now() / 1000))
@@ -8,7 +9,7 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 
   useEffect(() => {
     const feeEndTime = lastDepositedTime + withdrawalFeePeriod
     const secondsRemainingCalc = feeEndTime - currentSeconds
-    const doesUnstakingFeeApply = secondsRemainingCalc > 0
+    const doesUnstakingFeeApply = userShares && secondsRemainingCalc > 0
     const tick = () => {
       setCurrentSeconds((prevSeconds) => prevSeconds + 1)
     }
@@ -20,8 +21,9 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, withdrawalFeePeriod = 
       setHasUnstakingFee(false)
       clearInterval(timerInterval)
     }
+
     return () => clearInterval(timerInterval)
-  }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining, currentSeconds])
+  }, [lastDepositedTime, withdrawalFeePeriod, setSecondsRemaining, currentSeconds, userShares])
 
   return { hasUnstakingFee, secondsRemaining }
 }

--- a/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
+++ b/src/hooks/cakeVault/useWithdrawalFeeTimer.ts
@@ -9,7 +9,8 @@ const useWithdrawalFeeTimer = (lastDepositedTime: number, userShares: BigNumber,
   useEffect(() => {
     const feeEndTime = lastDepositedTime + withdrawalFeePeriod
     const secondsRemainingCalc = feeEndTime - currentSeconds
-    const doesUnstakingFeeApply = userShares && secondsRemainingCalc > 0
+    const doesUnstakingFeeApply = userShares.gt(0) && secondsRemainingCalc > 0
+
     const tick = () => {
       setCurrentSeconds((prevSeconds) => prevSeconds + 1)
     }

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -35,7 +35,7 @@ const UnstakingFeeCountdownRow = () => {
   )
 
   // The user has made a deposit, but has no fee
-  const noFeeToPay = lastDepositedTime && !hasUnstakingFee
+  const noFeeToPay = lastDepositedTime && !hasUnstakingFee && userShares.gt(0)
 
   // Show the timer if a user is connected, has deposited, and has an unstaking fee
   const shouldShowTimer = account && lastDepositedTime && hasUnstakingFee

--- a/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
+++ b/src/views/Pools/components/CakeVaultCard/UnstakingFeeCountdownRow.tsx
@@ -10,7 +10,7 @@ const UnstakingFeeCountdownRow = () => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const {
-    userData: { lastDepositedTime },
+    userData: { lastDepositedTime, userShares },
     fees: { withdrawalFee, withdrawalFeePeriod },
   } = useCakeVault()
   const feeAsDecimal = withdrawalFee / 100 || '-'
@@ -30,6 +30,7 @@ const UnstakingFeeCountdownRow = () => {
 
   const { secondsRemaining, hasUnstakingFee } = useWithdrawalFeeTimer(
     parseInt(lastDepositedTime, 10),
+    userShares,
     withdrawalFeePeriod,
   )
 

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -44,7 +44,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
   const [pendingTx, setPendingTx] = useState(false)
   const [stakeAmount, setStakeAmount] = useState('')
   const [percent, setPercent] = useState(0)
-  const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(lastDepositedTime))
+  const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(lastDepositedTime, 10), userShares)
   const cakePriceBusd = usePriceCakeBusd()
   const usdValueStaked = stakeAmount && formatNumber(new BigNumber(stakeAmount).times(cakePriceBusd).toNumber())
 


### PR DESCRIPTION
Preview: https://fix-fee-timer-display.netlify.app/pools

- The fee countdown condition wasn't taking into account whether the user has shares staked - meaning it would show 0% withdrawal fee even when a user doesn't have anything staked .
- Now it will show `0.1% unstaking fee if withdrawn within 72h` if a user has no shares staked.