### PR TITLE
style: (pools) Fix spaces and alignment for apr and totalstaked cell component

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -214,7 +214,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
           <>
             <Balance fontSize="16px" value={getTotalStakedBalance()} decimals={0} unit={` ${stakingToken.symbol}`} />
             <span ref={totalStakedTargetRef}>
-              <HelpIcon color="textSubtle" width="20px" ml="6px" />
+              <HelpIcon color="textSubtle" width="20px" ml="4px" />
             </span>
           </>
         ) : (

--- a/src/views/Pools/components/PoolsTable/Apr.tsx
+++ b/src/views/Pools/components/PoolsTable/Apr.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex, useModal, CalculateIcon, IconButton, Skeleton, FlexProps } from '@pancakeswap/uikit'
+import { Flex, useModal, CalculateIcon, Skeleton, FlexProps, Button } from '@pancakeswap/uikit'
 import { BASE_EXCHANGE_URL } from 'config'
 import ApyCalculatorModal from 'components/ApyCalculatorModal'
 import Balance from 'components/Balance'
@@ -45,28 +45,18 @@ const Apr: React.FC<AprProps> = ({ pool, showIcon, performanceFee = 0, ...props 
     <Flex alignItems="center" justifyContent="space-between" {...props}>
       {earningsPercentageToDisplay || isFinished ? (
         <>
-          <Flex>
-            <Balance
-              onClick={openRoiModal}
-              fontSize="16px"
-              isDisabled={isFinished}
-              value={isFinished ? 0 : earningsPercentageToDisplay}
-              decimals={2}
-              unit="%"
-            />
-          </Flex>
+          <Balance
+            onClick={openRoiModal}
+            fontSize="16px"
+            isDisabled={isFinished}
+            value={isFinished ? 0 : earningsPercentageToDisplay}
+            decimals={2}
+            unit="%"
+          />
           {!isFinished && showIcon && (
-            <Flex>
-              <IconButton
-                onClick={openRoiModal}
-                variant="text"
-                width="20px"
-                height="20px"
-                mr={['-14px', '-14px', '0px']}
-              >
-                <CalculateIcon color="textSubtle" width="20px" />
-              </IconButton>
-            </Flex>
+            <Button onClick={openRoiModal} variant="text" width="20px" height="20px" padding="0px" marginLeft="4px">
+              <CalculateIcon color="textSubtle" width="20px" />
+            </Button>
           )}
         </>
       ) : (

--- a/src/views/Pools/components/PoolsTable/Cells/AprCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/AprCell.tsx
@@ -28,12 +28,7 @@ const AprCell: React.FC<AprCellProps> = ({ pool, performanceFee }) => {
         <Text fontSize="12px" color="textSubtle" textAlign="left">
           {isAutoVault ? t('APY') : t('APR')}
         </Text>
-        <Apr
-          pool={pool}
-          performanceFee={isAutoVault ? performanceFee : 0}
-          showIcon={!isXs && !isSm}
-          alignItems="flex-start"
-        />
+        <Apr pool={pool} performanceFee={isAutoVault ? performanceFee : 0} showIcon={!isXs && !isSm} />
       </CellContent>
     </StyledCell>
   )

--- a/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/TotalStakedCell.tsx
@@ -42,7 +42,7 @@ const TotalStakedCell: React.FC<TotalStakedCellProps> = ({ pool }) => {
           {t('Total staked')}
         </Text>
         {totalStaked && totalStaked.gte(0) ? (
-          <Flex height="100%" alignItems="center">
+          <Flex height="20px" alignItems="center">
             <Balance fontSize="16px" value={totalStakedBalance} decimals={0} unit={` ${stakingToken.symbol}`} />
           </Flex>
         ) : (


### PR DESCRIPTION
To review:

https://deploy-preview-1562--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to pools
2. Select pool table
3. See issues below in desktop and mobile

Before: 

Space between apr data and icon in mobile

<img width="345" alt="Screenshot 2021-06-23 at 11 44 40" src="https://user-images.githubusercontent.com/2213635/123078248-12d3ad80-d41b-11eb-810e-2eca042e6617.png">

After:

<img width="344" alt="Screenshot 2021-06-23 at 11 45 01" src="https://user-images.githubusercontent.com/2213635/123078311-20893300-d41b-11eb-8c13-b68e0020b17a.png">

====================

Before: 

Misalignment in apr value and icon in desktop

<img width="400" alt="Screenshot 2021-06-23 at 11 49 32" src="https://user-images.githubusercontent.com/2213635/123078366-31d23f80-d41b-11eb-95e2-dc5b3c551020.png">

After:

<img width="316" alt="Screenshot 2021-06-23 at 11 54 06" src="https://user-images.githubusercontent.com/2213635/123078372-33036c80-d41b-11eb-9ced-7b2a8d4df1ee.png">

========================

Before:

Misalignment total staked cell component

<img width="387" alt="Screenshot 2021-06-23 at 12 22 43" src="https://user-images.githubusercontent.com/2213635/123081105-e2d9d980-d41d-11eb-9638-059b79acae64.png">


After: 

<img width="390" alt="Screenshot 2021-06-23 at 12 23 02" src="https://user-images.githubusercontent.com/2213635/123081139-ef5e3200-d41d-11eb-80f4-676bba0737a2.png">

