### PR TITLE
fix: (farms) Harvest button is enabled when 0

### DIFF
--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -62,7 +62,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
           {countUp > 0 && <Staked>~{countUp}USD</Staked>}
         </div>
         <Button
-          disabled={!earnings || pendingTx || !userDataReady}
+          disabled={earnings.eq(0) || pendingTx || !userDataReady}
           onClick={async () => {
             setPendingTx(true)
             await onReward()


### PR DESCRIPTION
To review:

https://deploy-preview-1490--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to farms
2. Check a farm that you don't have earnings
3. See harvest button enabled