### PR TITLE
fix: (farms) Fix farmcard loading error when has staked amount in farms with lowercase characters

### DIFF
--- a/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
+++ b/src/views/Farms/components/FarmCard/CardActionsContainer.tsx
@@ -44,7 +44,6 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
   const stakedBalance = new BigNumber(stakedBalanceAsString)
   const earnings = new BigNumber(earningsAsString)
   const lpAddress = getAddress(lpAddresses)
-  const lpName = farm.lpSymbol.toUpperCase()
   const isApproved = account && allowance && allowance.isGreaterThan(0)
   const web3 = useWeb3()
   const dispatch = useAppDispatch()
@@ -69,7 +68,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
       <StakeAction
         stakedBalance={stakedBalance}
         tokenBalance={tokenBalance}
-        tokenName={lpName}
+        tokenName={farm.lpSymbol}
         pid={pid}
         addLiquidityUrl={addLiquidityUrl}
       />
@@ -93,7 +92,7 @@ const CardActions: React.FC<FarmCardActionsProps> = ({ farm, account, addLiquidi
       <HarvestAction earnings={earnings} pid={pid} />
       <Flex>
         <Text bold textTransform="uppercase" color="secondary" fontSize="12px" pr="3px">
-          {lpName}
+          {farm.lpSymbol}
         </Text>
         <Text bold textTransform="uppercase" color="textSubtle" fontSize="12px">
           {t('Staked')}


### PR DESCRIPTION
To review:

https://deploy-preview-1495--pancakeswap-dev.netlify.app/

LP symbol converted to uppercase in farm cards then passed to staked components which makes LP price return error with undefined pid when symbol has lowercase characters in farm config

Issue only occurs when there is a stake amount in those farms

Fixes #1493 #1496

To reproduce the problem

1. Go to farms
2. Select card view
3. Find a staked farm that has lower case character (originally) (such as bmxx-bnb)
4. Check console for error 