### PR TITLE
fix: (pools) Add missing translations in pools table view

### DIFF
--- a/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { Flex, Skeleton, Text } from '@pancakeswap/uikit'
 import styled from 'styled-components'
+import { useTranslation } from 'contexts/Localization'
 import BigNumber from 'bignumber.js'
 import Balance from 'components/Balance'
 import { Pool } from 'state/types'
@@ -17,6 +18,7 @@ const StyledCell = styled(BaseCell)`
 `
 
 const TotalStakedCell: React.FC<TotalStakedCellProps> = ({ pool }) => {
+  const { t } = useTranslation()
   const { sousId, stakingToken, totalStaked, isAutoVault } = pool
   const { totalCakeInVault } = useCakeVault()
 
@@ -37,7 +39,7 @@ const TotalStakedCell: React.FC<TotalStakedCellProps> = ({ pool }) => {
     <StyledCell role="cell">
       <CellContent>
         <Text fontSize="12px" color="textSubtle" textAlign="left">
-          Total Staked
+          {t('Total staked')}
         </Text>
         {totalStakedBalance ? (
           <Flex height="100%" alignItems="center">

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -243,19 +243,19 @@ const Pools: React.FC = () => {
                 <Select
                   options={[
                     {
-                      label: 'Hot',
+                      label: t('Hot'),
                       value: 'hot',
                     },
                     {
-                      label: 'APR',
+                      label: t('APR'),
                       value: 'apr',
                     },
                     {
-                      label: 'Earned',
+                      label: t('Earned'),
                       value: 'earned',
                     },
                     {
-                      label: 'Total staked',
+                      label: t('Total staked'),
                       value: 'totalStaked',
                     },
                   ]}
@@ -268,7 +268,7 @@ const Pools: React.FC = () => {
                 {t('Search')}
               </Text>
               <ControlStretch>
-                <SearchInput onChange={handleChangeSearchQuery} placeholder="Search pools" />
+                <SearchInput onChange={handleChangeSearchQuery} placeholder="Search Pools" />
               </ControlStretch>
             </Flex>
           </SearchSortContainer>


### PR DESCRIPTION
Issues: 

1. Total staked column name in pools row
2. Sort by items in dropdown menu
3. Placeholder text in search input