### PR TITLE
fix: (collectmodal) NaN shown in usd price when earning token price is loading

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -29,7 +29,6 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
 
   const earningTokenDollarBalance = getBalanceNumber(earnings.multipliedBy(earningTokenPrice), earningToken.decimals)
-  const earningsDollarValue = formatNumber(earningTokenDollarBalance)
 
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const hasEarnings = earnings.toNumber() > 0
@@ -40,7 +39,7 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
       formattedBalance={formattedBalance}
       fullBalance={fullBalance}
       earningToken={earningToken}
-      earningsDollarValue={earningsDollarValue}
+      earningsDollarValue={earningTokenDollarBalance}
       sousId={sousId}
       isBnbPool={isBnbPool}
       isCompoundPool={isCompoundPool}

--- a/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
@@ -17,12 +17,13 @@ import { useSousHarvest } from 'hooks/useHarvest'
 import { useSousStake } from 'hooks/useStake'
 import useToast from 'hooks/useToast'
 import { Token } from 'config/constants/types'
+import { formatNumber } from 'utils/formatBalance'
 
 interface CollectModalProps {
   formattedBalance: string
   fullBalance: string
   earningToken: Token
-  earningsDollarValue: string
+  earningsDollarValue: number
   sousId: number
   isBnbPool: boolean
   isCompoundPool?: boolean
@@ -117,7 +118,9 @@ const CollectModal: React.FC<CollectModalProps> = ({
           <Heading>
             {formattedBalance} {earningToken.symbol}
           </Heading>
-          <Text fontSize="12px" color="textSubtle">{`~${earningsDollarValue || 0} USD`}</Text>
+          {earningsDollarValue > 0 && (
+            <Text fontSize="12px" color="textSubtle">{`~${formatNumber(earningsDollarValue)} USD`}</Text>
+          )}
         </Flex>
       </Flex>
 

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -38,7 +38,6 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   let hasEarnings = earnings.gt(0)
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
-  const earningsDollarValue = formatNumber(earningTokenDollarBalance)
   const isCompoundPool = sousId === 0
   const isBnbPool = poolCategory === PoolCategory.BINANCE
 
@@ -66,7 +65,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
       formattedBalance={formattedBalance}
       fullBalance={fullBalance}
       earningToken={earningToken}
-      earningsDollarValue={earningsDollarValue}
+      earningsDollarValue={earningTokenDollarBalance}
       sousId={sousId}
       isBnbPool={isBnbPool}
       isCompoundPool={isCompoundPool}

--- a/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -43,7 +43,6 @@ const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoad
   let hasEarnings = account && earnings.gt(0)
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
-  const earningsDollarValue = formatNumber(earningTokenDollarBalance)
   const isBnbPool = poolCategory === PoolCategory.BINANCE
 
   // Auto CAKE vault calculations
@@ -83,7 +82,7 @@ const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoad
       formattedBalance={formattedBalance}
       fullBalance={fullBalance}
       earningToken={earningToken}
-      earningsDollarValue={earningsDollarValue}
+      earningsDollarValue={earningTokenDollarBalance}
       sousId={sousId}
       isBnbPool={isBnbPool}
       isCompoundPool={isManualCakePool}


### PR DESCRIPTION
To review

https://deploy-preview-1557--pancakeswap-dev.netlify.app/

To reproduce the issue

1. Go to pools
2. Click harvest when earning token price is being loaded
3. See NaN

<img width="310" alt="Screenshot 2021-06-22 at 19 17 37" src="https://user-images.githubusercontent.com/2213635/122972750-c479cc80-d390-11eb-8eec-f958962176bc.png">

