### PR TITLE
fix: (prediction) Add missing timer label translation

### DIFF
--- a/src/views/Predictions/components/Label.tsx
+++ b/src/views/Predictions/components/Label.tsx
@@ -101,9 +101,10 @@ export const PricePairLabel: React.FC = () => {
 
 interface TimerLabelProps {
   interval: string
+  unit: 'm' | 'h' | 'd'
 }
 
-export const TimerLabel: React.FC<TimerLabelProps> = ({ interval }) => {
+export const TimerLabel: React.FC<TimerLabelProps> = ({ interval, unit }) => {
   const seconds = useRoundCountdown()
   const countdown = formatRoundTime(seconds)
   const { t } = useTranslation()
@@ -114,7 +115,7 @@ export const TimerLabel: React.FC<TimerLabelProps> = ({ interval }) => {
         <Title bold color="secondary">
           {seconds === 0 ? t('Closing') : countdown}
         </Title>
-        <Interval fontSize="12px">{interval}</Interval>
+        <Interval fontSize="12px">{`${interval}${t(unit)}`}</Interval>
       </Label>
       <Token right={0}>
         <PocketWatchIcon />

--- a/src/views/Predictions/components/Menu.tsx
+++ b/src/views/Predictions/components/Menu.tsx
@@ -54,7 +54,7 @@ const Menu = () => {
       <SetCol>
         <Flex alignItems="center" justifyContent="flex-end">
           <TimerLabelWrapper>
-            <TimerLabel interval="5m" />
+            <TimerLabel interval="5" unit="m" />
           </TimerLabelWrapper>
           <HelpButtonWrapper>
             <IconButton


### PR DESCRIPTION
Review: https://deploy-preview-1373--pancakeswap-dev.netlify.app/

To reproduce the issue:

1. Go to prediction
2. Select greek language for example
3. Check timer label in top right
4. See the minute unit is not translated

Before: 

<img width="308" alt="image" src="https://user-images.githubusercontent.com/2213635/119825676-7f7c8a80-bef7-11eb-8ccd-5d3800552553.png">

After: 

<img width="260" alt="Screenshot 2021-05-27 at 14 21 23" src="https://user-images.githubusercontent.com/2213635/119825691-84413e80-bef7-11eb-85fe-17125851da75.png">
