### PR TITLE
chore(fetch-public-farm-data): Remove race promise timeout from fetchFarm function

### DIFF
--- a/src/state/farms/fetchPublicFarmData.ts
+++ b/src/state/farms/fetchPublicFarmData.ts
@@ -7,115 +7,103 @@ import multicall from 'utils/multicall'
 import { Farm, SerializedBigNumber } from '../types'
 
 type PublicFarmData = {
-  tokenAmountMc?: SerializedBigNumber
-  quoteTokenAmountMc?: SerializedBigNumber
-  tokenAmountTotal?: SerializedBigNumber
-  quoteTokenAmountTotal?: SerializedBigNumber
-  lpTotalInQuoteToken?: SerializedBigNumber
-  lpTotalSupply?: SerializedBigNumber
-  tokenPriceVsQuote?: SerializedBigNumber
-  poolWeight?: SerializedBigNumber
-  multiplier?: string
+  tokenAmountMc: SerializedBigNumber
+  quoteTokenAmountMc: SerializedBigNumber
+  tokenAmountTotal: SerializedBigNumber
+  quoteTokenAmountTotal: SerializedBigNumber
+  lpTotalInQuoteToken: SerializedBigNumber
+  lpTotalSupply: SerializedBigNumber
+  tokenPriceVsQuote: SerializedBigNumber
+  poolWeight: SerializedBigNumber
+  multiplier: string
 }
 
 const fetchFarm = async (farm: Farm): Promise<PublicFarmData> => {
   const { pid, lpAddresses, token, quoteToken } = farm
   const lpAddress = getAddress(lpAddresses)
-  const farmFetch = async () => {
-    const calls = [
-      // Balance of token in the LP contract
-      {
-        address: getAddress(token.address),
-        name: 'balanceOf',
-        params: [lpAddress],
-      },
-      // Balance of quote token on LP contract
-      {
-        address: getAddress(quoteToken.address),
-        name: 'balanceOf',
-        params: [lpAddress],
-      },
-      // Balance of LP tokens in the master chef contract
-      {
-        address: lpAddress,
-        name: 'balanceOf',
-        params: [getMasterChefAddress()],
-      },
-      // Total supply of LP tokens
-      {
-        address: lpAddress,
-        name: 'totalSupply',
-      },
-      // Token decimals
-      {
-        address: getAddress(token.address),
-        name: 'decimals',
-      },
-      // Quote token decimals
-      {
-        address: getAddress(quoteToken.address),
-        name: 'decimals',
-      },
-    ]
+  const calls = [
+    // Balance of token in the LP contract
+    {
+      address: getAddress(token.address),
+      name: 'balanceOf',
+      params: [lpAddress],
+    },
+    // Balance of quote token on LP contract
+    {
+      address: getAddress(quoteToken.address),
+      name: 'balanceOf',
+      params: [lpAddress],
+    },
+    // Balance of LP tokens in the master chef contract
+    {
+      address: lpAddress,
+      name: 'balanceOf',
+      params: [getMasterChefAddress()],
+    },
+    // Total supply of LP tokens
+    {
+      address: lpAddress,
+      name: 'totalSupply',
+    },
+    // Token decimals
+    {
+      address: getAddress(token.address),
+      name: 'decimals',
+    },
+    // Quote token decimals
+    {
+      address: getAddress(quoteToken.address),
+      name: 'decimals',
+    },
+  ]
 
-    const [tokenBalanceLP, quoteTokenBalanceLP, lpTokenBalanceMC, lpTotalSupply, tokenDecimals, quoteTokenDecimals] =
-      await multicall(erc20, calls)
+  const [tokenBalanceLP, quoteTokenBalanceLP, lpTokenBalanceMC, lpTotalSupply, tokenDecimals, quoteTokenDecimals] =
+    await multicall(erc20, calls)
 
-    // Ratio in % of LP tokens that are staked in the MC, vs the total number in circulation
-    const lpTokenRatio = new BigNumber(lpTokenBalanceMC).div(new BigNumber(lpTotalSupply))
+  // Ratio in % of LP tokens that are staked in the MC, vs the total number in circulation
+  const lpTokenRatio = new BigNumber(lpTokenBalanceMC).div(new BigNumber(lpTotalSupply))
 
-    // Raw amount of token in the LP, including those not staked
-    const tokenAmountTotal = new BigNumber(tokenBalanceLP).div(BIG_TEN.pow(tokenDecimals))
-    const quoteTokenAmountTotal = new BigNumber(quoteTokenBalanceLP).div(BIG_TEN.pow(quoteTokenDecimals))
+  // Raw amount of token in the LP, including those not staked
+  const tokenAmountTotal = new BigNumber(tokenBalanceLP).div(BIG_TEN.pow(tokenDecimals))
+  const quoteTokenAmountTotal = new BigNumber(quoteTokenBalanceLP).div(BIG_TEN.pow(quoteTokenDecimals))
 
-    // Amount of token in the LP that are staked in the MC (i.e amount of token * lp ratio)
-    const tokenAmountMc = tokenAmountTotal.times(lpTokenRatio)
-    const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
+  // Amount of token in the LP that are staked in the MC (i.e amount of token * lp ratio)
+  const tokenAmountMc = tokenAmountTotal.times(lpTokenRatio)
+  const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
 
-    // Total staked in LP, in quote token value
-    const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
+  // Total staked in LP, in quote token value
+  const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
 
-    // Only make masterchef calls if farm has pid
-    const [info, totalAllocPoint] =
-      pid || pid === 0
-        ? await multicall(masterchefABI, [
-            {
-              address: getMasterChefAddress(),
-              name: 'poolInfo',
-              params: [pid],
-            },
-            {
-              address: getMasterChefAddress(),
-              name: 'totalAllocPoint',
-            },
-          ])
-        : [null, null]
+  // Only make masterchef calls if farm has pid
+  const [info, totalAllocPoint] =
+    pid || pid === 0
+      ? await multicall(masterchefABI, [
+          {
+            address: getMasterChefAddress(),
+            name: 'poolInfo',
+            params: [pid],
+          },
+          {
+            address: getMasterChefAddress(),
+            name: 'totalAllocPoint',
+          },
+        ])
+      : [null, null]
 
-    const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
-    const poolWeight = totalAllocPoint ? allocPoint.div(new BigNumber(totalAllocPoint)) : BIG_ZERO
+  const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
+  const poolWeight = totalAllocPoint ? allocPoint.div(new BigNumber(totalAllocPoint)) : BIG_ZERO
 
-    return {
-      tokenAmountMc: tokenAmountMc.toJSON(),
-      quoteTokenAmountMc: quoteTokenAmountMc.toJSON(),
-      tokenAmountTotal: tokenAmountTotal.toJSON(),
-      quoteTokenAmountTotal: quoteTokenAmountTotal.toJSON(),
-      lpTotalSupply: new BigNumber(lpTotalSupply).toJSON(),
-      lpTotalInQuoteToken: lpTotalInQuoteToken.toJSON(),
-      tokenPriceVsQuote: quoteTokenAmountTotal.div(tokenAmountTotal).toJSON(),
-      poolWeight: poolWeight.toJSON(),
-      multiplier: `${allocPoint.div(100).toString()}X`,
-    }
+  return {
+    tokenAmountMc: tokenAmountMc.toJSON(),
+    quoteTokenAmountMc: quoteTokenAmountMc.toJSON(),
+    tokenAmountTotal: tokenAmountTotal.toJSON(),
+    quoteTokenAmountTotal: quoteTokenAmountTotal.toJSON(),
+    lpTotalSupply: new BigNumber(lpTotalSupply).toJSON(),
+    lpTotalInQuoteToken: lpTotalInQuoteToken.toJSON(),
+    tokenPriceVsQuote: quoteTokenAmountTotal.div(tokenAmountTotal).toJSON(),
+    poolWeight: poolWeight.toJSON(),
+    multiplier: `${allocPoint.div(100).toString()}X`,
   }
-
-  // In some browsers promise above gets stuck that causes fetchFarms to not proceed.
-  const timeout = new Promise((resolve) => {
-    const id = setTimeout(() => {
-      clearTimeout(id)
-      resolve({})
-    }, 9000)
-  })
-
-  return Promise.race([timeout, farmFetch()])
 }
 
 export default fetchFarm


### PR DESCRIPTION
The race condition for the farm fetch was causing more problems than it was solving. The impact for a lot of users was that the farms never fetched within the timeout, and this has the knock-on impact of meaning price data (used for APRs throughout the site) was missing.

This PR removes the race condition between the farmFetch and the timeout

https://lucid-haibt-de8af4.netlify.app/