### PR TITLE
style(cake-vault-card): Remove cake-vault specific border radii

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -42,9 +42,8 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
 
   return (
     <StyledCard isPromoted={{ isDesktop: isXl }}>
-      <StyledCardInner isPromotedPool>
+      <StyledCardInner>
         <StyledCardHeader
-          isPromotedPool
           isStaking={accountHasSharesStaked}
           isAutoVault
           earningTokenSymbol="CAKE"

--- a/src/views/Pools/components/PoolCard/StyledCard.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCard.tsx
@@ -48,9 +48,9 @@ export const StyledCard = styled(Card)<{ isPromoted?: PromotedStyleCardProps; is
   }
 `
 
-export const StyledCardInner = styled(Box)<{ isPromotedPool?: boolean }>`
+export const StyledCardInner = styled(Box)`
   background: ${({ theme }) => theme.card.background};
-  border-radius: ${({ isPromotedPool, theme }) => (isPromotedPool ? '31px' : theme.radii.card)};
+  border-radius: ${({ theme }) => theme.radii.card};
 `
 
 export default StyledCard

--- a/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
+++ b/src/views/Pools/components/PoolCard/StyledCardHeader.tsx
@@ -3,11 +3,10 @@ import { CardHeader, Heading, Text, Flex, Image } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 
-const Wrapper = styled(CardHeader)<{ isFinished?: boolean; background?: string; isPromotedPool?: boolean }>`
+const Wrapper = styled(CardHeader)<{ isFinished?: boolean; background?: string }>`
   background: ${({ isFinished, background, theme }) =>
     isFinished ? theme.colors.backgroundDisabled : theme.colors.gradients[background]};
-  border-radius: ${({ theme, isPromotedPool }) =>
-    isPromotedPool ? '31px 31px 0 0' : `${theme.radii.card} ${theme.radii.card} 0 0`};
+  border-radius: ${({ theme }) => `${theme.radii.card} ${theme.radii.card} 0 0`};
 `
 
 const StyledCardHeader: React.FC<{
@@ -16,15 +15,7 @@ const StyledCardHeader: React.FC<{
   isAutoVault?: boolean
   isFinished?: boolean
   isStaking?: boolean
-  isPromotedPool?: boolean
-}> = ({
-  earningTokenSymbol,
-  stakingTokenSymbol,
-  isFinished = false,
-  isAutoVault = false,
-  isStaking = false,
-  isPromotedPool = false,
-}) => {
+}> = ({ earningTokenSymbol, stakingTokenSymbol, isFinished = false, isAutoVault = false, isStaking = false }) => {
   const { t } = useTranslation()
   const poolImageSrc = isAutoVault
     ? `cake-cakevault.svg`
@@ -56,7 +47,7 @@ const StyledCardHeader: React.FC<{
   }
 
   return (
-    <Wrapper isPromotedPool={isPromotedPool} isFinished={isFinished} background={background}>
+    <Wrapper isFinished={isFinished} background={background}>
       <Flex alignItems="center" justifyContent="space-between">
         <Flex flexDirection="column">
           <Heading color={isFinished ? 'textDisabled' : 'body'} scale="lg">


### PR DESCRIPTION
Not sure what triggered it, but some recent card style changes have removed the need for different border radii for promoted pools with rainbow borders. The code change is positive but the cake vault card looks nasty atm.

Live, icky:
<img width="386" alt="Screenshot 2021-06-09 at 10 58 04" src="https://user-images.githubusercontent.com/79279477/121335125-3a525280-c912-11eb-9f8e-8c457f485976.png">


After this PR's changes:
<img width="397" alt="Screenshot 2021-06-09 at 10 57 59" src="https://user-images.githubusercontent.com/79279477/121335145-3de5d980-c912-11eb-8a17-d81c10a2d63d.png">
