### PR TITLE
style(timer): Improvments to generic Timer component

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -26,6 +26,7 @@ const Balance: React.FC<BalanceProps> = ({
   useEffect(() => {
     previousValue.current = value
   }, [value])
+
   return (
     <Text color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
       {prefix && <span>{prefix}</span>}

--- a/src/components/Timer/index.tsx
+++ b/src/components/Timer/index.tsx
@@ -6,7 +6,8 @@ import { ContextApi } from 'contexts/Localization/types'
 import { getBscScanBlockNumberUrl } from 'utils/bscscan'
 
 export interface TimerProps {
-  timerStage?: string
+  prefix?: string
+  suffix?: string
   minutes?: number
   hours?: number
   days?: number
@@ -28,12 +29,24 @@ const Timer = ({ minutes, hours, days, showTooltip, HeadingTextComponent, BodyTe
 
   return (
     <StyledTimerFlex alignItems="flex-end" showTooltip={showTooltip}>
-      <HeadingTextComponent mr="2px">{days}</HeadingTextComponent>
-      <BodyTextComponent mr="16px">{t('d')}</BodyTextComponent>
-      <HeadingTextComponent mr="2px">{hours}</HeadingTextComponent>
-      <BodyTextComponent mr="16px">{t('h')}</BodyTextComponent>
-      <HeadingTextComponent mr="2px">{minutes}</HeadingTextComponent>
-      <BodyTextComponent>{t('m')}</BodyTextComponent>
+      {Boolean(days) && (
+        <>
+          <HeadingTextComponent mr="2px">{days}</HeadingTextComponent>
+          <BodyTextComponent mr="16px">{t('d')}</BodyTextComponent>
+        </>
+      )}
+      {Boolean(hours) && (
+        <>
+          <HeadingTextComponent mr="2px">{hours}</HeadingTextComponent>
+          <BodyTextComponent mr="16px">{t('h')}</BodyTextComponent>
+        </>
+      )}
+      {Boolean(minutes) && (
+        <>
+          <HeadingTextComponent mr="2px">{minutes}</HeadingTextComponent>
+          <BodyTextComponent>{t('m')}</BodyTextComponent>
+        </>
+      )}
     </StyledTimerFlex>
   )
 }
@@ -61,7 +74,8 @@ const TooltipContent = ({ blockNumber, t }: { blockNumber: number; t: ContextApi
 )
 
 const Wrapper: React.FC<TimerProps> = ({
-  timerStage,
+  prefix,
+  suffix,
   minutes,
   hours,
   days,
@@ -77,7 +91,7 @@ const Wrapper: React.FC<TimerProps> = ({
   const shouldDisplayTooltip = showTooltip && tooltipVisible
   return (
     <Flex alignItems="flex-end" position="relative">
-      <BodyTextComponent mr="16px">{timerStage}</BodyTextComponent>
+      {prefix && <BodyTextComponent mr="16px">{prefix}</BodyTextComponent>}
       <div ref={targetRef}>
         <Timer
           minutes={minutes}
@@ -89,6 +103,7 @@ const Wrapper: React.FC<TimerProps> = ({
         />
         {shouldDisplayTooltip && tooltip}
       </div>
+      {suffix && <BodyTextComponent ml="16px">{suffix}</BodyTextComponent>}
     </Flex>
   )
 }

--- a/src/views/TradingCompetition/components/Countdown/index.tsx
+++ b/src/views/TradingCompetition/components/Countdown/index.tsx
@@ -87,7 +87,7 @@ const Countdown: React.FC<{ currentPhase: CompetitionPhaseProps; hasCompetitionE
     }
     return (
       <Timer
-        timerStage={currentPhase.state === LIVE ? `${t('End')}:` : `${t('Start')}:`}
+        prefix={currentPhase.state === LIVE ? `${t('End')}:` : `${t('Start')}:`}
         minutes={minutes}
         hours={hours}
         days={days}


### PR DESCRIPTION
- Add prefix & suffix props & text components
- Add handling for not rendering DD/MM/HH if any values are missing

**Notes**
Using a condition like
```
     {days && (
        ...
      )}
```
Results in a 0 being rendered, if the value is 0 (falsey), i.e.

<img width="315" alt="Screenshot 2021-06-22 at 12 24 25" src="https://user-images.githubusercontent.com/79279477/122916555-ed7c6c00-d354-11eb-91d4-35cc3878f72f.png">

Hence wrapping this evaluation in a `Boolean()` - so that nothing is rendered