### PR TITLE
feat: (earnaprcard) Lazy load farms data to reduce amount of requests

### DIFF
--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react'
+
+const useIntersectionObserver = () => {
+  const observerRef = useRef<HTMLDivElement>(null)
+  const [observerIsSet, setObserverIsSet] = useState(false)
+  const [isIntersecting, setIsIntersecting] = useState(false)
+
+  useEffect(() => {
+    const checkObserverIsIntersecting = ([entry]: IntersectionObserverEntry[]) => {
+      setIsIntersecting(entry.isIntersecting)
+    }
+
+    if (!observerIsSet) {
+      const intersectionObserver = new IntersectionObserver(checkObserverIsIntersecting, {
+        rootMargin: '0px',
+        threshold: 1,
+      })
+      intersectionObserver.observe(observerRef.current)
+      setObserverIsSet(true)
+    }
+  }, [observerIsSet])
+
+  return { observerRef, isIntersecting }
+}
+
+export default useIntersectionObserver

--- a/src/views/Home/components/EarnAPRCard.tsx
+++ b/src/views/Home/components/EarnAPRCard.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch } from 'state'
 import { useFarms, usePriceCakeBusd } from 'state/hooks'
 import { fetchFarmsPublicDataAsync, nonArchivedFarms } from 'state/farms'
 import { getFarmApr } from 'utils/apr'
+import useIntersectionObserver from 'hooks/useIntersectionObserver'
 
 const StyledFarmStakingCard = styled(Card)`
   margin-left: auto;
@@ -34,6 +35,7 @@ const EarnAPRCard = () => {
   const { data: farmsLP } = useFarms()
   const cakePrice = usePriceCakeBusd()
   const dispatch = useAppDispatch()
+  const { observerRef, isIntersecting } = useIntersectionObserver()
 
   // Fetch farm data once to get the max APR
   useEffect(() => {
@@ -45,8 +47,10 @@ const EarnAPRCard = () => {
       }
     }
 
-    fetchFarmData()
-  }, [dispatch, setIsFetchingFarmData])
+    if (isIntersecting) {
+      fetchFarmData()
+    }
+  }, [dispatch, setIsFetchingFarmData, isIntersecting])
 
   const highestApr = useMemo(() => {
     if (cakePrice.gt(0)) {
@@ -80,7 +84,10 @@ const EarnAPRCard = () => {
             {highestApr && !isFetchingFarmData ? (
               `${highestApr}%`
             ) : (
-              <Skeleton animation="pulse" variant="rect" height="44px" />
+              <>
+                <Skeleton animation="pulse" variant="rect" height="44px" />
+                <div ref={observerRef} />
+              </>
             )}
           </CardMidContent>
           <Flex justifyContent="space-between">


### PR DESCRIPTION
This feature is mainly for mobiles (where earn apr card is not visible at first sight), if user does not scroll down after opening the page, requests drops to 27 from around 600 at opening.