### PR TITLE
feat(approve-confirm-buttons): Allow different visual arrangement of ApproveConfirmButtons. Add onApproveSuccess func

### DIFF
--- a/src/hooks/useApproveConfirmTransaction.ts
+++ b/src/hooks/useApproveConfirmTransaction.ts
@@ -88,6 +88,7 @@ interface ApproveConfirmTransaction {
   onConfirm: ContractHandler
   onRequiresApproval?: () => Promise<boolean>
   onSuccess: (state: State) => void
+  onApproveSuccess?: (state: State) => void
 }
 
 const useApproveConfirmTransaction = ({
@@ -95,6 +96,7 @@ const useApproveConfirmTransaction = ({
   onConfirm,
   onRequiresApproval,
   onSuccess = noop,
+  onApproveSuccess = noop,
 }: ApproveConfirmTransaction) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
@@ -129,6 +131,7 @@ const useApproveConfirmTransaction = ({
         })
         .on('receipt', (payload: Web3Payload) => {
           dispatch({ type: 'approve_receipt', payload })
+          onApproveSuccess(state)
         })
         .on('error', (error: Web3Payload) => {
           dispatch({ type: 'approve_error', payload: error })

--- a/src/views/Profile/components/ApproveConfirmButtons.tsx
+++ b/src/views/Profile/components/ApproveConfirmButtons.tsx
@@ -3,6 +3,11 @@ import styled from 'styled-components'
 import { ChevronRightIcon, Button as UIKitButton, AutoRenewIcon, ChevronDownIcon, Box, Flex } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 
+export enum ButtonArrangement {
+  ROW = 'row',
+  SEQUENTIAL = 'sequential',
+}
+
 interface ApproveConfirmButtonsProps {
   isApproveDisabled: boolean
   isApproving: boolean
@@ -10,9 +15,10 @@ interface ApproveConfirmButtonsProps {
   isConfirmDisabled: boolean
   onApprove: () => void
   onConfirm: () => void
+  buttonArrangement?: ButtonArrangement
 }
 
-const StyledApproveConfirmButtons = styled.div`
+const StyledApproveConfirmButtonRow = styled.div`
   align-items: center;
   display: grid;
   grid-template-columns: 1fr;
@@ -58,37 +64,67 @@ const ApproveConfirmButtons: React.FC<ApproveConfirmButtonsProps> = ({
   isConfirmDisabled,
   onApprove,
   onConfirm,
+  buttonArrangement = ButtonArrangement.ROW,
 }) => {
   const { t } = useTranslation()
 
-  return (
-    <StyledApproveConfirmButtons>
-      <Box>
-        <Button
-          disabled={isApproveDisabled}
-          onClick={onApprove}
-          endIcon={isApproving ? spinnerIcon : undefined}
-          isLoading={isApproving}
-        >
-          {isApproving ? t('Approving') : t('Approve')}
-        </Button>
-      </Box>
-      <Flex justifyContent="center">
-        <ChevronRight />
-        <ChevronBottom />
-      </Flex>
-      <Box>
-        <Button
-          onClick={onConfirm}
-          disabled={isConfirmDisabled}
-          isLoading={isConfirming}
-          endIcon={isConfirming ? spinnerIcon : undefined}
-        >
-          {isConfirming ? t('Confirming') : t('Confirm')}
-        </Button>
-      </Box>
-    </StyledApproveConfirmButtons>
-  )
+  const ApproveConfirmRow = () => {
+    return (
+      <StyledApproveConfirmButtonRow>
+        <Box>
+          <Button
+            disabled={isApproveDisabled}
+            onClick={onApprove}
+            endIcon={isApproving ? spinnerIcon : undefined}
+            isLoading={isApproving}
+          >
+            {isApproving ? t('Approving') : t('Approve')}
+          </Button>
+        </Box>
+        <Flex justifyContent="center">
+          <ChevronRight />
+          <ChevronBottom />
+        </Flex>
+        <Box>
+          <Button
+            onClick={onConfirm}
+            disabled={isConfirmDisabled}
+            isLoading={isConfirming}
+            endIcon={isConfirming ? spinnerIcon : undefined}
+          >
+            {isConfirming ? t('Confirming') : t('Confirm')}
+          </Button>
+        </Box>
+      </StyledApproveConfirmButtonRow>
+    )
+  }
+
+  const ApproveConfirmSequential = () => {
+    return (
+      <>
+        {isApproveDisabled ? (
+          <Box>
+            <Button
+              onClick={onConfirm}
+              disabled={isConfirmDisabled}
+              isLoading={isConfirming}
+              endIcon={isConfirming ? spinnerIcon : undefined}
+            >
+              {isConfirming ? t('Confirming') : t('Confirm')}
+            </Button>
+          </Box>
+        ) : (
+          <Box>
+            <Button onClick={onApprove} endIcon={isApproving ? spinnerIcon : undefined} isLoading={isApproving}>
+              {isApproving ? t('Approving') : t('Approve')}
+            </Button>
+          </Box>
+        )}
+      </>
+    )
+  }
+
+  return buttonArrangement === ButtonArrangement.ROW ? ApproveConfirmRow() : ApproveConfirmSequential()
 }
 
 export default ApproveConfirmButtons


### PR DESCRIPTION
Two changes:

*One*
- Enable the `ApproveConfirmButtons` to receive a `buttonArrangement` prop. This determines whether the approve & confirm buttons should be laid out in a row (the current style, set as the component default), or 'sequentially' (i.e. one after the other), as is a common pattern in other areas of the site (and will be used immediately within the Lottery).

```
<ApproveConfirmButtons
 isApproveDisabled={isApproved}
 ...
 buttonArrangement={ButtonArrangement.SEQUENTIAL}
/>
```

`isApproved` is false, therefore the approval button is rendered:
<img width="329" alt="Screenshot 2021-06-02 at 16 22 23" src="https://user-images.githubusercontent.com/79279477/120507571-d2a28180-c3be-11eb-94fd-57eb670a3a9b.png">

`isApproved` is true, therefore the confirm button is rendered:
<img width="328" alt="Screenshot 2021-06-02 at 16 22 42" src="https://user-images.githubusercontent.com/79279477/120507583-d6ce9f00-c3be-11eb-88aa-ccfb833c72de.png">

*Two*
- Call an `onApproveSuccess()` function when there is a transaction receipt from the `handleApprove` function within the `useApproveConfirmTransaction` hook. This allows the triggering of toasts when a user has successfully confirmed a transaction. Again, this will be used immediately within the new Lottery.

