### PR TITLE
refactor: Move public pools polling to pools view

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -35,13 +35,7 @@ export const useFetchPublicData = () => {
   const { slowRefresh } = useRefresh()
   const web3 = getWeb3NoAccount()
   useEffect(() => {
-    const fetchPoolsPublicData = async () => {
-      const blockNumber = await web3.eth.getBlockNumber()
-      dispatch(fetchPoolsPublicDataAsync(blockNumber))
-    }
     dispatch(fetchFarmsPublicDataAsync())
-    fetchPoolsPublicData()
-    dispatch(fetchPoolsStakingLimitsAsync())
   }, [dispatch, slowRefresh, web3])
 
   useEffect(() => {
@@ -153,6 +147,22 @@ export const useLpTokenPrice = (symbol: string) => {
 }
 
 // Pools
+
+export const useFetchPublicPoolsData = () => {
+  const dispatch = useAppDispatch()
+  const { slowRefresh } = useRefresh()
+  const web3 = getWeb3NoAccount()
+
+  useEffect(() => {
+    const fetchPoolsPublicData = async () => {
+      const blockNumber = await web3.eth.getBlockNumber()
+      dispatch(fetchPoolsPublicDataAsync(blockNumber))
+    }
+
+    fetchPoolsPublicData()
+    dispatch(fetchPoolsStakingLimitsAsync())
+  }, [dispatch, slowRefresh, web3])
+}
 
 export const usePools = (account): Pool[] => {
   const { fastRefresh } = useRefresh()

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy'
 import partition from 'lodash/partition'
 import { useTranslation } from 'contexts/Localization'
 import usePersistState from 'hooks/usePersistState'
-import { usePools, useFetchCakeVault } from 'state/hooks'
+import { usePools, useFetchCakeVault, useFetchPublicPoolsData } from 'state/hooks'
 import FlexLayout from 'components/layout/Flex'
 import Page from 'components/layout/Page'
 import PageHeader from 'components/PageHeader'
@@ -19,7 +19,6 @@ import BountyCard from './components/BountyCard'
 const NUMBER_OF_POOLS_VISIBLE = 12
 
 const Pools: React.FC = () => {
-  useFetchCakeVault()
   const { path } = useRouteMatch()
   const { t } = useTranslation()
   const { account } = useWeb3React()
@@ -42,6 +41,9 @@ const Pools: React.FC = () => {
 
   // This pool is passed explicitly to the cake vault
   const cakePoolData = useMemo(() => openPools.find((pool) => pool.sousId === 0), [openPools])
+
+  useFetchCakeVault()
+  useFetchPublicPoolsData()
 
   useEffect(() => {
     const showMorePools = (entries) => {


### PR DESCRIPTION
Extracts the pool data from the global hook and moves to the pool's view.
