### PR TITLE
fix(hooks): Fix usePriceBnbBusd hook to use quoteToken price

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -324,7 +324,7 @@ export const useGetApiPrice = (address: string) => {
 
 export const usePriceBnbBusd = (): BigNumber => {
   const bnbBusdFarm = useFarmFromPid(252)
-  return new BigNumber(bnbBusdFarm.token.busdPrice)
+  return new BigNumber(bnbBusdFarm.quoteToken.busdPrice)
 }
 
 export const usePriceCakeBusd = (): BigNumber => {


### PR DESCRIPTION
- usePriceBnbBusd hook was returning `token` (busd) .busdPrice instead of `quoteToken` (bnb) .busdPrice