### PR TITLE
chore: Update texts in farm header, pool card, pool table

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -41,7 +41,7 @@
   "Finished": "Finished",
   "Farming ends in %num% Blocks": "Farming ends in %num% Blocks",
   "Project site": "Project site",
-  "Info site": "Info site",
+  "See Token Info": "See Token Info",
   "You can unstake at any time.": "You can unstake at any time.",
   "Rewards are calculated per block.": "Rewards are calculated per block.",
   "Total": "Total",

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -390,7 +390,7 @@
   "Total staked": "Total staked",
   "Just stake some tokens to earn.": "Just stake some tokens to earn.",
   "High APR, low risk.": "High APR, low risk.",
-  "Stake Liquidity Pool (LP) tokens to earn.": "Stake Liquidity Pool (LP) tokens to earn.",
+  "Stake LP tokens to earn.": "Stake LP tokens to earn.",
   "Basic Sale": "Basic Sale",
   "Everyone can only commit a limited amount, but may expect a higher return per token committed.": "Everyone can only commit a limited amount, but may expect a higher return per token committed.",
   "Unlimited Sale": "Unlimited Sale",

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -349,7 +349,7 @@ const Farms: React.FC = () => {
           {t('Farms')}
         </Heading>
         <Heading scale="lg" color="text">
-          {t('Stake Liquidity Pool (LP) tokens to earn.')}
+          {t('Stake LP tokens to earn.')}
         </Heading>
       </PageHeader>
       <Page>

--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -148,7 +148,7 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
       )}
       <Flex mb="2px" justifyContent="flex-end">
         <LinkExternal href={`https://pancakeswap.info/token/${getAddress(earningToken.address)}`} bold={false} small>
-          {t('Info site')}
+          {t('See Token Info')}
         </LinkExternal>
       </Flex>
       <Flex mb="2px" justifyContent="flex-end">

--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -234,7 +234,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
         {shouldShowBlockCountdown && blocksRow}
         <Flex mb="8px" justifyContent={['flex-end', 'flex-end', 'flex-start']}>
           <LinkExternal href={`https://pancakeswap.info/token/${getAddress(earningToken.address)}`} bold={false}>
-            {t('Info site')}
+            {t('See Token Info')}
           </LinkExternal>
         </Flex>
         <Flex mb="8px" justifyContent={['flex-end', 'flex-end', 'flex-start']}>


### PR DESCRIPTION
- chore: Update farm header text (2ec1cfe)

![image](https://user-images.githubusercontent.com/82930772/123542906-534d6700-d74c-11eb-9b6a-73d051376a80.png)
Typically we use LP in the meaning of "Liquidity Provider". I removed "Liquidity pool" to avoid confusion.
![image](https://user-images.githubusercontent.com/82930772/123543095-48470680-d74d-11eb-9d63-627153be760c.png)

https://goofy-brattain-cbabe7.netlify.app/farms

.
- chore: Update pool card and table text (a2716ed) 

![image](https://user-images.githubusercontent.com/82930772/123542943-94457b80-d74c-11eb-8c73-660a54bc9249.png)
Pool page is linked to Info site with text "Info site", Farm page is linked to there with text "See Pair Info". The latter is descriptive and more user friendly, aligned then ones in Pool page with it.
![image](https://user-images.githubusercontent.com/82930772/123543085-36fdfa00-d74d-11eb-8ef2-4e199fbb6095.png)

https://goofy-brattain-cbabe7.netlify.app/pools