### PR TITLE
feat: Reduce amount of requests when tab is hidden

### DIFF
--- a/src/contexts/RefreshContext.tsx
+++ b/src/contexts/RefreshContext.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import useTabVisibility from 'hooks/useTabVisibility'
 
 const FAST_INTERVAL = 10000
 const SLOW_INTERVAL = 60000
@@ -9,20 +10,25 @@ const RefreshContext = React.createContext({ slow: 0, fast: 0 })
 const RefreshContextProvider = ({ children }) => {
   const [slow, setSlow] = useState(0)
   const [fast, setFast] = useState(0)
+  const { tabVisibleRef } = useTabVisibility()
 
   useEffect(() => {
     const interval = setInterval(async () => {
-      setFast((prev) => prev + 1)
+      if (tabVisibleRef.current) {
+        setFast((prev) => prev + 1)
+      }
     }, FAST_INTERVAL)
     return () => clearInterval(interval)
-  }, [])
+  }, [tabVisibleRef])
 
   useEffect(() => {
     const interval = setInterval(async () => {
-      setSlow((prev) => prev + 1)
+      if (tabVisibleRef.current) {
+        setSlow((prev) => prev + 1)
+      }
     }, SLOW_INTERVAL)
     return () => clearInterval(interval)
-  }, [])
+  }, [tabVisibleRef])
 
   return <RefreshContext.Provider value={{ slow, fast }}>{children}</RefreshContext.Provider>
 }

--- a/src/hooks/useTabVisibility.ts
+++ b/src/hooks/useTabVisibility.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+
+const useTabVisibility = () => {
+  const tabVisibleRef = useRef(true)
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      tabVisibleRef.current = !document.hidden
+    }
+
+    window.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      window.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  return { tabVisibleRef }
+}
+
+export default useTabVisibility


### PR DESCRIPTION
This will reduce amount of requests made when tab is hidden (not focus)

For example in pools when tab or window is hidden, Amount of requests is reduced from ~600 to ~30 per minute


Check it from

https://deploy-preview-1382--pancakeswap-dev.netlify.app/





