### PR TITLE
feat: Add translations for earn cards in home page

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -790,5 +790,7 @@
   "Contact": "Contact",
   "Merch": "Merch",
   "LP Migration": "LP Migration",
-  "V1 Liquidity (Old)": "V1 Liquidity (Old)"
+  "V1 Liquidity (Old)": "V1 Liquidity (Old)",
+  "Earn up to %highestApr% APR in Farms": "Earn up to %highestApr% APR in Farms",
+  "Earn %assets% in Pools": "Earn %assets% in Pools"
 }

--- a/src/views/Home/components/EarnAPRCard.tsx
+++ b/src/views/Home/components/EarnAPRCard.tsx
@@ -50,19 +50,22 @@ const EarnAPRCard = () => {
     return maxApr?.toLocaleString('en-US', { maximumFractionDigits: 2 })
   }, [cakePrice, farmsLP, prices])
 
+  const aprText = t('Earn up to %highestApr% APR in Farms', { highestApr })
+  const aprTextParts = aprText.split(highestApr)
+
   return (
     <StyledFarmStakingCard>
       <NavLink exact activeClassName="active" to="/farms" id="farm-apr-cta">
         <CardBody>
           <Heading color="contrast" scale="lg">
-            Earn up to
+            {aprTextParts[0]}
           </Heading>
           <CardMidContent color="#7645d9">
-            {highestApr ? `${highestApr}% ${t('APR')}` : <Skeleton animation="pulse" variant="rect" height="44px" />}
+            {highestApr ? `${highestApr}%` : <Skeleton animation="pulse" variant="rect" height="44px" />}
           </CardMidContent>
           <Flex justifyContent="space-between">
             <Heading color="contrast" scale="lg">
-              in Farms
+              {aprTextParts[1]}
             </Heading>
             <ArrowForwardIcon mt={30} color="primary" />
           </Flex>

--- a/src/views/Home/components/EarnAssetCard.tsx
+++ b/src/views/Home/components/EarnAssetCard.tsx
@@ -5,6 +5,7 @@ import { Heading, Card, CardBody, Flex, ArrowForwardIcon } from '@pancakeswap/ui
 import { NavLink } from 'react-router-dom'
 import pools from 'config/constants/pools'
 import { Pool } from 'state/types'
+import { useTranslation } from 'contexts/Localization'
 
 const StyledFarmStakingCard = styled(Card)`
   background: linear-gradient(#53dee9, #7645d9);
@@ -31,17 +32,21 @@ const latestPools: Pool[] = orderBy(activeNonCakePools, ['sortOrder', 'pid'], ['
 const assets = ['CAKE', ...latestPools.map((pool) => pool.earningToken.symbol)].join(', ')
 
 const EarnAssetCard = () => {
+  const { t } = useTranslation()
+  const assetText = t('Earn %assets% in Pools', { assets })
+  const assetTextParts = assetText.split(assets)
+
   return (
     <StyledFarmStakingCard>
       <NavLink exact activeClassName="active" to="/syrup" id="pool-cta">
         <CardBody>
           <Heading color="contrast" scale="lg">
-            Earn
+            {assetTextParts[0]}
           </Heading>
           <CardMidContent color="invertedContrast">{assets}</CardMidContent>
           <Flex justifyContent="space-between">
             <Heading color="contrast" scale="lg">
-              in Pools
+              {assetTextParts[1]}
             </Heading>
             <ArrowForwardIcon mt={30} color="primary" />
           </Flex>


### PR DESCRIPTION
Since we have different components for apr and asset text, this is the solution that i found. It is better than nothing I think. 