### PR TITLE
feat: Hydrate/dehydrate options for usePersistState

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -25,7 +25,7 @@ const Content = styled.div<{ isVisible: boolean }>`
 
 const Banner: React.FC<Props> = ({ id, title, defaultVisible = true, children, ...props }) => {
   const { t } = useTranslation()
-  const [isVisible, setIsVisible] = usePersistState(defaultVisible, `banner-${id}`)
+  const [isVisible, setIsVisible] = usePersistState(defaultVisible, { localStorageKey: `banner-${id}` })
   return (
     <Wrapper isVisible={isVisible} {...props}>
       <Flex justifyContent="space-between" flexDirection={['column', 'row']}>

--- a/src/hooks/usePersistState.ts
+++ b/src/hooks/usePersistState.ts
@@ -1,22 +1,35 @@
+import identity from 'lodash/identity'
 import { useEffect, useState } from 'react'
+
+interface UsePersistStateOptions {
+  localStorageKey: string
+  hydrate?: (value: any) => any
+  dehydrate?: (value: any) => any
+}
+
+const defaultOptions = {
+  hydrate: identity,
+  dehydrate: identity,
+}
 
 /**
  * Same as "useState" but saves the value to local storage each time it changes
  */
-const usePersistState = (initialValue: any, localStorageKey: string) => {
+const usePersistState = (initialValue: any, userOptions: UsePersistStateOptions) => {
+  const { localStorageKey, hydrate, dehydrate } = { ...defaultOptions, ...userOptions }
   const [value, setValue] = useState(() => {
     try {
       const valueFromLS = localStorage.getItem(localStorageKey)
 
-      return valueFromLS ? JSON.parse(valueFromLS) : initialValue
+      return valueFromLS ? hydrate(JSON.parse(valueFromLS)) : initialValue
     } catch (error) {
       return initialValue
     }
   })
 
   useEffect(() => {
-    localStorage.setItem(localStorageKey, JSON.stringify(value))
-  }, [value, localStorageKey])
+    localStorage.setItem(localStorageKey, JSON.stringify(dehydrate(value)))
+  }, [value, localStorageKey, dehydrate])
 
   return [value, setValue]
 }

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -106,7 +106,7 @@ const Farms: React.FC = () => {
   const { data: farmsLP, userDataLoaded } = useFarms()
   const cakePrice = usePriceCakeBusd()
   const [query, setQuery] = useState('')
-  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, 'pancake_farm_view')
+  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, { localStorageKey: 'pancake_farm_view' })
   const { account } = useWeb3React()
   const [sortOption, setSortOption] = useState('hot')
 

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -55,11 +55,11 @@ const Pools: React.FC = () => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const { pools: poolsWithoutAutoVault, userDataLoaded } = usePools(account)
-  const [stakedOnly, setStakedOnly] = usePersistState(false, 'pancake_pool_staked')
+  const [stakedOnly, setStakedOnly] = usePersistState(false, { localStorageKey: 'pancake_pool_staked' })
   const [numberOfPoolsVisible, setNumberOfPoolsVisible] = useState(NUMBER_OF_POOLS_VISIBLE)
   const [observerIsSet, setObserverIsSet] = useState(false)
   const loadMoreRef = useRef<HTMLDivElement>(null)
-  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, 'pancake_farm_view')
+  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, { localStorageKey: 'pancake_farm_view' })
   const [searchQuery, setSearchQuery] = useState('')
   const [sortOption, setSortOption] = useState('hot')
   const {

--- a/src/views/Predictions/index.tsx
+++ b/src/views/Predictions/index.tsx
@@ -29,8 +29,12 @@ const FUTURE_ROUND_COUNT = 2 // the number of rounds in the future to show
 
 const Predictions = () => {
   const { isXl } = useMatchBreakpoints()
-  const [hasAcceptedRisk, setHasAcceptedRisk] = usePersistState(false, 'pancake_predictions_accepted_risk')
-  const [hasAcceptedChart, setHasAcceptedChart] = usePersistState(false, 'pancake_predictions_chart')
+  const [hasAcceptedRisk, setHasAcceptedRisk] = usePersistState(false, {
+    localStorageKey: 'pancake_predictions_accepted_risk',
+  })
+  const [hasAcceptedChart, setHasAcceptedChart] = usePersistState(false, {
+    localStorageKey: 'pancake_predictions_chart',
+  })
   const { account } = useWeb3React()
   const status = useGetPredictionsStatus()
   const isChartPaneOpen = useIsChartPaneOpen()

--- a/src/views/Profile/PublicProfile.tsx
+++ b/src/views/Profile/PublicProfile.tsx
@@ -84,7 +84,9 @@ const Section = styled.div`
 const PublicProfile = () => {
   const { account } = useWeb3React()
   const { profile } = useProfile()
-  const [usernameVisibilityToggled, setUsernameVisibility] = usePersistState(false, 'username_visibility_toggled')
+  const [usernameVisibilityToggled, setUsernameVisibility] = usePersistState(false, {
+    localStorageKey: 'username_visibility_toggled',
+  })
   const { t } = useTranslation()
 
   if (!account) {


### PR DESCRIPTION
This change to the `usePersistState` hook allows for saving additional types like BigNumber to local storage by allowing consumer to pass in a hyrdate and dehydrate function.
