### PR TITLE
feat(lottery-v2): Factor discount into lottery max ticket buying

### DIFF
--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -151,12 +151,12 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       const limitedMaxPurchase = limitNumberByMaxTicketsPerBuy(maxBalancePurchase)
       let maxPurchase
 
-      // If the max ticket purchase is less than the SC limit - factor the ticket discount into the max possible purchase
+      // If the users' max possible ticket purchase is less than the limit - factor the ticket discount into the max possible purchase
       if (limitedMaxPurchase.lt(maxNumberTicketsPerBuyOrClaim)) {
         // Get details of the discount available for the users' max ticket purchase with their CAKE balance
         const { overallTicketBuy: maxPlusDiscountTickets } = getMaxTicketBuyWithDiscount(limitedMaxPurchase)
 
-        // Knowing how many tickets they can buy with the discount - plug that in, and see how much that total will get discounted
+        // Knowing how many tickets they can buy when counting the discount - plug that total in, and see how much that total will get discounted
         const { ticketsBoughtWithDiscount: secondTicketDiscountBuy } =
           getMaxTicketBuyWithDiscount(maxPlusDiscountTickets)
 
@@ -206,11 +206,6 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
   const twentyFivePercentOfBalance = getNumTicketsByPercentage(25)
   const fiftyPercentOfBalance = getNumTicketsByPercentage(50)
   const oneHundredPercentOfBalance = getNumTicketsByPercentage(100)
-
-  const getCakeValueOfTickets = (numberOfTickets: BigNumber): BigNumber => {
-    const totalTicketsCakeValue = priceTicketInCake.times(numberOfTickets)
-    return totalTicketsCakeValue
-  }
 
   const handleInputChange = (input: string) => {
     // Force input to integer
@@ -267,7 +262,6 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
     })
   }
 
-  const costInCake = () => getFullDisplayBalance(priceTicketInCake.times(ticketsToBuy))
   const percentageDiscount = () => {
     const percentageAsBn = new BigNumber(discountValue).div(new BigNumber(ticketCostBeforeDiscount)).times(100)
     if (percentageAsBn.isNaN() || percentageAsBn.eq(0)) {
@@ -317,7 +311,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
         onUserInput={handleInputChange}
         currencyValue={
           cakePriceBusd.gt(0) &&
-          `~${ticketsToBuy ? getFullDisplayBalance(getCakeValueOfTickets(new BigNumber(ticketsToBuy))) : '0.00'} CAKE`
+          `~${ticketsToBuy ? getFullDisplayBalance(priceTicketInCake.times(new BigNumber(ticketsToBuy))) : '0.00'} CAKE`
         }
       />
       <Flex alignItems="center" justifyContent="flex-end" mt="4px" mb="12px">
@@ -375,7 +369,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
             {t('Cost')} (CAKE)
           </Text>
           <Text color="textSubtle" fontSize="14px">
-            {priceTicketInCake && costInCake()} CAKE
+            {priceTicketInCake && getFullDisplayBalance(priceTicketInCake.times(ticketsToBuy))} CAKE
           </Text>
         </Flex>
         <Flex mb="8px" justifyContent="space-between">

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -60,7 +60,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       userTickets: { tickets: userCurrentTickets },
     },
   } = useLottery()
-  const [ticketsToBuy, setTicketsToBuy] = useState('0')
+  const [ticketsToBuy, setTicketsToBuy] = useState('')
   const [discountValue, setDiscountValue] = useState('')
   const [totalCost, setTotalCost] = useState('')
   const [ticketCostBeforeDiscount, setTicketCostBeforeDiscount] = useState('')
@@ -151,9 +151,9 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       const limitedMaxPurchase = limitNumberByMaxTicketsPerBuy(maxBalancePurchase)
       let maxPurchase
 
-      // If the users' max possible ticket purchase is less than the limit - factor the ticket discount into the max possible purchase
+      // If the users' max CAKE balance purchase is less than the contract limit - factor the discount logic into the max number of tickets they can purchase
       if (limitedMaxPurchase.lt(maxNumberTicketsPerBuyOrClaim)) {
-        // Get details of the discount available for the users' max ticket purchase with their CAKE balance
+        // Get max tickets purchaseble with the users' balance, as well as using the discount to buy tickets
         const { overallTicketBuy: maxPlusDiscountTickets } = getMaxTicketBuyWithDiscount(limitedMaxPurchase)
 
         // Knowing how many tickets they can buy when counting the discount - plug that total in, and see how much that total will get discounted
@@ -213,7 +213,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
     const inputAsBN = new BigNumber(inputAsInt)
     const limitedNumberTickets = limitNumberByMaxTicketsPerBuy(inputAsBN)
     validateInput(inputAsBN)
-    setTicketsToBuy(inputAsInt ? limitedNumberTickets.toString() : '0')
+    setTicketsToBuy(inputAsInt ? limitedNumberTickets.toString() : '')
   }
 
   const handleNumberButtonClick = (number: number) => {
@@ -369,7 +369,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
             {t('Cost')} (CAKE)
           </Text>
           <Text color="textSubtle" fontSize="14px">
-            {priceTicketInCake && getFullDisplayBalance(priceTicketInCake.times(ticketsToBuy))} CAKE
+            {priceTicketInCake && getFullDisplayBalance(priceTicketInCake.times(ticketsToBuy || 0))} CAKE
           </Text>
         </Flex>
         <Flex mb="8px" justifyContent="space-between">

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -307,6 +307,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       </Flex>
       <BalanceInput
         isWarning={userNotEnoughCake || maxTicketPurchaseExceeded}
+        placeholder="0"
         value={ticketsToBuy}
         onUserInput={handleInputChange}
         currencyValue={


### PR DESCRIPTION
- Modify initial `getMaxPossiblePurchase` logic to factor in discounts on ticket buys
- Add input validation logic, also evaluating whether a users has enough cake based the discount modifier
- Remove some unnecessary functions in `BuyTicketsModal`
- Remove '0' default for input so Cheems no longer accidentally buys 10x the desired tickets