### PR TITLE
fix: (pools) Remove redundant set pending state calls in vault stake modal

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -83,7 +83,6 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
 
     if (isWithdrawingAll) {
       const tx = await callWithEstimateGas(cakeVaultContract, 'withdrawAll')
-      setPendingTx(true)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
@@ -101,7 +100,6 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
       const tx = await callWithEstimateGas(cakeVaultContract, 'withdraw', [
         shareStakeToWithdraw.sharesAsBigNumber.toString(),
       ])
-      setPendingTx(true)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
@@ -135,12 +133,11 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
 
   const handleConfirmClick = async () => {
     const convertedStakeAmount = getDecimalAmount(new BigNumber(stakeAmount), stakingToken.decimals)
-    setPendingTx(true)
-    // unstaking
     if (isRemovingStake) {
+      // unstaking
       handleWithdrawal(convertedStakeAmount)
-      // staking
     } else {
+      // staking
       handleDeposit(convertedStakeAmount)
     }
   }


### PR DESCRIPTION
To review:

https://deploy-preview-1644--pancakeswap-dev.netlify.app/

Go to pools

Check confirm button disabled correctly in modal when unstake or stake in auto cake pool.

==============

The pending state call already in handleWithdrawal and handleDeposit functions both. 

https://github.com/pancakeswap/pancake-frontend/blob/3dbb051f13dac7ac85309a2df33df50319ec9c70/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx#L77

https://github.com/pancakeswap/pancake-frontend/blob/3dbb051f13dac7ac85309a2df33df50319ec9c70/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx#L122

And I also put comments to correct positions