### PR TITLE
chore(vault): Harvest gas limit

### DIFF
--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -51,7 +51,7 @@ const BountyModal: React.FC<BountyModalProps> = ({
   const handleConfirmClick = async () => {
     cakeVaultContract.methods
       .harvest()
-      .send({ from: account })
+      .send({ from: account, gas: 200000 })
       .on('sending', () => {
         setPendingTx(true)
       })


### PR DESCRIPTION
Default gas limit setting on Cake vault bounty harvest (same as pools).