### PR TITLE
fix: (tag) Add missing tag translation

### DIFF
--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -1,40 +1,58 @@
 import React from 'react'
-import { Tag, VerifiedIcon, CommunityIcon, BinanceIcon, RefreshIcon, AutoRenewIcon } from '@pancakeswap/uikit'
+import { Tag, VerifiedIcon, CommunityIcon, BinanceIcon, RefreshIcon, AutoRenewIcon, TagProps } from '@pancakeswap/uikit'
+import { useTranslation } from 'contexts/Localization'
 
-const CoreTag = (props) => (
-  <Tag variant="secondary" outline startIcon={<VerifiedIcon width="18px" color="secondary" mr="4px" />} {...props}>
-    Core
-  </Tag>
-)
+const CoreTag: React.FC<TagProps> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <Tag variant="secondary" outline startIcon={<VerifiedIcon width="18px" color="secondary" mr="4px" />} {...props}>
+      {t('Core')}
+    </Tag>
+  )
+}
 
-const CommunityTag = (props) => (
-  <Tag variant="textSubtle" outline startIcon={<CommunityIcon width="18px" color="secondary" mr="4px" />} {...props}>
-    Community
-  </Tag>
-)
+const CommunityTag: React.FC<TagProps> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <Tag variant="failure" outline startIcon={<CommunityIcon width="18px" color="failure" mr="4px" />} {...props}>
+      {t('Community')}
+    </Tag>
+  )
+}
 
-const BinanceTag = (props) => (
-  <Tag variant="binance" outline startIcon={<BinanceIcon width="18px" color="secondary" mr="4px" />} {...props}>
-    Binance
-  </Tag>
-)
+const BinanceTag: React.FC<TagProps> = (props) => {
+  return (
+    <Tag variant="binance" outline startIcon={<BinanceIcon width="18px" color="secondary" mr="4px" />} {...props}>
+      Binance
+    </Tag>
+  )
+}
 
-const DualTag = (props) => (
-  <Tag variant="textSubtle" outline {...props}>
-    Dual
-  </Tag>
-)
+const DualTag: React.FC<TagProps> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <Tag variant="textSubtle" outline {...props}>
+      {t('Dual')}
+    </Tag>
+  )
+}
 
-const ManualPoolTag = (props) => (
-  <Tag variant="secondary" outline startIcon={<RefreshIcon width="18px" color="secondary" mr="4px" />} {...props}>
-    Manual
-  </Tag>
-)
+const ManualPoolTag: React.FC<TagProps> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <Tag variant="secondary" outline startIcon={<RefreshIcon width="18px" color="secondary" mr="4px" />} {...props}>
+      {t('Manual')}
+    </Tag>
+  )
+}
 
-const CompoundingPoolTag = (props) => (
-  <Tag variant="success" outline startIcon={<AutoRenewIcon width="18px" color="success" mr="4px" />} {...props}>
-    Auto
-  </Tag>
-)
+const CompoundingPoolTag: React.FC<TagProps> = (props) => {
+  const { t } = useTranslation()
+  return (
+    <Tag variant="success" outline startIcon={<AutoRenewIcon width="18px" color="success" mr="4px" />} {...props}>
+      {t('Auto')}
+    </Tag>
+  )
+}
 
 export { CoreTag, CommunityTag, BinanceTag, DualTag, ManualPoolTag, CompoundingPoolTag }


### PR DESCRIPTION
Review: https://deploy-preview-1372--pancakeswap-dev.netlify.app/

Just took the part that @hachiojidev did in https://github.com/pancakeswap/pancake-frontend/pull/1301/files#diff-28711da0cf1463b4fe38771fa0db631fb3fb913ade15fb5ddc723611b781ab30 :)

To reproduce the issue

1. Change language to Russian for example
2. Go to pools 
3. Check bottom of the pool card
4. See Auto or Manual tag is not translated

Before:

<img width="717" alt="Screenshot 2021-05-27 at 13 05 00" src="https://user-images.githubusercontent.com/2213635/119816024-7fc35880-beec-11eb-866e-8decd32e349b.png">


After: 

<img width="750" alt="Screenshot 2021-05-27 at 13 04 20" src="https://user-images.githubusercontent.com/2213635/119815989-72a66980-beec-11eb-8e90-ee98407568a3.png">


