### PR TITLE
feat: (IFO): Add finished tags and grayfilter when Ifo pool card finished but still active

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -796,5 +796,6 @@
   "The higher your team’s rank, the better your prizes!": "The higher your team’s rank, the better your prizes!",
   "Get Ready": "Get Ready",
   "Earn up to %highestApr% APR in Farms": "Earn up to %highestApr% APR in Farms",
-  "Earn %assets% in Pools": "Earn %assets% in Pools"
+  "Earn %assets% in Pools": "Earn %assets% in Pools",
+  "Activate PancakeSwap Profile to take part in next IFO‘s!": "Activate PancakeSwap Profile to take part in next IFO‘s!"
 }

--- a/src/views/Ifos/components/IfoFoldableCard/Achievement.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/Achievement.tsx
@@ -23,6 +23,10 @@ const Container = styled(Flex)`
   }
 `
 
+const AchievementFlex = styled(Flex)<{ isFinished: boolean }>`
+  ${({ isFinished }) => (isFinished ? 'filter: grayscale(100%)' : '')};
+`
+
 const StyledLinkExternal = styled(LinkExternal)`
   margin-top: 32px;
   ${({ theme }) => theme.mediaQueries.md} {
@@ -38,7 +42,7 @@ const Achievement: React.FC<Props> = ({ ifo, publicIfoData }) => {
 
   return (
     <Container>
-      <Flex alignItems="center" flexGrow={1}>
+      <AchievementFlex isFinished={publicIfoData.status === 'finished'} alignItems="center" flexGrow={1}>
         <Image src={`/images/achievements/ifo-${tokenName}.svg`} width={56} height={56} mr="8px" />
         <Flex flexDirection="column">
           <Text color="secondary" fontSize="12px">
@@ -61,7 +65,7 @@ const Achievement: React.FC<Props> = ({ ifo, publicIfoData }) => {
             <Skeleton minHeight={18} width={80} />
           )}
         </Flex>
-      </Flex>
+      </AchievementFlex>
       <StyledLinkExternal href={ifo.articleUrl}>
         {t('Learn more about %title%', { title: campaignTitle })}
       </StyledLinkExternal>

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardTokens.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardTokens.tsx
@@ -64,6 +64,9 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
       return <SkeletonCardTokens />
     }
     if (account && !hasProfile) {
+      if (publicIfoData.status === 'finished') {
+        return <Text textAlign="center">{t('Activate PancakeSwap Profile to take part in next IFO‘s!')}</Text>
+      }
       return <Text textAlign="center">{t('You need an active PancakeSwap Profile to take part in an IFO!')}</Text>
     }
     if (publicIfoData.status === 'coming_soon') {

--- a/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -25,18 +25,18 @@ interface IfoFoldableCardProps {
   isInitiallyVisible: boolean
 }
 
-const getRibbonComponent = (status: IfoStatus, t: any) => {
+const getRibbonComponent = (ifo: Ifo, status: IfoStatus, t: any) => {
   if (status === 'coming_soon') {
     return <CardRibbon variantColor="textDisabled" ribbonPosition="left" text={t('Coming Soon')} />
   }
 
-  if (status === 'live') {
+  if (status === 'live' || (status === 'finished' && ifo.isActive)) {
     return (
       <CardRibbon
         variantColor="primary"
         ribbonPosition="left"
         style={{ textTransform: 'uppercase' }}
-        text={`${t('Live')}!`}
+        text={status === 'live' ? `${t('Live')}!` : `${t('Finished')}!`}
       />
     )
   }
@@ -94,7 +94,7 @@ const IfoFoldableCard: React.FC<IfoFoldableCardProps> = ({ ifo, publicIfoData, w
   const [isVisible, setIsVisible] = useState(isInitiallyVisible)
   const { t } = useTranslation()
 
-  const Ribbon = getRibbonComponent(publicIfoData.status, t)
+  const Ribbon = getRibbonComponent(ifo, publicIfoData.status, t)
   const isActive = publicIfoData.status !== 'finished' && ifo.isActive
 
   return (


### PR DESCRIPTION
Things done

-Added finisherd card ribbon when finished but active
-Grayfilter achievement when finished
-Change active profile warning when finished

Before:

<img width="760" alt="Screenshot 2021-05-21 at 16 58 22" src="https://user-images.githubusercontent.com/2213635/119157804-d7c60f00-ba55-11eb-89ee-b443bf1d0968.png">


After: 

<img width="780" alt="Screenshot 2021-05-21 at 16 58 34" src="https://user-images.githubusercontent.com/2213635/119157829-dbf22c80-ba55-11eb-8b35-405d6d93534c.png">
