### PR TITLE
fix: (predictions) Use bignumber in set position instead of number to avoid precision errors

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   ArrowBackIcon,
   CardBody,
@@ -47,24 +47,15 @@ const gasPrice = new BigNumber(6).times(BIG_TEN.pow(BIG_NINE)).toString()
 const dust = new BigNumber(0.01).times(DEFAULT_TOKEN_DECIMAL)
 const percentShortcuts = [10, 25, 50, 75]
 
-const getPercentDisplay = (percentage: number) => {
-  if (Number.isNaN(percentage)) {
-    return ''
+const getButtonProps = (value: BigNumber, bnbBalance: BigNumber, minBetAmountBalance: BigNumber) => {
+  const hasSufficientBalance = () => {
+    if (value.gt(0)) {
+      return value.lte(bnbBalance)
+    }
+    return bnbBalance.gt(0)
   }
 
-  if (percentage > 100) {
-    return ''
-  }
-
-  if (percentage < 0) {
-    return ''
-  }
-
-  return `${percentage.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`
-}
-
-const getButtonProps = (value: BigNumber, bnbBalance: BigNumber, minBetAmountBalance: number) => {
-  if (bnbBalance.eq(0)) {
+  if (!hasSufficientBalance()) {
     return { key: 'Insufficient BNB balance', disabled: true }
   }
 
@@ -86,30 +77,46 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
   const { toastError } = useToast()
   const predictionsContract = usePredictionsContract()
 
-  const balanceDisplay = getBnbAmount(bnbBalance).toString()
-  const maxBalance = getBnbAmount(bnbBalance.gt(dust) ? bnbBalance.minus(dust) : bnbBalance).toNumber()
+  const balanceDisplay = useMemo(() => {
+    return getBnbAmount(bnbBalance).toString()
+  }, [bnbBalance])
+  const maxBalance = useMemo(() => {
+    return getBnbAmount(bnbBalance.gt(dust) ? bnbBalance.minus(dust) : bnbBalance)
+  }, [bnbBalance])
+  const minBetAmountBalance = useMemo(() => {
+    return getBnbAmount(minBetAmount)
+  }, [minBetAmount])
+
   const valueAsBn = new BigNumber(value)
 
-  const percentageOfMaxBalance = valueAsBn.div(maxBalance).times(100).toNumber()
-  const percentageDisplay = getPercentDisplay(percentageOfMaxBalance)
   const showFieldWarning = account && valueAsBn.gt(0) && errorMessage !== null
-  const minBetAmountBalance = getBnbAmount(minBetAmount).toNumber()
 
-  const handleChange = (input) => {
+  const [percent, setPercent] = useState(0)
+
+  const handleInputChange = (input: string) => {
+    if (input) {
+      const percentage = Math.floor(new BigNumber(input).dividedBy(maxBalance).multipliedBy(100).toNumber())
+      setPercent(Math.min(percentage, 100))
+    } else {
+      setPercent(0)
+    }
     setValue(input)
   }
 
-  const handleSliderChange = (newValue: number) => {
-    setValue(newValue.toString())
-  }
-
-  const setMax = () => {
-    setValue(maxBalance.toString())
+  const handlePercentChange = (sliderPercent: number) => {
+    if (sliderPercent > 0) {
+      const percentageOfStakingMax = maxBalance.dividedBy(100).multipliedBy(sliderPercent)
+      setValue(percentageOfStakingMax.toFormat(18))
+    } else {
+      setValue('')
+    }
+    setPercent(sliderPercent)
   }
 
   // Clear value
   const handleGoBack = () => {
     setValue('')
+    setPercent(0)
     onBack()
   }
 
@@ -126,7 +133,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
     swiper.attachEvents()
   }
 
-  const { key, disabled } = getButtonProps(valueAsBn, bnbBalance, minBetAmountBalance)
+  const { key, disabled } = getButtonProps(valueAsBn, maxBalance, minBetAmountBalance)
 
   const handleEnterPosition = () => {
     const betMethod = position === BetPosition.BULL ? 'betBull' : 'betBear'
@@ -196,7 +203,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
         </Flex>
         <BalanceInput
           value={value}
-          onUserInput={handleChange}
+          onUserInput={handleInputChange}
           isWarning={showFieldWarning}
           inputProps={{ disabled: !account || isTxPending }}
         />
@@ -211,35 +218,40 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
         <Slider
           name="balance"
           min={0}
-          max={maxBalance}
-          value={valueAsBn.lte(maxBalance) ? valueAsBn.toNumber() : 0}
-          onValueChanged={handleSliderChange}
-          step={0.000000000000001}
-          valueLabel={account ? percentageDisplay : ''}
+          max={100}
+          value={percent}
+          onValueChanged={handlePercentChange}
+          valueLabel={account ? `${percent}%` : ''}
+          step={0.1}
           disabled={!account || isTxPending}
           mb="4px"
           className="swiper-no-swiping"
         />
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
-          {percentShortcuts.map((percent) => {
+          {percentShortcuts.map((percentShortcut) => {
             const handleClick = () => {
-              setValue(((percent / 100) * maxBalance).toLocaleString(undefined, { maximumFractionDigits: 18 }))
+              handlePercentChange(percentShortcut)
             }
 
             return (
               <Button
-                key={percent}
+                key={percentShortcut}
                 scale="xs"
                 variant="tertiary"
                 onClick={handleClick}
                 disabled={!account || isTxPending}
                 style={{ flex: 1 }}
               >
-                {`${percent}%`}
+                {`${percentShortcut}%`}
               </Button>
             )
           })}
-          <Button scale="xs" variant="tertiary" onClick={setMax} disabled={!account || isTxPending}>
+          <Button
+            scale="xs"
+            variant="tertiary"
+            onClick={() => handlePercentChange(100)}
+            disabled={!account || isTxPending}
+          >
             {t('Max')}
           </Button>
         </Flex>


### PR DESCRIPTION
To review: 

https://deploy-preview-1454--pancakeswap-dev.netlify.app/

To Reproduce the issue:

1. Go to prediction
2. Set position from card
3. Click max 
4. Check diff between your bnb balance and max (should be 0.01)

Before: 

<img width="357" alt="Screenshot 2021-06-07 at 11 46 15" src="https://user-images.githubusercontent.com/2213635/120995838-16fa9c80-c786-11eb-958a-90d6db9f6286.png">

After:

<img width="341" alt="Screenshot 2021-06-07 at 11 45 08" src="https://user-images.githubusercontent.com/2213635/120995833-15c96f80-c786-11eb-90d2-a0c9b2b1985f.png">
