### PR TITLE
fix: (predictions) Swiper moves when trying to move slider in set position card

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -218,6 +218,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
           valueLabel={account ? percentageDisplay : ''}
           disabled={!account || isTxPending}
           mb="4px"
+          className="swiper-no-swiping"
         />
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           {percentShortcuts.map((percent) => {


### PR DESCRIPTION
To review: 

https://deploy-preview-1458--pancakeswap-dev.netlify.app/

To reproduce the issue:

1. Go to predictions in mobile
2. Select down or up in open round card
3. Try to move bunny slider 
4. See swiper moves instead of slider

Before: 

https://user-images.githubusercontent.com/2213635/121023689-cf830900-c7a3-11eb-9e3d-8c807357b397.mp4

After:

https://user-images.githubusercontent.com/2213635/121023735-da3d9e00-c7a3-11eb-915c-327821970b97.mp4

