### PR TITLE
fix(achievements): Bail out if we do not have achievement in config

### DIFF
--- a/src/state/achievements/helpers.ts
+++ b/src/state/achievements/helpers.ts
@@ -50,6 +50,10 @@ export const getAchievements = async (account: string): Promise<Achievement[]> =
   }
 
   return pointIncreaseEvents.reduce((accum, userPoint) => {
+    if (!campaignMap.has(userPoint.campaignId)) {
+      return accum
+    }
+
     const campaignMeta = campaignMap.get(userPoint.campaignId)
 
     return [


### PR DESCRIPTION
Achievements could show up on the subgraph before we have added it to our config.
