### PR TITLE
chore: Update lottery link on Lottery page

### DIFF
--- a/src/views/Lottery/components/Hero.tsx
+++ b/src/views/Lottery/components/Hero.tsx
@@ -89,7 +89,7 @@ const Hero = () => {
             bold
             mt={20}
             external
-            href="https://voting.pancakeswap.finance/#/pancake/proposal/QmU8pcbmBrfbfVQXMMxmkExDq3mYq4s5cbBuFe6uCZzdmX"
+            href="https://pancakeswap.medium.com/pancakeswap-april-may-recap-a4e7cf990f72"
           >
             {t('Learn more')}
           </LinkExternal>


### PR DESCRIPTION
"Learn more" string is linked to the voting site in Lottery page, so I updated it to link to Medium article.
Similar change with #1532.

https://determined-bassi-fc8beb.netlify.app/
