### PR TITLE
fix: (Aprcalculatormodal) No space between bullet and text in bullet list

### DIFF
--- a/src/components/ApyCalculatorModal/index.tsx
+++ b/src/components/ApyCalculatorModal/index.tsx
@@ -31,6 +31,20 @@ const GridHeaderItem = styled.div`
 `
 
 const BulletList = styled.ul`
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    margin: 0;
+    padding: 0;
+  }
+
+  li::before {
+    content: '•';
+    margin-right: 4px;
+  }
+
   li::marker {
     font-size: 12px;
     color: ${({ theme }) => theme.colors.textSubtle};
@@ -187,24 +201,24 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
         <Box mb="28px" maxWidth="280px" p="4px">
           <BulletList>
             <li>
-              <Text ml="-8px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
+              <Text fontSize="12px" textAlign="center" color="textSubtle" display="inline">
                 {t('Calculated based on current rates.')}
               </Text>
             </li>
             <li>
-              <Text ml="-8px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
+              <Text fontSize="12px" textAlign="center" color="textSubtle" display="inline">
                 {t('Compounding %freq%x daily.', { freq: compoundFrequency.toLocaleString() })}
               </Text>
             </li>
             {isFarm && (
               <li>
-                <Text ml="-8px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
+                <Text fontSize="12px" textAlign="center" color="textSubtle" display="inline">
                   {t('LP rewards: 0.17% trading fees, distributed proportionally among LP token holders.')}
                 </Text>
               </li>
             )}
             <li>
-              <Text ml="-8px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
+              <Text fontSize="12px" textAlign="center" color="textSubtle" display="inline">
                 {t(
                   'All figures are estimates provided for your convenience only, and by no means represent guaranteed returns.',
                 )}
@@ -212,7 +226,7 @@ const ApyCalculatorModal: React.FC<ApyCalculatorModalProps> = ({
             </li>
             {performanceFee > 0 && (
               <li>
-                <Text mt="14px" ml="-8px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
+                <Text mt="14px" fontSize="12px" textAlign="center" color="textSubtle" display="inline">
                   {t('All estimated rates take into account this pool’s %fee%% performance fee', {
                     fee: performanceFee,
                   })}


### PR DESCRIPTION
To review:

https://deploy-preview-1574--pancakeswap-dev.netlify.app/

To reproduce the issue (in Firefox, Safari mobile)

1. Go to pools or farms
2. Click apr calculator button on any farm or pool

Check the gap issue has not been reintroduced in Chrome

Before:

<img width="328" alt="Screenshot 2021-06-25 at 14 15 43" src="https://user-images.githubusercontent.com/2213635/123423565-fde44f00-d5bf-11eb-837a-9c3552839dfa.png">

After:

<img width="314" alt="Screenshot 2021-06-25 at 14 15 20" src="https://user-images.githubusercontent.com/2213635/123423573-0177d600-d5c0-11eb-858b-1e6166fd3f65.png">

