### PR TITLE
feat: (farms) Use balance component for usd amounts instead of different components

### DIFF
--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -9,7 +9,7 @@ import { getBalanceAmount } from 'utils/formatBalance'
 import { BIG_ZERO } from 'utils/bigNumber'
 import { useWeb3React } from '@web3-react/core'
 import { usePriceCakeBusd } from 'state/hooks'
-import CardBusdValue from '../../../Home/components/CardBusdValue'
+import Balance from 'components/Balance'
 
 interface FarmCardActionsProps {
   earnings?: BigNumber
@@ -29,10 +29,12 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
 
   return (
     <Flex mb="8px" justifyContent="space-between" alignItems="center">
-      <Heading color={rawEarningsBalance.eq(0) ? 'textDisabled' : 'text'}>
-        {displayBalance}
-        {earningsBusd > 0 && <CardBusdValue value={earningsBusd} />}
-      </Heading>
+      <Flex flexDirection="column" alignItems="flex-start">
+        <Heading color={rawEarningsBalance.eq(0) ? 'textDisabled' : 'text'}>{displayBalance}</Heading>
+        {earningsBusd > 0 && (
+          <Balance fontSize="12px" color="textSubtle" decimals={2} value={earningsBusd} unit=" USD" prefix="~" />
+        )}
+      </Flex>
       <Button
         disabled={rawEarningsBalance.eq(0) || pendingTx}
         onClick={async () => {

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState } from 'react'
 import { Button, Skeleton } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
+import Balance from 'components/Balance'
 import { BIG_ZERO } from 'utils/bigNumber'
 import { getBalanceAmount } from 'utils/formatBalance'
 import { useAppDispatch } from 'state'
@@ -10,9 +11,8 @@ import { fetchFarmUserDataAsync } from 'state/farms'
 import { usePriceCakeBusd } from 'state/hooks'
 import { useHarvest } from 'hooks/useHarvest'
 import { useTranslation } from 'contexts/Localization'
-import { useCountUp } from 'react-countup'
 
-import { ActionContainer, ActionTitles, Title, Subtle, ActionContent, Earned, Staked } from './styles'
+import { ActionContainer, ActionTitles, Title, Subtle, ActionContent, Earned } from './styles'
 
 interface HarvestActionProps extends FarmWithStakedValue {
   userDataReady: boolean
@@ -37,18 +37,6 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
-  const { countUp, update } = useCountUp({
-    start: 0,
-    end: earningsBusd,
-    duration: 1,
-    separator: ',',
-    decimals: 3,
-  })
-  const updateValue = useRef(update)
-
-  useEffect(() => {
-    updateValue.current(earningsBusd)
-  }, [earningsBusd, updateValue])
 
   return (
     <ActionContainer>
@@ -59,7 +47,9 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
       <ActionContent>
         <div>
           <Earned>{displayBalance}</Earned>
-          {countUp > 0 && <Staked>~{countUp}USD</Staked>}
+          {earningsBusd > 0 && (
+            <Balance fontSize="12px" color="textSubtle" decimals={2} value={earningsBusd} unit=" USD" prefix="~" />
+          )}
         </div>
         <Button
           disabled={!earnings || pendingTx || !userDataReady}

--- a/src/views/Farms/components/FarmTable/Actions/styles.ts
+++ b/src/views/Farms/components/FarmTable/Actions/styles.ts
@@ -48,8 +48,3 @@ export const Earned = styled.div`
   font-size: 20px;
   color: ${({ theme }) => theme.colors.text};
 `
-
-export const Staked = styled.div`
-  font-size: 12px;
-  color: ${({ theme }) => theme.colors.textSubtle};
-`


### PR DESCRIPTION
To review:

https://deploy-preview-1491--pancakeswap-dev.netlify.app/

With this all usd amounts in farms will be in same representation.

1. Go to farms 
2. Go to a farm that you have earnings
3. Check amount in usd style in harvest