### PR TITLE
fix: (pools) Add missing translation of max percentage button text

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -200,7 +200,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
           75%
         </StyledButton>
         <StyledButton scale="xs" mx="2px" p="4px 16px" variant="tertiary" onClick={() => handleChangePercent(100)}>
-          MAX
+          {t('Max')}
         </StyledButton>
       </Flex>
       {isRemovingStake && hasUnstakingFee && (

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -174,7 +174,7 @@ const StakeModal: React.FC<StakeModalProps> = ({
         <PercentageButton onClick={() => handleChangePercent(25)}>25%</PercentageButton>
         <PercentageButton onClick={() => handleChangePercent(50)}>50%</PercentageButton>
         <PercentageButton onClick={() => handleChangePercent(75)}>75%</PercentageButton>
-        <PercentageButton onClick={() => handleChangePercent(100)}>MAX</PercentageButton>
+        <PercentageButton onClick={() => handleChangePercent(100)}>{t('Max')}</PercentageButton>
       </Flex>
       <Button
         isLoading={pendingTx}


### PR DESCRIPTION
To review: 

https://deploy-preview-1443--pancakeswap-dev.netlify.app/

To Reproduce the issue: 

1. Go to pools
2. Change language
3. Click stake button any of the pools
4. Check Max button translation

Before:

<img width="318" alt="Screenshot 2021-06-05 at 12 59 40" src="https://user-images.githubusercontent.com/2213635/120889535-ee479b00-c5fd-11eb-99ec-47bfe67351bb.png">

After: 

<img width="342" alt="Screenshot 2021-06-05 at 12 58 42" src="https://user-images.githubusercontent.com/2213635/120889513-cfe19f80-c5fd-11eb-9bec-a61521c83929.png">
