### PR TITLE
fix: (prediction) Show correct bnb balance with precision

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -86,7 +86,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
   const { toastError } = useToast()
   const predictionsContract = usePredictionsContract()
 
-  const balanceDisplay = getBnbAmount(bnbBalance).toNumber()
+  const balanceDisplay = getBnbAmount(bnbBalance).toString()
   const maxBalance = getBnbAmount(bnbBalance.gt(dust) ? bnbBalance.minus(dust) : bnbBalance).toNumber()
   const valueAsBn = new BigNumber(value)
 


### PR DESCRIPTION
To review:

https://deploy-preview-1447--pancakeswap-dev.netlify.app/

Bnb amount lose precision when converting to number instead of string for representation

To reproduce the issue

1. Go to prediction
2. Open set position card
3. Check bnb amount in "Balance: ...."
4. Compare the amount with bscscan balance or other api

