### PR TITLE
fix: Change Cakebusd price checks against 0 equality to greater than

### DIFF
--- a/src/views/Home/components/CakeHarvestBalance.tsx
+++ b/src/views/Home/components/CakeHarvestBalance.tsx
@@ -39,7 +39,7 @@ const CakeHarvestBalance = () => {
   return (
     <Block>
       <CardValue value={earningsSum} lineHeight="1.5" />
-      {!cakePriceBusd.eq(0) && <CardBusdValue value={earningsBusd} />}
+      {cakePriceBusd.gt(0) && <CardBusdValue value={earningsBusd} />}
     </Block>
   )
 }

--- a/src/views/Home/components/CakeWalletBalance.tsx
+++ b/src/views/Home/components/CakeWalletBalance.tsx
@@ -28,7 +28,7 @@ const CakeWalletBalance = () => {
   return (
     <>
       <CardValue value={getBalanceNumber(cakeBalance)} decimals={4} fontSize="24px" lineHeight="36px" />
-      {!cakePriceBusd.eq(0) ? <CardBusdValue value={busdBalance} /> : <br />}
+      {cakePriceBusd.gt(0) ? <CardBusdValue value={busdBalance} /> : <br />}
     </>
   )
 }

--- a/src/views/Home/components/CakeWinnings.tsx
+++ b/src/views/Home/components/CakeWinnings.tsx
@@ -35,7 +35,7 @@ const CakeWinnings: React.FC<CakeWinningsProps> = ({ claimAmount }) => {
   return (
     <Block>
       <CardValue value={cakeAmount} lineHeight="1.5" />
-      {!cakePriceBusd.eq(0) && <CardBusdValue value={claimAmountBusd} decimals={2} />}
+      {cakePriceBusd.gt(0) && <CardBusdValue value={claimAmountBusd} decimals={2} />}
     </Block>
   )
 }

--- a/src/views/Home/components/EarnAPRCard.tsx
+++ b/src/views/Home/components/EarnAPRCard.tsx
@@ -32,17 +32,20 @@ const EarnAPRCard = () => {
   const cakePrice = usePriceCakeBusd()
 
   const highestApr = useMemo(() => {
-    const aprs = farmsLP.map((farm) => {
-      // Filter inactive farms, because their theoretical APR is super high. In practice, it's 0.
-      if (farm.pid !== 0 && farm.multiplier !== '0X' && farm.lpTotalInQuoteToken && farm.quoteToken.busdPrice) {
-        const totalLiquidity = new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteToken.busdPrice)
-        return getFarmApr(farm.poolWeight, cakePrice, totalLiquidity)
-      }
-      return null
-    })
+    if (cakePrice.gt(0)) {
+      const aprs = farmsLP.map((farm) => {
+        // Filter inactive farms, because their theoretical APR is super high. In practice, it's 0.
+        if (farm.pid !== 0 && farm.multiplier !== '0X' && farm.lpTotalInQuoteToken && farm.quoteToken.busdPrice) {
+          const totalLiquidity = new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteToken.busdPrice)
+          return getFarmApr(farm.poolWeight, cakePrice, totalLiquidity)
+        }
+        return null
+      })
 
-    const maxApr = max(aprs)
-    return maxApr?.toLocaleString('en-US', { maximumFractionDigits: 2 })
+      const maxApr = max(aprs)
+      return maxApr?.toLocaleString('en-US', { maximumFractionDigits: 2 })
+    }
+    return null
   }, [cakePrice, farmsLP])
 
   const aprText = highestApr || '-'

