### PR TITLE
fix: Add fixed width option to balance component

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -9,6 +9,7 @@ interface BalanceProps extends TextProps {
   isDisabled?: boolean
   prefix?: string
   onClick?: (event: React.MouseEvent<HTMLElement>) => void
+  fixedWidth?: boolean
 }
 
 const Balance: React.FC<BalanceProps> = ({
@@ -19,19 +20,48 @@ const Balance: React.FC<BalanceProps> = ({
   unit,
   prefix,
   onClick,
+  fixedWidth,
   ...props
 }) => {
   const previousValue = useRef(0)
+  const containerStyles = () => {
+    if (fixedWidth) {
+      return {
+        marginRight: '0px',
+        marginLeft: '0px',
+        paddingRight: '0px',
+        paddingLeft: '0px',
+      }
+    }
+    return {}
+  }
+  const replaceDigitsWithWider = () => {
+    const valueString = value.toLocaleString(undefined, { maximumFractionDigits: decimals })
+    return valueString.replaceAll('1', '9')
+  }
 
   useEffect(() => {
     previousValue.current = value
   }, [value])
 
   return (
-    <Text color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
-      {prefix && <span>{prefix}</span>}
-      <CountUp start={previousValue.current} end={value} decimals={decimals} duration={1} separator="," />
-      {unit && <span>{unit}</span>}
+    <Text style={containerStyles()} color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
+      {fixedWidth && (
+        <Text style={{ visibility: 'hidden', height: '0px' }} {...props}>
+          {prefix && <span>{prefix}</span>}
+          {replaceDigitsWithWider()}
+          {unit && <span>{unit}</span>}
+        </Text>
+      )}
+      <CountUp
+        start={previousValue.current}
+        end={value}
+        prefix={prefix}
+        suffix={unit}
+        decimals={decimals}
+        duration={1}
+        separator=","
+      />
     </Text>
   )
 }

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -27,17 +27,11 @@ const Balance: React.FC<BalanceProps> = ({
   const containerStyles = () => {
     if (fixedWidth) {
       return {
-        marginRight: '0px',
-        marginLeft: '0px',
-        paddingRight: '0px',
-        paddingLeft: '0px',
+        fontVariantNumeric: 'tabular-nums',
+        fontFamily: 'sans-serif',
       }
     }
     return {}
-  }
-  const replaceDigitsWithWider = () => {
-    const valueString = value.toLocaleString(undefined, { maximumFractionDigits: decimals })
-    return valueString.replaceAll('1', '9')
   }
 
   useEffect(() => {
@@ -45,14 +39,7 @@ const Balance: React.FC<BalanceProps> = ({
   }, [value])
 
   return (
-    <Text style={containerStyles()} color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
-      {fixedWidth && (
-        <Text style={{ visibility: 'hidden', height: '0px' }} {...props}>
-          {prefix && <span>{prefix}</span>}
-          {replaceDigitsWithWider()}
-          {unit && <span>{unit}</span>}
-        </Text>
-      )}
+    <Text color={isDisabled ? 'textDisabled' : color} onClick={onClick} {...props}>
       <CountUp
         start={previousValue.current}
         end={value}
@@ -61,7 +48,10 @@ const Balance: React.FC<BalanceProps> = ({
         decimals={decimals}
         duration={1}
         separator=","
-      />
+        delay={0}
+      >
+        {({ countUpRef }) => <span style={containerStyles()} ref={countUpRef} />}
+      </CountUp>
     </Text>
   )
 }

--- a/src/views/Home/components/LotteryBanner.tsx
+++ b/src/views/Home/components/LotteryBanner.tsx
@@ -113,7 +113,16 @@ const LotteryBanner: React.FC<{ currentLotteryPrize: string }> = ({ currentLotte
                   <Skeleton height={40} width={120} mb="10px" mt="10px" mr="8px" />
                 </>
               ) : (
-                <Balance fontSize="40px" color="#ffffff" bold prefix="$" mr="8px" decimals={0} value={prizeTotal} />
+                <Balance
+                  fontSize="40px"
+                  color="#ffffff"
+                  bold
+                  prefix="$"
+                  mr="8px"
+                  decimals={0}
+                  value={prizeTotal}
+                  fixedWidth
+                />
               )}
             </>
             <Text fontSize="40px" color="#ffffff" bold>


### PR DESCRIPTION
To review

https://deploy-preview-1693--pancakeswap-dev.netlify.app/


Open webpage in iphone 12 pro, can also be reproduced with iphone 5/SE device simulator in browsers

Check lottery banner blinking while price counting up


@ChefHutch I have applied two different approach, please let me know which one suits you most.

First one converts all 1’s to 9 to get the maximum width but has a cornercase that if number has too many 1’s it ends up with long space at the end of it.

Downside of second one is different font  ( fallback one) ,which supports same width for digits by tabular-nums variant, than the default one.