### PR TITLE
fix: (pools) Simplify pool cards harvest actions dom

### DIFF
--- a/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
+++ b/src/views/Pools/components/PoolCard/CardActions/HarvestActions.tsx
@@ -47,45 +47,41 @@ const HarvestActions: React.FC<HarvestActionsProps> = ({
   )
 
   return (
-    <Flex flexDirection="column" mb="16px">
-      <Flex justifyContent="space-between" alignItems="center">
-        <Flex flexDirection="column">
-          {isLoading ? (
-            <Skeleton width="80px" height="48px" />
-          ) : (
-            <>
-              {hasEarnings ? (
-                <>
-                  <Balance bold fontSize="20px" decimals={5} value={earningTokenBalance} />
-                  {earningTokenPrice > 0 && (
-                    <Balance
-                      display="inline"
-                      fontSize="12px"
-                      color="textSubtle"
-                      decimals={2}
-                      prefix="~"
-                      value={earningTokenDollarBalance}
-                      unit=" USD"
-                    />
-                  )}
-                </>
-              ) : (
-                <>
-                  <Heading color="textDisabled">0</Heading>
-                  <Text fontSize="12px" color="textDisabled">
-                    0 USD
-                  </Text>
-                </>
-              )}
-            </>
-          )}
-        </Flex>
-        <Flex>
-          <Button disabled={!hasEarnings} onClick={onPresentCollect}>
-            {isCompoundPool ? t('Collect') : t('Harvest')}
-          </Button>
-        </Flex>
+    <Flex justifyContent="space-between" alignItems="center" mb="16px">
+      <Flex flexDirection="column">
+        {isLoading ? (
+          <Skeleton width="80px" height="48px" />
+        ) : (
+          <>
+            {hasEarnings ? (
+              <>
+                <Balance bold fontSize="20px" decimals={5} value={earningTokenBalance} />
+                {earningTokenPrice > 0 && (
+                  <Balance
+                    display="inline"
+                    fontSize="12px"
+                    color="textSubtle"
+                    decimals={2}
+                    prefix="~"
+                    value={earningTokenDollarBalance}
+                    unit=" USD"
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                <Heading color="textDisabled">0</Heading>
+                <Text fontSize="12px" color="textDisabled">
+                  0 USD
+                </Text>
+              </>
+            )}
+          </>
+        )}
       </Flex>
+      <Button disabled={!hasEarnings} onClick={onPresentCollect}>
+        {isCompoundPool ? t('Collect') : t('Harvest')}
+      </Button>
     </Flex>
   )
 }


### PR DESCRIPTION
To review:

https://deploy-preview-1573--pancakeswap-dev.netlify.app/

There are redundant flex's, you should not see any difference when you run the deployment preview.

1. Go to pools
2. Switch to pool card view