### PR TITLE
fix: (prediction) Reduce speed of swiper to make smooth transition between cards

### DIFF
--- a/src/views/Predictions/Positions.tsx
+++ b/src/views/Predictions/Positions.tsx
@@ -41,6 +41,8 @@ const Positions: React.FC = () => {
           freeMode
           freeModeSticky
           centeredSlides
+          freeModeMomentumRatio={0.25}
+          freeModeMomentumVelocityRatio={0.5}
           mousewheel
           keyboard
           resizeObserver


### PR DESCRIPTION
To review:

https://deploy-preview-1427--pancakeswap-dev.netlify.app/

Issue: Swiper sensivity is too high that it moves multiple cards even with slow swipe

Before: 

https://user-images.githubusercontent.com/2213635/120577704-f7314480-c424-11eb-9833-6da63812d3ac.mp4

After: 

https://user-images.githubusercontent.com/2213635/120577667-eb458280-c424-11eb-925b-c4ef04f277fe.mp4