### PR TITLE
fix: (pools) Cake vault card actions margin top to be aligned with other pool cards

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -64,7 +64,7 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
           <Box mt="8px">
             <UnstakingFeeCountdownRow />
           </Box>
-          <Flex mt="24px" flexDirection="column">
+          <Flex mt="32px" flexDirection="column">
             {account ? (
               <VaultCardActions pool={pool} accountHasSharesStaked={accountHasSharesStaked} isLoading={isLoading} />
             ) : (


### PR DESCRIPTION
Before:

<img width="1132" alt="Screenshot 2021-05-24 at 03 38 36" src="https://user-images.githubusercontent.com/2213635/119285110-9c883380-bc41-11eb-9c34-e8a877389f69.png">

After:

<img width="1138" alt="Screenshot 2021-05-24 at 03 38 05" src="https://user-images.githubusercontent.com/2213635/119285113-9eea8d80-bc41-11eb-9f04-ec7e362576c6.png">
