### PR TITLE
fix: (pools) Add missing colons in details descriptions in pools table

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -189,14 +189,14 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
 
   const aprRow = (
     <Flex justifyContent="space-between" alignItems="center" mb="8px">
-      <Text>{isAutoVault ? t('APY') : t('APR')}</Text>
+      <Text>{isAutoVault ? t('APY') : t('APR')}:</Text>
       <Apr pool={pool} showIcon performanceFee={isAutoVault ? performanceFeeAsDecimal : 0} />
     </Flex>
   )
 
   const totalStakedRow = (
     <Flex justifyContent="space-between" alignItems="center" mb="8px">
-      <Text maxWidth={['50px', '100%']}>{t('Total staked')}</Text>
+      <Text maxWidth={['50px', '100%']}>{t('Total staked')}:</Text>
       <Flex alignItems="center">
         {totalStaked ? (
           <>


### PR DESCRIPTION
To review:

https://deploy-preview-1500--pancakeswap-dev.netlify.app/

Reproduce the issue

1. Open webpage in mobile
2. Go to pools
3. Select table view
4. Check details of one of the pools
5. See missing colons in some descriptions

Before: 

<img width="363" alt="Screenshot 2021-06-14 at 16 52 09" src="https://user-images.githubusercontent.com/2213635/121912582-fe175b80-cd30-11eb-8d3e-62ec6b81482d.png">

After: 

<img width="349" alt="Screenshot 2021-06-14 at 16 52 46" src="https://user-images.githubusercontent.com/2213635/121912601-02437900-cd31-11eb-862b-21a418c89aae.png">
