### PR TITLE
fix: (prediction) Prevent swipe in set position when slider is active only

### DIFF
--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -218,7 +218,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
           valueLabel={account ? percentageDisplay : ''}
           disabled={!account || isTxPending}
           mb="4px"
-          className="swiper-no-swiping"
+          className={!account || isTxPending ? '' : 'swiper-no-swiping'}
         />
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           {percentShortcuts.map((percent) => {


### PR DESCRIPTION
Reproduce the issue:

1. Go to prediction
2. Logout from your wallet
3. Open set position card
4. Try to swipe on the slider when it is disabled