### PR TITLE
fix: (farms) Error when put amount with decimals more than 18

### DIFF
--- a/src/components/ModalInput/ModalInput.tsx
+++ b/src/components/ModalInput/ModalInput.tsx
@@ -12,6 +12,7 @@ interface ModalInputProps {
   value: string
   addLiquidityUrl?: string
   inputTitle?: string
+  decimals?: number
 }
 
 const getBoxShadow = ({ isWarning = false, theme }) => {
@@ -64,6 +65,7 @@ const ModalInput: React.FC<ModalInputProps> = ({
   value,
   addLiquidityUrl,
   inputTitle,
+  decimals = 18,
 }) => {
   const { t } = useTranslation()
   const isBalanceZero = max === '0' || !max
@@ -88,7 +90,7 @@ const ModalInput: React.FC<ModalInputProps> = ({
         </Flex>
         <Flex alignItems="flex-end" justifyContent="space-around">
           <StyledInput
-            pattern="^[0-9]*[.,]?[0-9]*$"
+            pattern={`^[0-9]*[.,]?[0-9]{0,${decimals}}$`}
             inputMode="decimal"
             step="any"
             min="0"


### PR DESCRIPTION
To review:

https://deploy-preview-1446--pancakeswap-dev.netlify.app/

To Reproduce the issue:

1. Go to farms
2. Click withdraw on any farm that you staked
3. Put amount with more than 20 decimals
4. Check error on console