### PR TITLE
chore(lottery-v2): Update contract ABI and tweak handleConfirm hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@binance-chain/bsc-connector": "^1.0.0",
     "@pancakeswap-libs/sdk": "^1.0.1",
-    "@pancakeswap/uikit": "^0.39.3",
+    "@pancakeswap/uikit": "^0.39.4",
     "@reduxjs/toolkit": "^1.5.0",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.4",

--- a/src/config/abi/lotteryV2.json
+++ b/src/config/abi/lotteryV2.json
@@ -65,7 +65,7 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "amount",
+        "name": "injectedAmount",
         "type": "uint256"
       }
     ],
@@ -128,6 +128,12 @@
         "indexed": false,
         "internalType": "uint256",
         "name": "firstTicketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "injectedAmount",
         "type": "uint256"
       }
     ],
@@ -434,6 +440,11 @@
         "internalType": "uint256",
         "name": "_lotteryId",
         "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_autoInjection",
+        "type": "bool"
       }
     ],
     "name": "drawFinalNumberAndMakeLotteryClaimable",
@@ -493,6 +504,19 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingInjectionNextLottery",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/src/config/constants/contracts.ts
+++ b/src/config/constants/contracts.ts
@@ -16,7 +16,7 @@ export default {
     56: '0x5e74094Cd416f55179DBd0E45b1a8ED030e396A1',
   },
   lotteryV2: {
-    97: '0x374524c998d1E9afC7EB4d2025153b0b3FDCCf29',
+    97: '0xc78819a896815310C1722774aFB1459c6B434FFC',
     56: '',
   },
   multiCall: {

--- a/src/hooks/useApproveConfirmTransaction.ts
+++ b/src/hooks/useApproveConfirmTransaction.ts
@@ -118,8 +118,8 @@ const useApproveConfirmTransaction = ({
       }
     },
     handleConfirm: async () => {
-      const tx = await onConfirm()
       dispatch({ type: 'confirm_sending' })
+      const tx = await onConfirm()
       const receipt = await tx.wait()
       if (receipt.status) {
         dispatch({ type: 'confirm_receipt' })

--- a/src/views/Lottery/components/YourPrizesCard/PrizesWonContent.tsx
+++ b/src/views/Lottery/components/YourPrizesCard/PrizesWonContent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
-import { Button, Heading, Won, useModal } from '@pancakeswap/uikit'
+import { Button, Heading, PresentWonIcon, useModal } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { useMultiClaimLottery } from 'hooks/useBuyLottery'
@@ -69,7 +69,7 @@ const PrizesWonContent: React.FC<PrizesWonContentProps> = ({ onSuccess }) => {
   return (
     <StyledCardContentInner>
       <IconWrapper>
-        <Won />
+        <PresentWonIcon />
       </IconWrapper>
       <Heading as="h3" scale="lg" color="secondary">
         {t('You won!')}

--- a/src/views/Profile/components/Header.tsx
+++ b/src/views/Profile/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Flex, Heading, useModal, Won } from '@pancakeswap/uikit'
+import { Button, Flex, Heading, useModal, PresentWonIcon } from '@pancakeswap/uikit'
 import { useProfile } from 'state/hooks'
 import { useTranslation } from 'contexts/Localization'
 import ClaimNftAndCakeModal, { useCanClaim } from './ClaimGiftModal'
@@ -30,7 +30,7 @@ const ProfileHeader = () => {
           {hasProfile && <Button onClick={onEditProfileModal}>{t('Edit Profile')}</Button>}
         </div>
         {canClaim && (
-          <Button variant="tertiary" onClick={onPresentClaimGiftModal} startIcon={<Won />}>
+          <Button variant="tertiary" onClick={onPresentClaimGiftModal} startIcon={<PresentWonIcon />}>
             {t('You’ve got a gift to claim!')}
           </Button>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@
     eslint-plugin-react "^7.21.5"
     eslint-plugin-react-hooks "^4.0.0"
 
-"@pancakeswap/uikit@^0.39.3":
-  version "0.39.3"
-  resolved "https://registry.yarnpkg.com/@pancakeswap/uikit/-/uikit-0.39.3.tgz#65159a2898c4939d884fcdadf142db5e356b9659"
-  integrity sha512-UEAM4rt28I9hGVEOEbmsE1SfEgA/jjy2u0SCjp4Yup1luWDOWASgZH8EOjqCH61qa2s4hdLTAdh8wT5wRnm5OA==
+"@pancakeswap/uikit@^0.39.4":
+  version "0.39.4"
+  resolved "https://registry.yarnpkg.com/@pancakeswap/uikit/-/uikit-0.39.4.tgz#bcb0812a5804ba647a0fc0b1b46b355038534849"
+  integrity sha512-fuH9SLQTB3CjlUp3m4lmVd4xBmhzQvqDBCnTsWGGUz0gjUC9d00LbWgJP4K7nMKfOukIunOxsUfnf5/gMNOmVw==
   dependencies:
     "@popperjs/core" "^2.9.2"
     "@types/lodash" "^4.14.168"


### PR DESCRIPTION
- Use latest lottery contract & ABI
- Bring in latest uikit & fix breaking changes (TBC - waiting on deploy)

- Change when `confirm_sending` state change fires to be before `await onConfirm()` within `handleConfirm` - this gives the user immediate feedback 
Before:
https://user-images.githubusercontent.com/79279477/123866183-aa0d9900-d924-11eb-9223-261c03685236.mov
After:
https://user-images.githubusercontent.com/79279477/123866260-b8f44b80-d924-11eb-9bb0-16e91a2aadab.mov