--- a/src/views/Lottery/components/PrizeGrid.tsx
+++ b/src/views/Lottery/components/PrizeGrid.tsx
@@ -85,7 +85,7 @@ const PrizeGrid: React.FC<PrizeGridProps> = ({
       <GridItem>
         <RightAlignedHeading scale="md">
           {fourMatchesAmount.toLocaleString()}
-          {!pastDraw && !cakeBusdPrice.eq(0) && <CardBusdValue value={getCakeBusdValue(fourMatchesAmount)} />}
+          {!pastDraw && cakeBusdPrice.gt(0) && <CardBusdValue value={getCakeBusdValue(fourMatchesAmount)} />}
         </RightAlignedHeading>
       </GridItem>
       {/* 3 matches row */}
@@ -100,7 +100,7 @@ const PrizeGrid: React.FC<PrizeGridProps> = ({
       <GridItem>
         <RightAlignedText>
           {threeMatchesAmount.toLocaleString()}
-          {!pastDraw && !cakeBusdPrice.eq(0) && <CardBusdValue value={getCakeBusdValue(threeMatchesAmount)} />}
+          {!pastDraw && cakeBusdPrice.gt(0) && <CardBusdValue value={getCakeBusdValue(threeMatchesAmount)} />}
         </RightAlignedText>
       </GridItem>
       {/* 2 matches row */}
@@ -115,7 +115,7 @@ const PrizeGrid: React.FC<PrizeGridProps> = ({
       <GridItem>
         <RightAlignedText>
           {twoMatchesAmount.toLocaleString()}
-          {!pastDraw && !cakeBusdPrice.eq(0) && <CardBusdValue value={getCakeBusdValue(twoMatchesAmount)} />}
+          {!pastDraw && cakeBusdPrice.gt(0) && <CardBusdValue value={getCakeBusdValue(twoMatchesAmount)} />}
         </RightAlignedText>
       </GridItem>
       {/* Burn row */}

--- a/src/views/Lottery/components/TotalPrizesCard/index.tsx
+++ b/src/views/Lottery/components/TotalPrizesCard/index.tsx
@@ -56,7 +56,8 @@ const TotalPrizesCard = () => {
   const { account } = useWeb3React()
   const [showFooter, setShowFooter] = useState(false)
   const lotteryPrizeAmount = +getBalanceNumber(useTotalRewards()).toFixed(0)
-  const lotteryPrizeAmountBusd = new BigNumber(lotteryPrizeAmount).multipliedBy(usePriceCakeBusd()).toNumber()
+  const cakePrice = usePriceCakeBusd()
+  const lotteryPrizeAmountBusd = new BigNumber(lotteryPrizeAmount).multipliedBy(cakePrice)
   const lotteryPrizeWithCommaSeparators = lotteryPrizeAmount.toLocaleString()
   const { currentLotteryNumber } = useContext(PastLotteryDataContext)
 
@@ -83,7 +84,7 @@ const TotalPrizesCard = () => {
                 {t('Total Pot:')}
               </Text>
               <Heading scale="lg">{lotteryPrizeWithCommaSeparators} CAKE</Heading>
-              {lotteryPrizeAmountBusd !== 0 && <CardBusdValue value={lotteryPrizeAmountBusd} />}
+              {cakePrice.gt(0) && <CardBusdValue value={lotteryPrizeAmountBusd.toNumber()} />}
             </PrizeCountWrapper>
           </Left>
           <Right>

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -35,14 +35,12 @@ const BountyCard = () => {
     fees: { callFee },
   } = useCakeVault()
   const cakePriceBusd = usePriceCakeBusd()
-  const cakePriceBusdAsNumber = cakePriceBusd.toNumber()
 
   const estimatedDollarBountyReward = useMemo(() => {
-    return new BigNumber(estimatedCakeBountyReward).multipliedBy(cakePriceBusdAsNumber)
-  }, [cakePriceBusdAsNumber, estimatedCakeBountyReward])
+    return new BigNumber(estimatedCakeBountyReward).multipliedBy(cakePriceBusd)
+  }, [cakePriceBusd, estimatedCakeBountyReward])
 
-  const hasFetchedDollarBounty =
-    cakePriceBusdAsNumber && estimatedDollarBountyReward ? estimatedDollarBountyReward.gte(0) : false
+  const hasFetchedDollarBounty = estimatedDollarBountyReward.gte(0)
   const hasFetchedCakeBounty = estimatedCakeBountyReward ? estimatedCakeBountyReward.gte(0) : false
   const dollarBountyToDisplay = hasFetchedDollarBounty ? getBalanceNumber(estimatedDollarBountyReward, 18) : 0
   const cakeBountyToDisplay = hasFetchedCakeBounty ? getBalanceNumber(estimatedCakeBountyReward, 18) : 0

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
@@ -22,7 +22,9 @@ const HasSharesActions: React.FC<HasStakeActionProps> = ({ pool, stakingTokenBal
   const { stakingToken } = pool
   const { cakeAsBigNumber, cakeAsNumberBalance } = convertSharesToCake(userShares, pricePerFullShare)
   const cakePriceBusd = usePriceCakeBusd()
-  const stakedDollarValue = getBalanceNumber(cakeAsBigNumber.multipliedBy(cakePriceBusd), stakingToken.decimals)
+  const stakedDollarValue = cakePriceBusd.gt(0)
+    ? getBalanceNumber(cakeAsBigNumber.multipliedBy(cakePriceBusd), stakingToken.decimals)
+    : 0
 
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
   const [onPresentStake] = useModal(<VaultStakeModal stakingMax={stakingTokenBalance} pool={pool} />)

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -46,7 +46,8 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
   const [percent, setPercent] = useState(0)
   const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(lastDepositedTime, 10), userShares)
   const cakePriceBusd = usePriceCakeBusd()
-  const usdValueStaked = stakeAmount && formatNumber(new BigNumber(stakeAmount).times(cakePriceBusd).toNumber())
+  const usdValueStaked =
+    cakePriceBusd.gt(0) && stakeAmount ? formatNumber(new BigNumber(stakeAmount).times(cakePriceBusd).toNumber()) : ''
 
   const handleStakeInputChange = (input: string) => {
     if (input) {
@@ -174,7 +175,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
       <BalanceInput
         value={stakeAmount}
         onUserInput={handleStakeInputChange}
-        currencyValue={`~${usdValueStaked || 0} USD`}
+        currencyValue={cakePriceBusd.gt(0) && `~${usdValueStaked || 0} USD`}
       />
       <Text mt="8px" ml="auto" color="textSubtle" fontSize="12px" mb="8px">
         {t('Balance: %balance%', { balance: getFullDisplayBalance(stakingMax, stakingToken.decimals) })}

--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -28,7 +28,7 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
 
   const earningTokenPrice = useBusdPriceFromToken(earningToken.symbol)
-  const earningTokenPriceAsNumber = earningTokenPrice ? earningTokenPrice.toNumber() : 0
+  const earningTokenPriceAsNumber = earningTokenPrice && earningTokenPrice.gt(0) ? earningTokenPrice.toNumber() : 0
   const earningTokenDollarBalance = getBalanceNumber(
     earnings.multipliedBy(earningTokenPriceAsNumber),
     earningToken.decimals,

--- a/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/StakeActions.tsx
@@ -30,7 +30,7 @@ const StakeAction: React.FC<StakeActionsProps> = ({
   const { t } = useTranslation()
   const stakedTokenBalance = getBalanceNumber(stakedBalance, stakingToken.decimals)
   const stakingTokenPrice = useBusdPriceFromToken(stakingToken.symbol)
-  const stakingTokenPriceAsNumber = stakingTokenPrice ? stakingTokenPrice.toNumber() : 0
+  const stakingTokenPriceAsNumber = stakingTokenPrice && stakingTokenPrice.gt(0) ? stakingTokenPrice.toNumber() : 0
   const stakedTokenDollarBalance = getBalanceNumber(
     stakedBalance.multipliedBy(stakingTokenPriceAsNumber),
     stakingToken.decimals,

--- a/src/views/TradingCompetition/components/YourScore/UserPrizeGrid.tsx
+++ b/src/views/TradingCompetition/components/YourScore/UserPrizeGrid.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   TeamPlayerIcon,
   TrophyGoldIcon,
+  Skeleton,
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { UserTradingInformationProps } from '../../types'
@@ -40,9 +41,13 @@ const UserPrizeGrid: React.FC<{ userTradingInformation?: UserTradingInformationP
           <BoldTd>
             <Flex flexDirection="column">
               <Text bold>{cakeReward.toFixed(2)}</Text>
-              <Text fontSize="12px" color="textSubtle">
-                ~{dollarValueOfCakeReward} USD
-              </Text>
+              {dollarValueOfCakeReward ? (
+                <Text fontSize="12px" color="textSubtle">
+                  ~{dollarValueOfCakeReward} USD
+                </Text>
+              ) : (
+                <Skeleton height={24} width={80} />
+              )}
             </Flex>
           </BoldTd>
           <Td>

--- a/src/views/TradingCompetition/helpers.ts
+++ b/src/views/TradingCompetition/helpers.ts
@@ -12,7 +12,10 @@ export const useCompetitionCakeRewards = (userCakeReward: ReactText) => {
   const cakeAsBigNumber = new BigNumber(userCakeReward as string)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
   const cakePriceBusd = usePriceCakeBusd()
-  return { cakeReward: cakeBalance, dollarValueOfCakeReward: cakeBalance * cakePriceBusd.toNumber() }
+  return {
+    cakeReward: cakeBalance,
+    dollarValueOfCakeReward: cakePriceBusd.gt(0) ? cakeBalance * cakePriceBusd.toNumber() : null,
+  }
 }
 
 // 1 is a reasonable teamRank default: accessing the first team in the config.


### PR DESCRIPTION
Root cause: usePriceCakeBusd() returns NaN that also not equals to 0 (which makes our condition always true from the beginning in that component) which causes in firefox browser to not rerender the component when price is available

To reproduce: Check Farms & Staking section on homepage with Production build on firefox

Issue:

<img width="571" alt="image" src="https://user-images.githubusercontent.com/2213635/119657822-ad48cd00-be2c-11eb-88b3-78234336ae54.png">
