### PR TITLE
fix: (teams) Add missing description translation in team list card

### DIFF
--- a/src/config/constants/teams.ts
+++ b/src/config/constants/teams.ts
@@ -20,7 +20,7 @@ const teams: Team[] = [
   {
     id: 2,
     name: 'Fearsome Flippers',
-    description: "The flippening is coming. Don't get in these bunnies' way, or you'll get flipped too!",
+    description: "The flippening is coming. Don't get in these bunnies' way, or you'll get flipped, too!",
     images: {
       lg: 'fearsome-flippers-lg.png',
       md: 'fearsome-flippers-md.png',

--- a/src/views/Teams/components/TeamListCard.tsx
+++ b/src/views/Teams/components/TeamListCard.tsx
@@ -108,7 +108,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ rank, team }) => {
             <TeamName>{team.name}</TeamName>
           </Flex>
           <Text as="p" color="textSubtle" pr="24px" mb="16px">
-            {team.description}
+            {t(team.description)}
           </Text>
           <Flex>
             <Flex>


### PR DESCRIPTION
To reproduce the issue

1. Go to team & profile -> leaderboard
2. Change language
3. Check teams description text

Should be translated as well