### PR TITLE
fix: (farms) Farm data and cake price cannot be seen for very long time mainly Firefox

### DIFF
--- a/src/state/farms/fetchFarm.ts
+++ b/src/state/farms/fetchFarm.ts
@@ -2,8 +2,7 @@ import { Farm } from 'state/types'
 import fetchPublicFarmData from './fetchPublicFarmData'
 
 const fetchFarm = async (farm: Farm): Promise<Farm> => {
-  const { pid, lpAddresses, token, quoteToken } = farm
-  const farmPublicData = await fetchPublicFarmData(pid, lpAddresses, token, quoteToken)
+  const farmPublicData = await fetchPublicFarmData(farm)
 
   return { ...farm, ...farmPublicData }
 }

--- a/src/state/farms/fetchPublicFarmData.ts
+++ b/src/state/farms/fetchPublicFarmData.ts
@@ -1,96 +1,120 @@
 import BigNumber from 'bignumber.js'
-import { Address, Token } from 'config/constants/types'
 import masterchefABI from 'config/abi/masterchef.json'
 import erc20 from 'config/abi/erc20.json'
 import { getAddress, getMasterChefAddress } from 'utils/addressHelpers'
 import { BIG_TEN, BIG_ZERO } from 'utils/bigNumber'
 import multicall from 'utils/multicall'
+import { Farm, SerializedBigNumber } from '../types'
 
