### PR TITLE
Feature/farm polling refactor v2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Router, Redirect, Route, Switch } from 'react-router-dom'
 import { ResetCSS } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import useEagerConnect from 'hooks/useEagerConnect'
-import { useFetchProfile, useFetchPublicData, usePollBlockNumber } from 'state/hooks'
+import { usePollCoreFarmData, useFetchProfile, usePollBlockNumber } from 'state/hooks'
 import GlobalStyle from './style/Global'
 import Menu from './components/Menu'
 import SuspenseWithChunkError from './components/SuspenseWithChunkError'
@@ -36,8 +36,8 @@ BigNumber.config({
 const App: React.FC = () => {
   usePollBlockNumber()
   useEagerConnect()
-  useFetchPublicData()
   useFetchProfile()
+  usePollCoreFarmData()
 
   return (
     <Router history={history}>

--- a/src/hooks/useApprove.ts
+++ b/src/hooks/useApprove.ts
@@ -3,25 +3,23 @@ import { useWeb3React } from '@web3-react/core'
 import { Contract } from 'web3-eth-contract'
 import { ethers } from 'ethers'
 import { useAppDispatch } from 'state'
-import { updateUserAllowance, fetchFarmUserDataAsync } from 'state/actions'
+import { updateUserAllowance } from 'state/actions'
 import { approve } from 'utils/callHelpers'
 import { useMasterchef, useCake, useSousChef, useLottery } from './useContract'
 
 // Approve a Farm
 export const useApprove = (lpContract: Contract) => {
-  const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const masterChefContract = useMasterchef()
 
   const handleApprove = useCallback(async () => {
     try {
       const tx = await approve(lpContract, masterChefContract, account)
-      dispatch(fetchFarmUserDataAsync(account))
       return tx
     } catch (e) {
       return false
     }
-  }, [account, dispatch, lpContract, masterChefContract])
+  }, [account, lpContract, masterChefContract])
 
   return { onApprove: handleApprove }
 }

--- a/src/hooks/useHarvest.ts
+++ b/src/hooks/useHarvest.ts
@@ -1,20 +1,18 @@
 import { useCallback } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { useAppDispatch } from 'state'
-import { fetchFarmUserDataAsync, updateUserBalance, updateUserPendingReward } from 'state/actions'
+import { updateUserBalance, updateUserPendingReward } from 'state/actions'
 import { soushHarvest, soushHarvestBnb, harvest } from 'utils/callHelpers'
 import { useMasterchef, useSousChef } from './useContract'
 
 export const useHarvest = (farmPid: number) => {
-  const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const masterChefContract = useMasterchef()
 
   const handleHarvest = useCallback(async () => {
     const txHash = await harvest(masterChefContract, farmPid, account)
-    dispatch(fetchFarmUserDataAsync({ account, pids: [farmPid] }))
     return txHash
-  }, [account, dispatch, farmPid, masterChefContract])
+  }, [account, farmPid, masterChefContract])
 
   return { onReward: handleHarvest }
 }

