### PR TITLE
fix: (translations) Use locale upper/lower case

### DIFF
--- a/src/components/ApyCalculatorModal/index.tsx
+++ b/src/components/ApyCalculatorModal/index.tsx
@@ -40,7 +40,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
   compoundFrequency = 1,
   performanceFee = 0,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const oneThousandDollarsWorthOfToken = 1000 / tokenPrice
 
   const tokenEarnedPerThousand1D = tokenEarnedPerThousandDollarsCompounding({
@@ -80,18 +80,18 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
     <Modal title={t('ROI')} onDismiss={onDismiss}>
       <Grid>
         <GridHeaderItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="12px">
-            {t('Timeframe')}
+          <Text fontSize="12px" bold color="textSubtle" mb="12px">
+            {t('Timeframe').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </GridHeaderItem>
         <GridHeaderItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mr="12px" ml="12px" mb="12px">
-            {t('ROI')}
+          <Text fontSize="12px" bold color="textSubtle" mr="12px" ml="12px" mb="12px">
+            {t('ROI').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </GridHeaderItem>
         <GridHeaderItem>
-          <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase" mb="12px">
-            {t('%symbol% per $1,000', { symbol: earningTokenSymbol })}
+          <Text fontSize="12px" bold color="textSubtle" mb="12px">
+            {t('%symbol% per $1,000', { symbol: earningTokenSymbol }).toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </GridHeaderItem>
         {/* 1 day row */}

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -102,7 +102,7 @@ const NUMBER_OF_FARMS_VISIBLE = 12
 const Farms: React.FC = () => {
   const { path } = useRouteMatch()
   const { pathname } = useLocation()
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { data: farmsLP, userDataLoaded } = useFarms()
   const cakePrice = usePriceCakeBusd()
   const [query, setQuery] = useState('')
@@ -360,7 +360,7 @@ const Farms: React.FC = () => {
           </ViewControls>
           <FilterContainer>
             <LabelWrapper>
-              <Text textTransform="uppercase">{t('Sort by')}</Text>
+              <Text>{t('Sort by').toLocaleUpperCase(currentLanguage.locale)}</Text>
               <Select
                 options={[
                   {
@@ -388,7 +388,7 @@ const Farms: React.FC = () => {
               />
             </LabelWrapper>
             <LabelWrapper style={{ marginLeft: 16 }}>
-              <Text textTransform="uppercase">{t('Search')}</Text>
+              <Text>{t('Search').toLocaleUpperCase(currentLanguage.locale)}</Text>
               <SearchInput onChange={handleChangeQuery} placeholder="Search Farms" />
             </LabelWrapper>
           </FilterContainer>

--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -30,7 +30,7 @@ interface FarmCardActionsProps {
 }
 
 const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidityUrl }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const [requestedApproval, setRequestedApproval] = useState(false)
   const { pid, lpAddresses } = farm
   const {
@@ -86,8 +86,8 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
         <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
           CAKE
         </Text>
-        <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
-          {t('Earned')}
+        <Text bold color="textSubtle" fontSize="12px">
+          {t('Earned').toLocaleUpperCase(currentLanguage.locale)}
         </Text>
       </Flex>
       <HarvestAction earnings={earnings} pid={pid} />
@@ -95,8 +95,8 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
         <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
           {lpName}
         </Text>
-        <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
-          {t('Staked')}
+        <Text bold color="textSubtle" fontSize="12px">
+          {t('Staked').toLocaleUpperCase(currentLanguage.locale)}
         </Text>
       </Flex>
       {!account ? <UnlockButton mt="8px" width="100%" /> : renderApprovalOrStakeButton()}

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -33,7 +33,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
 
   const [pendingTx, setPendingTx] = useState(false)
   const { onReward } = useHarvest(pid)
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const { countUp, update } = useCountUp({
@@ -53,7 +53,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
     <ActionContainer>
       <ActionTitles>
         <Title>CAKE </Title>
-        <Subtle>{t('Earned').toUpperCase()}</Subtle>
+        <Subtle>{t('Earned').toLocaleUpperCase(currentLanguage.locale)}</Subtle>
       </ActionTitles>
       <ActionContent>
         <div>

--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -38,7 +38,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
   token,
   userDataReady,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { account } = useWeb3React()
   const [requestedApproval, setRequestedApproval] = useState(false)
   const { allowance, tokenBalance, stakedBalance } = useFarmUser(pid)
@@ -100,7 +100,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Start Farming').toUpperCase()}</Subtle>
+          <Subtle>{t('Start Farming').toLocaleUpperCase(currentLanguage.locale)}</Subtle>
         </ActionTitles>
         <ActionContent>
           <UnlockButton width="100%" />
@@ -115,7 +115,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
         <ActionContainer>
           <ActionTitles>
             <Title>{lpSymbol} </Title>
-            <Subtle>{t('Staked').toUpperCase()}</Subtle>
+            <Subtle>{t('Staked').toLocaleUpperCase(currentLanguage.locale)}</Subtle>
           </ActionTitles>
           <ActionContent>
             <div>
@@ -141,7 +141,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Stake').toUpperCase()} </Subtle>
+          <Subtle>{t('Stake').toLocaleUpperCase(currentLanguage.locale)} </Subtle>
           <Title>{lpSymbol}</Title>
         </ActionTitles>
         <ActionContent>
@@ -162,7 +162,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Start Farming').toUpperCase()}</Subtle>
+          <Subtle>{t('Start Farming').toLocaleUpperCase(currentLanguage.locale)}</Subtle>
         </ActionTitles>
         <ActionContent>
           <Skeleton width={180} marginBottom={28} marginTop={14} />
@@ -174,7 +174,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
   return (
     <ActionContainer>
       <ActionTitles>
-        <Subtle>{t('Enable Farm').toUpperCase()}</Subtle>
+        <Subtle>{t('Enable Farm').toLocaleUpperCase(currentLanguage.locale)}</Subtle>
       </ActionTitles>
       <ActionContent>
         <Button width="100%" disabled={requestedApproval} onClick={handleApprove} variant="secondary">

--- a/src/views/Farms/components/FarmTable/Farm.tsx
+++ b/src/views/Farms/components/FarmTable/Farm.tsx
@@ -33,14 +33,14 @@ const Container = styled.div`
 
 const Farm: React.FunctionComponent<FarmProps> = ({ image, label, pid }) => {
   const { stakedBalance } = useFarmUser(pid)
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const rawStakedBalance = getBalanceNumber(stakedBalance)
 
   const handleRenderFarming = (): JSX.Element => {
     if (rawStakedBalance) {
       return (
-        <Text color="secondary" fontSize="12px" bold textTransform="uppercase">
-          {t('Farming')}
+        <Text color="secondary" fontSize="12px" bold>
+          {t('Farming').toLocaleUpperCase(currentLanguage.locale)}
         </Text>
       )
     }

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardTokens.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardTokens.tsx
@@ -33,7 +33,7 @@ const TokenSection: React.FC<TokenSectionProps> = ({ img, children, ...props }) 
   )
 }
 
-const Label = (props) => <Text bold fontSize="12px" color="secondary" textTransform="uppercase" {...props} />
+const Label = (props) => <Text bold fontSize="12px" color="secondary" {...props} />
 
 const Value = (props) => <Text bold fontSize="20px" style={{ wordBreak: 'break-all' }} {...props} />
 
@@ -59,7 +59,7 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
   enableStatus,
 }) => {
   const { account } = useWeb3React()
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     t(
       'Sorry, you didn’t contribute enough LP tokens to meet the minimum threshold. You didn’t buy anything in this sale, but you can still reclaim your LP tokens.',
@@ -89,7 +89,7 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
       return (
         <>
           <TokenSection img="/images/bunny-placeholder.svg">
-            <Label>{t('On sale')}</Label>
+            <Label>{t('On sale').toLocaleUpperCase(currentLanguage.locale)}</Label>
             <Value>{ifo[poolId].saleAmount}</Value>
           </TokenSection>
           <Text fontSize="14px" color="textSubtle" pl="48px">
@@ -113,7 +113,9 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
       return (
         <>
           <TokenSection img="/images/farms/cake-bnb.svg" mb="24px">
-            <Label>{t('Your %symbol% committed', { symbol: currency.symbol })}</Label>
+            <Label>
+              {t('Your %symbol% committed', { symbol: currency.symbol }).toLocaleUpperCase(currentLanguage.locale)}
+            </Label>
             <Value>{getBalanceNumber(userPoolCharacteristics.amountTokenCommittedInLP, currency.decimals)}</Value>
             <PercentageOfTotal
               userAmount={userPoolCharacteristics.amountTokenCommittedInLP}
@@ -121,7 +123,9 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
             />
           </TokenSection>
           <TokenSection img={tokenImage}>
-            <Label>{t('%symbol% to receive', { symbol: token.symbol })}</Label>
+            <Label>
+              {t('%symbol% to receive', { symbol: token.symbol }).toLocaleUpperCase(currentLanguage.locale)}
+            </Label>
             <Value>{getBalanceNumber(userPoolCharacteristics.offeringAmountInToken, token.decimals)}</Value>
           </TokenSection>
         </>
@@ -137,7 +141,9 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
         <>
           <TokenSection img="/images/farms/cake-bnb.svg" mb="24px">
             <Label>
-              {t(hasClaimed ? 'Your %symbol% RECLAIMED' : 'Your %symbol% TO RECLAIM', { symbol: currency.symbol })}
+              {t(hasClaimed ? 'Your %symbol% RECLAIMED' : 'Your %symbol% TO RECLAIM', {
+                symbol: currency.symbol,
+              }).toLocaleUpperCase(currentLanguage.locale)}
             </Label>
             <Flex alignItems="center">
               <Value>{getBalanceNumber(userPoolCharacteristics.refundingAmountInLP, currency.decimals)}</Value>
@@ -149,7 +155,12 @@ const IfoCardTokens: React.FC<IfoCardTokensProps> = ({
             />
           </TokenSection>
           <TokenSection img={tokenImage}>
-            <Label> {t(hasClaimed ? '%symbol% received' : '%symbol% to receive', { symbol: token.symbol })}</Label>
+            <Label>
+              {' '}
+              {t(hasClaimed ? '%symbol% received' : '%symbol% to receive', { symbol: token.symbol }).toLocaleUpperCase(
+                currentLanguage.locale,
+              )}
+            </Label>
             <Flex alignItems="center">
               <Value>{getBalanceNumber(userPoolCharacteristics.offeringAmountInToken, token.decimals)}</Value>
               {!hasClaimed && userPoolCharacteristics.offeringAmountInToken.isEqualTo(0) && (

--- a/src/views/Ifos/components/IfoFoldableCard/Timer.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/Timer.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const Timer: React.FC<Props> = ({ publicIfoData }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { status, secondsUntilStart, secondsUntilEnd, startBlockNum } = publicIfoData
   const countdownToUse = status === 'coming_soon' ? secondsUntilStart : secondsUntilEnd
   const timeUntil = getTimePeriods(countdownToUse)
@@ -33,14 +33,8 @@ const Timer: React.FC<Props> = ({ publicIfoData }) => {
                 minute: timeUntil.minutes,
               })}
             </Text>
-            <Link
-              href={getBscScanBlockCountdownUrl(startBlockNum)}
-              target="blank"
-              rel="noopener noreferrer"
-              ml="8px"
-              textTransform="lowercase"
-            >
-              {`(${t('Blocks')})`}
+            <Link href={getBscScanBlockCountdownUrl(startBlockNum)} target="blank" rel="noopener noreferrer" ml="8px">
+              {`(${t('Blocks').toLocaleLowerCase(currentLanguage.locale)})`}
             </Link>
           </Flex>
         </>

--- a/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -10,6 +10,7 @@ import {
   Progress,
   Button,
   ChevronUpIcon,
+  Language,
 } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
@@ -19,6 +20,7 @@ import { useIfoApprove } from 'hooks/useApprove'
 import { useERC20 } from 'hooks/useContract'
 import useToast from 'hooks/useToast'
 import { useTranslation } from 'contexts/Localization'
+import { ContextApi } from 'contexts/Localization/types'
 import { getAddress } from 'utils/addressHelpers'
 import { EnableStatus } from './types'
 import IfoPoolCard from './IfoPoolCard'
@@ -32,7 +34,7 @@ interface IfoFoldableCardProps {
   isInitiallyVisible: boolean
 }
 
-const getRibbonComponent = (ifo: Ifo, status: IfoStatus, t: any) => {
+const getRibbonComponent = (ifo: Ifo, status: IfoStatus, t: ContextApi['t'], currentLanguage: Language) => {
   if (status === 'coming_soon') {
     return <CardRibbon variantColor="textDisabled" ribbonPosition="left" text={t('Coming Soon')} />
   }
@@ -42,8 +44,11 @@ const getRibbonComponent = (ifo: Ifo, status: IfoStatus, t: any) => {
       <CardRibbon
         variantColor="primary"
         ribbonPosition="left"
-        style={{ textTransform: 'uppercase' }}
-        text={status === 'live' ? `${t('Live')}!` : `${t('Finished')}!`}
+        text={
+          status === 'live'
+            ? `${t('Live').toLocaleUpperCase(currentLanguage.locale)}!`
+            : `${t('Finished').toLocaleUpperCase(currentLanguage.locale)}!`
+        }
       />
     )
   }
@@ -100,10 +105,10 @@ const StyledCardFooter = styled(CardFooter)`
 const IfoFoldableCard: React.FC<IfoFoldableCardProps> = ({ ifo, publicIfoData, walletIfoData, isInitiallyVisible }) => {
   const [isVisible, setIsVisible] = useState(isInitiallyVisible)
   const [enableStatus, setEnableStatus] = useState(EnableStatus.DISABLED)
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { account } = useWeb3React()
   const raisingTokenContract = useERC20(getAddress(ifo.currency.address))
-  const Ribbon = getRibbonComponent(ifo, publicIfoData.status, t)
+  const Ribbon = getRibbonComponent(ifo, publicIfoData.status, t, currentLanguage)
   const isActive = publicIfoData.status !== 'finished' && ifo.isActive
   const { contract } = walletIfoData
   const onApprove = useIfoApprove(raisingTokenContract, contract.options.address)

--- a/src/views/Lottery/components/PastDrawsHistory/PastDrawsHistoryCard.tsx
+++ b/src/views/Lottery/components/PastDrawsHistory/PastDrawsHistoryCard.tsx
@@ -31,7 +31,7 @@ const LabelWrapper = styled.div`
 `
 
 const PastDrawsHistoryCard: React.FC = () => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const [showLast, setShowLast] = useState<'max' | number>(50)
   const handleShowLastChange = (option: OptionProps): void => {
     setShowLast(option.value)
@@ -44,7 +44,7 @@ const PastDrawsHistoryCard: React.FC = () => {
         <Wrapper>
           <Legend />
           <LabelWrapper>
-            <Text textTransform="uppercase">{t('Show Last')}</Text>
+            <Text>{t('Show Last').toLocaleUpperCase(currentLanguage.locale)}</Text>
             <Select
               options={[
                 {

--- a/src/views/Lottery/components/TicketCard/BuyTicketModal.tsx
+++ b/src/views/Lottery/components/TicketCard/BuyTicketModal.tsx
@@ -18,7 +18,7 @@ const BuyTicketModal: React.FC<BuyTicketModalProps> = ({ max, onDismiss }) => {
   const [val, setVal] = useState('1')
   const [pendingTx, setPendingTx] = useState(false)
   const [, setRequestedBuy] = useState(false)
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const fullBalance = useMemo(() => {
     return getBalanceNumber(max)
   }, [max])
@@ -75,7 +75,7 @@ const BuyTicketModal: React.FC<BuyTicketModalProps> = ({ max, onDismiss }) => {
         onSelectMax={handleSelectMax}
         onChange={handleChange}
         max={fullBalance}
-        symbol={t('Ticket').toUpperCase()}
+        symbol={t('Ticket').toLocaleUpperCase(currentLanguage.locale)}
         availableSymbol="CAKE"
       />
       <div>

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
@@ -19,7 +19,7 @@ const CakeVaultCardActions: React.FC<{
   isLoading: boolean
 }> = ({ pool, accountHasSharesStaked, isLoading }) => {
   const { stakingToken, userData } = pool
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO
 
   const { isVaultApproved, setLastUpdated } = useCheckVaultApprovalStatus()
@@ -28,21 +28,15 @@ const CakeVaultCardActions: React.FC<{
     <Flex flexDirection="column">
       <Flex flexDirection="column">
         <Box display="inline">
-          <InlineText
-            color={accountHasSharesStaked ? 'secondary' : 'textSubtle'}
-            textTransform="uppercase"
-            bold
-            fontSize="12px"
-          >
-            {accountHasSharesStaked ? stakingToken.symbol : t('Stake')}{' '}
+          <InlineText color={accountHasSharesStaked ? 'secondary' : 'textSubtle'} bold fontSize="12px">
+            {accountHasSharesStaked
+              ? stakingToken.symbol.toUpperCase()
+              : t('Stake').toLocaleUpperCase(currentLanguage.locale)}{' '}
           </InlineText>
-          <InlineText
-            color={accountHasSharesStaked ? 'textSubtle' : 'secondary'}
-            textTransform="uppercase"
-            bold
-            fontSize="12px"
-          >
-            {accountHasSharesStaked ? t('Staked (compounding)') : `${stakingToken.symbol}`}
+          <InlineText color={accountHasSharesStaked ? 'textSubtle' : 'secondary'} bold fontSize="12px">
+            {accountHasSharesStaked
+              ? t('Staked (compounding)').toLocaleUpperCase(currentLanguage.locale)
+              : `${stakingToken.symbol.toUpperCase()}`}
           </InlineText>
         </Box>
         {isVaultApproved ? (

--- a/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -24,7 +24,7 @@ interface CakeVaultProps {
 }
 
 const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { isXl } = useMatchBreakpoints()
   const { account } = useWeb3React()
   const {
@@ -63,8 +63,8 @@ const CakeVaultCard: React.FC<CakeVaultProps> = ({ pool, showStakedOnly }) => {
               <VaultCardActions pool={pool} accountHasSharesStaked={accountHasSharesStaked} isLoading={isLoading} />
             ) : (
               <>
-                <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
-                  {t('Start earning')}
+                <Text mb="10px" fontSize="12px" color="textSubtle" bold>
+                  {t('Start earning').toLocaleUpperCase(currentLanguage.locale)}
                 </Text>
                 <UnlockButton />
               </>

--- a/src/views/Pools/components/PoolCard/CardActions/index.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/index.tsx
@@ -23,7 +23,7 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
   const { sousId, stakingToken, earningToken, harvest, poolCategory, userData, earningTokenPrice } = pool
   // Pools using native BNB behave differently than pools using a token
   const isBnbPool = poolCategory === PoolCategory.BINANCE
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const allowance = userData?.allowance ? new BigNumber(userData.allowance) : BIG_ZERO
   const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO
   const earnings = userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO
@@ -40,8 +40,8 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
               <InlineText color="secondary" textTransform="uppercase" bold fontSize="12px">
                 {`${earningToken.symbol} `}
               </InlineText>
-              <InlineText color="textSubtle" textTransform="uppercase" bold fontSize="12px">
-                {t('Earned')}
+              <InlineText color="textSubtle" bold fontSize="12px">
+                {t('Earned').toLocaleUpperCase(currentLanguage.locale)}
               </InlineText>
             </Box>
             <HarvestActions
@@ -55,11 +55,11 @@ const CardActions: React.FC<CardActionsProps> = ({ pool, stakedBalance }) => {
           </>
         )}
         <Box display="inline">
-          <InlineText color={isStaked ? 'secondary' : 'textSubtle'} textTransform="uppercase" bold fontSize="12px">
-            {isStaked ? stakingToken.symbol : t('Stake')}{' '}
+          <InlineText color={isStaked ? 'secondary' : 'textSubtle'} bold fontSize="12px">
+            {isStaked ? stakingToken.symbol.toUpperCase() : t('Stake').toLocaleUpperCase(currentLanguage.locale)}{' '}
           </InlineText>
-          <InlineText color={isStaked ? 'textSubtle' : 'secondary'} textTransform="uppercase" bold fontSize="12px">
-            {isStaked ? t('Staked') : `${stakingToken.symbol}`}
+          <InlineText color={isStaked ? 'textSubtle' : 'secondary'} bold fontSize="12px">
+            {isStaked ? t('Staked').toLocaleUpperCase(currentLanguage.locale) : `${stakingToken.symbol.toUpperCase()}`}
           </InlineText>
         </Box>
         {needsApproval ? (

--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -35,7 +35,7 @@ const ExpandedWrapper = styled(Flex)`
 `
 
 const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { currentBlock } = useBlock()
   const {
     totalCakeInVault,
@@ -96,8 +96,8 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
             ) : (
               <Skeleton width="54px" height="21px" />
             )}
-            <Text ml="4px" color="primary" small textTransform="lowercase">
-              {t('Blocks')}
+            <Text ml="4px" color="primary" small>
+              {t('Blocks').toLocaleLowerCase(currentLanguage.locale)}
             </Text>
             <TimerIcon ml="4px" color="primary" />
           </Flex>

--- a/src/views/Pools/components/PoolCard/index.tsx
+++ b/src/views/Pools/components/PoolCard/index.tsx
@@ -13,7 +13,7 @@ import CardActions from './CardActions'
 
 const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) => {
   const { sousId, stakingToken, earningToken, isFinished, userData } = pool
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
   const accountHasStakedBalance = stakedBalance.gt(0)
 
@@ -36,8 +36,8 @@ const PoolCard: React.FC<{ pool: Pool; account: string }> = ({ pool, account }) 
               <CardActions pool={pool} stakedBalance={stakedBalance} />
             ) : (
               <>
-                <Text mb="10px" textTransform="uppercase" fontSize="12px" color="textSubtle" bold>
-                  {t('Start earning')}
+                <Text mb="10px" fontSize="12px" color="textSubtle" bold>
+                  {t('Start earning').toLocaleUpperCase(currentLanguage.locale)}
                 </Text>
                 <UnlockButton />
               </>

--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -107,7 +107,7 @@ const InfoSection = styled(Box)`
 
 const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded, expanded, breakpoints }) => {
   const { sousId, stakingToken, earningToken, totalStaked, endBlock, stakingLimit, isAutoVault } = pool
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { currentBlock } = useBlock()
   const { isXs, isSm, isMd } = breakpoints
   const showSubtitle = (isXs || isSm) && sousId === 0
@@ -173,8 +173,8 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
         <Flex>
           <Link external href={getBscScanBlockCountdownUrl(endBlock)}>
             <Balance fontSize="16px" value={blocksToDisplay} decimals={0} color="primary" />
-            <Text ml="4px" color="primary" textTransform="lowercase">
-              {t('Blocks')}
+            <Text ml="4px" color="primary">
+              {t('Blocks').toLocaleLowerCase(currentLanguage.locale)}
             </Text>
             <TimerIcon ml="4px" color="primary" />
           </Link>

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -28,7 +28,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   isAutoVault,
   earningTokenPrice,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { account } = useWeb3React()
 
   const earnings = userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO
@@ -79,16 +79,16 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   )
 
   const actionTitle = isAutoVault ? (
-    <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
-      {t('Recent CAKE profit')}
+    <Text fontSize="12px" bold color="secondary" as="span">
+      {t('Recent CAKE profit').toLocaleUpperCase(currentLanguage.locale)}
     </Text>
   ) : (
     <>
       <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
         {earningToken.symbol}{' '}
       </Text>
-      <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
-        {t('Earned')}
+      <Text fontSize="12px" bold color="textSubtle" as="span">
+        {t('Earned').toLocaleUpperCase(currentLanguage.locale)}
       </Text>
     </>
   )

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -41,7 +41,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
     stakingTokenPrice,
     isAutoVault,
   } = pool
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { account } = useWeb3React()
 
   const stakingTokenContract = useERC20(stakingToken.address ? getAddress(stakingToken.address) : '')
@@ -135,8 +135,8 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
     return (
       <ActionContainer>
         <ActionTitles>
-          <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
-            {t('Start staking')}
+          <Text fontSize="12px" bold color="textSubtle" as="span">
+            {t('Start staking').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </ActionTitles>
         <ActionContent>
@@ -150,8 +150,8 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
     return (
       <ActionContainer>
         <ActionTitles>
-          <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
-            {t('Start staking')}
+          <Text fontSize="12px" bold color="textSubtle" as="span">
+            {t('Start staking').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </ActionTitles>
         <ActionContent>
@@ -165,8 +165,8 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
     return (
       <ActionContainer>
         <ActionTitles>
-          <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
-            {t('Enable pool')}
+          <Text fontSize="12px" bold color="textSubtle" as="span">
+            {t('Enable pool').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </ActionTitles>
         <ActionContent>
@@ -186,8 +186,10 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
           <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
             {stakingToken.symbol}{' '}
           </Text>
-          <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
-            {isAutoVault ? t('Staked (compounding)') : t('Staked')}
+          <Text fontSize="12px" bold color="textSubtle" as="span">
+            {isAutoVault
+              ? t('Staked (compounding)').toLocaleUpperCase(currentLanguage.locale)
+              : t('Staked').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         </ActionTitles>
         <ActionContent>
@@ -238,8 +240,8 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
   return (
     <ActionContainer>
       <ActionTitles>
-        <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
-          {t('Stake')}{' '}
+        <Text fontSize="12px" bold color="secondary" as="span">
+          {t('Stake').toLocaleUpperCase(currentLanguage.locale)}{' '}
         </Text>
         <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
           {stakingToken.symbol}

--- a/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
@@ -20,7 +20,7 @@ const StyledCell = styled(BaseCell)`
 const EndsInCell: React.FC<FinishCellProps> = ({ pool }) => {
   const { sousId, totalStaked, endBlock, isFinished } = pool
   const { currentBlock } = useBlock()
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
 
   const { shouldShowBlockCountdown, blocksUntilStart, blocksRemaining, hasPoolStarted, blocksToDisplay } =
     getPoolBlockInfo(pool, currentBlock)
@@ -31,9 +31,7 @@ const EndsInCell: React.FC<FinishCellProps> = ({ pool }) => {
     <Flex alignItems="center">
       <Flex flex="1.3">
         <Balance fontSize="16px" value={blocksToDisplay} decimals={0} />
-        <Text ml="4px" textTransform="lowercase">
-          {t('Blocks')}
-        </Text>
+        <Text ml="4px">{t('Blocks').toLocaleLowerCase(currentLanguage.locale)}</Text>
       </Flex>
       <Flex flex="1">
         <Link external href={getBscScanBlockCountdownUrl(endBlock)} onClick={(e) => e.stopPropagation()}>

--- a/src/views/Pools/components/PoolsTable/Cells/NameCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/NameCell.tsx
@@ -23,7 +23,7 @@ const StyledCell = styled(BaseCell)`
 `
 
 const NameCell: React.FC<NameCellProps> = ({ pool }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { isXs, isSm } = useMatchBreakpoints()
   const { sousId, stakingToken, earningToken, userData, isFinished, isAutoVault } = pool
   const {
@@ -58,8 +58,8 @@ const NameCell: React.FC<NameCellProps> = ({ pool }) => {
       <Image src={`/images/pools/${iconFile}`} alt="icon" width={40} height={40} mr="8px" />
       <CellContent>
         {showStakedTag && (
-          <Text fontSize="12px" bold color={isFinished ? 'failure' : 'secondary'} textTransform="uppercase">
-            {t('Staked')}
+          <Text fontSize="12px" bold color={isFinished ? 'failure' : 'secondary'}>
+            {t('Staked').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
         )}
         <Text bold={!isXs && !isSm} small={isXs || isSm}>

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -52,7 +52,7 @@ const NUMBER_OF_POOLS_VISIBLE = 12
 
 const Pools: React.FC = () => {
   const location = useLocation()
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { account } = useWeb3React()
   const { pools: poolsWithoutAutoVault, userDataLoaded } = usePools(account)
   const [stakedOnly, setStakedOnly] = usePersistState(false, { localStorageKey: 'pancake_pool_staked' })
@@ -236,8 +236,8 @@ const Pools: React.FC = () => {
           />
           <SearchSortContainer>
             <Flex flexDirection="column" width="50%">
-              <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase">
-                {t('Sort by')}
+              <Text fontSize="12px" bold color="textSubtle">
+                {t('Sort by').toLocaleUpperCase(currentLanguage.locale)}
               </Text>
               <ControlStretch>
                 <Select
@@ -264,8 +264,8 @@ const Pools: React.FC = () => {
               </ControlStretch>
             </Flex>
             <Flex flexDirection="column" width="50%">
-              <Text fontSize="12px" bold color="textSubtle" textTransform="uppercase">
-                {t('Search')}
+              <Text fontSize="12px" bold color="textSubtle">
+                {t('Search').toLocaleUpperCase(currentLanguage.locale)}
               </Text>
               <ControlStretch>
                 <SearchInput onChange={handleChangeSearchQuery} placeholder="Search Pools" />

--- a/src/views/Predictions/components/History/BetResult.tsx
+++ b/src/views/Predictions/components/History/BetResult.tsx
@@ -27,7 +27,7 @@ const StyledBetResult = styled(Box)`
 `
 
 const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const { isRefundable } = useIsRefundable(bet.round.epoch)
@@ -96,8 +96,8 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
       <Flex alignItems="center" justifyContent="space-between" mb="8px">
         <Heading>{t('Your History')}</Heading>
         <Flex alignItems="center">
-          <Heading as="h3" color={getHeaderColor()} textTransform="uppercase" bold mr="4px">
-            {getHeaderText()}
+          <Heading as="h3" color={getHeaderColor()} bold mr="4px">
+            {getHeaderText().toLocaleUpperCase(currentLanguage.locale)}
           </Heading>
           {getHeaderIcon()}
         </Flex>
@@ -122,7 +122,9 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           <Text>{t('Your direction')}</Text>
           <PositionTag betPosition={bet.position}>
-            {bet.position === BetPosition.BULL ? t('Up') : t('Down')}
+            {bet.position === BetPosition.BULL
+              ? t('Up').toLocaleUpperCase(currentLanguage.locale)
+              : t('Down').toLocaleUpperCase(currentLanguage.locale)}
           </PositionTag>
         </Flex>
         <Flex alignItems="center" justifyContent="space-between" mb="16px">

--- a/src/views/Predictions/components/PositionTag.tsx
+++ b/src/views/Predictions/components/PositionTag.tsx
@@ -29,7 +29,7 @@ export const Tag: React.FC<TagProps> = ({ bg = 'success', startIcon, children, o
       {...props}
     >
       {icon}
-      <Text textTransform="uppercase" color="white" ml="4px">
+      <Text color="white" ml="4px">
         {children}
       </Text>
     </StyledTag>

--- a/src/views/Predictions/components/RoundCard/CardHeader.tsx
+++ b/src/views/Predictions/components/RoundCard/CardHeader.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react'
+import { useTranslation } from 'contexts/Localization'
 import { Flex, Text } from '@pancakeswap/uikit'
 import styled, { DefaultTheme } from 'styled-components'
 
@@ -62,6 +63,7 @@ const Round = styled.div`
 `
 
 const CardHeader: React.FC<CardHeaderProps> = ({ status, title, epoch, icon }) => {
+  const { currentLanguage } = useTranslation()
   const textColor = getTextColorByStatus(status, 'text')
   const isLive = status === 'live'
 
@@ -69,8 +71,10 @@ const CardHeader: React.FC<CardHeaderProps> = ({ status, title, epoch, icon }) =
     <StyledCardHeader status={status}>
       <Flex alignItems="center">
         {icon}
-        <Text color={textColor} bold={isLive} textTransform={isLive ? 'uppercase' : 'capitalize'} lineHeight="21px">
-          {title}
+        <Text color={textColor} bold={isLive} lineHeight="21px">
+          {isLive
+            ? title.toLocaleUpperCase(currentLanguage.locale)
+            : title.charAt(0).toLocaleUpperCase(currentLanguage.locale) + title.slice(1)}
         </Text>
       </Flex>
       <Round>

--- a/src/views/Predictions/components/RoundCard/EnteredTag.tsx
+++ b/src/views/Predictions/components/RoundCard/EnteredTag.tsx
@@ -13,11 +13,10 @@ const StyledEnteredTag = styled(Tag).attrs({
   startIcon: <CheckmarkCircleIcon width="18px" />,
 })`
   font-weight: bold;
-  text-transform: uppercase;
 `
 
 const EnteredTag: React.FC<EnteredTagProps> = ({ amount }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnb(amount)} BNB`}</div>,
     { placement: 'bottom' },
@@ -26,7 +25,7 @@ const EnteredTag: React.FC<EnteredTagProps> = ({ amount }) => {
   return (
     <>
       <span ref={targetRef}>
-        <StyledEnteredTag>{t('Entered')}</StyledEnteredTag>{' '}
+        <StyledEnteredTag>{t('Entered').toLocaleUpperCase(currentLanguage.locale)}</StyledEnteredTag>{' '}
       </span>{' '}
       {tooltipVisible && tooltip}
     </>

--- a/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
@@ -42,7 +42,7 @@ const LiveRoundCard: React.FC<LiveRoundCardProps> = ({
   bullMultiplier,
   bearMultiplier,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { lockPrice, lockBlock, totalAmount } = round
   const { currentBlock } = useBlock()
   const totalInterval = useGetIntervalBlocks()
@@ -92,8 +92,8 @@ const LiveRoundCard: React.FC<LiveRoundCardProps> = ({
             isActive={isBull}
           />
           <RoundResultBox betPosition={isBull ? BetPosition.BULL : BetPosition.BEAR}>
-            <Text color="textSubtle" fontSize="12px" bold textTransform="uppercase" mb="8px">
-              {t('Last Price')}
+            <Text color="textSubtle" fontSize="12px" bold mb="8px">
+              {t('Last Price').toLocaleUpperCase(currentLanguage.locale)}
             </Text>
             <Flex alignItems="center" justifyContent="space-between" mb="16px" height="36px">
               <div ref={targetRef}>
@@ -102,7 +102,7 @@ const LiveRoundCard: React.FC<LiveRoundCardProps> = ({
                 </TooltipText>
               </div>
               <PositionTag betPosition={isBull ? BetPosition.BULL : BetPosition.BEAR}>
-                {formatUsd(priceDifference)}
+                {formatUsd(priceDifference).toUpperCase()}
               </PositionTag>
             </Flex>
             {lockPrice && <LockPriceRow lockPrice={lockPrice} />}

--- a/src/views/Predictions/components/RoundCard/MultiplierArrow.tsx
+++ b/src/views/Predictions/components/RoundCard/MultiplierArrow.tsx
@@ -60,7 +60,7 @@ const MultiplierArrow: React.FC<MultiplierArrowProps> = ({
   isDisabled = false,
   isActive = false,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const upColor = getTextColor('success')(isActive, isDisabled)
   const downColor = getTextColor('failure')(isActive, isDisabled)
   const textColor = getTextColor()(isActive, isDisabled)
@@ -97,8 +97,8 @@ const MultiplierArrow: React.FC<MultiplierArrowProps> = ({
           {getEnteredTag({ bottom: 0, right: 0 })}
           <Content>
             {!isDisabled && multiplierText}
-            <Text bold fontSize="20px" mb="8px" color={downColor} textTransform="uppercase">
-              {t('Down')}
+            <Text bold fontSize="20px" mb="8px" color={downColor}>
+              {t('Down').toLocaleUpperCase(currentLanguage.locale)}
             </Text>
           </Content>
         </ArrowWrapper>
@@ -112,8 +112,8 @@ const MultiplierArrow: React.FC<MultiplierArrowProps> = ({
         <RoundMultiplierUpArrow isActive={isActive} />
         {getEnteredTag({ top: 0, left: 0 })}
         <Content>
-          <Text bold fontSize="20px" lineHeight="21px" color={upColor} textTransform="uppercase">
-            {t('Up')}
+          <Text bold fontSize="20px" lineHeight="21px" color={upColor}>
+            {t('Up').toLocaleUpperCase(currentLanguage.locale)}
           </Text>
           {!isDisabled && multiplierText}
         </Content>

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -42,7 +42,7 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
     isSettingPosition: false,
     position: BetPosition.BULL,
   })
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const interval = useGetIntervalBlocks()
   const { toastSuccess } = useToast()
   const { account } = useWeb3React()
@@ -50,7 +50,10 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
   const { currentBlock } = useBlock()
   const { isSettingPosition, position } = state
   const isBufferPhase = currentBlock >= round.startBlock + interval
-  const positionDisplay = position === BetPosition.BULL ? t('Up').toUpperCase() : t('Down').toUpperCase()
+  const positionDisplay =
+    position === BetPosition.BULL
+      ? t('Up').toLocaleUpperCase(currentLanguage.locale)
+      : t('Down').toLocaleUpperCase(currentLanguage.locale)
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnb(betAmount)} BNB`}</div>,
     { placement: 'top' },

--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -82,7 +82,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
   const { swiper } = useSwiper()
   const { balance: bnbBalance } = useGetBnbBalance()
   const minBetAmount = useGetMinBetAmount()
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { toastError } = useToast()
   const predictionsContract = usePredictionsContract()
 
@@ -178,7 +178,9 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
             <Heading scale="md">{t('Set Position')}</Heading>
           </FlexRow>
           <PositionTag betPosition={position} onClick={togglePosition}>
-            {position === BetPosition.BULL ? t('Up') : t('Down')}
+            {position === BetPosition.BULL
+              ? t('Up').toLocaleUpperCase(currentLanguage.locale)
+              : t('Down').toLocaleUpperCase(currentLanguage.locale)}
           </PositionTag>
         </Flex>
       </CardHeader>

--- a/src/views/Predictions/components/RoundResult/RoundResult.tsx
+++ b/src/views/Predictions/components/RoundResult/RoundResult.tsx
@@ -14,24 +14,24 @@ const RoundResult: React.FC<RoundResultProps> = ({ round, children, ...props }) 
   const { lockPrice, closePrice, totalAmount } = round
   const betPosition = closePrice > lockPrice ? BetPosition.BULL : BetPosition.BEAR
   const isPositionUp = betPosition === BetPosition.BULL
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const priceDifference = closePrice - lockPrice
 
   return (
     <RoundResultBox betPosition={betPosition} {...props}>
-      <Text color="textSubtle" fontSize="12px" bold textTransform="uppercase" mb="8px">
-        {t('Closed Price')}
+      <Text color="textSubtle" fontSize="12px" bold mb="8px">
+        {t('Closed Price').toLocaleUpperCase(currentLanguage.locale)}
       </Text>
       {round.failed ? (
-        <Text bold textTransform="uppercase" color="textDisabled" mb="16px" fontSize="24px">
-          {t('Canceled')}
+        <Text bold color="textDisabled" mb="16px" fontSize="24px">
+          {t('Canceled').toLocaleUpperCase(currentLanguage.locale)}
         </Text>
       ) : (
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           <Text color={isPositionUp ? 'success' : 'failure'} bold fontSize="24px">
             {formatUsd(closePrice)}
           </Text>
-          <PositionTag betPosition={betPosition}>{formatUsd(priceDifference)}</PositionTag>
+          <PositionTag betPosition={betPosition}>{formatUsd(priceDifference).toUpperCase()}</PositionTag>
         </Flex>
       )}
       {lockPrice && <LockPriceRow lockPrice={lockPrice} />}

--- a/src/views/Predictions/components/RoundResult/styles.tsx
+++ b/src/views/Predictions/components/RoundResult/styles.tsx
@@ -45,14 +45,12 @@ interface PayoutRowProps extends FlexProps {
 }
 
 export const PayoutRow: React.FC<PayoutRowProps> = ({ positionLabel, multiplier, amount, ...props }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const formattedMultiplier = `${multiplier.toLocaleString(undefined, { maximumFractionDigits: 2 })}x`
 
   return (
     <Row height="18px" {...props}>
-      <Text fontSize="12px" textTransform="uppercase">
-        {positionLabel}:
-      </Text>
+      <Text fontSize="12px">{positionLabel.toLocaleUpperCase(currentLanguage.locale)}:</Text>
       <Flex alignItems="center">
         <Text fontSize="12px" lineHeight="18px" bold>
           {t('%multiplier% Payout', { multiplier: formattedMultiplier })}

--- a/src/views/Profile/PublicProfile.tsx
+++ b/src/views/Profile/PublicProfile.tsx
@@ -87,7 +87,7 @@ const PublicProfile = () => {
   const [usernameVisibilityToggled, setUsernameVisibility] = usePersistState(false, {
     localStorageKey: 'username_visibility_toggled',
   })
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
 
   if (!account) {
     return <WalletNotConnected />
@@ -136,7 +136,12 @@ const PublicProfile = () => {
             </Status>
           </CardHeader>
           <CardBody>
-            <StatBox icon={PrizeIcon} title={points} subtitle={t('Points')} mb="24px" />
+            <StatBox
+              icon={PrizeIcon}
+              title={points}
+              subtitle={t('Points').toLocaleUpperCase(currentLanguage.locale)}
+              mb="24px"
+            />
             <Section>
               <Heading as="h4" scale="md" mb="16px">
                 {t('Achievements')}

--- a/src/views/Profile/components/StatBox.tsx
+++ b/src/views/Profile/components/StatBox.tsx
@@ -18,7 +18,7 @@ const StatBox: React.FC<StatBoxProps> = ({ icon: Icon, title, subtitle, isDisabl
           <Heading as="h3" scale="xl" color={isDisabled ? 'textDisabled' : 'text'}>
             {title}
           </Heading>
-          <Text textTransform="uppercase" color={isDisabled ? 'textDisabled' : 'textSubtle'} fontSize="12px" bold>
+          <Text color={isDisabled ? 'textDisabled' : 'textSubtle'} fontSize="12px" bold>
             {subtitle}
           </Text>
         </div>

--- a/src/views/Teams/components/TeamCard.tsx
+++ b/src/views/Teams/components/TeamCard.tsx
@@ -74,7 +74,7 @@ const StatRow = styled.div`
 `
 
 const TeamCard: React.FC<TeamCardProps> = ({ team }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
 
   return (
     <Wrapper>
@@ -90,8 +90,17 @@ const TeamCard: React.FC<TeamCardProps> = ({ team }) => {
         </StyledCardHeader>
         <CardBody>
           <StatRow>
-            <StatBox icon={CommunityIcon} title={team.users} subtitle={t('Active Members')} />
-            <StatBox icon={PrizeIcon} title={t('Coming Soon')} subtitle={t('Team Points')} isDisabled />
+            <StatBox
+              icon={CommunityIcon}
+              title={team.users}
+              subtitle={t('Active Members').toLocaleUpperCase(currentLanguage.locale)}
+            />
+            <StatBox
+              icon={PrizeIcon}
+              title={t('Coming Soon')}
+              subtitle={t('Team Points').toLocaleUpperCase(currentLanguage.locale)}
+              isDisabled
+            />
           </StatRow>
           <Heading as="h3">{t('Team Achievements')}</Heading>
           <ComingSoon />

--- a/src/views/TradingCompetition/components/Countdown/ProgressStepper.tsx
+++ b/src/views/TradingCompetition/components/Countdown/ProgressStepper.tsx
@@ -20,12 +20,12 @@ const Spacer = styled.div<{ isPastSpacer?: boolean }>`
 `
 
 const ProgressStepper: React.FC<CountdownProps> = ({ steps, activeStepIndex }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   return (
     <Flex>
       {steps.map((step, index) => {
         const isPastSpacer = index < activeStepIndex
-        const stepText = t(step.text).toUpperCase()
+        const stepText = t(step.text).toLocaleUpperCase(currentLanguage.locale)
 
         return (
           <React.Fragment key={_uniqueId('ProgressStep-')}>

--- a/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
+++ b/src/views/TradingCompetition/components/PrizesInfo/PrizesGrid/index.tsx
@@ -79,7 +79,7 @@ const getTotalAchievementPoints = (achievements: Rank['achievements']) => {
 
 const PrizesGrid = () => {
   const [tab, setTab] = useState(0)
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const rows = easterPrizes[tab + 1]
 
   const handleItemClick = (index: number) => setTab(index)
@@ -95,11 +95,11 @@ const PrizesGrid = () => {
         <StyledPrizeTable>
           <thead>
             <tr>
-              <th>{t('Rank in team')}</th>
-              <th>{t('Tier')}</th>
-              <th>{t('CAKE Prizes (Split)')}</th>
-              <th>{t('Achievements')}</th>
-              <th>{t('NFT')}</th>
+              <th>{t('Rank in team').toLocaleUpperCase(currentLanguage.locale)}</th>
+              <th>{t('Tier').toLocaleUpperCase(currentLanguage.locale)}</th>
+              <th>{t('CAKE Prizes (Split)').toLocaleUpperCase(currentLanguage.locale)}</th>
+              <th>{t('Achievements').toLocaleUpperCase(currentLanguage.locale)}</th>
+              <th>{t('NFT').toLocaleUpperCase(currentLanguage.locale)}</th>
             </tr>
           </thead>
           <tbody>
@@ -112,8 +112,8 @@ const PrizesGrid = () => {
                   <BoldTd>{row.rank}</BoldTd>
                   <Td>
                     <Icon />
-                    <Text color={color} fontSize="12px" bold textTransform="uppercase">
-                      {t(label.text)}
+                    <Text color={color} fontSize="12px" bold>
+                      {t(label.text).toLocaleUpperCase(currentLanguage.locale)}
                     </Text>
                   </Td>
                   <BoldTd>

--- a/src/views/TradingCompetition/components/StyledPrizeTable.tsx
+++ b/src/views/TradingCompetition/components/StyledPrizeTable.tsx
@@ -24,7 +24,6 @@ export const StyledPrizeTable = styled.table`
   & > thead th {
     font-size: 12px;
     padding: 16px 0;
-    text-transform: uppercase;
 
     ${({ theme }) => theme.mediaQueries.xs} {
       padding: 16px 8px;

--- a/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
+++ b/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
@@ -47,7 +47,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({
   userLeaderboardInformation,
   currentPhase,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const [onPresentShareModal] = useModal(
     <ShareImageModal profile={profile} userLeaderboardInformation={userLeaderboardInformation} />,
     false,
@@ -174,7 +174,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({
               {volume > 0 && (
                 <UserRankBox
                   flex="1"
-                  title={t('Rank in team').toUpperCase()}
+                  title={t('Rank in team').toLocaleUpperCase(currentLanguage.locale)}
                   footer={userLeaderboardInformation ? t('#%global% Overall', { global: global.toLocaleString() }) : ''}
                   mr={[0, '8px']}
                   mb={['8px', 0]}
@@ -193,7 +193,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({
               )}
               <UserRankBox
                 flex="1"
-                title={t('Your volume').toUpperCase()}
+                title={t('Your volume').toLocaleUpperCase(currentLanguage.locale)}
                 footer={t('Since start')}
                 // Add responsive mr if competition is LIVE
                 mr={currentPhase.state === LIVE ? [0, null, '8px'] : 0}
@@ -213,7 +213,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({
                 // If user is first
                 <NextRankBox
                   flex="2"
-                  title={t('Your tier: gold').toUpperCase()}
+                  title={t('Your tier: gold').toLocaleUpperCase(currentLanguage.locale)}
                   footer={t('Love, The Chefs x')}
                   currentMedal={medal.current}
                   hideArrow
@@ -223,7 +223,7 @@ const CardUserInfo: React.FC<YourScoreProps> = ({
               ) : (
                 <NextRankBox
                   flex="2"
-                  title={`${t('Next tier').toUpperCase()}: ${nextTier.color}`}
+                  title={`${t('Next tier').toLocaleUpperCase(currentLanguage.locale)}: ${nextTier.color}`}
                   footer={t('to become #%rank% in team', { rank: nextTier.rank })}
                   currentMedal={medal.current}
                   nextMedal={medal.next}

--- a/src/views/TradingCompetition/components/YourScore/UserPrizeGrid.tsx
+++ b/src/views/TradingCompetition/components/YourScore/UserPrizeGrid.tsx
@@ -22,7 +22,7 @@ const StyledThead = styled.thead`
 const UserPrizeGrid: React.FC<{ userTradingInformation?: UserTradingInformationProps }> = ({
   userTradingInformation,
 }) => {
-  const { t } = useTranslation()
+  const { t, currentLanguage } = useTranslation()
   const { userRewardGroup, userCakeRewards, userPointReward, canClaimNFT } = userTradingInformation
   const { cakeReward, dollarValueOfCakeReward } = useCompetitionCakeRewards(userCakeRewards)
   const { champion, teamPlayer } = getRewardGroupAchievements(userRewardGroup)
@@ -55,8 +55,8 @@ const UserPrizeGrid: React.FC<{ userTradingInformation?: UserTradingInformationP
               {champion && <CrownIcon mr={[0, '4px']} />}
               {teamPlayer && <TeamPlayerIcon mr={[0, '4px']} />}
               <TrophyGoldIcon mr={[0, '4px']} />
-              <Text fontSize="12px" color="textSubtle" textTransform="lowercase">
-                + {userPointReward} {t('Points')}
+              <Text fontSize="12px" color="textSubtle">
+                + {userPointReward.toLowerCase()} {t('Points').toLocaleLowerCase(currentLanguage.locale)}
               </Text>
             </Flex>
           </Td>


### PR DESCRIPTION
Although https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform css covers locale upper/lower case, It only does that when OS language(browser language too) and the translation language are the same.

Reproduce one of the issue of many:

1. Go to team battle
2. Change language to turkish
3. Check comptation phases top right (Entry - Live - End in english)
4. First text should be GİRİŞ instead of GIRIŞ

Next one
1. Go to prediction
2. Change language to turkish
3. Check Last Price translation in cards 
4. Text should be SON FİYAT instead of SON FIYAT (see the difference in I character)

Pr is mainly for Turkish language 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase

but In other languages we might end up with a different word when we use upper case with localization.
