### PR TITLE
feat(lottery-v2): Use node calls to populate recent User and Public Lottery data

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -30,7 +30,12 @@ import { getCanClaim } from './predictions/helpers'
 import { transformPool } from './pools/helpers'
 import { fetchPoolsStakingLimitsAsync } from './pools'
 import { fetchFarmUserDataAsync, nonArchivedFarms } from './farms'
-import { fetchCurrentLotteryId, fetchCurrentLottery, fetchUserTicketsAndLotteries, fetchPastLotteries } from './lottery'
+import {
+  fetchCurrentLotteryId,
+  fetchCurrentLottery,
+  fetchUserTicketsAndLotteries,
+  fetchPublicLotteries,
+} from './lottery'
 import { useProcessLotteryResponse } from './lottery/helpers'
 
 export const usePollFarmsData = (includeArchive = false) => {
@@ -531,14 +536,15 @@ export const useFetchLottery = () => {
   const currentLotteryId = useGetCurrentLotteryId()
 
   useEffect(() => {
-    // get current lottery ID, max tickets and historical lottery subgraph data
+    // get current lottery ID & max ticket buy
     dispatch(fetchCurrentLotteryId())
-    dispatch(fetchPastLotteries())
   }, [dispatch])
 
   useEffect(() => {
-    // get public data for current lottery
     if (currentLotteryId) {
+      // Get historical lottery data from nodes + subgraph
+      dispatch(fetchPublicLotteries({ currentLotteryId }))
+      // get public data for current lottery
       dispatch(fetchCurrentLottery({ currentLotteryId }))
     }
   }, [dispatch, currentLotteryId, fastRefresh])
@@ -546,7 +552,7 @@ export const useFetchLottery = () => {
   useEffect(() => {
     // get user tickets for current lottery, and user lottery subgraph data
     if (account && currentLotteryId) {
-      dispatch(fetchUserTicketsAndLotteries({ account, lotteryId: currentLotteryId }))
+      dispatch(fetchUserTicketsAndLotteries({ account, currentLotteryId }))
     }
   }, [dispatch, currentLotteryId, account])
 }

--- a/src/state/lottery/fetchUnclaimedUserRewards.ts
+++ b/src/state/lottery/fetchUnclaimedUserRewards.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { ethers } from 'ethers'
 import { LotteryStatus, LotteryTicket, LotteryTicketClaimData } from 'config/constants/types'
-import { LotteryUserGraphEntity, LotteryRoundGraphEntity, UserRound } from 'state/types'
+import { LotteryUserGraphEntity, LotteryRoundGraphEntity } from 'state/types'
 import { multicallv2 } from 'utils/multicall'
 import lotteryV2Abi from 'config/abi/lotteryV2.json'
 import { getLotteryV2Address } from 'utils/addressHelpers'

--- a/src/state/lottery/fetchUnclaimedUserRewards.ts
+++ b/src/state/lottery/fetchUnclaimedUserRewards.ts
@@ -121,7 +121,6 @@ export const fetchUserTicketsForMultipleRounds = async (
 
   try {
     const multicallRes = await multicallv2(lotteryV2Abi, multicalls, { requireSuccess: false })
-
     // Use callsWithRoundData to slice multicall responses by round
     const multicallResPerRound = []
     let resCount = 0

--- a/src/state/lottery/fetchUnclaimedUserRewards.ts
+++ b/src/state/lottery/fetchUnclaimedUserRewards.ts
@@ -105,7 +105,10 @@ const getWinningNumbersForRound = (targetRoundId: string, lotteriesData: Lottery
   return targetRound?.finalNumber
 }
 
-export const fetchUserTicketsForMultipleRounds = async (roundsToCheck: UserRound[], account: string) => {
+export const fetchUserTicketsForMultipleRounds = async (
+  roundsToCheck: { totalTickets: string; lotteryId: string }[],
+  account: string,
+) => {
   // Build calls with data to help with merging multicall responses
   const callsWithRoundData = roundsToCheck.map((round) => {
     const totalTickets = parseInt(round.totalTickets, 10)
@@ -125,7 +128,9 @@ export const fetchUserTicketsForMultipleRounds = async (roundsToCheck: UserRound
     for (let i = 0; i < callsWithRoundData.length; i += 1) {
       const callOptions = callsWithRoundData[i]
 
-      multicallResPerRound.push(multicallRes.slice(resCount, resCount + callOptions.count))
+      const singleRoundResponse = multicallRes.slice(resCount, resCount + callOptions.count)
+      // Don't push null responses values - can happen when the check is using fallback behaviour because it has no subgraph past rounds
+      multicallResPerRound.push(singleRoundResponse.filter((res) => res))
       resCount += callOptions.count
     }
     const mergedMulticallResponse = multicallResPerRound.map((res) => mergeViewUserTicketInfoMulticallResponse(res))

--- a/src/state/lottery/fetchUnclaimedUserRewards.ts
+++ b/src/state/lottery/fetchUnclaimedUserRewards.ts
@@ -7,7 +7,6 @@ import lotteryV2Abi from 'config/abi/lotteryV2.json'
 import { getLotteryV2Address } from 'utils/addressHelpers'
 import { BIG_ZERO } from 'utils/bigNumber'
 import {
-  fetchMultipleLotteries,
   getViewUserTicketInfoCalls,
   mergeViewUserTicketInfoMulticallResponse,
   processRawTicketsResponse,
@@ -125,12 +124,10 @@ export const fetchUserTicketsForMultipleRounds = async (roundsToCheck: UserRound
     let resCount = 0
     for (let i = 0; i < callsWithRoundData.length; i += 1) {
       const callOptions = callsWithRoundData[i]
-      const singleRoundResponse = multicallRes.slice(resCount, resCount + callOptions.count)
-      // Don't push null responses values - can happen when the check is using fallback behaviour because it has no subgraph past rounds
-      multicallResPerRound.push(singleRoundResponse.filter((res) => res))
+
+      multicallResPerRound.push(multicallRes.slice(resCount, resCount + callOptions.count))
       resCount += callOptions.count
     }
-
     const mergedMulticallResponse = multicallResPerRound.map((res) => mergeViewUserTicketInfoMulticallResponse(res))
 
     return mergedMulticallResponse
@@ -144,66 +141,39 @@ const fetchUnclaimedUserRewards = async (
   account: string,
   userLotteryData: LotteryUserGraphEntity,
   lotteriesData: LotteryRoundGraphEntity[],
-  currentLotteryId: string,
 ): Promise<LotteryTicketClaimData[]> => {
-  // const { rounds } = userLotteryData
+  const { rounds } = userLotteryData
 
-  const rounds = []
-  let userRoundsToCheck
+  // If there is no user round history - return an empty array
+  if (rounds.length === 0) {
+    return []
+  }
 
   // If the web3 provider account doesn't equal the userLotteryData account, return an empty array - this is effectively a loading state as the user switches accounts
   if (userLotteryData.account.toLowerCase() !== account.toLowerCase()) {
     return []
   }
 
-  // Fallback behaviour if there is no user subgraph rounds history - check current and previous three rounds
-  if (rounds.length === 0) {
-    const currentIdAsInt = parseInt(currentLotteryId, 10)
-    const ticketsToRequest = 5000
-    const numRoundsToCheck = 4
-    const roundIds = []
+  // Filter out non-claimable rounds
+  const claimableRounds = rounds.filter((round) => {
+    return round.status.toLowerCase() === LotteryStatus.CLAIMABLE
+  })
 
-    for (let i = 0; i < numRoundsToCheck; i++) {
-      roundIds.push(currentIdAsInt - i)
-    }
+  // If there are any rounds tickets haven't been claimed for, OR a user has over 100 tickets in a round - check user tickets for those rounds
+  const roundsToCheck = claimableRounds.filter((round) => {
+    return !round.claimed || parseInt(round.totalTickets, 10) > 100
+  })
 
-    // TODO: type
-    const fallbackRoundData = roundIds.map((roundId) => {
-      return {
-        totalTickets: ticketsToRequest,
-        lotteryId: roundId,
-      }
-    })
-    userRoundsToCheck = fallbackRoundData
-  } else {
-    // Filter out open rounds. We still check 'close' rounds due to a potential delay in the subgraph data returning 'close' when that round is in fact now 'claimable'
-    const claimableRounds = rounds.filter((round) => {
-      return round.status.toLowerCase() !== LotteryStatus.OPEN
-    })
-
-    // If there are any rounds tickets haven't been claimed for, OR a user has over 100 tickets in a round - check user tickets for those rounds
-    userRoundsToCheck = claimableRounds.filter((round) => {
-      return !round.claimed || parseInt(round.totalTickets, 10) > 100
-    })
-  }
-
-  if (userRoundsToCheck.length > 0) {
-    const idsToCheck = userRoundsToCheck.map((round) => round.lotteryId)
-    // TODO: Use node call instead of subgraph for winning number
-    const publicRoundData = fetchMultipleLotteries(idsToCheck)
-
-    const rawUserTicketData = await fetchUserTicketsForMultipleRounds(userRoundsToCheck, account)
+  if (roundsToCheck.length > 0) {
+    const rawUserTicketData = await fetchUserTicketsForMultipleRounds(roundsToCheck, account)
 
     if (rawUserTicketData.length === 0) {
       // In case of error with ticket calls, return empty array
       return []
     }
 
-    const roundIds = userRoundsToCheck.map((round) => round.lotteryId)
+    const roundIds = roundsToCheck.map((round) => round.lotteryId)
     const roundDataAndUserTickets = rawUserTicketData.map((rawRoundTicketData, index) => {
-      console.log(lotteriesData)
-
-      debugger // eslint-disable-line
       return {
         roundId: roundIds[index],
         userTickets: processRawTicketsResponse(rawRoundTicketData),

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -51,7 +51,6 @@ const applyNodeDataToLotteriesGraphResponse = (
 }
 
 const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
-  let lotteries
   try {
     const response = await request(
       GRAPH_API_LOTTERY,
@@ -71,12 +70,11 @@ const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
         }
       `,
     )
-    ;({ lotteries } = response)
+    return response.lotteries
   } catch (error) {
-    lotteries = []
     console.error(error)
+    return []
   }
-  return lotteries
 }
 
 const getLotteriesData = async (currentLotteryId: string): Promise<LotteryRoundGraphEntity[]> => {

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -1,0 +1,66 @@
+import { request, gql } from 'graphql-request'
+import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
+import { LotteryRoundGraphEntity, LotteryResponse } from 'state/types'
+import { getRoundIdsArray, fetchMultipleLotteries } from './helpers'
+
+const applyNodeDataToLotteriesGraphResponse = (
+  nodeData: LotteryResponse[],
+  graphRespose: LotteryRoundGraphEntity[],
+): LotteryRoundGraphEntity[] => {
+  const mergedResponse = graphRespose.map((graphRound, index) => {
+    const nodeRound = nodeData[index]
+    if (nodeRound) {
+      // if isLoading === true, there has been an error - return graphRound
+      if (!nodeRound.isLoading) {
+        return {
+          endTime: nodeRound.endTime,
+          finalNumber: nodeRound.finalNumber.toString(),
+          startTime: nodeRound.startTime,
+          status: nodeRound.status,
+          id: graphRound.id,
+          ticketPrice: graphRound.ticketPrice,
+          totalTickets: graphRound.totalTickets,
+          totalUsers: graphRound.totalTickets,
+          winningTickets: graphRound.totalTickets,
+        }
+      }
+      return graphRound
+    }
+    return graphRound
+  })
+  return mergedResponse
+}
+
+const getLotteriesData = async (currentLotteryId: string): Promise<LotteryRoundGraphEntity[]> => {
+  const idsForNodesCall = getRoundIdsArray(currentLotteryId)
+  const nodeData = await fetchMultipleLotteries(idsForNodesCall)
+  const graphResponse = await getGraphLotteries()
+  const mergedData = applyNodeDataToLotteriesGraphResponse(nodeData, graphResponse)
+  return mergedData
+}
+
+const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
+  const response = await request(
+    GRAPH_API_LOTTERY,
+    gql`
+      query getLotteries {
+        lotteries(first: 100, orderDirection: desc, orderBy: block) {
+          id
+          totalUsers
+          totalTickets
+          winningTickets
+          status
+          finalNumber
+          startTime
+          endTime
+          ticketPrice
+        }
+      }
+    `,
+  )
+
+  const { lotteries } = response
+  return lotteries
+}
+
+export default getLotteriesData

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -15,17 +15,16 @@ const applyNodeDataToLotteriesGraphResponse = (
         finalNumber: nodeRound.finalNumber.toString(),
         startTime: nodeRound.startTime,
         status: nodeRound.status,
-        id: nodeRound.lotteryId,
-        // TODO: To be fully self-sufficient when the graph goes down, this null & BN data needs handling in the FE
+        id: nodeRound.lotteryId.toString(),
         ticketPrice: nodeRound.priceTicketInCake,
-        totalTickets: null,
-        totalUsers: null,
-        winningTickets: null,
+        totalTickets: '',
+        totalUsers: '',
+        winningTickets: '',
       }
     })
   }
 
-  //   Else if there is a graph response - merge with node data where node data is more accurate
+  //   Else if there is a graph response - merge with node data where node data is more reliable
   const mergedResponse = graphResponse.map((graphRound, index) => {
     const nodeRound = nodeData[index]
     // if there is node data for this index, overwrite graph data. Otherwise - return graph data.
@@ -49,14 +48,6 @@ const applyNodeDataToLotteriesGraphResponse = (
     return graphRound
   })
   return mergedResponse
-}
-
-const getLotteriesData = async (currentLotteryId: string): Promise<LotteryRoundGraphEntity[]> => {
-  const idsForNodesCall = getRoundIdsArray(currentLotteryId)
-  const nodeData = await fetchMultipleLotteries(idsForNodesCall)
-  const graphResponse = await getGraphLotteries()
-  const mergedData = applyNodeDataToLotteriesGraphResponse(nodeData, graphResponse)
-  return mergedData
 }
 
 const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
@@ -86,6 +77,14 @@ const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
     console.error(error)
   }
   return lotteries
+}
+
+const getLotteriesData = async (currentLotteryId: string): Promise<LotteryRoundGraphEntity[]> => {
+  const idsForNodesCall = getRoundIdsArray(currentLotteryId)
+  const nodeData = await fetchMultipleLotteries(idsForNodesCall)
+  const graphResponse = await getGraphLotteries()
+  const mergedData = applyNodeDataToLotteriesGraphResponse(nodeData, graphResponse)
+  return mergedData
 }
 
 export default getLotteriesData

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -16,7 +16,7 @@ const applyNodeDataToLotteriesGraphResponse = (
         startTime: nodeRound.startTime,
         status: nodeRound.status,
         id: nodeRound.lotteryId,
-        // TODO: To be fully self-sufficient without the graph, this null & BN data needs handling in the FE
+        // TODO: To be fully self-sufficient when the graph goes down, this null & BN data needs handling in the FE
         ticketPrice: nodeRound.priceTicketInCake,
         totalTickets: null,
         totalUsers: null,
@@ -28,6 +28,7 @@ const applyNodeDataToLotteriesGraphResponse = (
   //   Else if there is a graph response - merge with node data where node data is more accurate
   const mergedResponse = graphResponse.map((graphRound, index) => {
     const nodeRound = nodeData[index]
+    // if there is node data for this index, overwrite graph data. Otherwise - return graph data.
     if (nodeRound) {
       // if isLoading === true, there has been a node error - return graphRound
       if (!nodeRound.isLoading) {

--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -86,7 +86,7 @@ const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEnt
     if (!userRes) {
       user = blankUser
     } else {
-      const formattedUser = userRes && {
+      user = {
         account: userRes.id,
         totalCake: userRes.totalCake,
         totalTickets: userRes.totalTickets,
@@ -100,8 +100,6 @@ const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEnt
           }
         }),
       }
-
-      user = formattedUser
     }
   } catch (error) {
     console.error(error)

--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -70,6 +70,7 @@ const getUserLotteryData = async (account: string, currentLotteryId: string): Pr
 
   const lotteriesNodeData = await fetchMultipleLotteries(idsForLotteriesNodeCall)
   const graphResponse = await getGraphLotteryUser(account)
+
   const mergedRoundData = applyNodeDataToUserGraphResponse(
     lotteriesNodeData,
     graphResponse.rounds,

--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -1,0 +1,105 @@
+import BigNumber from 'bignumber.js'
+import { request, gql } from 'graphql-request'
+import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
+import { LotteryUserGraphEntity } from 'state/types'
+import { getLotteryV2Contract } from 'utils/contractHelpers'
+import { getRoundIdsArray, fetchMultipleLotteries, NUM_ROUNDS_TO_FETCH_FROM_NODES } from './helpers'
+import { fetchUserTicketsForMultipleRounds } from './fetchUnclaimedUserRewards'
+
+const lotteryContract = getLotteryV2Contract()
+// Variable used to determine how many past rounds should be populated by node data rather than subgraph
+
+const getUserLotteryData = async (account: string, currentLotteryId: string): Promise<LotteryUserGraphEntity> => {
+  const idsForNodeCall = getRoundIdsArray(currentLotteryId)
+  const ticketsToRequestPerRound = '5000'
+
+  const blindRoundData = idsForNodeCall.map((roundId) => {
+    return {
+      totalTickets: ticketsToRequestPerRound,
+      lotteryId: roundId,
+    }
+  })
+  const rawUserTicketData = await fetchUserTicketsForMultipleRounds(blindRoundData, account)
+
+  // uses - TOTAL TICKETS,
+  //  account (but as an 'isloaded')
+  // status - filtering on FinishedRoundTable, whether to show FinishedRoundTable
+  // round id - display & sort
+  // endTime - display
+  // claimed - for a visual on the histories chart
+  //
+
+  // Find out if user has any tickets in any of these lotteries
+  // See if they have claimed any of those tickets
+  // Get status of that lottery from node
+
+  const graphResponse = await getGraphLotteryUser(account)
+
+  // graphResponse.rounds {
+  // claimed: null
+  // status: "Open"
+  // endTime: "1625767200"
+  // lotteryId: "12"
+  // totalTickets: "10"
+  // }
+
+  return graphResponse
+}
+
+const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEntity> => {
+  const response = await request(
+    GRAPH_API_LOTTERY,
+    gql`
+      query getUserLotteries($account: ID!) {
+        user(id: $account) {
+          id
+          totalTickets
+          totalCake
+          rounds(first: 100, orderDirection: desc, orderBy: block) {
+            id
+            lottery {
+              id
+              endTime
+              status
+            }
+            claimed
+            totalTickets
+          }
+        }
+      }
+    `,
+    { account: account.toLowerCase() },
+  )
+  const { user } = response
+
+  // If no subgraph response - return blank user
+  if (!response || !user) {
+    const blankUser = {
+      account,
+      totalCake: '',
+      totalTickets: '',
+      rounds: [],
+    }
+
+    return blankUser
+  }
+
+  const formattedUser = user && {
+    account: user.id,
+    totalCake: user.totalCake,
+    totalTickets: user.totalTickets,
+    rounds: user.rounds.map((round) => {
+      return {
+        lotteryId: round?.lottery?.id,
+        endTime: round?.lottery?.endTime,
+        claimed: round?.claimed,
+        totalTickets: round?.totalTickets,
+        status: round?.lottery?.status,
+      }
+    }),
+  }
+
+  return formattedUser
+}
+
+export default getUserLotteryData

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -191,6 +191,7 @@ export const fetchTickets = async (
 }
 
 export const getRoundIdsArray = (currentLotteryId: string): string[] => {
+  // TODO: This returns a number, but the currentId being typed as a string is deep in the logic and needs untangling
   const currentIdAsInt = parseInt(currentLotteryId, 10)
   const roundIds = []
   for (let i = 0; i < NUM_ROUNDS_TO_FETCH_FROM_NODES; i++) {
@@ -238,4 +239,8 @@ export const useProcessLotteryResponse = (
     countWinnersPerBracket: lotteryData.countWinnersPerBracket,
     rewardsBreakdown: lotteryData.rewardsBreakdown,
   }
+}
+
+export const hasRoundBeenClaimed = (): boolean => {
+  return true
 }

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -213,11 +213,15 @@ export const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> =>
   return lotteries
 }
 
+export const getUserLotteryData = async (account: string): Promise<LotteryUserGraphEntity> => {
+  return getGraphLotteryUser(account)
+}
+
 export const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEntity> => {
   const response = await request(
     GRAPH_API_LOTTERY,
     gql`
-      query getUserLotteryData($account: ID!) {
+      query getUserLotteries($account: ID!) {
         user(id: $account) {
           id
           totalTickets

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -11,7 +11,7 @@ import { ethersToSerializedBigNumber } from 'utils/bigNumber'
 
 const lotteryContract = getLotteryV2Contract()
 // Variable used to determine how many past rounds should be populated by node data rather than subgraph
-export const NUM_ROUNDS_TO_FETCH_FROM_NODES = 8
+export const NUM_ROUNDS_TO_FETCH_FROM_NODES = 4
 
 const processViewLotterySuccessResponse = (response, lotteryId: string): LotteryResponse => {
   const {

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -187,7 +187,12 @@ export const fetchTickets = async (
   }
 }
 
-export const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
+export const getLotteriesData = async (currentLotteryId: string): Promise<LotteryRoundGraphEntity[]> => {
+  const graphResponse = getGraphLotteries()
+  return graphResponse
+}
+
+const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> => {
   const response = await request(
     GRAPH_API_LOTTERY,
     gql`
@@ -213,11 +218,16 @@ export const getGraphLotteries = async (): Promise<LotteryRoundGraphEntity[]> =>
   return lotteries
 }
 
-export const getUserLotteryData = async (account: string): Promise<LotteryUserGraphEntity> => {
-  return getGraphLotteryUser(account)
+export const getUserLotteryData = async (
+  account: string,
+  currentLotteryId: string,
+): Promise<LotteryUserGraphEntity> => {
+  const graphResponse = getGraphLotteryUser(account)
+
+  return graphResponse
 }
 
-export const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEntity> => {
+const getGraphLotteryUser = async (account: string): Promise<LotteryUserGraphEntity> => {
   const response = await request(
     GRAPH_API_LOTTERY,
     gql`

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -241,6 +241,7 @@ export const useProcessLotteryResponse = (
   }
 }
 
-export const hasRoundBeenClaimed = (): boolean => {
-  return true
+export const hasRoundBeenClaimed = (tickets: LotteryTicket[]): boolean => {
+  const claimedTickets = tickets.filter((ticket) => ticket.status)
+  return claimedTickets.length > 0
 }

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -83,6 +83,23 @@ export const fetchLottery = async (lotteryId: string): Promise<LotteryResponse> 
   }
 }
 
+export const fetchMultipleLotteries = async (lotteryIds: string[]): Promise<LotteryResponse[]> => {
+  const calls = lotteryIds.map((id) => ({
+    name: 'viewLottery',
+    address: getLotteryV2Address(),
+    params: [id],
+  }))
+
+  try {
+    // TODO: Process response
+    const multicallRes = await multicallv2(lotteryV2Abi, calls, { requireSuccess: false })
+    return multicallRes
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
 export const fetchCurrentLotteryIdAndMaxBuy = async () => {
   try {
     const calls = ['currentLotteryId', 'maxNumberTicketsPerBuyOrClaim'].map((method) => ({

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -8,6 +8,7 @@ import {
   fetchLottery,
   fetchCurrentLotteryIdAndMaxBuy,
   fetchTickets,
+  getUserLotteryData,
 } from './helpers'
 
 interface PublicLotteryData {
@@ -60,7 +61,7 @@ export const fetchUserTicketsAndLotteries = createAsyncThunk<
   { userTickets: LotteryTicket[]; userLotteries: LotteryUserGraphEntity },
   { account: string; lotteryId: string }
 >('lottery/fetchUserTicketsAndLotteries', async ({ account, lotteryId }) => {
-  const userLotteriesRes = await getGraphLotteryUser(account)
+  const userLotteriesRes = await getUserLotteryData(account)
   const userRoundData = userLotteriesRes.rounds?.find((round) => round.lotteryId === lotteryId)
   const userTickets = await fetchTickets(account, lotteryId, userRoundData)
 
@@ -83,7 +84,7 @@ export const fetchPastLotteries = createAsyncThunk<LotteryRoundGraphEntity[]>(
 export const fetchUserLotteries = createAsyncThunk<LotteryUserGraphEntity, { account: string }>(
   'lottery/fetchUserLotteries',
   async ({ account }) => {
-    const userLotteries = await getGraphLotteryUser(account)
+    const userLotteries = await getUserLotteryData(account)
     return userLotteries
   },
 )

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -58,7 +58,9 @@ export const fetchUserTicketsAndLotteries = createAsyncThunk<
   { account: string; currentLotteryId: string }
 >('lottery/fetchUserTicketsAndLotteries', async ({ account, currentLotteryId }) => {
   const userLotteriesRes = await getUserLotteryData(account, currentLotteryId)
-  const { totalTickets } = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
+  const userParticipationInCurrentRound = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
+
+  const totalTickets = userParticipationInCurrentRound?.totalTickets || '0'
   // Get user tickets for current round
   // TODO: This can come from the getUserLotteryData function instead
   const userTickets = await fetchTickets(account, currentLotteryId, totalTickets)

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -17,6 +17,7 @@ const initialState: LotteryState = {
   maxNumberTicketsPerBuyOrClaim: null,
   currentRound: {
     isLoading: true,
+    lotteryId: null,
     status: LotteryStatus.PENDING,
     startTime: '',
     endTime: '',

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -60,6 +60,7 @@ export const fetchUserTicketsAndLotteries = createAsyncThunk<
   const userLotteriesRes = await getUserLotteryData(account, currentLotteryId)
   const { totalTickets } = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
   // Get user tickets for current round
+  // TODO: This can come from the getUserLotteryData function instead
   const userTickets = await fetchTickets(account, currentLotteryId, totalTickets)
 
   // user has not bought tickets for the current lottery

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -2,13 +2,9 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { LotteryTicket, LotteryStatus } from 'config/constants/types'
 import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
-import {
-  fetchLottery,
-  fetchCurrentLotteryIdAndMaxBuy,
-  fetchTickets,
-  getUserLotteryData,
-  getLotteriesData,
-} from './helpers'
+import { fetchLottery, fetchCurrentLotteryIdAndMaxBuy, fetchTickets } from './helpers'
+import getLotteriesData from './getLotteriesData'
+import getUserLotteryData from './getUserLotteryData'
 
 interface PublicLotteryData {
   currentLotteryId: string

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -3,12 +3,11 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { LotteryTicket, LotteryStatus } from 'config/constants/types'
 import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
 import {
-  getGraphLotteries,
-  getGraphLotteryUser,
   fetchLottery,
   fetchCurrentLotteryIdAndMaxBuy,
   fetchTickets,
   getUserLotteryData,
+  getLotteriesData,
 } from './helpers'
 
 interface PublicLotteryData {
@@ -59,11 +58,11 @@ export const fetchCurrentLotteryId = createAsyncThunk<PublicLotteryData>('lotter
 
 export const fetchUserTicketsAndLotteries = createAsyncThunk<
   { userTickets: LotteryTicket[]; userLotteries: LotteryUserGraphEntity },
-  { account: string; lotteryId: string }
->('lottery/fetchUserTicketsAndLotteries', async ({ account, lotteryId }) => {
-  const userLotteriesRes = await getUserLotteryData(account)
-  const userRoundData = userLotteriesRes.rounds?.find((round) => round.lotteryId === lotteryId)
-  const userTickets = await fetchTickets(account, lotteryId, userRoundData)
+  { account: string; currentLotteryId: string }
+>('lottery/fetchUserTicketsAndLotteries', async ({ account, currentLotteryId }) => {
+  const userLotteriesRes = await getUserLotteryData(account, currentLotteryId)
+  const userRoundData = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
+  const userTickets = await fetchTickets(account, currentLotteryId, userRoundData)
 
   // user has not bought tickets for the current lottery
   if (userTickets.length === 0) {
@@ -73,21 +72,21 @@ export const fetchUserTicketsAndLotteries = createAsyncThunk<
   return { userTickets, userLotteries: userLotteriesRes }
 })
 
-export const fetchPastLotteries = createAsyncThunk<LotteryRoundGraphEntity[]>(
-  'lottery/fetchPastLotteries',
-  async () => {
-    const lotteries = await getGraphLotteries()
+export const fetchPublicLotteries = createAsyncThunk<LotteryRoundGraphEntity[], { currentLotteryId: string }>(
+  'lottery/fetchPublicLotteries',
+  async ({ currentLotteryId }) => {
+    const lotteries = await getLotteriesData(currentLotteryId)
     return lotteries
   },
 )
 
-export const fetchUserLotteries = createAsyncThunk<LotteryUserGraphEntity, { account: string }>(
-  'lottery/fetchUserLotteries',
-  async ({ account }) => {
-    const userLotteries = await getUserLotteryData(account)
-    return userLotteries
-  },
-)
+export const fetchUserLotteries = createAsyncThunk<
+  LotteryUserGraphEntity,
+  { account: string; currentLotteryId: string }
+>('lottery/fetchUserLotteries', async ({ account, currentLotteryId }) => {
+  const userLotteries = await getUserLotteryData(account, currentLotteryId)
+  return userLotteries
+})
 
 export const setLotteryIsTransitioning = createAsyncThunk<{ isTransitioning: boolean }, { isTransitioning: boolean }>(
   `lottery/setIsTransitioning`,
@@ -120,7 +119,7 @@ export const LotterySlice = createSlice({
         state.userLotteryData = action.payload.userLotteries
       },
     )
-    builder.addCase(fetchPastLotteries.fulfilled, (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
+    builder.addCase(fetchPublicLotteries.fulfilled, (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
       state.lotteriesData = action.payload
     })
     builder.addCase(fetchUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -61,8 +61,9 @@ export const fetchUserTicketsAndLotteries = createAsyncThunk<
   { account: string; currentLotteryId: string }
 >('lottery/fetchUserTicketsAndLotteries', async ({ account, currentLotteryId }) => {
   const userLotteriesRes = await getUserLotteryData(account, currentLotteryId)
-  const userRoundData = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
-  const userTickets = await fetchTickets(account, currentLotteryId, userRoundData)
+  const { totalTickets } = userLotteriesRes.rounds?.find((round) => round.lotteryId === currentLotteryId)
+  // Get user tickets for current round
+  const userTickets = await fetchTickets(account, currentLotteryId, totalTickets)
 
   // user has not bought tickets for the current lottery
   if (userTickets.length === 0) {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -389,14 +389,12 @@ export interface LotteryRoundGraphEntity {
   id: string
   totalUsers: string
   totalTickets: string
+  winningTickets: string
   status: LotteryStatus
   finalNumber: string
-  winningTickets: string
   startTime: string
   endTime: string
   ticketPrice: SerializedBigNumber
-  firstTicket: string
-  lastTicket: string
 }
 
 export interface LotteryUserGraphEntity {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -408,9 +408,9 @@ export interface LotteryUserGraphEntity {
 export interface UserRound {
   claimed: boolean
   lotteryId: string
-  totalTickets: string
   status: LotteryStatus
   endTime: string
+  totalTickets: string
   tickets?: LotteryTicket[]
 }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -348,6 +348,7 @@ export interface LotteryRoundUserTickets {
 
 interface LotteryRoundGenerics {
   isLoading?: boolean
+  lotteryId: string
   status: LotteryStatus
   startTime: string
   endTime: string

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -257,7 +257,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
       },
       onSuccess: async () => {
         onDismiss()
-        dispatch(fetchUserTicketsAndLotteries({ account, lotteryId: currentLotteryId }))
+        dispatch(fetchUserTicketsAndLotteries({ account, currentLotteryId }))
         toastSuccess(t('Lottery tickets purchased!'))
       },
     })

--- a/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
+++ b/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
@@ -21,7 +21,7 @@ const ClaimInnerContainer: React.FC<ClaimInnerProps> = ({ onSuccess, roundsToCla
   const { account } = useWeb3React()
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const { maxNumberTicketsPerBuyOrClaim } = useLottery()
+  const { maxNumberTicketsPerBuyOrClaim, currentLotteryId } = useLottery()
   const { toastSuccess, toastError } = useToast()
   const [activeClaimIndex, setActiveClaimIndex] = useState(0)
   const [pendingTx, setPendingTx] = useState(false)
@@ -60,7 +60,7 @@ const ClaimInnerContainer: React.FC<ClaimInnerProps> = ({ onSuccess, roundsToCla
     if (roundsToClaim.length > activeClaimIndex + 1) {
       // If there are still rounds to claim, move onto the next claim
       setActiveClaimIndex(activeClaimIndex + 1)
-      dispatch(fetchUserLotteries({ account }))
+      dispatch(fetchUserLotteries({ account, currentLotteryId }))
     } else {
       onSuccess()
     }

--- a/src/views/Lottery/components/ClaimPrizesModal/index.tsx
+++ b/src/views/Lottery/components/ClaimPrizesModal/index.tsx
@@ -7,6 +7,7 @@ import { delay } from 'lodash'
 import confetti from 'canvas-confetti'
 import { LotteryTicketClaimData } from 'config/constants/types'
 import { useAppDispatch } from 'state'
+import { useLottery } from 'state/hooks'
 import { fetchUserLotteries } from 'state/lottery'
 import ClaimPrizesInner from './ClaimPrizesInner'
 
@@ -55,6 +56,7 @@ interface ClaimPrizesModalModalProps {
 const ClaimPrizesModal: React.FC<ClaimPrizesModalModalProps> = ({ onDismiss, roundsToClaim }) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
+  const { currentLotteryId } = useLottery()
   const dispatch = useAppDispatch()
 
   useEffect(() => {
@@ -75,7 +77,7 @@ const ClaimPrizesModal: React.FC<ClaimPrizesModalModalProps> = ({ onDismiss, rou
       <ModalBody p="24px">
         <ClaimPrizesInner
           onSuccess={() => {
-            dispatch(fetchUserLotteries({ account }))
+            dispatch(fetchUserLotteries({ account, currentLotteryId }))
             onDismiss()
           }}
           roundsToClaim={roundsToClaim}

--- a/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
@@ -65,7 +65,7 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
             </Box>
             <Box mb="24px">
               <Text fontSize="14px">
-                {t('Total players this round')}: {lotteryGraphData.totalUsers.toLocaleString()}
+                {t('Total players this round')}: {lotteryGraphData.totalUsers?.toLocaleString()}
               </Text>
             </Box>
           </Flex>

--- a/src/views/Lottery/components/ViewTicketsModal/PreviousRoundTicketsInner.tsx
+++ b/src/views/Lottery/components/ViewTicketsModal/PreviousRoundTicketsInner.tsx
@@ -63,7 +63,7 @@ const PreviousRoundTicketsInner: React.FC<{ roundId: string }> = ({ roundId }) =
   const { t } = useTranslation()
   const { theme } = useTheme()
   const { account } = useWeb3React()
-  const userLotteryRoundData = useGetUserLotteryGraphRoundById(roundId)
+  const { totalTickets } = useGetUserLotteryGraphRoundById(roundId)
   const [onPresentClaimModal] = useModal(<ClaimPrizesModal roundsToClaim={[userWinningTickets.claimData]} />, false)
 
   const TooltipComponent = () => (
@@ -108,7 +108,7 @@ const PreviousRoundTicketsInner: React.FC<{ roundId: string }> = ({ roundId }) =
     }
 
     const fetchData = async () => {
-      const userTickets = await fetchTickets(account, roundId, userLotteryRoundData)
+      const userTickets = await fetchTickets(account, roundId, totalTickets)
       const lotteryData = await fetchLottery(roundId)
       const processedLotteryData = processLotteryResponse(lotteryData)
       const winningTickets = await getWinningTickets({
@@ -139,7 +139,7 @@ const PreviousRoundTicketsInner: React.FC<{ roundId: string }> = ({ roundId }) =
     }
 
     fetchData()
-  }, [roundId, account, userLotteryRoundData])
+  }, [roundId, account, totalTickets])
 
   const getFooter = () => {
     if (userWinningTickets?.ticketsWithUnclaimedRewards?.length > 0) {

--- a/src/views/Lottery/helpers.tsx
+++ b/src/views/Lottery/helpers.tsx
@@ -42,6 +42,7 @@ export const processLotteryResponse = (
 
   return {
     isLoading: lotteryData.isLoading,
+    lotteryId: lotteryData.lotteryId,
     userTickets: lotteryData.userTickets,
     status: lotteryData.status,
     startTime: lotteryData.startTime,

--- a/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
+++ b/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
@@ -11,7 +11,7 @@ export enum FetchStatus {
 
 const useGetUnclaimedRewards = () => {
   const { account } = useWeb3React()
-  const { isTransitioning } = useLottery()
+  const { isTransitioning, currentLotteryId } = useLottery()
   const userLotteryData = useGetUserLotteriesGraphData()
   const lotteriesData = useGetLotteriesGraphData()
   const [unclaimedRewards, setUnclaimedRewards] = useState([])
@@ -24,7 +24,12 @@ const useGetUnclaimedRewards = () => {
 
   const fetchAllRewards = async () => {
     setFetchStatus(FetchStatus.IN_PROGRESS)
-    const unclaimedRewardsResponse = await fetchUnclaimedUserRewards(account, userLotteryData, lotteriesData)
+    const unclaimedRewardsResponse = await fetchUnclaimedUserRewards(
+      account,
+      userLotteryData,
+      lotteriesData,
+      currentLotteryId,
+    )
     setUnclaimedRewards(unclaimedRewardsResponse)
     setFetchStatus(FetchStatus.SUCCESS)
   }

--- a/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
+++ b/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
@@ -24,12 +24,7 @@ const useGetUnclaimedRewards = () => {
 
   const fetchAllRewards = async () => {
     setFetchStatus(FetchStatus.IN_PROGRESS)
-    const unclaimedRewardsResponse = await fetchUnclaimedUserRewards(
-      account,
-      userLotteryData,
-      lotteriesData,
-      currentLotteryId,
-    )
+    const unclaimedRewardsResponse = await fetchUnclaimedUserRewards(account, userLotteryData, lotteriesData)
     setUnclaimedRewards(unclaimedRewardsResponse)
     setFetchStatus(FetchStatus.SUCCESS)
   }

--- a/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
+++ b/src/views/Lottery/hooks/useGetUnclaimedRewards.ts
@@ -11,7 +11,7 @@ export enum FetchStatus {
 
 const useGetUnclaimedRewards = () => {
   const { account } = useWeb3React()
-  const { isTransitioning, currentLotteryId } = useLottery()
+  const { isTransitioning } = useLottery()
   const userLotteryData = useGetUserLotteriesGraphData()
   const lotteriesData = useGetLotteriesGraphData()
   const [unclaimedRewards, setUnclaimedRewards] = useState([])


### PR DESCRIPTION
### Testing approved 👍 good to merge on Mon/Tues

Preview https://new-node-calls.netlify.app/lottery

**What does it do**
- Fundamentally change two of the base data-fetching queries: `getUserLotteryData` & `getLotteriesData`
- Previously, for all non-current round data, we were reliant on the subgraph. This was problematic particularly when rounds ended, as the subgraph would drift out of sync and return stale data.
- These two queries **now make node calls as well as subgraph calls, for all essential user & public lottery data for the past 4 rounds.**
- The two data sources are blended - in all cases, essential data is being handled by the nodes, and some supplementary UI data comes from the subgraph
- For rounds older than 4 rounds ago - the subgraph is used as normal.
- This PR includes a fallback for where there is no subgraph data (i.e. in the case that thegraph goes down). In that instance, the 4 rounds worth of node responses will be used, and any graph data will be null.

**Notes**
- There are some follow-up TODOs marked in the PR, but we're keen to get this out to solve the transition lag.