### PR TITLE
fix: (IFO) Add missing translations in IFO

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -391,6 +391,7 @@
   "Everyone can only commit a limited amount, but may expect a higher return per token committed.": "Everyone can only commit a limited amount, but may expect a higher return per token committed.",
   "Unlimited Sale": "Unlimited Sale",
   "No limits on the amount you can commit. Additional fee applies when claiming.": "No limits on the amount you can commit. Additional fee applies when claiming.",
+  "Every person can only commit a limited amount, but may expect a higher return per token committed.": "Every person can only commit a limited amount, but may expect a higher return per token committed.",
   "You didn’t participate in this sale!": "You didn’t participate in this sale!",
   "Max. LP token entry": "Max. LP token entry",
   "How to Take Part": "How to Take Part",

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/index.tsx
@@ -54,7 +54,7 @@ const SmallCard: React.FC<IfoCardProps> = ({ poolId, ifo, publicIfoData, walletI
         <CardHeader variant={config.variant}>
           <Flex justifyContent="space-between" alignItems="center">
             <Text bold fontSize="20px">
-              {config.title}
+              {t(config.title)}
             </Text>
             <div ref={targetRef}>
               <HelpIcon />

--- a/src/views/Ifos/components/IfoFoldableCard/Timer.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/Timer.tsx
@@ -33,8 +33,14 @@ const Timer: React.FC<Props> = ({ publicIfoData }) => {
                 minute: timeUntil.minutes,
               })}
             </Text>
-            <Link href={getBscScanBlockCountdownUrl(startBlockNum)} target="blank" rel="noopener noreferrer" ml="8px">
-              (blocks)
+            <Link
+              href={getBscScanBlockCountdownUrl(startBlockNum)}
+              target="blank"
+              rel="noopener noreferrer"
+              ml="8px"
+              textTransform="lowercase"
+            >
+              {`(${t('Blocks')})`}
             </Link>
           </Flex>
         </>

--- a/src/views/Ifos/components/IfoQuestions/config.ts
+++ b/src/views/Ifos/components/IfoQuestions/config.ts
@@ -23,7 +23,7 @@ const config = [
   {
     title: 'Where does the participation fee go?',
     description: [
-      'We burn it. The CAKE-BNB LP tokens from the participation fee will be decomposed, then we use the BNB portion to market buy the CAKE equivalent, then finally throw all of the CAKE into the weekly token burn.',
+      'We burn it. The CAKE-BNB LP tokens from the participation fee will be decomposed. We will then use the BNB portion to market buy the CAKE equivalent, and finally throw all of the CAKE into the weekly token burn.',
     ],
   },
   {


### PR DESCRIPTION
Review: https://deploy-preview-1368--pancakeswap-dev.netlify.app/

To reproduce the issues: 

1. Go to ifo page 
2. Check translation of titles of the IfoPoolCards is not translated (Basic Sale and Unlimited Sale) (it is available in many languages)
3. Check in details section the 4th question's (Where does the participation fee go?) answer is not translated.
4. Check "(blocks)" translation next to the remaining Time above the IfoPoolCards (it will be visible in the next IFO)