### PR TITLE
fix: (pools) Remove redundant empty space visible in mobile and tablets in action panel

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -98,10 +98,13 @@ interface ActionPanelProps {
 }
 
 const InfoSection = styled(Box)`
-  flex: 0 0 230px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
   padding: 8px 8px;
   ${({ theme }) => theme.mediaQueries.lg} {
     padding: 0;
+    flex-basis: 230px;
   }
 `
 


### PR DESCRIPTION
To review:

https://deploy-preview-1484--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to pools tables in mobile or tablet (especially)
2. Check action details
3. See empty space at the end of the action panel

Before:

<img width="748" alt="Screenshot 2021-06-10 at 10 33 10" src="https://user-images.githubusercontent.com/2213635/121492634-51a74380-c9d7-11eb-9e40-71b8ec31d507.png">

After: 

<img width="744" alt="Screenshot 2021-06-10 at 10 31 50" src="https://user-images.githubusercontent.com/2213635/121492646-553aca80-c9d7-11eb-898f-40b4f0292191.png">
