### PR TITLE
chore(balance): Show prefix and unit for 0 balances

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -26,15 +26,11 @@ const Balance: React.FC<BalanceProps> = ({
   useEffect(() => {
     previousValue.current = value
   }, [value])
-
-  const showPrefix = Boolean(value && prefix)
-  const showUnit = Boolean(value && unit)
-
   return (
     <Text color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
-      {showPrefix && <span>{prefix}</span>}
+      {prefix && <span>{prefix}</span>}
       <CountUp start={previousValue.current} end={value} decimals={decimals} duration={1} separator="," />
-      {showUnit && <span>{unit}</span>}
+      {unit && <span>{unit}</span>}
     </Text>
   )
 }


### PR DESCRIPTION
Add balance prefix/unit regardless of whether the value is 0

i.e. instead of `0.00` (dollars)
<img width="298" alt="Screenshot 2021-06-07 at 12 50 36" src="https://user-images.githubusercontent.com/79279477/121012703-e6b7fb80-c78f-11eb-9c6a-5fc26fef8f40.png">

show
`~0.00 USD`
<img width="324" alt="Screenshot 2021-06-07 at 12 50 44" src="https://user-images.githubusercontent.com/79279477/121012824-04856080-c790-11eb-8abe-8407a35d5658.png">
