### PR TITLE
fix: (lottery) Add missing translation for select in history chart

### DIFF
--- a/src/views/Lottery/components/PastDrawsHistory/PastDrawsHistoryCard.tsx
+++ b/src/views/Lottery/components/PastDrawsHistory/PastDrawsHistoryCard.tsx
@@ -60,7 +60,7 @@ const PastDrawsHistoryCard: React.FC = () => {
                   value: 200,
                 },
                 {
-                  label: 'Max',
+                  label: t('Max'),
                   value: 'max',
                 },
               ]}


### PR DESCRIPTION
To reproduce the issue

1. Go to lottery
2. Change language
3. Check history chart show last select dropdown menu
4. Check Max text translation 