### PR TITLE
fix(fetch-public-farm-data): Increase timeout on farmFetch to 9s

### DIFF
--- a/src/state/farms/fetchPublicFarmData.ts
+++ b/src/state/farms/fetchPublicFarmData.ts
@@ -111,7 +111,7 @@ const fetchFarm = async (farm: Farm): Promise<PublicFarmData> => {
     const id = setTimeout(() => {
       clearTimeout(id)
       resolve({})
-    }, 5000)
+    }, 9000)
   })
 
   return Promise.race([timeout, farmFetch()])

--- a/src/state/farms/fetchPublicFarmData.ts
+++ b/src/state/farms/fetchPublicFarmData.ts
@@ -15,6 +15,7 @@ type PublicFarmData = {
   lpTotalSupply?: SerializedBigNumber
   tokenPriceVsQuote?: SerializedBigNumber
   poolWeight?: SerializedBigNumber
+  multiplier?: string
 }
 
 const fetchFarm = async (farm: Farm): Promise<PublicFarmData> => {


### PR DESCRIPTION
- Increase time before dropping farm fetch requests from 5s to 9s
- Add multiplier to return type