### PR TITLE
fix: (menu) Add missing translation in menu

### DIFF
--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -82,7 +82,7 @@ const config: (t: ContextApi['t']) => MenuEntry[] = (t) => [
     icon: 'InfoIcon',
     href: 'https://pancakeswap.info',
     status: {
-      text: 'NEW',
+      text: t('New').toLocaleUpperCase(),
       color: 'success',
     },
   },

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -820,9 +820,9 @@
   "Max. stake per user": "Max. stake per user",
   "You have claimed your rewards!": "You have claimed your rewards!",
   "Already Collected": "Already Collected",
-  "Up or Down?": "Up or Down?",
   "Predictions Now Live": "Predictions Now Live",
   "Beta Version": "Beta Version",
   "Over %amount% in BNB won so far": "Over %amount% in BNB won so far",
-  "Try Now": "Try Now"
+  "Try Now": "Try Now",
+  "New": "New"
 }


### PR DESCRIPTION
To reproduce the issue

1. Check sidebar menu
2. Change language
3. Check translation of 'New' tag