### PR TITLE
feat(farm/pool): HGET

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -39,6 +39,16 @@ const farms: FarmConfig[] = [
    * V3 by order of release (some may be out of PID order due to multiplier boost)
    */
   {
+    pid: 296,
+    lpSymbol: 'HGET-BNB LP',
+    lpAddresses: {
+      97: '',
+      56: '0xF74ee1e10e097dc326a2ad004F9Cc95CB71088d3',
+    },
+    token: tokens.hget,
+    quoteToken: tokens.wbnb,
+  },
+  {
     pid: 386,
     lpSymbol: 'HOTCROSS-BNB LP',
     lpAddresses: {
@@ -926,16 +936,6 @@ const farms: FarmConfig[] = [
       56: '0x1F37d4226d23d09044B8005c127C0517BD7e94fD',
     },
     token: tokens.lit,
-    quoteToken: tokens.wbnb,
-  },
-  {
-    pid: 296,
-    lpSymbol: 'HGET-BNB LP',
-    lpAddresses: {
-      97: '',
-      56: '0xF74ee1e10e097dc326a2ad004F9Cc95CB71088d3',
-    },
-    token: tokens.hget,
     quoteToken: tokens.wbnb,
   },
   {

--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -28,7 +28,7 @@ const pools: PoolConfig[] = [
     harvest: true,
     tokenPerBlock: '0.03553',
     sortOrder: 999,
-    isFinished: true,
+    isFinished: false,
   },
   {
     sousId: 151,

--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -17,6 +17,20 @@ const pools: PoolConfig[] = [
     isFinished: false,
   },
   {
+    sousId: 152,
+    stakingToken: tokens.cake,
+    earningToken: tokens.hget,
+    contractAddress: {
+      97: '',
+      56: '0x8e8125f871eb5ba9d55361365f5391ab437f9acc',
+    },
+    poolCategory: PoolCategory.CORE,
+    harvest: true,
+    tokenPerBlock: '0.03553',
+    sortOrder: 999,
+    isFinished: true,
+  },
+  {
     sousId: 151,
     stakingToken: tokens.cake,
     earningToken: tokens.hotcross,


### PR DESCRIPTION
note: token config etc already exists because this is a boost

pool:
--------------
**Stake:** CAKE
**Stake Token Contract Address:** 0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82
**Earn:** HGET
**Earn Token Contract Address:** https://bscscan.com/token/0xc7d8d35eba58a0935ff2d5a33df105dd9f071731
**Rewards per block:** 0.03553 HGET
**Max Stake per wallet for the first 48 hours:** `100000000000000000000` (100)
**Start block:** 7592800
**End block:** 8456800
**Token Decimals:** 6
**Project website:** https://www.hedget.com/

farm
---------------
PID 296 (HGET-BNB) to 0.5x
0.5x multiple to run for 14 days from 5am UTC on May 21st (Block 7592800) until 5am UTC on June 4th (Block 8456800), before reverting back to 0.1x CAKE rewards after that.
