### PR TITLE
Fix/tooltip portal and positioning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,5 +52,6 @@
     </noscript>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="portal-root"></div>
   </body>
 </html>

--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -25,7 +25,7 @@ const AprRow: React.FC<AprRowProps> = ({ pool, isAutoVault = false, compoundFreq
     ? t('APY includes compounding, APR doesn’t. This pool’s CAKE is compounded automatically, so we show APY.')
     : t('This pool’s rewards aren’t compounded automatically, so we show APR')
 
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, { placement: 'bottom-end' })
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, { placement: 'bottom-start' })
 
   const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
   const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.toNumber()

--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -58,7 +58,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account, isAutoVa
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     t('Subtracted automatically from each yield harvest and burned.'),
-    { placement: 'bottom-end' },
+    { placement: 'bottom-start' },
   )
 
   const getTotalStakedBalance = () => {

--- a/src/views/Pools/components/PoolCard/CardFooter/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/index.tsx
@@ -32,7 +32,7 @@ const Footer: React.FC<FooterProps> = ({ pool, account, isAutoVault = false }) =
   )
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(isAutoVault ? autoTooltipText : manualTooltipText, {
-    placement: 'bottom-end',
+    placement: 'bottom',
   })
 
   return (


### PR DESCRIPTION
Depends on https://github.com/pancakeswap/pancake-toolkit/pull/113 to be merged first.

- Added a `div` to index.html to use a default render portal for tooltips.
- Adjusted some tooltip positions that were confined by their containers previously.
- Checked all tooltips to make sure they not doing any funny stuff.

The initial reason for it that tooltip in other langauges get cropped as discovered by @memoyil with German language in Pool card.
Also it is nice to not care about portals in code at all.

Before:
![Screenshot 2021-05-21 at 20 10 32](https://user-images.githubusercontent.com/81824236/119175380-6a74a700-ba72-11eb-9d2f-8936fa2be534.png)

After:
![Screenshot 2021-05-21 at 20 10 17](https://user-images.githubusercontent.com/81824236/119175392-6f395b00-ba72-11eb-8098-5a5a5ad7b246.png)
