### PR TITLE
fix: (pools) Total staked shows symbol only when loading in pools table mobile

### DIFF
--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -14,6 +14,7 @@ import {
   useTooltip,
   Button,
   Link,
+  HelpIcon,
 } from '@pancakeswap/uikit'
 import { BASE_BSC_SCAN_URL, BASE_URL } from 'config'
 import { useBlock, useCakeVault } from 'state/hooks'
@@ -72,21 +73,30 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
     return getBalanceNumber(totalStaked, stakingToken.decimals)
   }
 
+  const {
+    targetRef: totalStakedTargetRef,
+    tooltip: totalStakedTooltip,
+    tooltipVisible: totalStakedTooltipVisible,
+  } = useTooltip(t('Total amount of %symbol% staked in this pool', { symbol: stakingToken.symbol }), {
+    placement: 'bottom',
+  })
+
   return (
     <ExpandedWrapper flexDirection="column">
       <Flex mb="2px" justifyContent="space-between" alignItems="center">
         <Text small>{t('Total staked')}:</Text>
         <Flex alignItems="flex-start">
-          {totalStaked ? (
+          {totalStaked && totalStaked.gte(0) ? (
             <>
-              <Balance small value={getTotalStakedBalance()} />
-              <Text small ml="4px">
-                {stakingToken.symbol}
-              </Text>
+              <Balance small value={getTotalStakedBalance()} decimals={0} unit={` ${stakingToken.symbol}`} />
+              <span ref={totalStakedTargetRef}>
+                <HelpIcon color="textSubtle" width="20px" ml="6px" mt="4px" />
+              </span>
             </>
           ) : (
             <Skeleton width="90px" height="21px" />
           )}
+          {totalStakedTooltipVisible && totalStakedTooltip}
         </Flex>
       </Flex>
       {stakingLimit && stakingLimit.gt(0) && (

--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -198,7 +198,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
     <Flex justifyContent="space-between" alignItems="center" mb="8px">
       <Text maxWidth={['50px', '100%']}>{t('Total staked')}:</Text>
       <Flex alignItems="center">
-        {totalStaked ? (
+        {totalStaked && totalStaked.gte(0) ? (
           <>
             <Balance fontSize="16px" value={getTotalStakedBalance()} decimals={0} unit={` ${stakingToken.symbol}`} />
             <span ref={totalStakedTargetRef}>

--- a/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
@@ -41,7 +41,7 @@ const TotalStakedCell: React.FC<TotalStakedCellProps> = ({ pool }) => {
         <Text fontSize="12px" color="textSubtle" textAlign="left">
           {t('Total staked')}
         </Text>
-        {totalStakedBalance ? (
+        {totalStaked && totalStaked.gte(0) ? (
           <Flex height="100%" alignItems="center">
             <Balance fontSize="16px" value={totalStakedBalance} decimals={0} unit={` ${stakingToken.symbol}`} />
           </Flex>


### PR DESCRIPTION
To review:

https://deploy-preview-1502--pancakeswap-dev.netlify.app/

To reproduce issue:

1. Go to pools open in mobile
2. Go to table view
3. Go to details
4. Check total staked when pool data loading

It also fixes an issue that shows skeleton instead of the value when total staked is exact 0

Before: 

<img width="343" alt="Screenshot 2021-06-14 at 20 27 51" src="https://user-images.githubusercontent.com/2213635/121952797-ff5e7d80-cd5c-11eb-8298-196b7c34d5a2.png">

After:

<img width="341" alt="Screenshot 2021-06-14 at 20 25 29" src="https://user-images.githubusercontent.com/2213635/121952808-02596e00-cd5d-11eb-8fd5-f7ed1915cd22.png">


