### PR TITLE
fix: (farms) Stake and harvest buttons stuck when transaction rejected

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -902,5 +902,6 @@
   "Check voting power": "Check voting power",
   "Amount to collect": "Amount to collect",
   "Your winnings": "Your winnings",
-  "Includes your original position and your winnings, minus the %fee% fee.": "Includes your original position and your winnings, minus the %fee% fee."
+  "Includes your original position and your winnings, minus the %fee% fee.": "Includes your original position and your winnings, minus the %fee% fee.",
+  "Your funds have been staked in the farm": "Your funds have been staked in the farm"
 }

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -4,6 +4,7 @@ import { Button, Modal } from '@pancakeswap/uikit'
 import { ModalActions, ModalInput } from 'components/Modal'
 import { useTranslation } from 'contexts/Localization'
 import { getFullDisplayBalance } from 'utils/formatBalance'
+import useToast from 'hooks/useToast'
 
 interface WithdrawModalProps {
   max: BigNumber
@@ -14,6 +15,7 @@ interface WithdrawModalProps {
 
 const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '' }) => {
   const [val, setVal] = useState('')
+  const { toastSuccess, toastError } = useToast()
   const [pendingTx, setPendingTx] = useState(false)
   const { t } = useTranslation()
   const fullBalance = useMemo(() => {
@@ -54,9 +56,16 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
           disabled={pendingTx || !valNumber.isFinite() || valNumber.eq(0) || valNumber.gt(fullBalanceNumber)}
           onClick={async () => {
             setPendingTx(true)
-            await onConfirm(val)
-            setPendingTx(false)
-            onDismiss()
+            try {
+              await onConfirm(val)
+              toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
+              onDismiss()
+            } catch (e) {
+              toastError(t('Canceled'), t('Please try again and confirm the transaction.'))
+              console.error(e)
+            } finally {
+              setPendingTx(false)
+            }
           }}
           width="100%"
         >


### PR DESCRIPTION
To review:

https://deploy-preview-1621--pancakeswap-dev.netlify.app/

To reproduce the issue:

1. Go to farms
2. Click harvest on one of the farms that you staked
3. Then click reject transaction on your wallet 
4. See harvest button still disabled

Same happens for unstake or stake