### PR TITLE
feat: (prediction) Don't render trading view chart and websockets when it is not open

### DIFF
--- a/src/views/Predictions/Desktop.tsx
+++ b/src/views/Predictions/Desktop.tsx
@@ -176,9 +176,7 @@ const Desktop: React.FC = () => {
             )}
           </PositionPane>
           <Gutter ref={gutterRef} />
-          <ChartPane ref={chartRef}>
-            <TradingView />
-          </ChartPane>
+          <ChartPane ref={chartRef}>{isChartPaneOpen && <TradingView />}</ChartPane>
         </SplitWrapper>
         <HistoryPane isHistoryPaneOpen={isHistoryPaneOpen}>
           <History />


### PR DESCRIPTION
To review:

https://deploy-preview-1555--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to predictions
2. Check websockets when chart is not open
3. See trading view websockets are instantiated
4. It should not be instantiated until chart is open