### PR TITLE
fix: (apymodal) Long grid titles shown together in another languages

### DIFF
--- a/src/components/ApyCalculatorModal/index.tsx
+++ b/src/components/ApyCalculatorModal/index.tsx
@@ -18,13 +18,15 @@ interface ApyCalculatorModalProps {
 
 const Grid = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, auto);
   grid-template-rows: repeat(4, auto);
-  margin-bottom: 24px;
+  margin-bottom: 12px;
 `
 
-const GridItem = styled.div`
-  margin-bottom: '10px';
+const GridItem = styled.div``
+
+const GridHeaderItem = styled.div`
+  max-width: 180px;
 `
 
 const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
@@ -77,27 +79,27 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
   return (
     <Modal title={t('ROI')} onDismiss={onDismiss}>
       <Grid>
-        <GridItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="20px">
+        <GridHeaderItem>
+          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="12px">
             {t('Timeframe')}
           </Text>
-        </GridItem>
-        <GridItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="20px">
+        </GridHeaderItem>
+        <GridHeaderItem>
+          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mr="12px" ml="12px" mb="12px">
             {t('ROI')}
           </Text>
-        </GridItem>
-        <GridItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="20px">
+        </GridHeaderItem>
+        <GridHeaderItem>
+          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="12px">
             {t('%symbol% per $1,000', { symbol: earningTokenSymbol })}
           </Text>
-        </GridItem>
+        </GridHeaderItem>
         {/* 1 day row */}
         <GridItem>
           <Text>{t('%num%d', { num: 1 })}</Text>
         </GridItem>
         <GridItem>
-          <Text>
+          <Text mr="12px" ml="12px">
             {getRoi({ amountEarned: tokenEarnedPerThousand1D, amountInvested: oneThousandDollarsWorthOfToken }).toFixed(
               roundingDecimals,
             )}
@@ -112,7 +114,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
           <Text>{t('%num%d', { num: 7 })}</Text>
         </GridItem>
         <GridItem>
-          <Text>
+          <Text mr="12px" ml="12px">
             {getRoi({ amountEarned: tokenEarnedPerThousand7D, amountInvested: oneThousandDollarsWorthOfToken }).toFixed(
               roundingDecimals,
             )}
@@ -127,7 +129,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
           <Text>{t('%num%d', { num: 30 })}</Text>
         </GridItem>
         <GridItem>
-          <Text>
+          <Text mr="12px" ml="12px">
             {getRoi({
               amountEarned: tokenEarnedPerThousand30D,
               amountInvested: oneThousandDollarsWorthOfToken,
@@ -139,11 +141,11 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
           <Text>{tokenEarnedPerThousand30D}</Text>
         </GridItem>
         {/* 365 day / APY row */}
-        <GridItem>
+        <GridItem style={{ maxWidth: '180px' }}>
           <Text>{t('365d(APY)')}</Text>
         </GridItem>
         <GridItem>
-          <Text>
+          <Text mr="12px" ml="12px">
             {getRoi({
               amountEarned: tokenEarnedPerThousand365D,
               amountInvested: oneThousandDollarsWorthOfToken,
@@ -155,19 +157,21 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
           <Text>{tokenEarnedPerThousand365D}</Text>
         </GridItem>
       </Grid>
-      <Box mb="28px" maxWidth="280px">
-        <Text fontSize="12px" color="textSubtle">
-          {t(
-            'Calculated based on current rates. Compounding %freq%x daily. Rates are estimates provided for your convenience only, and by no means represent guaranteed returns.',
-            { freq: compoundFrequency.toLocaleString() },
-          )}
-        </Text>
-        {performanceFee > 0 && (
-          <Text mt="14px" fontSize="12px" color="textSubtle">
-            {t('All estimated rates take into account this pool’s %fee%% performance fee', { fee: performanceFee })}
+      <Flex justifyContent="center">
+        <Box mb="28px" maxWidth="280px">
+          <Text fontSize="12px" textAlign="center" color="textSubtle">
+            {t(
+              'Calculated based on current rates. Compounding %freq%x daily. Rates are estimates provided for your convenience only, and by no means represent guaranteed returns.',
+              { freq: compoundFrequency.toLocaleString() },
+            )}
           </Text>
-        )}
-      </Box>
+          {performanceFee > 0 && (
+            <Text mt="14px" fontSize="12px" textAlign="center" color="textSubtle">
+              {t('All estimated rates take into account this pool’s %fee%% performance fee', { fee: performanceFee })}
+            </Text>
+          )}
+        </Box>
+      </Flex>
       <Flex justifyContent="center">
         <LinkExternal href={linkHref}>{linkLabel}</LinkExternal>
       </Flex>


### PR DESCRIPTION
Reproduce to issue

1. Go to farms
2. Change language to italian
3. Select any apy
4. Check table titles

**Roi and first title merged since the first one is very long, and bottom part has empty area at right when it is too wide**

<img width="50%" height="50%" alt="Screenshot 2021-06-02 at 16 21 28" src="https://user-images.githubusercontent.com/2213635/120500296-07afd380-c3c1-11eb-8618-04340fa72d65.png">

**After alignment**

<img width="75%" height="75%" alt="Screenshot 2021-06-03 at 01 31 09" src="https://user-images.githubusercontent.com/2213635/120564643-a3fec800-c40b-11eb-9ce3-465726f9685b.png">

========================

- Width of modal depends on the widest grid item whose width applied to each cell makes modal very wide
- APY text merged with roi number when it is too long

<img width="75%" height="75%" alt="Screenshot 2021-06-03 at 01 01 58" src="https://user-images.githubusercontent.com/2213635/120562766-5da76a00-c407-11eb-9c08-a2ded5a05f8c.png">

**After alignment**

<img width="75%" height="75%" alt="Screenshot 2021-06-03 at 01 35 28" src="https://user-images.githubusercontent.com/2213635/120564820-0788f580-c40c-11eb-95d8-add373713eaf.png">

