### PR TITLE
feat: (home) Do not send tvl and stats requests when it is not visible

### DIFF
--- a/src/hooks/api.ts
+++ b/src/hooks/api.ts
@@ -11,7 +11,7 @@ export interface DeBankTvlResponse {
   tvl: number
 }
 
-export const useGetStats = () => {
+export const useGetStats = (loadData = true) => {
   const [data, setData] = useState<DeBankTvlResponse | null>(null)
 
   useEffect(() => {
@@ -26,8 +26,10 @@ export const useGetStats = () => {
       }
     }
 
-    fetchData()
-  }, [setData])
+    if (loadData) {
+      fetchData()
+    }
+  }, [setData, loadData])
 
   return data
 }

--- a/src/hooks/useTokenBalance.ts
+++ b/src/hooks/useTokenBalance.ts
@@ -50,7 +50,7 @@ const useTokenBalance = (tokenAddress: string) => {
   return balanceState
 }
 
-export const useTotalSupply = () => {
+export const useTotalSupply = (loadData = true) => {
   const { slowRefresh } = useRefresh()
   const [totalSupply, setTotalSupply] = useState<BigNumber>()
 
@@ -61,13 +61,15 @@ export const useTotalSupply = () => {
       setTotalSupply(new BigNumber(supply))
     }
 
-    fetchTotalSupply()
-  }, [slowRefresh])
+    if (loadData) {
+      fetchTotalSupply()
+    }
+  }, [slowRefresh, loadData])
 
   return totalSupply
 }
 
-export const useBurnedBalance = (tokenAddress: string) => {
+export const useBurnedBalance = (tokenAddress: string, loadData = true) => {
   const [balance, setBalance] = useState(BIG_ZERO)
   const { slowRefresh } = useRefresh()
 
@@ -78,8 +80,10 @@ export const useBurnedBalance = (tokenAddress: string) => {
       setBalance(new BigNumber(res))
     }
 
-    fetchBalance()
-  }, [tokenAddress, slowRefresh])
+    if (loadData) {
+      fetchBalance()
+    }
+  }, [tokenAddress, slowRefresh, loadData])
 
   return balance
 }

--- a/src/views/Home/components/CakeStats.tsx
+++ b/src/views/Home/components/CakeStats.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { Card, CardBody, Heading, Text } from '@pancakeswap/uikit'
+import React, { useEffect, useState } from 'react'
+import { Card, CardBody, Heading, Skeleton, Text } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { useTotalSupply, useBurnedBalance } from 'hooks/useTokenBalance'
+import useIntersectionObserver from 'hooks/useIntersectionObserver'
 import { useTranslation } from 'contexts/Localization'
 import { getCakeAddress } from 'utils/addressHelpers'
 import CardValue from './CardValue'
@@ -22,23 +23,36 @@ const Row = styled.div`
 
 const CakeStats = () => {
   const { t } = useTranslation()
-  const totalSupply = useTotalSupply()
-  const burnedBalance = getBalanceNumber(useBurnedBalance(getCakeAddress()))
+  const { observerRef, isIntersecting } = useIntersectionObserver()
+  const [loadData, setLoadData] = useState(false)
+  const totalSupply = useTotalSupply(loadData)
+  const burnedBalance = getBalanceNumber(useBurnedBalance(getCakeAddress(), loadData))
   const cakeSupply = totalSupply ? getBalanceNumber(totalSupply) - burnedBalance : 0
+
+  useEffect(() => {
+    if (isIntersecting) {
+      setLoadData(true)
+    }
+  }, [isIntersecting])
 
   return (
     <StyledCakeStats>
+      {!loadData && <div ref={observerRef} />}
       <CardBody>
         <Heading scale="xl" mb="24px">
           {t('Cake Stats')}
         </Heading>
         <Row>
           <Text fontSize="14px">{t('Total CAKE Supply')}</Text>
-          {cakeSupply && <CardValue fontSize="14px" value={cakeSupply} />}
+          {cakeSupply > 0 ? <CardValue fontSize="14px" value={cakeSupply} /> : <Skeleton width="77px" height="14px" />}
         </Row>
         <Row>
           <Text fontSize="14px">{t('Total CAKE Burned')}</Text>
-          <CardValue fontSize="14px" decimals={0} value={burnedBalance} />
+          {burnedBalance > 0 ? (
+            <CardValue fontSize="14px" decimals={0} value={burnedBalance} />
+          ) : (
+            <Skeleton width="77px" height="14px" />
+          )}
         </Row>
         <Row>
           <Text fontSize="14px">{t('New CAKE/block')}</Text>

--- a/src/views/Home/components/TotalValueLockedCard.tsx
+++ b/src/views/Home/components/TotalValueLockedCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Card, CardBody, Heading, Skeleton, Text } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useGetStats } from 'hooks/api'
+import useIntersectionObserver from 'hooks/useIntersectionObserver'
 
 const StyledTotalValueLockedCard = styled(Card)`
   align-items: center;
@@ -12,8 +13,16 @@ const StyledTotalValueLockedCard = styled(Card)`
 
 const TotalValueLockedCard = () => {
   const { t } = useTranslation()
-  const data = useGetStats()
+  const { observerRef, isIntersecting } = useIntersectionObserver()
+  const [loadData, setLoadData] = useState(false)
+  const data = useGetStats(loadData)
   const tvl = data ? data.tvl.toLocaleString('en-US', { maximumFractionDigits: 0 }) : null
+
+  useEffect(() => {
+    if (isIntersecting) {
+      setLoadData(true)
+    }
+  }, [isIntersecting])
 
   return (
     <StyledTotalValueLockedCard>
@@ -27,7 +36,10 @@ const TotalValueLockedCard = () => {
             <Text color="textSubtle">{t('Across all LPs and Syrup Pools')}</Text>
           </>
         ) : (
-          <Skeleton height={66} />
+          <>
+            <Skeleton height={66} />
+            <div ref={observerRef} />
+          </>
         )}
       </CardBody>
     </StyledTotalValueLockedCard>


### PR DESCRIPTION
After first intersection, the load data status won't be changed to not send flood of requests when user scrolls up and down.

3 requests dropped if user doesn't scroll down (both applicable mobile and desktop since they are at the bottom)