### PR TITLE
feat: (pools) Add link to bscscan countdown and max stake info in pools cards details

### DIFF
--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -13,12 +13,14 @@ import {
   Skeleton,
   useTooltip,
   Button,
+  Link,
 } from '@pancakeswap/uikit'
 import { BASE_BSC_SCAN_URL, BASE_URL } from 'config'
 import { useBlock, useCakeVault } from 'state/hooks'
 import { Pool } from 'state/types'
 import { getAddress, getCakeVaultAddress } from 'utils/addressHelpers'
 import { registerToken } from 'utils/wallet'
+import { getBscScanBlockCountdownUrl } from 'utils/bscscan'
 import Balance from 'components/Balance'
 import { getPoolBlockInfo } from 'views/Pools/helpers'
 
@@ -42,7 +44,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
     fees: { performanceFee },
   } = useCakeVault()
 
-  const { stakingToken, earningToken, totalStaked, contractAddress, sousId, isAutoVault } = pool
+  const { stakingToken, earningToken, totalStaked, endBlock, contractAddress, sousId, isAutoVault } = pool
 
   const tokenAddress = earningToken.address ? getAddress(earningToken.address) : ''
   const poolContractAddress = getAddress(contractAddress)
@@ -89,18 +91,20 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
       </Flex>
       {shouldShowBlockCountdown && (
         <Flex mb="2px" justifyContent="space-between" alignItems="center">
-          <Text small>{hasPoolStarted ? t('End') : t('Start')}:</Text>
-          <Flex alignItems="center">
-            {blocksRemaining || blocksUntilStart ? (
-              <Balance color="primary" fontSize="14px" value={blocksToDisplay} decimals={0} />
-            ) : (
-              <Skeleton width="54px" height="21px" />
-            )}
-            <Text ml="4px" color="primary" small textTransform="lowercase">
-              {t('Blocks')}
-            </Text>
-            <TimerIcon ml="4px" color="primary" />
-          </Flex>
+          <Text small>{hasPoolStarted ? t('Ends in') : t('Starts in')}:</Text>
+          {blocksRemaining || blocksUntilStart ? (
+            <Flex alignItems="center">
+              <Link external href={getBscScanBlockCountdownUrl(endBlock)}>
+                <Balance small value={blocksToDisplay} decimals={0} color="primary" />
+                <Text small ml="4px" color="primary" textTransform="lowercase">
+                  {t('Blocks')}
+                </Text>
+                <TimerIcon ml="4px" color="primary" />
+              </Link>
+            </Flex>
+          ) : (
+            <Skeleton width="54px" height="21px" />
+          )}
         </Flex>
       )}
       {isAutoVault && (

--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import BigNumber from 'bignumber.js'
 import styled from 'styled-components'
-import { getBalanceNumber } from 'utils/formatBalance'
+import { getBalanceNumber, getFullDisplayBalance } from 'utils/formatBalance'
 import { useTranslation } from 'contexts/Localization'
 import {
   Flex,
@@ -44,7 +44,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
     fees: { performanceFee },
   } = useCakeVault()
 
-  const { stakingToken, earningToken, totalStaked, endBlock, contractAddress, sousId, isAutoVault } = pool
+  const { stakingToken, earningToken, totalStaked, endBlock, stakingLimit, contractAddress, sousId, isAutoVault } = pool
 
   const tokenAddress = earningToken.address ? getAddress(earningToken.address) : ''
   const poolContractAddress = getAddress(contractAddress)
@@ -79,8 +79,8 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
         <Flex alignItems="flex-start">
           {totalStaked ? (
             <>
-              <Balance fontSize="14px" value={getTotalStakedBalance()} />
-              <Text ml="4px" fontSize="14px">
+              <Balance small value={getTotalStakedBalance()} />
+              <Text small ml="4px">
                 {stakingToken.symbol}
               </Text>
             </>
@@ -89,6 +89,12 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
           )}
         </Flex>
       </Flex>
+      {stakingLimit && stakingLimit.gt(0) && (
+        <Flex mb="2px" justifyContent="space-between">
+          <Text small>{t('Max. stake per user')}:</Text>
+          <Text small>{`${getFullDisplayBalance(stakingLimit, stakingToken.decimals, 0)} ${stakingToken.symbol}`}</Text>
+        </Flex>
+      )}
       {shouldShowBlockCountdown && (
         <Flex mb="2px" justifyContent="space-between" alignItems="center">
           <Text small>{hasPoolStarted ? t('Ends in') : t('Starts in')}:</Text>


### PR DESCRIPTION
To review: 

https://deploy-preview-1499--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go pools
2. Go live ones
3. Go to pool cards
4. Click detail of any pool (except auto vault)
5. Check Block countdown and check max stake per user info

Block coundown should be clickable and forwards you to bscscan like in pools table. 
Max stake per user info should be visible in card details.