### PR TITLE
fix: (pools) Countdown link should link to start block before pool started

### DIFF
--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -44,7 +44,17 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
     fees: { performanceFee },
   } = useCakeVault()
 
-  const { stakingToken, earningToken, totalStaked, endBlock, stakingLimit, contractAddress, sousId, isAutoVault } = pool
+  const {
+    stakingToken,
+    earningToken,
+    totalStaked,
+    startBlock,
+    endBlock,
+    stakingLimit,
+    contractAddress,
+    sousId,
+    isAutoVault,
+  } = pool
 
   const tokenAddress = earningToken.address ? getAddress(earningToken.address) : ''
   const poolContractAddress = getAddress(contractAddress)
@@ -100,7 +110,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
           <Text small>{hasPoolStarted ? t('Ends in') : t('Starts in')}:</Text>
           {blocksRemaining || blocksUntilStart ? (
             <Flex alignItems="center">
-              <Link external href={getBscScanBlockCountdownUrl(endBlock)}>
+              <Link external href={getBscScanBlockCountdownUrl(hasPoolStarted ? endBlock : startBlock)}>
                 <Balance small value={blocksToDisplay} decimals={0} color="primary" />
                 <Text small ml="4px" color="primary" textTransform="lowercase">
                   {t('Blocks')}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -109,7 +109,7 @@ const InfoSection = styled(Box)`
 `
 
 const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded, expanded, breakpoints }) => {
-  const { sousId, stakingToken, earningToken, totalStaked, endBlock, stakingLimit, isAutoVault } = pool
+  const { sousId, stakingToken, earningToken, totalStaked, startBlock, endBlock, stakingLimit, isAutoVault } = pool
   const { t } = useTranslation()
   const { currentBlock } = useBlock()
   const { isXs, isSm, isMd } = breakpoints
@@ -174,7 +174,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
       <Flex mb="8px" justifyContent="space-between">
         <Text>{hasPoolStarted ? t('Ends in') : t('Starts in')}:</Text>
         <Flex>
-          <Link external href={getBscScanBlockCountdownUrl(endBlock)}>
+          <Link external href={getBscScanBlockCountdownUrl(hasPoolStarted ? endBlock : startBlock)}>
             <Balance fontSize="16px" value={blocksToDisplay} decimals={0} color="primary" />
             <Text ml="4px" color="primary" textTransform="lowercase">
               {t('Blocks')}

--- a/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
@@ -18,7 +18,7 @@ const StyledCell = styled(BaseCell)`
 `
 
 const EndsInCell: React.FC<FinishCellProps> = ({ pool }) => {
-  const { sousId, totalStaked, endBlock, isFinished } = pool
+  const { sousId, totalStaked, startBlock, endBlock, isFinished } = pool
   const { currentBlock } = useBlock()
   const { t } = useTranslation()
 
@@ -36,7 +36,11 @@ const EndsInCell: React.FC<FinishCellProps> = ({ pool }) => {
         </Text>
       </Flex>
       <Flex flex="1">
-        <Link external href={getBscScanBlockCountdownUrl(endBlock)} onClick={(e) => e.stopPropagation()}>
+        <Link
+          external
+          href={getBscScanBlockCountdownUrl(hasPoolStarted ? endBlock : startBlock)}
+          onClick={(e) => e.stopPropagation()}
+        >
           <TimerIcon ml="4px" />
         </Link>
       </Flex>


### PR DESCRIPTION
To reproduce the issue

1. Go to pools
2. Check block count down bscscan link before pool started
3. It should show the start block instead of end block