--- a/src/hooks/useHarvest.ts
+++ b/src/hooks/useHarvest.ts
@@ -12,7 +12,7 @@ export const useHarvest = (farmPid: number) => {
 
   const handleHarvest = useCallback(async () => {
     const txHash = await harvest(masterChefContract, farmPid, account)
-    dispatch(fetchFarmUserDataAsync(account))
+    dispatch(fetchFarmUserDataAsync({ account, pids: [farmPid] }))
     return txHash
   }, [account, dispatch, farmPid, masterChefContract])
 

--- a/src/hooks/useStake.ts
+++ b/src/hooks/useStake.ts
@@ -1,22 +1,20 @@
 import { useCallback } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { useAppDispatch } from 'state'
-import { fetchFarmUserDataAsync, updateUserStakedBalance, updateUserBalance } from 'state/actions'
+import { updateUserStakedBalance, updateUserBalance } from 'state/actions'
 import { stake, sousStake, sousStakeBnb } from 'utils/callHelpers'
 import { useMasterchef, useSousChef } from './useContract'
 
 const useStake = (pid: number) => {
-  const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const masterChefContract = useMasterchef()
 
   const handleStake = useCallback(
     async (amount: string) => {
       const txHash = await stake(masterChefContract, pid, amount, account)
-      dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },
-    [account, dispatch, masterChefContract, pid],
+    [account, masterChefContract, pid],
   )
 
   return { onStake: handleStake }

--- a/src/hooks/useUnstake.ts
+++ b/src/hooks/useUnstake.ts
@@ -1,27 +1,20 @@
 import { useCallback } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { useAppDispatch } from 'state'
-import {
-  fetchFarmUserDataAsync,
-  updateUserStakedBalance,
-  updateUserBalance,
-  updateUserPendingReward,
-} from 'state/actions'
+import { updateUserStakedBalance, updateUserBalance, updateUserPendingReward } from 'state/actions'
 import { unstake, sousUnstake, sousEmergencyUnstake } from 'utils/callHelpers'
 import { useMasterchef, useSousChef } from './useContract'
 
 const useUnstake = (pid: number) => {
-  const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const masterChefContract = useMasterchef()
 
   const handleUnstake = useCallback(
     async (amount: string) => {
       const txHash = await unstake(masterChefContract, pid, amount, account)
-      dispatch(fetchFarmUserDataAsync(account))
       console.info(txHash)
     },
-    [account, dispatch, masterChefContract, pid],
+    [account, masterChefContract, pid],
   )
 
   return { onUnstake: handleUnstake }

--- a/src/state/farms/fetchFarm.ts
+++ b/src/state/farms/fetchFarm.ts
@@ -1,0 +1,11 @@
+import { Farm } from 'state/types'
+import fetchPublicFarmData from './fetchPublicFarmData'
+
+const fetchFarm = async (farm: Farm): Promise<Farm> => {
+  const { pid, lpAddresses, token, quoteToken } = farm
+  const farmPublicData = await fetchPublicFarmData(pid, lpAddresses, token, quoteToken)
+
+  return { ...farm, ...farmPublicData }
+}
+
+export default fetchFarm

--- a/src/state/farms/fetchFarms.ts
+++ b/src/state/farms/fetchFarms.ts
@@ -1,16 +1,11 @@
 import { FarmConfig } from 'config/constants/types'
-import fetchPublicFarmData from './fetchPublicFarmData'
+import fetchFarm from './fetchFarm'
 
 const fetchFarms = async (farmsToFetch: FarmConfig[]) => {
   const data = await Promise.all(
     farmsToFetch.map(async (farmConfig) => {
-      const { pid, lpAddresses, token, quoteToken } = farmConfig
-      const publicFarmData = await fetchPublicFarmData(pid, lpAddresses, token, quoteToken)
-
-      return {
-        ...farmConfig,
-        ...publicFarmData,
-      }
+      const farm = await fetchFarm(farmConfig)
+      return farm
     }),
   )
   return data

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import farmsConfig from 'config/constants/farms'
+import isArchivedPid from 'utils/farmHelpers'
 import priceHelperLpsConfig from 'config/constants/priceHelperLps'
 import fetchFarms from './fetchFarms'
 import fetchFarmsPrices from './fetchFarmsPrices'
@@ -23,6 +24,8 @@ const noAccountFarmConfig = farmsConfig.map((farm) => ({
 }))
 
 const initialState: FarmsState = { data: noAccountFarmConfig, loadArchivedFarmsData: false, userDataLoaded: false }
+
+export const nonArchivedFarms = farmsConfig.filter(({ pid }) => !isArchivedPid(pid))
 
 // Async thunks
 export const fetchFarmsPublicDataAsync = createAsyncThunk<Farm[], number[]>(

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-param-reassign */
-import { createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import farmsConfig from 'config/constants/farms'
 import priceHelperLpsConfig from 'config/constants/priceHelperLps'
-import isArchivedPid from 'utils/farmHelpers'
 import fetchFarms from './fetchFarms'
 import fetchFarmsPrices from './fetchFarmsPrices'
 import {
@@ -12,8 +11,6 @@ import {
   fetchFarmUserStakedBalances,
 } from './fetchFarmUser'
 import { FarmsState, Farm } from '../types'
-
-const nonArchivedFarms = farmsConfig.filter(({ pid }) => !isArchivedPid(pid))
 
 const noAccountFarmConfig = farmsConfig.map((farm) => ({
   ...farm,
@@ -27,68 +24,87 @@ const noAccountFarmConfig = farmsConfig.map((farm) => ({
 
 const initialState: FarmsState = { data: noAccountFarmConfig, loadArchivedFarmsData: false, userDataLoaded: false }
 
+// Async thunks
+export const fetchFarmsPublicDataAsync = createAsyncThunk<Farm[], number[]>(
+  'farms/fetchFarmsPublicDataAsync',
+  async (pids) => {
+    const farmsToFetch = farmsConfig.filter((farmConfig) => pids.includes(farmConfig.pid))
+
+    // Add price helper farms
+    const farmsWithPriceHelpers = farmsToFetch.concat(priceHelperLpsConfig)
+
+    const farms = await fetchFarms(farmsWithPriceHelpers)
+    const farmsWithPrices = await fetchFarmsPrices(farms)
+
+    // Filter out price helper LP config farms
+    const farmsWithoutHelperLps = farmsWithPrices.filter((farm: Farm) => {
+      return farm.pid || farm.pid === 0
+    })
+
+    return farmsWithoutHelperLps
+  },
+)
+
+interface FarmUserDataResponse {
+  pid: number
+  allowance: string
+  tokenBalance: string
+  stakedBalance: string
+  earnings: string
+}
+
+export const fetchFarmUserDataAsync = createAsyncThunk<FarmUserDataResponse[], { account: string; pids: number[] }>(
+  'farms/fetchFarmUserDataAsync',
+  async ({ account, pids }) => {
+    const farmsToFetch = farmsConfig.filter((farmConfig) => pids.includes(farmConfig.pid))
+    const userFarmAllowances = await fetchFarmUserAllowances(account, farmsToFetch)
+    const userFarmTokenBalances = await fetchFarmUserTokenBalances(account, farmsToFetch)
+    const userStakedBalances = await fetchFarmUserStakedBalances(account, farmsToFetch)
+    const userFarmEarnings = await fetchFarmUserEarnings(account, farmsToFetch)
+
+    return userFarmAllowances.map((farmAllowance, index) => {
+      return {
+        pid: farmsToFetch[index].pid,
+        allowance: userFarmAllowances[index],
+        tokenBalance: userFarmTokenBalances[index],
+        stakedBalance: userStakedBalances[index],
+        earnings: userFarmEarnings[index],
+      }
+    })
+  },
+)
+
 export const farmsSlice = createSlice({
   name: 'Farms',
   initialState,
   reducers: {
-    setFarmsPublicData: (state, action) => {
-      const liveFarmsData: Farm[] = action.payload
-      state.data = state.data.map((farm) => {
-        const liveFarmData = liveFarmsData.find((f) => f.pid === farm.pid)
-        return { ...farm, ...liveFarmData }
-      })
-    },
-    setFarmUserData: (state, action) => {
-      const { arrayOfUserDataObjects } = action.payload
-      arrayOfUserDataObjects.forEach((userDataEl) => {
-        const { pid } = userDataEl
-        const index = state.data.findIndex((farm) => farm.pid === pid)
-        state.data[index] = { ...state.data[index], userData: userDataEl }
-      })
-      state.userDataLoaded = true
-    },
     setLoadArchivedFarmsData: (state, action) => {
       const loadArchivedFarmsData = action.payload
       state.loadArchivedFarmsData = loadArchivedFarmsData
     },
   },
+  extraReducers: (builder) => {
+    // Update farms with live data
+    builder.addCase(fetchFarmsPublicDataAsync.fulfilled, (state, action) => {
+      state.data = state.data.map((farm) => {
+        const liveFarmData = action.payload.find((farmData) => farmData.pid === farm.pid)
+        return { ...farm, ...liveFarmData }
+      })
+    })
+
+    // Update farms with user data
+    builder.addCase(fetchFarmUserDataAsync.fulfilled, (state, action) => {
+      action.payload.forEach((userDataEl) => {
+        const { pid } = userDataEl
+        const index = state.data.findIndex((farm) => farm.pid === pid)
+        state.data[index] = { ...state.data[index], userData: userDataEl }
+      })
+      state.userDataLoaded = true
+    })
+  },
 })
 
 // Actions
-export const { setFarmsPublicData, setFarmUserData, setLoadArchivedFarmsData } = farmsSlice.actions
-
-// Thunks
-export const fetchFarmsPublicDataAsync = () => async (dispatch, getState) => {
-  const fetchArchived = getState().farms.loadArchivedFarmsData
-  const farmsToFetch = fetchArchived ? farmsConfig : nonArchivedFarms
-  const farmsWithPriceHelpers = farmsToFetch.concat(priceHelperLpsConfig)
-  const farms = await fetchFarms(farmsWithPriceHelpers)
-  const farmsWithPrices = await fetchFarmsPrices(farms)
-  // Filter out price helper LP config farms
-  const farmsWithoutHelperLps = farmsWithPrices.filter((farm: Farm) => {
-    return farm.pid || farm.pid === 0
-  })
-  dispatch(setFarmsPublicData(farmsWithoutHelperLps))
-}
-export const fetchFarmUserDataAsync = (account: string) => async (dispatch, getState) => {
-  const fetchArchived = getState().farms.loadArchivedFarmsData
-  const farmsToFetch = fetchArchived ? farmsConfig : nonArchivedFarms
-  const userFarmAllowances = await fetchFarmUserAllowances(account, farmsToFetch)
-  const userFarmTokenBalances = await fetchFarmUserTokenBalances(account, farmsToFetch)
-  const userStakedBalances = await fetchFarmUserStakedBalances(account, farmsToFetch)
-  const userFarmEarnings = await fetchFarmUserEarnings(account, farmsToFetch)
-
-  const arrayOfUserDataObjects = userFarmAllowances.map((farmAllowance, index) => {
-    return {
-      pid: farmsToFetch[index].pid,
-      allowance: userFarmAllowances[index],
-      tokenBalance: userFarmTokenBalances[index],
-      stakedBalance: userStakedBalances[index],
-      earnings: userFarmEarnings[index],
-    }
-  })
-
-  dispatch(setFarmUserData({ arrayOfUserDataObjects }))
-}
+export const { setLoadArchivedFarmsData } = farmsSlice.actions
 
 export default farmsSlice.reducer

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -12,7 +12,6 @@ import { getBalanceAmount } from 'utils/formatBalance'
 import { BIG_ZERO } from 'utils/bigNumber'
 import useRefresh from 'hooks/useRefresh'
 import { filterFarmsByQuoteToken } from 'utils/farmsPriceHelpers'
-import isArchivedPid from 'utils/farmHelpers'
 import {
   fetchFarmsPublicDataAsync,
   fetchPoolsPublicDataAsync,
@@ -31,7 +30,7 @@ import { fetchWalletNfts } from './collectibles'
 import { getCanClaim } from './predictions/helpers'
 import { transformPool } from './pools/helpers'
 import { fetchPoolsStakingLimitsAsync } from './pools'
-import { fetchFarmUserDataAsync } from './farms'
+import { fetchFarmUserDataAsync, nonArchivedFarms } from './farms'
 
 export const usePollFarmsData = (includeArchive = false) => {
   const dispatch = useAppDispatch()
@@ -40,7 +39,7 @@ export const usePollFarmsData = (includeArchive = false) => {
   const { account } = useWeb3React()
 
   useEffect(() => {
-    const farmsToFetch = includeArchive ? farmsConfig : farmsConfig.filter(({ pid }) => !isArchivedPid(pid))
+    const farmsToFetch = includeArchive ? farmsConfig : nonArchivedFarms
     const pids = farmsToFetch.map((farmToFetch) => farmToFetch.pid)
 
     dispatch(fetchFarmsPublicDataAsync(pids))

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -111,7 +111,7 @@ export const useLpTokenPrice = (symbol: string) => {
     // Double it to get overall value in LP
     const overallValueOfAllTokensInFarm = valueOfBaseTokenInFarm.times(2)
     // Divide total value of all tokens, by the number of LP tokens
-    const totalLpTokens = getBalanceAmount(farm.lpTotalSupply)
+    const totalLpTokens = getBalanceAmount(new BigNumber(farm.lpTotalSupply))
     lpTokenPrice = overallValueOfAllTokensInFarm.div(totalLpTokens)
   }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -11,14 +11,14 @@ export type TranslatableText =
     }
 
 export interface Farm extends FarmConfig {
-  tokenAmountMc?: BigNumber
-  quoteTokenAmountMc?: BigNumber
-  tokenAmountTotal?: BigNumber
-  quoteTokenAmountTotal?: BigNumber
-  lpTotalInQuoteToken?: BigNumber
-  lpTotalSupply?: BigNumber
-  tokenPriceVsQuote?: BigNumber
-  poolWeight?: BigNumber
+  tokenAmountMc?: string
+  quoteTokenAmountMc?: string
+  tokenAmountTotal?: string
+  quoteTokenAmountTotal?: string
+  lpTotalInQuoteToken?: string
+  lpTotalSupply?: string
+  tokenPriceVsQuote?: string
+  poolWeight?: string
   userData?: {
     allowance: string
     tokenBalance: string

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -10,15 +10,17 @@ export type TranslatableText =
       }
     }
 
+export type SerializedBigNumber = string
+
 export interface Farm extends FarmConfig {
-  tokenAmountMc?: string
-  quoteTokenAmountMc?: string
-  tokenAmountTotal?: string
-  quoteTokenAmountTotal?: string
-  lpTotalInQuoteToken?: string
-  lpTotalSupply?: string
-  tokenPriceVsQuote?: string
-  poolWeight?: string
+  tokenAmountMc?: SerializedBigNumber
+  quoteTokenAmountMc?: SerializedBigNumber
+  tokenAmountTotal?: SerializedBigNumber
+  quoteTokenAmountTotal?: SerializedBigNumber
+  lpTotalInQuoteToken?: SerializedBigNumber
+  lpTotalSupply?: SerializedBigNumber
+  tokenPriceVsQuote?: SerializedBigNumber
+  poolWeight?: SerializedBigNumber
   userData?: {
     allowance: string
     tokenBalance: string

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -172,7 +172,7 @@ const Farms: React.FC = () => {
           return farm
         }
         const totalLiquidity = new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteToken.busdPrice)
-        const apr = isActive ? getFarmApr(farm.poolWeight, cakePrice, totalLiquidity) : 0
+        const apr = isActive ? getFarmApr(new BigNumber(farm.poolWeight), cakePrice, totalLiquidity) : 0
 
         return { ...farm, apr, liquidity: totalLiquidity }
       })

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect, useCallback, useState, useMemo, useRef } from 'react'
 import { Route, useRouteMatch, useLocation } from 'react-router-dom'
-import { useAppDispatch } from 'state'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
 import { Image, Heading, RowType, Toggle, Text } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import FlexLayout from 'components/layout/Flex'
 import Page from 'components/layout/Page'
-import { useFarms, usePriceCakeBusd } from 'state/hooks'
-import useRefresh from 'hooks/useRefresh'
-import { fetchFarmUserDataAsync } from 'state/actions'
+import { useFarms, usePollFarmsData, usePriceCakeBusd } from 'state/hooks'
 import usePersistState from 'hooks/usePersistState'
 import { Farm } from 'state/types'
 import { useTranslation } from 'contexts/Localization'
@@ -19,7 +16,6 @@ import { orderBy } from 'lodash'
 import isArchivedPid from 'utils/farmHelpers'
 import { latinise } from 'utils/latinise'
 import PageHeader from 'components/PageHeader'
-import { fetchFarmsPublicDataAsync, setLoadArchivedFarmsData } from 'state/farms'
 import Select, { OptionProps } from 'components/Select/Select'
 import FarmCard, { FarmWithStakedValue } from './components/FarmCard/FarmCard'
 import Table from './components/FarmTable/FarmTable'
@@ -114,17 +110,11 @@ const Farms: React.FC = () => {
   const { account } = useWeb3React()
   const [sortOption, setSortOption] = useState('hot')
 
-  const dispatch = useAppDispatch()
-  const { fastRefresh } = useRefresh()
-  useEffect(() => {
-    if (account) {
-      dispatch(fetchFarmUserDataAsync(account))
-    }
-  }, [account, dispatch, fastRefresh])
-
   const isArchived = pathname.includes('archived')
   const isInactive = pathname.includes('history')
   const isActive = !isInactive && !isArchived
+
+  usePollFarmsData(isArchived)
 
   // Users with no wallet connected should see 0 as Earned amount
   // Connected users should see loading indicator until first userData has loaded
@@ -134,20 +124,6 @@ const Farms: React.FC = () => {
   useEffect(() => {
     setStakedOnly(!isActive)
   }, [isActive])
-
-  useEffect(() => {
-    // Makes the main scheduled fetching to request archived farms data
-    dispatch(setLoadArchivedFarmsData(isArchived))
-
-    // Immediately request data for archived farms so users don't have to wait
-    // 60 seconds for public data and 10 seconds for user data
-    if (isArchived) {
-      dispatch(fetchFarmsPublicDataAsync())
-      if (account) {
-        dispatch(fetchFarmUserDataAsync(account))
-      }
-    }
-  }, [isArchived, dispatch, account])
 
   const activeFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier !== '0X' && !isArchivedPid(farm.pid))
   const inactiveFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X' && !isArchivedPid(farm.pid))

--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -2,9 +2,11 @@ import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { provider as ProviderType } from 'web3-core'
 import BigNumber from 'bignumber.js'
+import { Button, Flex, Text } from '@pancakeswap/uikit'
 import { getAddress } from 'utils/addressHelpers'
 import { getBep20Contract } from 'utils/contractHelpers'
-import { Button, Flex, Text } from '@pancakeswap/uikit'
+import { useAppDispatch } from 'state'
+import { fetchFarmUserDataAsync } from 'state/farms'
 import { Farm } from 'state/types'
 import { useTranslation } from 'contexts/Localization'
 import useWeb3 from 'hooks/useWeb3'
@@ -45,6 +47,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
   const lpName = farm.lpSymbol.toUpperCase()
   const isApproved = account && allowance && allowance.isGreaterThan(0)
   const web3 = useWeb3()
+  const dispatch = useAppDispatch()
 
   const lpContract = getBep20Contract(lpAddress, web3)
 
@@ -54,11 +57,12 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
     try {
       setRequestedApproval(true)
       await onApprove()
+      dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
       setRequestedApproval(false)
     } catch (e) {
       console.error(e)
     }
-  }, [onApprove])
+  }, [onApprove, dispatch, account, pid])
 
   const renderApprovalOrStakeButton = () => {
     return isApproved ? (

--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import BigNumber from 'bignumber.js'
 import { Button, Flex, Heading } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useAppDispatch } from 'state'
+import { fetchFarmUserDataAsync } from 'state/farms'
 import { useHarvest } from 'hooks/useHarvest'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { useWeb3React } from '@web3-react/core'
@@ -19,7 +21,7 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
   const [pendingTx, setPendingTx] = useState(false)
   const { onReward } = useHarvest(pid)
   const cakePrice = usePriceCakeBusd()
-
+  const dispatch = useAppDispatch()
   const rawEarningsBalance = account ? getBalanceNumber(earnings) : 0
   const displayBalance = rawEarningsBalance.toLocaleString()
   const earningsBusd = rawEarningsBalance ? new BigNumber(rawEarningsBalance).multipliedBy(cakePrice).toNumber() : 0
@@ -35,6 +37,8 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
         onClick={async () => {
           setPendingTx(true)
           await onReward()
+          dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+
           setPendingTx(false)
         }}
       >

--- a/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -1,9 +1,12 @@
 import React, { useCallback } from 'react'
+import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 import { Button, Flex, Heading, IconButton, AddIcon, MinusIcon, useModal } from '@pancakeswap/uikit'
 import { useLocation } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
+import { useAppDispatch } from 'state'
+import { fetchFarmUserDataAsync } from 'state/farms'
 import useStake from 'hooks/useStake'
 import useUnstake from 'hooks/useUnstake'
 import { getBalanceNumber, getFullDisplayBalance } from 'utils/formatBalance'
@@ -36,6 +39,18 @@ const StakeAction: React.FC<FarmCardActionsProps> = ({
   const { onStake } = useStake(pid)
   const { onUnstake } = useUnstake(pid)
   const location = useLocation()
+  const dispatch = useAppDispatch()
+  const { account } = useWeb3React()
+
+  const handleStake = async (amount: string) => {
+    await onStake(amount)
+    dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+  }
+
+  const handleUnstake = async (amount: string) => {
+    await onUnstake(amount)
+    dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+  }
 
   const displayBalance = useCallback(() => {
     const stakedBalanceNumber = getBalanceNumber(stakedBalance)
@@ -46,10 +61,10 @@ const StakeAction: React.FC<FarmCardActionsProps> = ({
   }, [stakedBalance])
 
   const [onPresentDeposit] = useModal(
-    <DepositModal max={tokenBalance} onConfirm={onStake} tokenName={tokenName} addLiquidityUrl={addLiquidityUrl} />,
+    <DepositModal max={tokenBalance} onConfirm={handleStake} tokenName={tokenName} addLiquidityUrl={addLiquidityUrl} />,
   )
   const [onPresentWithdraw] = useModal(
-    <WithdrawModal max={stakedBalance} onConfirm={onUnstake} tokenName={tokenName} />,
+    <WithdrawModal max={stakedBalance} onConfirm={handleUnstake} tokenName={tokenName} />,
   )
 
   const renderStakingButtons = () => {

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { Button, Skeleton } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
+import { useWeb3React } from '@web3-react/core'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
 import { getBalanceNumber } from 'utils/formatBalance'
+import { useAppDispatch } from 'state'
+import { fetchFarmUserDataAsync } from 'state/farms'
+import { usePriceCakeBusd } from 'state/hooks'
 import { useHarvest } from 'hooks/useHarvest'
 import { useTranslation } from 'contexts/Localization'
-import { usePriceCakeBusd } from 'state/hooks'
 import { useCountUp } from 'react-countup'
 
 import { ActionContainer, ActionTitles, Title, Subtle, ActionContent, Earned, Staked } from './styles'
@@ -31,7 +34,8 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
   const [pendingTx, setPendingTx] = useState(false)
   const { onReward } = useHarvest(pid)
   const { t } = useTranslation()
-
+  const dispatch = useAppDispatch()
+  const { account } = useWeb3React()
   const { countUp, update } = useCountUp({
     start: 0,
     end: earningsBusd,
@@ -61,6 +65,8 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
           onClick={async () => {
             setPendingTx(true)
             await onReward()
+            dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
+
             setPendingTx(false)
           }}
           ml="4px"

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { Heading, Text, BaseLayout } from '@pancakeswap/uikit'
+import { useAppDispatch } from 'state'
+import { fetchFarmsPublicDataAsync, nonArchivedFarms } from 'state/farms'
 import { useTranslation } from 'contexts/Localization'
 import Page from 'components/layout/Page'
 import FarmStakingCard from 'views/Home/components/FarmStakingCard'
@@ -86,6 +88,12 @@ const CTACards = styled(BaseLayout)`
 
 const Home: React.FC = () => {
   const { t } = useTranslation()
+  const dispatch = useAppDispatch()
+
+  // Fetch farm data once to get the max APR
+  useEffect(() => {
+    dispatch(fetchFarmsPublicDataAsync(nonArchivedFarms.map((nonArchivedFarm) => nonArchivedFarm.pid)))
+  }, [dispatch])
 
   return (
     <Page>

--- a/src/views/Home/components/EarnAPRCard.tsx
+++ b/src/views/Home/components/EarnAPRCard.tsx
@@ -37,7 +37,7 @@ const EarnAPRCard = () => {
         // Filter inactive farms, because their theoretical APR is super high. In practice, it's 0.
         if (farm.pid !== 0 && farm.multiplier !== '0X' && farm.lpTotalInQuoteToken && farm.quoteToken.busdPrice) {
           const totalLiquidity = new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteToken.busdPrice)
-          return getFarmApr(farm.poolWeight, cakePrice, totalLiquidity)
+          return getFarmApr(new BigNumber(farm.poolWeight), cakePrice, totalLiquidity)
         }
         return null
       })

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy'
 import partition from 'lodash/partition'
 import { useTranslation } from 'contexts/Localization'
 import usePersistState from 'hooks/usePersistState'
-import { usePools, useFetchCakeVault, useFetchPublicPoolsData, usePollCoreFarmData } from 'state/hooks'
+import { usePools, useFetchCakeVault, useFetchPublicPoolsData, usePollFarmsData } from 'state/hooks'
 import FlexLayout from 'components/layout/Flex'
 import Page from 'components/layout/Page'
 import PageHeader from 'components/PageHeader'
@@ -44,7 +44,7 @@ const Pools: React.FC = () => {
 
   useFetchCakeVault()
   useFetchPublicPoolsData()
-  usePollCoreFarmData()
+  usePollFarmsData()
 
   useEffect(() => {
     const showMorePools = (entries) => {

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy'
 import partition from 'lodash/partition'
 import { useTranslation } from 'contexts/Localization'
 import usePersistState from 'hooks/usePersistState'
-import { usePools, useFetchCakeVault, useFetchPublicPoolsData } from 'state/hooks'
+import { usePools, useFetchCakeVault, useFetchPublicPoolsData, usePollCoreFarmData } from 'state/hooks'
 import FlexLayout from 'components/layout/Flex'
 import Page from 'components/layout/Page'
 import PageHeader from 'components/PageHeader'
@@ -44,6 +44,7 @@ const Pools: React.FC = () => {
 
   useFetchCakeVault()
   useFetchPublicPoolsData()
+  usePollCoreFarmData()
 
   useEffect(() => {
     const showMorePools = (entries) => {


### PR DESCRIPTION
- Created a global farm data fetching hook that only fetches farm data
- Refactored the farm fetching thunk to accept an array of `pids` so different hooks can fetch specific farms. This should allow the ability to add in "smart" fetching tied to our lazy loading.
- Refactored staking hooks to make them more pure. Now the consumers handle the refreshing of the data.