### PR TITLE
fix: Auto scrolling ticket input to view, iOS numeric keypad

### DIFF
--- a/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
@@ -216,7 +216,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[0]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 0)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -229,7 +229,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[1]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 1)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -242,7 +242,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[2]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 2)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -255,7 +255,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[3]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 3)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -268,7 +268,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[4]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 4)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
@@ -281,7 +281,7 @@ const TicketContaier: React.FC<{
           value={ticket.numbers[5]}
           onKeyDown={(e: React.KeyboardEvent) => onChangeHandler(e, 5)}
           placeholder="_"
-          onChange={() => null}
+          onChange={(e) => e.preventDefault()}
           disabled={disabled}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}

--- a/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
@@ -75,6 +75,7 @@ const TicketContaier: React.FC<{
   disabled: boolean
 }> = ({ ticket, duplicateWith, updateTicket, disabled }) => {
   const [focused, setFocused] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   const digit1 = useRef<HTMLInputElement>(null)
   const digit2 = useRef<HTMLInputElement>(null)
   const digit3 = useRef<HTMLInputElement>(null)
@@ -86,6 +87,12 @@ const TicketContaier: React.FC<{
 
   const digitRefs = [digit1, digit2, digit3, digit4, digit5, digit6]
 
+  const scrollInputIntoView = () => {
+    if (containerRef.current) {
+      containerRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }
+  }
+
   const onPasteHandler = (e: React.ClipboardEvent) => {
     e.preventDefault()
     const pasteContent = e.clipboardData.getData('Text')
@@ -96,6 +103,7 @@ const TicketContaier: React.FC<{
   }
 
   const onFocusHandler = () => {
+    scrollInputIntoView()
     setFocused(true)
   }
 
@@ -195,7 +203,12 @@ const TicketContaier: React.FC<{
           {duplicateWith.length !== 0 && t('Duplicate')}
         </Text>
       </Flex>
-      <InputsContainer focused={focused} isDuplicate={duplicateWith.length !== 0}>
+      <InputsContainer
+        ref={containerRef}
+        onClick={scrollInputIntoView}
+        focused={focused}
+        isDuplicate={duplicateWith.length !== 0}
+      >
         <DigitInput
           ref={digit1}
           type="number"
@@ -207,6 +220,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
         <DigitInput
           ref={digit2}
@@ -219,6 +233,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
         <DigitInput
           ref={digit3}
@@ -231,6 +246,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
         <DigitInput
           ref={digit4}
@@ -243,6 +259,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
         <DigitInput
           ref={digit5}
@@ -255,6 +272,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
         <DigitInput
           ref={digit6}
@@ -267,6 +285,7 @@ const TicketContaier: React.FC<{
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
           onPaste={onPasteHandler}
+          inputMode="numeric"
         />
       </InputsContainer>
     </>

--- a/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
@@ -114,8 +114,9 @@ const TicketContaier: React.FC<{
   const onChangeHandler = (event: React.KeyboardEvent, digitId: number) => {
     const currentKey = parseInt(event.key, 10)
 
-    if (event.key === 'e' || event.key === 'E' || event.key === '.') {
+    if (['e', 'E', '.', ',', '-', 'Unidentified'].includes(event.key)) {
       event.preventDefault()
+      return
     }
 
     // Handling numberic inputs


### PR DESCRIPTION
- The input you're editing should not be covered by the keyboard or other elements anymore (it scrolls into the view when you click on it)
- iOS should show numeric keypad instead of full keyboard