### PR TITLE
fix: (Team Battle) Add missing translations in team battle and fix test to check translations with carriage return

### DIFF
--- a/src/__tests__/config/translations.test.ts
+++ b/src/__tests__/config/translations.test.ts
@@ -26,11 +26,16 @@ describe('Check translations available', () => {
   throughDirectory('src/')
 
   it.each(files)('Translation key should exist in translations json', (file) => {
-    const regex = /\bt\('([^']*)'/gm
+    const regexWithoutCarriageReturn = /\bt\('([^']*)'/gm
+    const regexWithCarriageReturn = /\bt\([\r\n]\s+'([^']*)'/gm
     const data = fs.readFileSync(file, { encoding: 'utf8', flag: 'r' })
     let match
-    // eslint-disable-next-line no-cond-assign
-    while ((match = regex.exec(data)) !== null) {
+    while (
+      // eslint-disable-next-line no-cond-assign
+      (match = regexWithoutCarriageReturn.exec(data)) !== null ||
+      // eslint-disable-next-line no-cond-assign
+      (match = regexWithCarriageReturn.exec(data)) !== null
+    ) {
       if (match[1].trim()) {
         const includes = translationKeys.includes(match[1])
         try {

--- a/src/views/TradingCompetition/components/Rules/FAQs.tsx
+++ b/src/views/TradingCompetition/components/Rules/FAQs.tsx
@@ -103,7 +103,7 @@ const FAQ = () => {
           <FoldableText title={t('How do I claim my prize(s)?')} mt="24px">
             <Text fontSize="14px" color="textSubtle">
               {t(
-                'After the battle ends, visit the event page and click the “Claim Prizes” button in the top section or in the “Your Score” section. Once you claim your prizes successfully, the button text will change to “Prizes Claimed”.',
+                'After the battle ends, visit the event page and click the “Claim Prizes” button in the top section or in “Your Score” section. Once you claim your prizes successfully, the button text will change to “Prizes Claimed”.',
               )}
             </Text>
           </FoldableText>


### PR DESCRIPTION
Review: https://deploy-preview-1367--pancakeswap-dev.netlify.app/

To reproduce the issue: 

1. Change language to French or Magyar for example (the text that is missing is translated there)
2. Go to Team Battle
3. Go to FAQ
4. Click details of "How do I claim my prize(s)?" (the bottom one)
5. See the answer is not translated

I also added a rule to unit test that catches these translation keys
