### PR TITLE
refactor: (multiplier) Remove redundant div in multiplier tooltip

### DIFF
--- a/src/views/Farms/components/FarmTable/Multiplier.tsx
+++ b/src/views/Farms/components/FarmTable/Multiplier.tsx
@@ -32,12 +32,12 @@ const Multiplier: React.FunctionComponent<MultiplierProps> = ({ multiplier }) =>
   const displayMultiplier = multiplier ? multiplier.toLowerCase() : <Skeleton width={30} />
   const { t } = useTranslation()
   const tooltipContent = (
-    <div>
+    <>
       {t('The multiplier represents the amount of CAKE rewards each farm gets.')}
       <br />
       <br />
       {t('For example, if a 1x farm was getting 1 CAKE per block, a 40x farm would be getting 40 CAKE per block.')}
-    </div>
+    </>
   )
   const { targetRef, tooltip, tooltipVisible } = useTooltip(tooltipContent, {
     placement: 'top-end',


### PR DESCRIPTION
To review:

https://deploy-preview-1590--pancakeswap-dev.netlify.app/

There should not be no difference in view when reviewing

To review:

1. Farms
2. Hover in desktop on question mark next to the multiplier
3. See no difference in tooltip