### PR TITLE
fix(lottery-v2): Hide ticket shortcut button when the percentage buy is less than 1

### DIFF
--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -38,6 +38,13 @@ const StyledModal = styled(Modal)`
   max-width: 320px;
 `
 
+const ShortcutButtonsWrapper = styled(Flex)<{ isVisible: boolean }>`
+  justify-content: space-between;
+  margin-top: 8px;
+  margin-bottom: 24px;
+  display: ${({ isVisible }) => (isVisible ? 'flex' : 'none')};
+`
+
 interface BuyTicketsModalProps {
   onDismiss?: () => void
 }
@@ -337,35 +344,32 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
         </Flex>
       </Flex>
 
-      <Flex alignItems="center" justifyContent="space-between" mt="8px" mb="24px">
-        {!hasFetchedBalance ? (
-          <Skeleton width="100%" height={20} />
-        ) : (
-          <>
-            {tenPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(tenPercentOfBalance)}>
-                {hasFetchedBalance ? tenPercentOfBalance : ``}
-              </NumTicketsToBuyButton>
-            )}
-            {twentyFivePercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}>
-                {hasFetchedBalance ? twentyFivePercentOfBalance : ``}
-              </NumTicketsToBuyButton>
-            )}
-            {fiftyPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}>
-                {hasFetchedBalance ? fiftyPercentOfBalance : ``}
-              </NumTicketsToBuyButton>
-            )}
-            {oneHundredPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}>
-                MAX
-              </NumTicketsToBuyButton>
-            )}
-          </>
-        )}
-      </Flex>
-
+      {!hasFetchedBalance ? (
+        <Skeleton width="100%" height={20} mt="8px" mb="24px" />
+      ) : (
+        <ShortcutButtonsWrapper isVisible={hasFetchedBalance && oneHundredPercentOfBalance >= 1}>
+          {tenPercentOfBalance >= 1 && (
+            <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(tenPercentOfBalance)}>
+              {hasFetchedBalance ? tenPercentOfBalance : ``}
+            </NumTicketsToBuyButton>
+          )}
+          {twentyFivePercentOfBalance >= 1 && (
+            <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}>
+              {hasFetchedBalance ? twentyFivePercentOfBalance : ``}
+            </NumTicketsToBuyButton>
+          )}
+          {fiftyPercentOfBalance >= 1 && (
+            <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}>
+              {hasFetchedBalance ? fiftyPercentOfBalance : ``}
+            </NumTicketsToBuyButton>
+          )}
+          {oneHundredPercentOfBalance >= 1 && (
+            <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}>
+              MAX
+            </NumTicketsToBuyButton>
+          )}
+        </ShortcutButtonsWrapper>
+      )}
       <Flex flexDirection="column">
         <Flex mb="8px" justifyContent="space-between">
           <Text color="textSubtle" fontSize="14px">

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -343,34 +343,22 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
         ) : (
           <>
             {tenPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton
-                disabled={!hasFetchedBalance}
-                onClick={() => handleNumberButtonClick(tenPercentOfBalance)}
-              >
+              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(tenPercentOfBalance)}>
                 {hasFetchedBalance ? tenPercentOfBalance : ``}
               </NumTicketsToBuyButton>
             )}
             {twentyFivePercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton
-                disabled={!hasFetchedBalance}
-                onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}
-              >
+              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}>
                 {hasFetchedBalance ? twentyFivePercentOfBalance : ``}
               </NumTicketsToBuyButton>
             )}
             {fiftyPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton
-                disabled={!hasFetchedBalance}
-                onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}
-              >
+              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}>
                 {hasFetchedBalance ? fiftyPercentOfBalance : ``}
               </NumTicketsToBuyButton>
             )}
             {oneHundredPercentOfBalance >= 1 && (
-              <NumTicketsToBuyButton
-                disabled={!hasFetchedBalance}
-                onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}
-              >
+              <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}>
                 MAX
               </NumTicketsToBuyButton>
             )}

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -338,30 +338,44 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       </Flex>
 
       <Flex alignItems="center" justifyContent="space-between" mt="8px" mb="24px">
-        <NumTicketsToBuyButton
-          disabled={!hasFetchedBalance || tenPercentOfBalance < 1}
-          onClick={() => handleNumberButtonClick(tenPercentOfBalance)}
-        >
-          {hasFetchedBalance ? tenPercentOfBalance : ``}
-        </NumTicketsToBuyButton>
-        <NumTicketsToBuyButton
-          disabled={!hasFetchedBalance || twentyFivePercentOfBalance < 1}
-          onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}
-        >
-          {hasFetchedBalance ? twentyFivePercentOfBalance : ``}
-        </NumTicketsToBuyButton>
-        <NumTicketsToBuyButton
-          disabled={!hasFetchedBalance || fiftyPercentOfBalance < 1}
-          onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}
-        >
-          {hasFetchedBalance ? fiftyPercentOfBalance : ``}
-        </NumTicketsToBuyButton>
-        <NumTicketsToBuyButton
-          disabled={!hasFetchedBalance || oneHundredPercentOfBalance < 1}
-          onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}
-        >
-          MAX
-        </NumTicketsToBuyButton>
+        {!hasFetchedBalance ? (
+          <Skeleton width="100%" height={20} />
+        ) : (
+          <>
+            {tenPercentOfBalance >= 1 && (
+              <NumTicketsToBuyButton
+                disabled={!hasFetchedBalance}
+                onClick={() => handleNumberButtonClick(tenPercentOfBalance)}
+              >
+                {hasFetchedBalance ? tenPercentOfBalance : ``}
+              </NumTicketsToBuyButton>
+            )}
+            {twentyFivePercentOfBalance >= 1 && (
+              <NumTicketsToBuyButton
+                disabled={!hasFetchedBalance}
+                onClick={() => handleNumberButtonClick(twentyFivePercentOfBalance)}
+              >
+                {hasFetchedBalance ? twentyFivePercentOfBalance : ``}
+              </NumTicketsToBuyButton>
+            )}
+            {fiftyPercentOfBalance >= 1 && (
+              <NumTicketsToBuyButton
+                disabled={!hasFetchedBalance}
+                onClick={() => handleNumberButtonClick(fiftyPercentOfBalance)}
+              >
+                {hasFetchedBalance ? fiftyPercentOfBalance : ``}
+              </NumTicketsToBuyButton>
+            )}
+            {oneHundredPercentOfBalance >= 1 && (
+              <NumTicketsToBuyButton
+                disabled={!hasFetchedBalance}
+                onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}
+              >
+                MAX
+              </NumTicketsToBuyButton>
+            )}
+          </>
+        )}
       </Flex>
 
       <Flex flexDirection="column">

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -166,7 +166,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
         maxPurchase = limitedMaxPurchase
       }
 
-      if (hasFetchedBalance && maxPurchase.eq(0)) {
+      if (hasFetchedBalance && maxPurchase.lt(1)) {
         setUserNotEnoughCake(true)
       } else {
         setUserNotEnoughCake(false)


### PR DESCRIPTION
- Hide ticket-buying shortcut buttons rather than disabling them and showing `0`
- Tested across various balances on testnet