### PR TITLE
feat(prediction): Default gasPrice on BetBull/BetBear

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -25,6 +25,7 @@ import useToast from 'hooks/useToast'
 import { BetPosition } from 'state/types'
 import { getDecimalAmount } from 'utils/formatBalance'
 import UnlockButton from 'components/UnlockButton'
+import { BIG_NINE, BIG_TEN } from 'utils/bigNumber'
 import PositionTag from '../PositionTag'
 import { getBnbAmount } from '../../helpers'
 import useSwiper from '../../hooks/useSwiper'
@@ -37,6 +38,10 @@ interface SetPositionCardProps {
   onBack: () => void
   onSuccess: (decimalValue: BigNumber, hash: string) => Promise<void>
 }
+
+// /!\ TEMPORARY /!\
+// Set default gasPrice (6 gwei) when calling BetBull/BetBear before new contract is released fixing this 'issue'.
+const gasPrice = new BigNumber(6).times(BIG_TEN.pow(BIG_NINE)).toString()
 
 const dust = new BigNumber(0.01).times(DEFAULT_TOKEN_DECIMAL)
 const percentShortcuts = [10, 25, 50, 75]
@@ -127,7 +132,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
     const decimalValue = getDecimalAmount(valueAsBn)
 
     predictionsContract.methods[betMethod]()
-      .send({ from: account, value: decimalValue })
+      .send({ from: account, value: decimalValue, gasPrice })
       .once('sending', () => {
         setIsTxPending(true)
       })

--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -41,6 +41,7 @@ interface SetPositionCardProps {
 
 // /!\ TEMPORARY /!\
 // Set default gasPrice (6 gwei) when calling BetBull/BetBear before new contract is released fixing this 'issue'.
+// TODO: Remove on beta-v2 smart contract release.
 const gasPrice = new BigNumber(6).times(BIG_TEN.pow(BIG_NINE)).toString()
 
 const dust = new BigNumber(0.01).times(DEFAULT_TOKEN_DECIMAL)


### PR DESCRIPTION
To remove when new smart contract is live, or to update when BSC network fees are updated.