### PR TITLE
fix: (trading battle) Banner text not visible in dark mode

### DIFF
--- a/src/views/TradingCompetition/components/BattleBanner/index.tsx
+++ b/src/views/TradingCompetition/components/BattleBanner/index.tsx
@@ -53,7 +53,7 @@ const BattleBanner = () => {
       <StyledHeading2Text background={theme.colors.gradients.gold} $fill>
         {t('$200,000 in Prizes!')}
       </StyledHeading2Text>
-      <StyledHeading scale="md" color="inputSecondary" mt="16px">
+      <StyledHeading scale="md" color={theme.isDark ? 'textSubtle' : 'inputSecondary'} mt="16px">
         {t('Compete with other teams to win CAKE, collectible NFTs, achievements & more!')}
       </StyledHeading>
     </Flex>


### PR DESCRIPTION
To review:

https://deploy-preview-1477--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to team battle
2. Change theme to dark
3. Check banner text "Compete with other teams to win CAKE, collectible NFTs, achievements & more!" under "$200,000 in Prizes!"