### PR TITLE
fix: (pools) Use earning token decimals when unstake in balance input

### DIFF
--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -147,7 +147,7 @@ const StakeModal: React.FC<StakeModalProps> = ({
         onUserInput={handleStakeInputChange}
         currencyValue={stakingTokenPrice !== 0 && `~${usdValueStaked || 0} USD`}
         isWarning={hasReachedStakeLimit}
-        decimals={stakingToken.decimals}
+        decimals={isRemovingStake ? earningToken.decimals : stakingToken.decimals}
       />
       {hasReachedStakeLimit && (
         <Text color="failure" fontSize="12px" style={{ textAlign: 'right' }} mt="4px">


### PR DESCRIPTION
Although most of them are 18, it is nice to have this check