### PR TITLE
fix: (pools) Help icon in cake vault row shows default date when there is no earnings

### DIFF
--- a/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -132,7 +132,7 @@ const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoad
                   </Text>
                 )}
               </Box>
-              {isAutoVault && !isXs && !isSm && (
+              {isAutoVault && hasEarnings && !isXs && !isSm && (
                 <HelpIconWrapper ref={targetRef}>
                   <HelpIcon color="textSubtle" />
                 </HelpIconWrapper>


### PR DESCRIPTION
<img width="425" alt="Screenshot 2021-05-31 at 10 47 46" src="https://user-images.githubusercontent.com/2213635/120167326-e652ba00-c1fd-11eb-84cf-837df13c6614.png">
