### PR TITLE
chore(useTokenBalance): Add hasFetchedBalance state to useTokenBalance

### DIFF
--- a/src/hooks/useHasCakeBalance.ts
+++ b/src/hooks/useHasCakeBalance.ts
@@ -6,7 +6,7 @@ import useTokenBalance from './useTokenBalance'
  * A hook to check if a wallet's CAKE balance is at least the amount passed in
  */
 const useHasCakeBalance = (minimumBalance: BigNumber) => {
-  const cakeBalance = useTokenBalance(getCakeAddress())
+  const { balance: cakeBalance } = useTokenBalance(getCakeAddress())
   return cakeBalance.gte(minimumBalance)
 }
 

--- a/src/hooks/useTokenBalance.ts
+++ b/src/hooks/useTokenBalance.ts
@@ -7,32 +7,38 @@ import useWeb3 from './useWeb3'
 import useRefresh from './useRefresh'
 import useLastUpdated from './useLastUpdated'
 
-export type FetchStatus = 'notFetched' | 'fetching' | 'success' | 'failed'
+type UseTokenBalanceState = {
+  balance: BigNumber
+  fetchStatus: FetchStatus
+}
+
+export enum FetchStatus {
+  NOT_FETCHED = 'not-fetched',
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}
 
 const useTokenBalance = (tokenAddress: string) => {
-  const [balanceState, setBalanceState] = useState({
+  const { NOT_FETCHED, SUCCESS, FAILED } = FetchStatus
+  const [balanceState, setBalanceState] = useState<UseTokenBalanceState>({
     balance: BIG_ZERO,
-    fetchStatus: 'notFetched' as FetchStatus,
+    fetchStatus: NOT_FETCHED,
   })
-  const { account } = useWeb3React()
   const web3 = useWeb3()
+  const { account } = useWeb3React()
   const { fastRefresh } = useRefresh()
 
   useEffect(() => {
     const fetchBalance = async () => {
       const contract = getBep20Contract(tokenAddress, web3)
-      setBalanceState((prev) => ({
-        ...prev,
-        fetchStatus: 'fetching',
-      }))
       try {
         const res = await contract.methods.balanceOf(account).call()
-        setBalanceState({ balance: new BigNumber(res), fetchStatus: 'success' })
+        setBalanceState({ balance: new BigNumber(res), fetchStatus: SUCCESS })
       } catch (e) {
         console.error(e)
         setBalanceState((prev) => ({
           ...prev,
-          fetchStatus: 'failed',
+          fetchStatus: FAILED,
         }))
       }
     }
@@ -40,7 +46,7 @@ const useTokenBalance = (tokenAddress: string) => {
     if (account) {
       fetchBalance()
     }
-  }, [account, tokenAddress, web3, fastRefresh])
+  }, [account, tokenAddress, web3, fastRefresh, SUCCESS, FAILED])
 
   return balanceState
 }

--- a/src/hooks/useTokenBalance.ts
+++ b/src/hooks/useTokenBalance.ts
@@ -8,7 +8,7 @@ import useRefresh from './useRefresh'
 import useLastUpdated from './useLastUpdated'
 
 const useTokenBalance = (tokenAddress: string) => {
-  const [balance, setBalance] = useState(BIG_ZERO)
+  const [balanceState, setBalanceState] = useState({ balance: BIG_ZERO, hasFetchedBalance: false })
   const { account } = useWeb3React()
   const web3 = useWeb3()
   const { fastRefresh } = useRefresh()
@@ -16,8 +16,12 @@ const useTokenBalance = (tokenAddress: string) => {
   useEffect(() => {
     const fetchBalance = async () => {
       const contract = getBep20Contract(tokenAddress, web3)
-      const res = await contract.methods.balanceOf(account).call()
-      setBalance(new BigNumber(res))
+      try {
+        const res = await contract.methods.balanceOf(account).call()
+        setBalanceState({ balance: new BigNumber(res), hasFetchedBalance: true })
+      } catch (e) {
+        console.error(e)
+      }
     }
 
     if (account) {
@@ -25,7 +29,7 @@ const useTokenBalance = (tokenAddress: string) => {
     }
   }, [account, tokenAddress, web3, fastRefresh])
 
-  return balance
+  return { ...balanceState }
 }
 
 export const useTotalSupply = () => {

--- a/src/views/Home/components/CakeWalletBalance.tsx
+++ b/src/views/Home/components/CakeWalletBalance.tsx
@@ -12,7 +12,7 @@ import CardBusdValue from './CardBusdValue'
 
 const CakeWalletBalance = () => {
   const { t } = useTranslation()
-  const cakeBalance = useTokenBalance(getCakeAddress())
+  const { balance: cakeBalance } = useTokenBalance(getCakeAddress())
   const cakePriceBusd = usePriceCakeBusd()
   const busdBalance = new BigNumber(getBalanceNumber(cakeBalance)).multipliedBy(cakePriceBusd).toNumber()
   const { account } = useWeb3React()

--- a/src/views/Home/components/LotteryCard.tsx
+++ b/src/views/Home/components/LotteryCard.tsx
@@ -54,7 +54,7 @@ const LotteryCard = () => {
   const [onPresentApprove] = useModal(<PurchaseWarningModal />)
   const { claimAmount, setLastUpdated } = useTotalClaim()
   const { onMultiClaim } = useMultiClaimLottery()
-  const cakeBalance = useTokenBalance(getCakeAddress())
+  const { balance: cakeBalance } = useTokenBalance(getCakeAddress())
   const { handleApprove, requestedApproval } = useApproval(onPresentApprove)
 
   const handleClaim = useCallback(async () => {

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeButton.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeButton.tsx
@@ -24,7 +24,7 @@ const ContributeButton: React.FC<Props> = ({ poolId, ifo, publicIfoData, walletI
   const { limitPerUserInLP } = publicPoolCharacteristics
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const userCurrencyBalance = useTokenBalance(getAddress(ifo.currency.address))
+  const { balance: userCurrencyBalance } = useTokenBalance(getAddress(ifo.currency.address))
 
   // Refetch all the data, and display a message when fetching is done
   const handleContributeSuccess = async (amount: BigNumber) => {

--- a/src/views/Ifos/components/IfoSteps.tsx
+++ b/src/views/Ifos/components/IfoSteps.tsx
@@ -33,7 +33,7 @@ const IfoSteps: React.FC<Props> = ({ ifo, walletIfoData }) => {
   const { poolBasic, poolUnlimited } = walletIfoData
   const { hasProfile } = useProfile()
   const { t } = useTranslation()
-  const balance = useTokenBalance(getAddress(ifo.currency.address))
+  const { balance } = useTokenBalance(getAddress(ifo.currency.address))
   const stepsValidationStatus = [
     hasProfile,
     balance.isGreaterThan(0),

--- a/src/views/Lottery/components/TicketCard/TicketActions.tsx
+++ b/src/views/Lottery/components/TicketCard/TicketActions.tsx
@@ -26,7 +26,7 @@ const TicketCard: React.FC = () => {
   const { t } = useTranslation()
   const allowance = useLotteryAllowance()
   const lotteryHasDrawn = useGetLotteryHasDrawn()
-  const cakeBalance = useTokenBalance(getCakeAddress())
+  const { balance: cakeBalance } = useTokenBalance(getCakeAddress())
   const tickets = useTickets()
   const ticketsLength = tickets.length
   const [onPresentMyTickets] = useModal(<MyTicketsModal myTicketNumbers={tickets} from="buy" />)


### PR DESCRIPTION
At the moment the state returned by `useTokenBalance` defaults to `BIG_ZERO`

Meaning there's no difference in state between these two scenarios:
- ‘finished fetching, user has none of that token’
- ‘not yet fetched the user balance’

In the new Lottery, we may want to conditionally send the users to purchase more CAKE if they have a zero balance. We wouldn't want to show that while the user balance is still being fetched. The new `fetchStatus` enum allows us to do this.