### PR TITLE
refactor: Extract block number polling into its own hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Router, Redirect, Route, Switch } from 'react-router-dom'
 import { ResetCSS } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import useEagerConnect from 'hooks/useEagerConnect'
-import { useFetchPriceList, useFetchProfile, useFetchPublicData } from 'state/hooks'
+import { useFetchPriceList, useFetchProfile, useFetchPublicData, usePollBlockNumber } from 'state/hooks'
 import GlobalStyle from './style/Global'
 import Menu from './components/Menu'
 import SuspenseWithChunkError from './components/SuspenseWithChunkError'
@@ -34,6 +34,7 @@ BigNumber.config({
 })
 
 const App: React.FC = () => {
+  usePollBlockNumber()
   useEagerConnect()
   useFetchPublicData()
   useFetchProfile()

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -43,6 +43,11 @@ export const useFetchPublicData = () => {
     fetchPoolsPublicData()
     dispatch(fetchPoolsStakingLimitsAsync())
   }, [dispatch, slowRefresh, web3])
+}
+
+export const usePollBlockNumber = () => {
+  const dispatch = useAppDispatch()
+  const web3 = getWeb3NoAccount()
 
   useEffect(() => {
     const interval = setInterval(async () => {


### PR DESCRIPTION
Moved the global polling of the block number to its own hook. No logic has changed. 
