### PR TITLE
feat: Unify confirm button text when pending transaction

### DIFF
--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -74,7 +74,7 @@ const DepositModal: React.FC<DepositModalProps> = ({ max, onConfirm, onDismiss, 
             }
           }}
         >
-          {pendingTx ? t('Pending Confirmation') : t('Confirm')}
+          {pendingTx ? t('Confirming') : t('Confirm')}
         </Button>
       </ModalActions>
       <LinkExternal href={addLiquidityUrl} style={{ alignSelf: 'center' }}>

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -72,7 +72,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
           }}
           width="100%"
         >
-          {pendingTx ? t('Pending Confirmation') : t('Confirm')}
+          {pendingTx ? t('Confirming') : t('Confirm')}
         </Button>
       </ModalActions>
     </Modal>


### PR DESCRIPTION
To review: 

https://deploy-preview-1733--pancakeswap-dev.netlify.app/

1. Go to farms
2. Click stake or unstake button
3. Check confirm button when pending transaction 
4. Other places (pools) are using text 'Confirming', so it should be unified. 