-const fetchFarm = async (pid: number, lpAddresses: Address, token: Token, quoteToken: Token) => {
+type PublicFarmData = {
+  tokenAmountMc?: SerializedBigNumber
+  quoteTokenAmountMc?: SerializedBigNumber
+  tokenAmountTotal?: SerializedBigNumber
+  quoteTokenAmountTotal?: SerializedBigNumber
+  lpTotalInQuoteToken?: SerializedBigNumber
+  lpTotalSupply?: SerializedBigNumber
+  tokenPriceVsQuote?: SerializedBigNumber
+  poolWeight?: SerializedBigNumber
+}
+
+const fetchFarm = async (farm: Farm): Promise<PublicFarmData> => {
+  const { pid, lpAddresses, token, quoteToken } = farm
   const lpAddress = getAddress(lpAddresses)
-  const calls = [
-    // Balance of token in the LP contract
-    {
-      address: getAddress(token.address),
-      name: 'balanceOf',
-      params: [lpAddress],
-    },
-    // Balance of quote token on LP contract
-    {
-      address: getAddress(quoteToken.address),
-      name: 'balanceOf',
-      params: [lpAddress],
-    },
-    // Balance of LP tokens in the master chef contract
-    {
-      address: lpAddress,
-      name: 'balanceOf',
-      params: [getMasterChefAddress()],
-    },
-    // Total supply of LP tokens
-    {
-      address: lpAddress,
-      name: 'totalSupply',
-    },
-    // Token decimals
-    {
-      address: getAddress(token.address),
-      name: 'decimals',
-    },
-    // Quote token decimals
-    {
-      address: getAddress(quoteToken.address),
-      name: 'decimals',
-    },
-  ]
+  const farmFetch = async () => {
+    const calls = [
+      // Balance of token in the LP contract
+      {
+        address: getAddress(token.address),
+        name: 'balanceOf',
+        params: [lpAddress],
+      },
+      // Balance of quote token on LP contract
+      {
+        address: getAddress(quoteToken.address),
+        name: 'balanceOf',
+        params: [lpAddress],
+      },
+      // Balance of LP tokens in the master chef contract
+      {
+        address: lpAddress,
+        name: 'balanceOf',
+        params: [getMasterChefAddress()],
+      },
+      // Total supply of LP tokens
+      {
+        address: lpAddress,
+        name: 'totalSupply',
+      },
+      // Token decimals
+      {
+        address: getAddress(token.address),
+        name: 'decimals',
+      },
+      // Quote token decimals
+      {
+        address: getAddress(quoteToken.address),
+        name: 'decimals',
+      },
+    ]
 
-  const [tokenBalanceLP, quoteTokenBalanceLP, lpTokenBalanceMC, lpTotalSupply, tokenDecimals, quoteTokenDecimals] =
-    await multicall(erc20, calls)
+    const [tokenBalanceLP, quoteTokenBalanceLP, lpTokenBalanceMC, lpTotalSupply, tokenDecimals, quoteTokenDecimals] =
+      await multicall(erc20, calls)
 
-  // Ratio in % of LP tokens that are staked in the MC, vs the total number in circulation
-  const lpTokenRatio = new BigNumber(lpTokenBalanceMC).div(new BigNumber(lpTotalSupply))
+    // Ratio in % of LP tokens that are staked in the MC, vs the total number in circulation
+    const lpTokenRatio = new BigNumber(lpTokenBalanceMC).div(new BigNumber(lpTotalSupply))
 
-  // Raw amount of token in the LP, including those not staked
-  const tokenAmountTotal = new BigNumber(tokenBalanceLP).div(BIG_TEN.pow(tokenDecimals))
-  const quoteTokenAmountTotal = new BigNumber(quoteTokenBalanceLP).div(BIG_TEN.pow(quoteTokenDecimals))
+    // Raw amount of token in the LP, including those not staked
+    const tokenAmountTotal = new BigNumber(tokenBalanceLP).div(BIG_TEN.pow(tokenDecimals))
+    const quoteTokenAmountTotal = new BigNumber(quoteTokenBalanceLP).div(BIG_TEN.pow(quoteTokenDecimals))
 
-  // Amount of token in the LP that are staked in the MC (i.e amount of token * lp ratio)
-  const tokenAmountMc = tokenAmountTotal.times(lpTokenRatio)
-  const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
+    // Amount of token in the LP that are staked in the MC (i.e amount of token * lp ratio)
+    const tokenAmountMc = tokenAmountTotal.times(lpTokenRatio)
+    const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
 
-  // Total staked in LP, in quote token value
-  const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
+    // Total staked in LP, in quote token value
+    const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
 
-  // Only make masterchef calls if farm has pid
-  const [info, totalAllocPoint] =
-    pid || pid === 0
-      ? await multicall(masterchefABI, [
-          {
-            address: getMasterChefAddress(),
-            name: 'poolInfo',
-            params: [pid],
-          },
-          {
-            address: getMasterChefAddress(),
-            name: 'totalAllocPoint',
-          },
-        ])
-      : [null, null]
+    // Only make masterchef calls if farm has pid
+    const [info, totalAllocPoint] =
+      pid || pid === 0
+        ? await multicall(masterchefABI, [
+            {
+              address: getMasterChefAddress(),
+              name: 'poolInfo',
+              params: [pid],
+            },
+            {
+              address: getMasterChefAddress(),
+              name: 'totalAllocPoint',
+            },
+          ])
+        : [null, null]
 
-  const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
-  const poolWeight = totalAllocPoint ? allocPoint.div(new BigNumber(totalAllocPoint)) : BIG_ZERO
+    const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
+    const poolWeight = totalAllocPoint ? allocPoint.div(new BigNumber(totalAllocPoint)) : BIG_ZERO
 
-  return {
-    tokenAmountMc: tokenAmountMc.toJSON(),
-    quoteTokenAmountMc: quoteTokenAmountMc.toJSON(),
-    tokenAmountTotal: tokenAmountTotal.toJSON(),
-    quoteTokenAmountTotal: quoteTokenAmountTotal.toJSON(),
-    lpTotalSupply: new BigNumber(lpTotalSupply).toJSON(),
-    lpTotalInQuoteToken: lpTotalInQuoteToken.toJSON(),
-    tokenPriceVsQuote: quoteTokenAmountTotal.div(tokenAmountTotal).toJSON(),
-    poolWeight: poolWeight.toJSON(),
-    multiplier: `${allocPoint.div(100).toString()}X`,
+    return {
+      tokenAmountMc: tokenAmountMc.toJSON(),
+      quoteTokenAmountMc: quoteTokenAmountMc.toJSON(),
+      tokenAmountTotal: tokenAmountTotal.toJSON(),
+      quoteTokenAmountTotal: quoteTokenAmountTotal.toJSON(),
+      lpTotalSupply: new BigNumber(lpTotalSupply).toJSON(),
+      lpTotalInQuoteToken: lpTotalInQuoteToken.toJSON(),
+      tokenPriceVsQuote: quoteTokenAmountTotal.div(tokenAmountTotal).toJSON(),
+      poolWeight: poolWeight.toJSON(),
+      multiplier: `${allocPoint.div(100).toString()}X`,
+    }
   }
+
+  // In some browsers promise above gets stuck that causes fetchFarms to not proceed.
+  const timeout = new Promise((resolve) => {
+    const id = setTimeout(() => {
+      clearTimeout(id)
+      resolve({})
+    }, 5000)
+  })
+
+  return Promise.race([timeout, farmFetch()])
 }
 
 export default fetchFarm


### PR DESCRIPTION
Issue mainly happens on firefox but might also happen on other browsers as well. If one of the farms fetching got stuck, that causes already fetched farms data to not be pushed to redux. Therefore user cannot see farm details as well as cake/busd price for very long time. Since we are using slowRefresh there user has to wait additional one minute to renew the request (and that request might also get stuck).  So I added timeout promise alongside with fetch promise and use promise race.

Review: https://deploy-preview-1318--pancakeswap-dev.netlify.app/

To reproduce the issue:

1. Open main page in firefox
2. See cake price is not loading 
3. If it is loaded quickly refresh the page and check it again.