### PR TITLE
feat: Add structure to type contract calls

### DIFF
--- a/src/utils/contractHelpers.ts
+++ b/src/utils/contractHelpers.ts
@@ -55,6 +55,7 @@ import chainlinkOracleAbi from 'config/abi/chainlinkOracle.json'
 import MultiCallAbi from 'config/abi/Multicall.json'
 import bunnySpecialCakeVaultAbi from 'config/abi/bunnySpecialCakeVault.json'
 import bunnySpecialPredictionAbi from 'config/abi/bunnySpecialPrediction.json'
+import { PredictionsContract } from './types'
 
 const getContract = (abi: any, address: string, signer?: ethers.Signer | ethers.providers.Provider) => {
   const signerOrProvider = signer ?? simpleRpcProvider
@@ -127,9 +128,11 @@ export const getEasterNftContract = (signer?: ethers.Signer | ethers.providers.P
 export const getCakeVaultContract = (signer?: ethers.Signer | ethers.providers.Provider) => {
   return getContract(cakeVaultAbi, getCakeVaultAddress(), signer)
 }
+
 export const getPredictionsContract = (signer?: ethers.Signer | ethers.providers.Provider) => {
-  return getContract(predictionsAbi, getPredictionsAddress(), signer)
+  return getContract(predictionsAbi, getPredictionsAddress(), signer) as PredictionsContract
 }
+
 export const getChainlinkOracleContract = (signer?: ethers.Signer | ethers.providers.Provider) => {
   return getContract(chainlinkOracleAbi, getChainlinkOracleAddress(), signer)
 }

--- a/src/utils/multicall.ts
+++ b/src/utils/multicall.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers'
 import { getMulticallContract } from 'utils/contractHelpers'
+import { MultiCallResponse } from './types'
 
 export interface Call {
   address: string // Address of the contract
@@ -11,7 +12,7 @@ interface MulticallOptions {
   requireSuccess?: boolean
 }
 
-const multicall = async (abi: any[], calls: Call[]) => {
+const multicall = async <T = any>(abi: any[], calls: Call[]): Promise<T> => {
   try {
     const multi = getMulticallContract()
     const itf = new ethers.utils.Interface(abi)
@@ -33,11 +34,11 @@ const multicall = async (abi: any[], calls: Call[]) => {
  * 1. If "requireSuccess" is false multicall will not bail out if one of the calls fails
  * 2. The return inclues a boolean whether the call was successful e.g. [wasSuccessfull, callResult]
  */
-export const multicallv2 = async (
+export const multicallv2 = async <T = any>(
   abi: any[],
   calls: Call[],
   options: MulticallOptions = { requireSuccess: true },
-): Promise<any> => {
+): Promise<MultiCallResponse<T>> => {
   const { requireSuccess } = options
   const multi = getMulticallContract()
   const itf = new ethers.utils.Interface(abi)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,19 +2,21 @@ import ethers, { Contract, ContractFunction } from 'ethers'
 
 export type MultiCallResponse<T> = T | null
 
+export interface PredictionsRounds {
+  epoch: ethers.BigNumber
+  startBlock: ethers.BigNumber
+  lockBlock: ethers.BigNumber
+  endBlock: ethers.BigNumber
+  lockPrice: ethers.BigNumber
+  closePrice: ethers.BigNumber
+  totalAmount: ethers.BigNumber
+  bullAmount: ethers.BigNumber
+  bearAmount: ethers.BigNumber
+  rewardBaseCalAmount: ethers.BigNumber
+  rewardAmount: ethers.BigNumber
+  oracleCalled: boolean
+}
+
 export interface PredictionsContract extends Contract {
-  rounds: ContractFunction<{
-    epoch: ethers.BigNumber
-    startBlock: ethers.BigNumber
-    lockBlock: ethers.BigNumber
-    endBlock: ethers.BigNumber
-    lockPrice: ethers.BigNumber
-    closePrice: ethers.BigNumber
-    totalAmount: ethers.BigNumber
-    bullAmount: ethers.BigNumber
-    bearAmount: ethers.BigNumber
-    rewardBaseCalAmount: ethers.BigNumber
-    rewardAmount: ethers.BigNumber
-    oracleCalled: boolean
-  }>
+  rounds: ContractFunction<PredictionsRounds>
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,20 @@
+import ethers, { Contract, ContractFunction } from 'ethers'
+
+export type MultiCallResponse<T> = T | null
+
+export interface PredictionsContract extends Contract {
+  rounds: ContractFunction<{
+    epoch: ethers.BigNumber
+    startBlock: ethers.BigNumber
+    lockBlock: ethers.BigNumber
+    endBlock: ethers.BigNumber
+    lockPrice: ethers.BigNumber
+    closePrice: ethers.BigNumber
+    totalAmount: ethers.BigNumber
+    bullAmount: ethers.BigNumber
+    bearAmount: ethers.BigNumber
+    rewardBaseCalAmount: ethers.BigNumber
+    rewardAmount: ethers.BigNumber
+    oracleCalled: boolean
+  }>
+}


### PR DESCRIPTION
#### Add typing for multicall. You can now specify the type like so

```
const booleans = await multicall<boolean[]>(abi, calls)
```
`multicallv2` is a little different as it can return null (although doesn't change the typescript message).

#### Add example on how to type contract functions.

We can now type contract functions to make it easier to work with.
