### PR TITLE
fix(auto-pools): Use static gas values & wrap calls in try/catch to fix error handling

### DIFF
--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -11,7 +11,6 @@ import { useTranslation } from 'contexts/Localization'
 import UnlockButton from 'components/UnlockButton'
 import Balance from 'components/Balance'
 import { useCakeVault, usePriceCakeBusd } from 'state/hooks'
-import { callWithEstimateGas } from 'utils/calls'
 
 interface BountyModalProps {
   onDismiss?: () => void
@@ -56,18 +55,18 @@ const BountyModal: React.FC<BountyModalProps> = ({ onDismiss, TooltipComponent }
   })
 
   const handleConfirmClick = async () => {
-    const tx = await callWithEstimateGas(cakeVaultContract, 'harvest', [], 5000)
     setPendingTx(true)
-    const receipt = await tx.wait()
-    if (receipt.status) {
-      toastSuccess(t('Bounty collected!'), t('CAKE bounty has been sent to your wallet.'))
-      setPendingTx(false)
-      onDismiss()
-    } else {
+    try {
+      const tx = await cakeVaultContract.harvest({ gasLimit: 285000 })
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        toastSuccess(t('Bounty collected!'), t('CAKE bounty has been sent to your wallet.'))
+        setPendingTx(false)
+        onDismiss()
+      }
+    } catch (error) {
       toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
-
       setPendingTx(false)
-      onDismiss()
     }
   }
 

--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -57,7 +57,7 @@ const BountyModal: React.FC<BountyModalProps> = ({ onDismiss, TooltipComponent }
   const handleConfirmClick = async () => {
     setPendingTx(true)
     try {
-      const tx = await cakeVaultContract.harvest({ gasLimit: 285000 })
+      const tx = await cakeVaultContract.harvest({ gasLimit: 210000 })
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(t('Bounty collected!'), t('CAKE bounty has been sent to your wallet.'))

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -16,7 +16,6 @@ import useToast from 'hooks/useToast'
 import { fetchCakeVaultUserData } from 'state/pools'
 import { Pool } from 'state/types'
 import { getAddress } from 'utils/addressHelpers'
-import { callWithEstimateGas } from 'utils/calls'
 import { convertCakeToShares } from '../../helpers'
 import FeeSummary from './FeeSummary'
 
@@ -30,6 +29,10 @@ interface VaultStakeModalProps {
 const StyledButton = styled(Button)`
   flex-grow: 1;
 `
+
+const callOptions = {
+  gasLimit: 285000,
+}
 
 const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isRemovingStake = false, onDismiss }) => {
   const dispatch = useAppDispatch()
@@ -82,34 +85,32 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
     const isWithdrawingAll = sharesRemaining.lte(triggerWithdrawAllThreshold)
 
     if (isWithdrawingAll) {
-      const tx = await callWithEstimateGas(cakeVaultContract, 'withdrawAll', [], 5000)
-      const receipt = await tx.wait()
-      if (receipt.status) {
-        toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
-        setPendingTx(false)
-        onDismiss()
-        dispatch(fetchCakeVaultUserData({ account }))
-      } else {
-        // Remove message from toast before prod
+      try {
+        const tx = await cakeVaultContract.withdrawAll(callOptions)
+        const receipt = await tx.wait()
+        if (receipt.status) {
+          toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
+          setPendingTx(false)
+          onDismiss()
+          dispatch(fetchCakeVaultUserData({ account }))
+        }
+      } catch (error) {
         toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
         setPendingTx(false)
       }
     } else {
       // .toString() being called to fix a BigNumber error in prod
       // as suggested here https://github.com/ChainSafe/web3.js/issues/2077
-      const tx = await callWithEstimateGas(
-        cakeVaultContract,
-        'withdraw',
-        [shareStakeToWithdraw.sharesAsBigNumber.toString()],
-        5000,
-      )
-      const receipt = await tx.wait()
-      if (receipt.status) {
-        toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
-        setPendingTx(false)
-        onDismiss()
-        dispatch(fetchCakeVaultUserData({ account }))
-      } else {
+      try {
+        const tx = await cakeVaultContract.withdraw(shareStakeToWithdraw.sharesAsBigNumber.toString(), callOptions)
+        const receipt = await tx.wait()
+        if (receipt.status) {
+          toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
+          setPendingTx(false)
+          onDismiss()
+          dispatch(fetchCakeVaultUserData({ account }))
+        }
+      } catch (error) {
         toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
         setPendingTx(false)
       }
@@ -117,18 +118,19 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({ pool, stakingMax, isR
   }
 
   const handleDeposit = async (convertedStakeAmount: BigNumber) => {
-    // .toString() being called to fix a BigNumber error in prod
-    // as suggested here https://github.com/ChainSafe/web3.js/issues/2077
-    const tx = await callWithEstimateGas(cakeVaultContract, 'deposit', [convertedStakeAmount.toString()], 5000)
     setPendingTx(true)
-    const receipt = await tx.wait()
-    if (receipt.status) {
-      toastSuccess(t('Staked!'), t('Your funds have been staked in the pool'))
-      setPendingTx(false)
-      onDismiss()
-      dispatch(fetchCakeVaultUserData({ account }))
-    } else {
-      // Remove message from toast before prod
+    try {
+      // .toString() being called to fix a BigNumber error in prod
+      // as suggested here https://github.com/ChainSafe/web3.js/issues/2077
+      const tx = await cakeVaultContract.deposit(convertedStakeAmount.toString(), callOptions)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        toastSuccess(t('Staked!'), t('Your funds have been staked in the pool'))
+        setPendingTx(false)
+        onDismiss()
+        dispatch(fetchCakeVaultUserData({ account }))
+      }
+    } catch (error) {
       toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
       setPendingTx(false)
     }


### PR DESCRIPTION
- Use static gas values for harvest, deposit & withdraw auto pool calls.
- Updated calls to be within try/catch: transaction error handling as-is in a lot of the app doesn't work as intended (to see for yourself - cancel a transaction and notice none of the fail state functions fire), as per: https://pancakeswap.slack.com/archives/C01GL551EF6/p1625483421174300
