### PR TITLE
fix: (pools) Bounty modal shows obsolete values when cake vault data changes

### DIFF
--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -32,7 +32,6 @@ const BountyCard = () => {
   const { t } = useTranslation()
   const {
     estimatedCakeBountyReward,
-    totalPendingCakeHarvest,
     fees: { callFee },
   } = useCakeVault()
   const cakePriceBusd = usePriceCakeBusd()
@@ -46,7 +45,7 @@ const BountyCard = () => {
   const dollarBountyToDisplay = hasFetchedDollarBounty ? getBalanceNumber(estimatedDollarBountyReward, 18) : 0
   const cakeBountyToDisplay = hasFetchedCakeBounty ? getBalanceNumber(estimatedCakeBountyReward, 18) : 0
 
-  const TooltipComponent = () => (
+  const TooltipComponent = ({ fee }: { fee: number }) => (
     <>
       <Text mb="16px">{t('This bounty is given as a reward for providing a service to other users.')}</Text>
       <Text mb="16px">
@@ -55,22 +54,14 @@ const BountyCard = () => {
         )}
       </Text>
       <Text style={{ fontWeight: 'bold' }}>
-        {t('Auto-Compound Bounty: %fee%% of all Auto CAKE pool users pending yield', { fee: callFee / 100 })}
+        {t('Auto-Compound Bounty: %fee%% of all Auto CAKE pool users pending yield', { fee: fee / 100 })}
       </Text>
     </>
   )
 
-  const [onPresentBountyModal] = useModal(
-    <BountyModal
-      cakeBountyToDisplay={cakeBountyToDisplay}
-      dollarBountyToDisplay={dollarBountyToDisplay}
-      totalPendingCakeHarvest={totalPendingCakeHarvest}
-      callFee={callFee}
-      TooltipComponent={TooltipComponent}
-    />,
-  )
+  const [onPresentBountyModal] = useModal(<BountyModal TooltipComponent={TooltipComponent} />)
 
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(<TooltipComponent />, {
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(<TooltipComponent fee={callFee} />, {
     placement: 'bottom-end',
     tooltipOffset: [20, 10],
   })


### PR DESCRIPTION
To review: 

https://deploy-preview-1439--pancakeswap-dev.netlify.app/

To reproduce the issue:

1. Check the difference between data shown in pools page and bounty modal when it is open for a while

Before:

https://user-images.githubusercontent.com/2213635/120809187-1c6ba300-c54a-11eb-9354-10551b7db37b.mov

After:

https://user-images.githubusercontent.com/2213635/120809175-1aa1df80-c54a-11eb-9bb0-ba77b73b1a69.mov