### PR TITLE
fix: (poolcard) Earning token dolar balance shows usd text only when price is loading

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -55,26 +55,27 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
           ) : (
             <>
               {hasEarnings ? (
-                <Balance bold fontSize="20px" decimals={5} value={earningTokenBalance} />
-              ) : (
-                <Heading color="textDisabled">0</Heading>
-              )}
-              {earningTokenPrice !== 0 && (
-                <Text fontSize="12px" color={hasEarnings ? 'textSubtle' : 'textDisabled'}>
-                  ~
-                  {hasEarnings ? (
+                <>
+                  <Balance bold fontSize="20px" decimals={5} value={earningTokenBalance} />
+                  {earningTokenPrice > 0 && (
                     <Balance
                       display="inline"
                       fontSize="12px"
                       color="textSubtle"
                       decimals={2}
+                      prefix="~"
                       value={earningTokenDollarBalance}
                       unit=" USD"
                     />
-                  ) : (
-                    '0 USD'
                   )}
-                </Text>
+                </>
+              ) : (
+                <>
+                  <Heading color="textDisabled">0</Heading>
+                  <Text fontSize="12px" color="textDisabled">
+                    0 USD
+                  </Text>
+                </>
               )}
             </>
           )}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Text, useModal, Flex, TooltipText, useTooltip, Skeleton } from '@pancakeswap/uikit'
+import { Button, Text, useModal, Flex, TooltipText, useTooltip, Skeleton, Heading } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
 import { getCakeVaultEarnings } from 'views/Pools/helpers'
@@ -59,7 +59,6 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   hasEarnings = isAutoVault ? hasAutoEarnings : hasEarnings
   earningTokenDollarBalance = isAutoVault ? autoUsdToDisplay : earningTokenDollarBalance
 
-  const displayBalance = hasEarnings ? earningTokenBalance : 0
   const [onPresentCollect] = useModal(
     <CollectModal
       formattedBalance={formattedBalance}
@@ -120,22 +119,31 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
       <ActionTitles>{actionTitle}</ActionTitles>
       <ActionContent>
         <Flex flex="1" pt="16px" flexDirection="column" alignSelf="flex-start">
-          <Balance lineHeight="1" bold fontSize="20px" decimals={5} value={displayBalance} />
-          {hasEarnings ? (
-            <Balance
-              display="inline"
-              fontSize="12px"
-              color={hasEarnings ? 'textSubtle' : 'textDisabled'}
-              decimals={2}
-              value={earningTokenDollarBalance}
-              unit=" USD"
-              prefix="~"
-            />
-          ) : (
-            <Text fontSize="12px" color={hasEarnings ? 'textSubtle' : 'textDisabled'}>
-              0 USD
-            </Text>
-          )}
+          <>
+            {hasEarnings ? (
+              <>
+                <Balance lineHeight="1" bold fontSize="20px" decimals={5} value={earningTokenBalance} />
+                {earningTokenPrice > 0 && (
+                  <Balance
+                    display="inline"
+                    fontSize="12px"
+                    color="textSubtle"
+                    decimals={2}
+                    prefix="~"
+                    value={earningTokenDollarBalance}
+                    unit=" USD"
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                <Heading color="textDisabled">0</Heading>
+                <Text fontSize="12px" color="textDisabled">
+                  0 USD
+                </Text>
+              </>
+            )}
+          </>
         </Flex>
         {isAutoVault ? (
           <Flex flex="1.3" flexDirection="column" alignSelf="flex-start" alignItems="flex-start">

--- a/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -116,17 +116,21 @@ const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoad
                   value={hasEarnings ? earningTokenBalance : 0}
                 />
                 {hasEarnings ? (
-                  <Balance
-                    display="inline"
-                    fontSize="12px"
-                    color={hasEarnings ? 'textSubtle' : 'textDisabled'}
-                    decimals={2}
-                    value={earningTokenDollarBalance}
-                    unit=" USD"
-                    prefix="~"
-                  />
+                  <>
+                    {earningTokenPrice > 0 && (
+                      <Balance
+                        display="inline"
+                        fontSize="12px"
+                        color="textSubtle"
+                        decimals={2}
+                        prefix="~"
+                        value={earningTokenDollarBalance}
+                        unit=" USD"
+                      />
+                    )}
+                  </>
                 ) : (
-                  <Text mt="4px" fontSize="12px" color={hasEarnings ? 'textSubtle' : 'textDisabled'}>
+                  <Text mt="4px" fontSize="12px" color="textDisabled">
                     0 USD
                   </Text>
                 )}


### PR DESCRIPTION
To review:

https://deploy-preview-1556--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to pools
2. See one of the pools (except cakes) earning token price loading
3. Check usd  (see below)

<img width="366" alt="Screenshot 2021-06-22 at 18 22 13" src="https://user-images.githubusercontent.com/2213635/122971788-bb3c3000-d38f-11eb-976e-827d889414be.png">

<img width="352" alt="Screenshot 2021-06-22 at 21 04 34" src="https://user-images.githubusercontent.com/2213635/122986006-22adac00-d39f-11eb-8fee-bc068538ca00.png">

<img width="439" alt="Screenshot 2021-06-22 at 20 57 09" src="https://user-images.githubusercontent.com/2213635/122986114-4670f200-d39f-11eb-8384-047fc25477d1.png">


With this solution it will not show anything regarding to usd price (like in farm cards) until usd price is loaded