### PR TITLE
feat: (farms) Use Text component instead of Subtle and Title

### DIFF
--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -82,7 +82,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
   return (
     <Action>
       <Flex>
-        <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
+        <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="4px">
           CAKE
         </Text>
         <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
@@ -91,7 +91,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
       </Flex>
       <HarvestAction earnings={earnings} pid={pid} />
       <Flex>
-        <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
+        <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="4px">
           {farm.lpSymbol}
         </Text>
         <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Button, Skeleton } from '@pancakeswap/uikit'
+import { Button, Skeleton, Text } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
 import { FarmWithStakedValue } from 'views/Farms/components/FarmCard/FarmCard'
@@ -12,7 +12,7 @@ import { usePriceCakeBusd } from 'state/hooks'
 import { useHarvest } from 'hooks/useHarvest'
 import { useTranslation } from 'contexts/Localization'
 
-import { ActionContainer, ActionTitles, Title, Subtle, ActionContent, Earned } from './styles'
+import { ActionContainer, ActionTitles, ActionContent, Earned } from './styles'
 
 interface HarvestActionProps extends FarmWithStakedValue {
   userDataReady: boolean
@@ -41,8 +41,12 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
   return (
     <ActionContainer>
       <ActionTitles>
-        <Title>CAKE </Title>
-        <Subtle>{t('Earned').toUpperCase()}</Subtle>
+        <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="4px">
+          CAKE
+        </Text>
+        <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
+          {t('Earned')}
+        </Text>
       </ActionTitles>
       <ActionContent>
         <div>

--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
-import { Button, useModal, IconButton, AddIcon, MinusIcon, Skeleton } from '@pancakeswap/uikit'
+import { Button, useModal, IconButton, AddIcon, MinusIcon, Skeleton, Text } from '@pancakeswap/uikit'
 import { useLocation } from 'react-router-dom'
 import { BigNumber } from 'bignumber.js'
 import UnlockButton from 'components/UnlockButton'
@@ -22,7 +22,7 @@ import useWeb3 from 'hooks/useWeb3'
 
 import DepositModal from '../../DepositModal'
 import WithdrawModal from '../../WithdrawModal'
-import { ActionContainer, ActionTitles, ActionContent, Earned, Title, Subtle } from './styles'
+import { ActionContainer, ActionTitles, ActionContent, Earned } from './styles'
 
 const IconButtonWrapper = styled.div`
   display: flex;
@@ -103,7 +103,9 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Start Farming').toUpperCase()}</Subtle>
+          <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
+            {t('Start Farming')}
+          </Text>
         </ActionTitles>
         <ActionContent>
           <UnlockButton width="100%" />
@@ -117,8 +119,12 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
       return (
         <ActionContainer>
           <ActionTitles>
-            <Title>{lpSymbol} </Title>
-            <Subtle>{t('Staked').toUpperCase()}</Subtle>
+            <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="4px">
+              {lpSymbol}
+            </Text>
+            <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
+              {t('Staked')}
+            </Text>
           </ActionTitles>
           <ActionContent>
             <div>
@@ -154,8 +160,12 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Stake').toUpperCase()} </Subtle>
-          <Title>{lpSymbol}</Title>
+          <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px" pr="4px">
+            {t('Stake').toUpperCase()}
+          </Text>
+          <Text bold textTransform="uppercase" color="secondary" fontSize="12px">
+            {lpSymbol}
+          </Text>
         </ActionTitles>
         <ActionContent>
           <Button
@@ -175,7 +185,9 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
     return (
       <ActionContainer>
         <ActionTitles>
-          <Subtle>{t('Start Farming').toUpperCase()}</Subtle>
+          <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
+            {t('Start Farming')}
+          </Text>
         </ActionTitles>
         <ActionContent>
           <Skeleton width={180} marginBottom={28} marginTop={14} />
@@ -187,7 +199,9 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
   return (
     <ActionContainer>
       <ActionTitles>
-        <Subtle>{t('Enable Farm').toUpperCase()}</Subtle>
+        <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
+          {t('Enable Farm')}
+        </Text>
       </ActionTitles>
       <ActionContent>
         <Button width="100%" disabled={requestedApproval} onClick={handleApprove} variant="secondary">

--- a/src/views/Farms/components/FarmTable/Actions/styles.ts
+++ b/src/views/Farms/components/FarmTable/Actions/styles.ts
@@ -24,18 +24,7 @@ export const ActionContainer = styled.div`
 `
 
 export const ActionTitles = styled.div`
-  font-weight: 600;
-  font-size: 12px;
-  margin-bottom: 8px;
-`
-
-export const Title = styled.span`
-  color: ${({ theme }) => theme.colors.secondary};
-`
-
-// TODO: Use `Text` instead
-export const Subtle = styled.span`
-  color: ${({ theme }) => theme.colors.textSubtle};
+  display: flex;
 `
 
 export const ActionContent = styled.div`


### PR DESCRIPTION
To review:

https://deploy-preview-1492--pancakeswap-dev.netlify.app/

There is a Todo above Subtle style component decleration which is waiting to be fixed.

https://github.com/pancakeswap/pancake-frontend/blob/5bc14994d8cd1334adb48acf0c40a2e68162c64b/src/views/Farms/components/FarmTable/Actions/styles.ts#L36