### PR TITLE
fix: (lottery) History chart tooltip legend colors

### DIFF
--- a/src/views/Lottery/components/PastDrawsHistory/HistoryChart.tsx
+++ b/src/views/Lottery/components/PastDrawsHistory/HistoryChart.tsx
@@ -110,7 +110,7 @@ const HistoryChart: React.FC<HistoryChartProps> = ({ showLast }) => {
           labelColor: (tooltipItem, chart) => {
             return {
               borderColor: chart.config.data.datasets[tooltipItem.datasetIndex].cardBorder,
-              backgroundColor: chart.config.data.datasets[tooltipItem.datasetIndex].cardBorder,
+              backgroundColor: chart.config.data.datasets[tooltipItem.datasetIndex].borderColor,
             }
           },
         },


### PR DESCRIPTION
To review:

https://deploy-preview-1422--pancakeswap-dev.netlify.app/

Reproduce to issue:

1. Go to lottery
2. Hover on history chart graphic (click if you are on mobile)
3. Check tooltip legend colors all white

Before:
<img width="578" alt="Screenshot 2021-06-02 at 14 00 16" src="https://user-images.githubusercontent.com/2213635/120476704-302cd300-c3ab-11eb-9a72-17f55d16e9b4.png">

After:
<img width="595" alt="Screenshot 2021-06-02 at 13 59 52" src="https://user-images.githubusercontent.com/2213635/120476695-2dca7900-c3ab-11eb-8528-5d6fd18aaabf.png">

