### PR TITLE
fix: (select) Dropdown is not closed when clicking outside of the element

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -108,7 +108,10 @@ const Select: React.FunctionComponent<SelectProps> = ({ options, onChange }) => 
   const [selectedOptionIndex, setSelectedOptionIndex] = useState(0)
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
 
-  const toggling = () => setIsOpen(!isOpen)
+  const toggling = (event: React.MouseEvent<HTMLDivElement>) => {
+    setIsOpen(!isOpen)
+    event.stopPropagation()
+  }
 
   const onOptionClicked = (selectedIndex: number) => () => {
     setSelectedOptionIndex(selectedIndex)
@@ -124,6 +127,15 @@ const Select: React.FunctionComponent<SelectProps> = ({ options, onChange }) => 
       width: dropdownRef.current.offsetWidth, // Consider border
       height: dropdownRef.current.offsetHeight,
     })
+
+    const handleClickOutside = () => {
+      setIsOpen(false)
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
To review:

https://deploy-preview-1551--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to pools
2. Click sort by dropdown
3. Then click outside of the element to close it intuitively
4. Dropdown should be collapsed