### PR TITLE
feat(swap-warning-modals): Add warning modals for specific tokens when swapping

### DIFF
--- a/src/components/SearchModal/CurrencySearchModal.tsx
+++ b/src/components/SearchModal/CurrencySearchModal.tsx
@@ -54,8 +54,8 @@ export default function CurrencySearchModal({
 
   const handleCurrencySelect = useCallback(
     (currency: Currency) => {
-      onCurrencySelect(currency)
       onDismiss()
+      onCurrencySelect(currency)
     },
     [onDismiss, onCurrencySelect],
   )

--- a/src/config/constants/swapWarningTokens.ts
+++ b/src/config/constants/swapWarningTokens.ts
@@ -1,7 +1,7 @@
 import tokens from 'config/constants/tokens'
 import { Address } from './types'
 
-const { bondly } = tokens
+const { bondly, safemoon } = tokens
 
 interface WarningToken {
   symbol: string
@@ -13,13 +13,7 @@ interface WarningTokenList {
 }
 
 const SwapWarningTokens = <WarningTokenList>{
-  safemoon: {
-    symbol: 'SAFEMOON',
-    address: {
-      56: '0x8076C74C5e3F5852037F31Ff0093Eeb8c8ADd8D3',
-      97: '',
-    },
-  },
+  safemoon,
   bondly,
 }
 

--- a/src/config/constants/swapWarningTokens.ts
+++ b/src/config/constants/swapWarningTokens.ts
@@ -1,4 +1,18 @@
-const SwapWarningTokens = {
+import tokens from 'config/constants/tokens'
+import { Address } from './types'
+
+const { bondly } = tokens
+
+interface WarningToken {
+  symbol: string
+  address: Address
+}
+
+interface WarningTokenList {
+  [key: string]: WarningToken
+}
+
+const SwapWarningTokens = <WarningTokenList>{
   safemoon: {
     symbol: 'SAFEMOON',
     address: {
@@ -6,13 +20,7 @@ const SwapWarningTokens = {
       97: '',
     },
   },
-  bondly: {
-    symbol: 'BONDLY',
-    address: {
-      56: '0x96058f8C3e16576D9BD68766f3836d9A33158f89',
-      97: '',
-    },
-  },
+  bondly,
 }
 
 export default SwapWarningTokens

--- a/src/config/constants/swapWarningTokens.ts
+++ b/src/config/constants/swapWarningTokens.ts
@@ -1,0 +1,18 @@
+const SwapWarningTokens = {
+  safemoon: {
+    symbol: 'SAFEMOON',
+    address: {
+      56: '0x8076C74C5e3F5852037F31Ff0093Eeb8c8ADd8D3',
+      97: '',
+    },
+  },
+  bondly: {
+    symbol: 'BONDLY',
+    address: {
+      56: '0x96058f8C3e16576D9BD68766f3836d9A33158f89',
+      97: '',
+    },
+  },
+}
+
+export default SwapWarningTokens

--- a/src/config/constants/tokens.ts
+++ b/src/config/constants/tokens.ts
@@ -1756,6 +1756,15 @@ const tokens = {
     decimals: 18,
     projectLink: 'https://decentral.games/',
   },
+  safemoon: {
+    symbol: 'SAFEMOON',
+    address: {
+      56: '0x8076C74C5e3F5852037F31Ff0093Eeb8c8ADd8D3',
+      97: '',
+    },
+    decimals: 9,
+    projectLink: 'https://safemoon.net/',
+  },
 }
 
 export default tokens

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1182,5 +1182,10 @@
   "Waiting For Confirmation": "Waiting For Confirmation",
   "Confirm this transaction in your wallet": "Confirm this transaction in your wallet",
   "Dismiss": "Dismiss",
-  "Latest": "Latest"
+  "Latest": "Latest",
+  "Notice for trading %symbol%": "Notice for trading %symbol%",
+  "To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+": "To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+",
+  "This is because SafeMoon taxes a 10% fee on each transaction.": "This is because SafeMoon taxes a 10% fee on each transaction.",
+  "• 5% fee = redistributed to all existing holders": "• 5% fee = redistributed to all existing holders",
+  "• 5% fee = used to add liquidity": "• 5% fee = used to add liquidity"
 }

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1184,8 +1184,11 @@
   "Dismiss": "Dismiss",
   "Latest": "Latest",
   "Notice for trading %symbol%": "Notice for trading %symbol%",
-  "To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+": "To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+",
-  "This is because SafeMoon taxes a 10% fee on each transaction.": "This is because SafeMoon taxes a 10% fee on each transaction.",
-  "• 5% fee = redistributed to all existing holders": "• 5% fee = redistributed to all existing holders",
-  "• 5% fee = used to add liquidity": "• 5% fee = used to add liquidity"
+  "To trade SAFEMOON, you must:": "To trade SAFEMOON, you must:",
+  "Click on the settings icon": "Click on the settings icon",
+  "Set your slippage tolerance to 12%+": "Set your slippage tolerance to 12%+",
+  "This is because SafeMoon taxes a 10% fee on each transaction:": "This is because SafeMoon taxes a 10% fee on each transaction:",
+  "5% fee = redistributed to all existing holders": "5% fee = redistributed to all existing holders",
+  "5% fee = used to add liquidity": "5% fee = used to add liquidity",
+  "Warning: BONDLY has been compromised. Please remove liqudity until further notice.": "Warning: BONDLY has been compromised. Please remove liqudity until further notice."
 }

--- a/src/views/Swap/components/ImportTokenWarningModal.tsx
+++ b/src/views/Swap/components/ImportTokenWarningModal.tsx
@@ -8,7 +8,7 @@ interface Props extends InjectedModalProps {
   onCancel: () => void
 }
 
-const TokenWarningModal: React.FC<Props> = ({ tokens, onDismiss, onCancel }) => {
+const ImportTokenWarningModal: React.FC<Props> = ({ tokens, onDismiss, onCancel }) => {
   return (
     <Modal
       title="Import Token"
@@ -25,4 +25,4 @@ const TokenWarningModal: React.FC<Props> = ({ tokens, onDismiss, onCancel }) => 
   )
 }
 
-export default TokenWarningModal
+export default ImportTokenWarningModal

--- a/src/views/Swap/components/SwapWarningModal/Acknowledgement.tsx
+++ b/src/views/Swap/components/SwapWarningModal/Acknowledgement.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'contexts/Localization'
+import { Text, Flex, Checkbox, Button } from '@pancakeswap/uikit'
+
+interface AcknowledgementProps {
+  handleContinueClick: () => void
+}
+
+const Acknowledgement: React.FC<AcknowledgementProps> = ({ handleContinueClick }) => {
+  const { t } = useTranslation()
+  const [isConfirmed, setIsConfirmed] = useState(false)
+
+  return (
+    <>
+      <Flex justifyContent="space-between">
+        <Flex alignItems="center">
+          <Checkbox
+            name="confirmed"
+            type="checkbox"
+            checked={isConfirmed}
+            onChange={() => setIsConfirmed(!isConfirmed)}
+            scale="sm"
+          />
+          <Text ml="10px" style={{ userSelect: 'none' }}>
+            {t('I understand')}
+          </Text>
+        </Flex>
+
+        <Button disabled={!isConfirmed} onClick={handleContinueClick}>
+          {t('Continue')}
+        </Button>
+      </Flex>
+    </>
+  )
+}
+
+export default Acknowledgement

--- a/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { Text } from '@pancakeswap/uikit'
-import Acknowledgement from './Acknowledgement'
+import { useTranslation } from 'contexts/Localization'
 import { DefaultWarningProps } from './types'
 
-const BondlyWarning: React.FC<DefaultWarningProps> = ({ onDismiss }) => {
+const BondlyWarning: React.FC<DefaultWarningProps> = () => {
+  const { t } = useTranslation()
+
   return (
     <>
-      <Text mb="24px">A cluster of stuff about Bondly</Text>
-      <Text mb="24px">Text TBC</Text>
-      <Acknowledgement handleContinueClick={onDismiss} />
+      <Text>{t('Warning: BONDLY has been compromised. Please remove liqudity until further notice.')}</Text>
     </>
   )
 }

--- a/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Text } from '@pancakeswap/uikit'
+import Acknowledgement from './Acknowledgement'
+import { DefaultWarningProps } from './types'
+
+const BondlyWarning: React.FC<DefaultWarningProps> = ({ onDismiss }) => {
+  return (
+    <>
+      <Text mb="24px">A cluster of stuff about Bondly</Text>
+      <Text mb="24px">Text TBC</Text>
+      <Acknowledgement handleContinueClick={onDismiss} />
+    </>
+  )
+}
+
+export default BondlyWarning

--- a/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/BondlyWarning.tsx
@@ -1,16 +1,11 @@
 import React from 'react'
 import { Text } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
-import { DefaultWarningProps } from './types'
 
-const BondlyWarning: React.FC<DefaultWarningProps> = () => {
+const BondlyWarning = () => {
   const { t } = useTranslation()
 
-  return (
-    <>
-      <Text>{t('Warning: BONDLY has been compromised. Please remove liqudity until further notice.')}</Text>
-    </>
-  )
+  return <Text>{t('Warning: BONDLY has been compromised. Please remove liqudity until further notice.')}</Text>
 }
 
 export default BondlyWarning

--- a/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { useTranslation } from 'contexts/Localization'
+import { Text } from '@pancakeswap/uikit'
+import Acknowledgement from './Acknowledgement'
+import { DefaultWarningProps } from './types'
+
+const SafemoonWarning: React.FC<DefaultWarningProps> = ({ onDismiss }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <Text mb="24px">
+        {t('To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+')}
+      </Text>
+      <Text mb="24px">{t('This is because SafeMoon taxes a 10% fee on each transaction.')}</Text>
+      <Text mb="12px">{t('• 5% fee = redistributed to all existing holders')}</Text>
+      <Text mb="24px">{t('• 5% fee = used to add liquidity')}</Text>
+      <Acknowledgement handleContinueClick={onDismiss} />
+    </>
+  )
+}
+
+export default SafemoonWarning

--- a/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { useTranslation } from 'contexts/Localization'
 import { Text } from '@pancakeswap/uikit'
-import { DefaultWarningProps } from './types'
 
-const SafemoonWarning: React.FC<DefaultWarningProps> = () => {
+const SafemoonWarning = () => {
   const { t } = useTranslation()
 
   return (

--- a/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
 import { useTranslation } from 'contexts/Localization'
 import { Text } from '@pancakeswap/uikit'
-import Acknowledgement from './Acknowledgement'
 import { DefaultWarningProps } from './types'
 
-const SafemoonWarning: React.FC<DefaultWarningProps> = ({ onDismiss }) => {
+const SafemoonWarning: React.FC<DefaultWarningProps> = () => {
   const { t } = useTranslation()
 
   return (
     <>
-      <Text mb="24px">
-        {t('To trade SAFEMOON, you must click on the settings icon and set your slippage tolerance to 12%+')}
-      </Text>
-      <Text mb="24px">{t('This is because SafeMoon taxes a 10% fee on each transaction.')}</Text>
-      <Text mb="12px">{t('• 5% fee = redistributed to all existing holders')}</Text>
-      <Text mb="24px">{t('• 5% fee = used to add liquidity')}</Text>
-      <Acknowledgement handleContinueClick={onDismiss} />
+      <Text>{t('To trade SAFEMOON, you must:')} </Text>
+      <Text>• {t('Click on the settings icon')}</Text>
+      <Text mb="24px">• {t('Set your slippage tolerance to 12%+')}</Text>
+      <Text>{t('This is because SafeMoon taxes a 10% fee on each transaction:')}</Text>
+      <Text>• {t('5% fee = redistributed to all existing holders')}</Text>
+      <Text>• {t('5% fee = used to add liquidity')}</Text>
     </>
   )
 }

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
-import { ModalBody, ModalContainer, Message, ModalHeader, Box, ErrorIcon, Flex, Heading } from '@pancakeswap/uikit'
+import { ModalBody, ModalContainer, Message, ModalHeader, Box, Heading } from '@pancakeswap/uikit'
 import useTheme from 'hooks/useTheme'
 import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
@@ -12,6 +12,11 @@ import Acknowledgement from './Acknowledgement'
 
 const StyledModalContainer = styled(ModalContainer)`
   max-width: 440px;
+`
+
+const MessageContainer = styled(Message)`
+  align-items: flex-start;
+  justify-content: flex-start;
 `
 
 interface SwapWarningModalProps {
@@ -64,9 +69,9 @@ const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDis
         <Heading p="12px 24px">{t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
       </ModalHeader>
       <ModalBody p="24px">
-        <Message variant="warning" mb="24px">
+        <MessageContainer variant="warning" mb="24px">
           <Box>{SWAP_WARNING.component}</Box>
-        </Message>
+        </MessageContainer>
         <Acknowledgement handleContinueClick={onDismiss} />
       </ModalBody>
     </StyledModalContainer>

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -4,7 +4,7 @@ import { ModalContainer, ModalHeader, Heading, ErrorIcon, ModalBody } from '@pan
 import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
 import { WrappedTokenInfo } from 'state/lists/hooks'
-import SwapWarningTokens from 'config/constants/swapWarningTokens'
+import SwapWarningTokensConfig from 'config/constants/swapWarningTokens'
 import SafemoonWarning from './SafemoonWarning'
 import BondlyWarning from './BondlyWarning'
 
@@ -43,18 +43,18 @@ const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDis
   const { t } = useTranslation()
   usePreventModalOverlayClick()
 
-  const WARNING_DATA = {
-    [getAddress(SwapWarningTokens.safemoon.address)]: {
-      symbol: SwapWarningTokens.safemoon.symbol,
+  const TOKEN_WARNINGS = {
+    [getAddress(SwapWarningTokensConfig.safemoon.address)]: {
+      symbol: SwapWarningTokensConfig.safemoon.symbol,
       component: <SafemoonWarning onDismiss={onDismiss} />,
     },
-    [getAddress(SwapWarningTokens.bondly.address)]: {
-      symbol: SwapWarningTokens.bondly.symbol,
+    [getAddress(SwapWarningTokensConfig.bondly.address)]: {
+      symbol: SwapWarningTokensConfig.bondly.symbol,
       component: <BondlyWarning onDismiss={onDismiss} />,
     },
   }
 
-  const SWAP_WARNING = WARNING_DATA[swapCurrency.address]
+  const SWAP_WARNING = TOKEN_WARNINGS[swapCurrency.address]
 
   return (
     <StyledModalContainer minWidth="320px">

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { ModalContainer, ModalHeader, Heading, ErrorIcon, ModalBody } from '@pancakeswap/uikit'
+import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
 import { WrappedTokenInfo } from 'state/lists/hooks'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
@@ -41,14 +42,13 @@ const usePreventModalOverlayClick = () => {
 const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDismiss }) => {
   const { t } = useTranslation()
   usePreventModalOverlayClick()
-  const chainId = process.env.REACT_APP_CHAIN_ID
 
   const WARNING_DATA = {
-    [SwapWarningTokens.safemoon.address[chainId]]: {
+    [getAddress(SwapWarningTokens.safemoon.address)]: {
       symbol: SwapWarningTokens.safemoon.symbol,
       component: <SafemoonWarning onDismiss={onDismiss} />,
     },
-    [SwapWarningTokens.bondly.address[chainId]]: {
+    [getAddress(SwapWarningTokens.bondly.address)]: {
       symbol: SwapWarningTokens.bondly.symbol,
       component: <BondlyWarning onDismiss={onDismiss} />,
     },

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,16 +1,26 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
-import { ModalContainer, ModalHeader, Heading, ErrorIcon, ModalBody } from '@pancakeswap/uikit'
+import { ModalBody, ModalContainer, ModalHeader, Box, ErrorIcon, Flex, Heading } from '@pancakeswap/uikit'
+import useTheme from 'hooks/useTheme'
 import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
 import { WrappedTokenInfo } from 'state/lists/hooks'
 import SwapWarningTokensConfig from 'config/constants/swapWarningTokens'
 import SafemoonWarning from './SafemoonWarning'
 import BondlyWarning from './BondlyWarning'
+import Acknowledgement from './Acknowledgement'
 
 const StyledModalContainer = styled(ModalContainer)`
-  max-width: 420px;
-  border: 1px ${({ theme }) => theme.colors.warning} solid;
+  max-width: 440px;
+`
+
+const WarningMessageWrapper = styled(Flex)`
+  border-radius: ${({ theme }) => theme.radii.default};
+  align-items: flex-start;
+  padding: 16px;
+  margin-bottom: 24px;
+  background-color: ${({ theme }) => theme.colors.warning}1A; /* Hex value for 0.1 opacity */
+  border: 1px solid ${({ theme }) => theme.colors.warning};
 `
 
 interface SwapWarningModalProps {
@@ -41,6 +51,7 @@ const usePreventModalOverlayClick = () => {
 
 const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDismiss }) => {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   usePreventModalOverlayClick()
 
   const TOKEN_WARNINGS = {
@@ -57,12 +68,19 @@ const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDis
   const SWAP_WARNING = TOKEN_WARNINGS[swapCurrency.address]
 
   return (
-    <StyledModalContainer minWidth="320px">
-      <ModalHeader>
-        <ErrorIcon height="24px" width="24px" color="warning" mr="8px" />
-        <Heading> {t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
+    <StyledModalContainer minWidth="280px">
+      <ModalHeader background={theme.colors.gradients.cardHeader}>
+        <Heading p="12px 24px">{t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
       </ModalHeader>
-      <ModalBody p="24px">{SWAP_WARNING.component}</ModalBody>
+      <ModalBody p="24px">
+        <WarningMessageWrapper>
+          <Box>
+            <ErrorIcon height="24px" width="24px" color="warning" mr="8px" />
+          </Box>
+          <Box>{SWAP_WARNING.component}</Box>
+        </WarningMessageWrapper>
+        <Acknowledgement handleContinueClick={onDismiss} />
+      </ModalBody>
     </StyledModalContainer>
   )
 }

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -57,11 +57,11 @@ const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDis
   const TOKEN_WARNINGS = {
     [getAddress(SwapWarningTokensConfig.safemoon.address)]: {
       symbol: SwapWarningTokensConfig.safemoon.symbol,
-      component: <SafemoonWarning onDismiss={onDismiss} />,
+      component: <SafemoonWarning />,
     },
     [getAddress(SwapWarningTokensConfig.bondly.address)]: {
       symbol: SwapWarningTokensConfig.bondly.symbol,
-      component: <BondlyWarning onDismiss={onDismiss} />,
+      component: <BondlyWarning />,
     },
   }
 

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
-import { ModalBody, ModalContainer, ModalHeader, Box, ErrorIcon, Flex, Heading } from '@pancakeswap/uikit'
+import { ModalBody, ModalContainer, Message, ModalHeader, Box, ErrorIcon, Flex, Heading } from '@pancakeswap/uikit'
 import useTheme from 'hooks/useTheme'
 import { getAddress } from 'utils/addressHelpers'
 import { useTranslation } from 'contexts/Localization'
@@ -12,15 +12,6 @@ import Acknowledgement from './Acknowledgement'
 
 const StyledModalContainer = styled(ModalContainer)`
   max-width: 440px;
-`
-
-const WarningMessageWrapper = styled(Flex)`
-  border-radius: ${({ theme }) => theme.radii.default};
-  align-items: flex-start;
-  padding: 16px;
-  margin-bottom: 24px;
-  background-color: ${({ theme }) => theme.colors.warning}1A; /* Hex value for 0.1 opacity */
-  border: 1px solid ${({ theme }) => theme.colors.warning};
 `
 
 interface SwapWarningModalProps {
@@ -73,12 +64,9 @@ const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDis
         <Heading p="12px 24px">{t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
       </ModalHeader>
       <ModalBody p="24px">
-        <WarningMessageWrapper>
-          <Box>
-            <ErrorIcon height="24px" width="24px" color="warning" mr="8px" />
-          </Box>
+        <Message variant="warning" mb="24px">
           <Box>{SWAP_WARNING.component}</Box>
-        </WarningMessageWrapper>
+        </Message>
         <Acknowledgement handleContinueClick={onDismiss} />
       </ModalBody>
     </StyledModalContainer>

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react'
+import styled from 'styled-components'
+import { ModalContainer, ModalHeader, Heading, ErrorIcon, ModalBody } from '@pancakeswap/uikit'
+import { useTranslation } from 'contexts/Localization'
+import { WrappedTokenInfo } from 'state/lists/hooks'
+import SwapWarningTokens from 'config/constants/swapWarningTokens'
+import SafemoonWarning from './SafemoonWarning'
+import BondlyWarning from './BondlyWarning'
+
+const StyledModalContainer = styled(ModalContainer)`
+  max-width: 420px;
+  border: 1px ${({ theme }) => theme.colors.warning} solid;
+`
+
+interface SwapWarningModalProps {
+  swapCurrency: WrappedTokenInfo
+  onDismiss?: () => void
+}
+
+// Modal is fired by a useEffect and doesn't respond to closeOnOverlayClick prop being set to false
+const usePreventModalOverlayClick = () => {
+  useEffect(() => {
+    const preventClickHandler = (e) => {
+      e.stopPropagation()
+      e.preventDefault()
+      return false
+    }
+
+    document.querySelectorAll('[role="presentation"]').forEach((el) => {
+      el.addEventListener('click', preventClickHandler, true)
+    })
+
+    return () => {
+      document.querySelectorAll('[role="presentation"]').forEach((el) => {
+        el.removeEventListener('click', preventClickHandler, true)
+      })
+    }
+  }, [])
+}
+
+const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDismiss }) => {
+  const { t } = useTranslation()
+  usePreventModalOverlayClick()
+  const chainId = process.env.REACT_APP_CHAIN_ID
+
+  const WARNING_DATA = {
+    [SwapWarningTokens.safemoon.address[chainId]]: {
+      symbol: SwapWarningTokens.safemoon.symbol,
+      component: <SafemoonWarning onDismiss={onDismiss} />,
+    },
+    [SwapWarningTokens.bondly.address[chainId]]: {
+      symbol: SwapWarningTokens.bondly.symbol,
+      component: <BondlyWarning onDismiss={onDismiss} />,
+    },
+  }
+
+  const SWAP_WARNING = WARNING_DATA[swapCurrency.address]
+
+  return (
+    <StyledModalContainer minWidth="320px">
+      <ModalHeader>
+        <ErrorIcon height="24px" width="24px" color="warning" mr="8px" />
+        <Heading> {t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
+      </ModalHeader>
+      <ModalBody p="24px">{SWAP_WARNING.component}</ModalBody>
+    </StyledModalContainer>
+  )
+}
+
+export default SwapWarningModal

--- a/src/views/Swap/components/SwapWarningModal/types.ts
+++ b/src/views/Swap/components/SwapWarningModal/types.ts
@@ -1,3 +1,0 @@
-export interface DefaultWarningProps {
-  onDismiss: () => void
-}

--- a/src/views/Swap/components/SwapWarningModal/types.ts
+++ b/src/views/Swap/components/SwapWarningModal/types.ts
@@ -1,0 +1,3 @@
+export interface DefaultWarningProps {
+  onDismiss: () => void
+}

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -6,6 +6,7 @@ import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
 import { RouteComponentProps } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
+import SwapWarningTokens from 'config/constants/swapWarningTokens'
 import AddressInputPanel from './components/AddressInputPanel'
 import { GreyCard } from '../../components/Card'
 import Column, { AutoColumn } from '../../components/Layout/Column'
@@ -16,7 +17,7 @@ import AdvancedSwapDetailsDropdown from './components/AdvancedSwapDetailsDropdow
 import confirmPriceImpactWithoutFee from './components/confirmPriceImpactWithoutFee'
 import { ArrowWrapper, SwapCallbackError, Wrapper } from './components/styleds'
 import TradePrice from './components/TradePrice'
-import TokenWarningModal from './components/TokenWarningModal'
+import ImportTokenWarningModal from './components/ImportTokenWarningModal'
 import ProgressSteps from './components/ProgressSteps'
 import { AppHeader, AppBody } from '../../components/App'
 import UnlockButton from '../../components/UnlockButton'
@@ -39,6 +40,7 @@ import { maxAmountSpend } from '../../utils/maxAmountSpend'
 import { computeTradePriceBreakdown, warningSeverity } from '../../utils/prices'
 import CircleLoader from '../../components/Loader/CircleLoader'
 import Page from '../Page'
+import SwapWarningModal from './components/SwapWarningModal'
 
 const Label = styled(Text)`
   font-size: 12px;
@@ -214,10 +216,35 @@ export default function Swap({ history }: RouteComponentProps) {
     setSwapState({ tradeToConfirm: trade, swapErrorMessage, txHash, attemptingTxn })
   }, [attemptingTxn, swapErrorMessage, trade, txHash])
 
+  // swap warning state
+  const [swapWarningCurrency, setSwapWarningCurrency] = useState(null)
+  const [onPresentSwapWarningModal] = useModal(<SwapWarningModal swapCurrency={swapWarningCurrency} />)
+
+  const shouldShowSwapWarning = (swapCurrency) => {
+    const isWarningToken = Object.entries(SwapWarningTokens).find((warningTokenConfig) => {
+      const warningTokenData = warningTokenConfig[1]
+      return warningTokenData.address[process.env.REACT_APP_CHAIN_ID] === swapCurrency.address
+    })
+    return Boolean(isWarningToken)
+  }
+
+  useEffect(() => {
+    if (swapWarningCurrency) {
+      onPresentSwapWarningModal()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [swapWarningCurrency])
+
   const handleInputSelect = useCallback(
     (inputCurrency) => {
       setApprovalSubmitted(false) // reset 2 step UI for approvals
       onCurrencySelection(Field.INPUT, inputCurrency)
+      const showSwapWarning = shouldShowSwapWarning(inputCurrency)
+      if (showSwapWarning) {
+        setSwapWarningCurrency(inputCurrency)
+      } else {
+        setSwapWarningCurrency(null)
+      }
     },
     [onCurrencySelection],
   )
@@ -229,19 +256,28 @@ export default function Swap({ history }: RouteComponentProps) {
   }, [maxAmountInput, onUserInput])
 
   const handleOutputSelect = useCallback(
-    (outputCurrency) => onCurrencySelection(Field.OUTPUT, outputCurrency),
+    (outputCurrency) => {
+      onCurrencySelection(Field.OUTPUT, outputCurrency)
+      const showSwapWarning = shouldShowSwapWarning(outputCurrency)
+      if (showSwapWarning) {
+        setSwapWarningCurrency(outputCurrency)
+      } else {
+        setSwapWarningCurrency(null)
+      }
+    },
+
     [onCurrencySelection],
   )
 
   const swapIsUnsupported = useIsTransactionUnsupported(currencies?.INPUT, currencies?.OUTPUT)
 
-  const [onPresentTokenWarningModal] = useModal(
-    <TokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap/')} />,
+  const [onPresentImportTokenWarningModal] = useModal(
+    <ImportTokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap/')} />,
   )
 
   useEffect(() => {
     if (importTokensNotInDefault.length > 0) {
-      onPresentTokenWarningModal()
+      onPresentImportTokenWarningModal()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [importTokensNotInDefault.length])

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -7,6 +7,7 @@ import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
 import { RouteComponentProps } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
+import { getAddress } from 'utils/addressHelpers'
 import AddressInputPanel from './components/AddressInputPanel'
 import { GreyCard } from '../../components/Card'
 import Column, { AutoColumn } from '../../components/Layout/Column'
@@ -223,7 +224,8 @@ export default function Swap({ history }: RouteComponentProps) {
   const shouldShowSwapWarning = (swapCurrency) => {
     const isWarningToken = Object.entries(SwapWarningTokens).find((warningTokenConfig) => {
       const warningTokenData = warningTokenConfig[1]
-      return warningTokenData.address[process.env.REACT_APP_CHAIN_ID] === swapCurrency.address
+      const warningTokenAddress = getAddress(warningTokenData.address)
+      return swapCurrency.address === warningTokenAddress
     })
     return Boolean(isWarningToken)
   }


### PR DESCRIPTION
Preview: https://exchange-warning-modals.netlify.app/swap
To test, select as either swap SAFEMOON (`0x8076c74c5e3f5852037f31ff0093eeb8c8add8d3`), or BONDLY (`0x96058f8C3e16576D9BD68766f3836d9A33158f89 `)

Steps to add future warnings:
1. Add new entry to `swapWarningTokens` with `symbol` and an `address` object. The key should be similar to the token symbol, lowercased (although honestly this can be anything - it's just used as a key to access the object in step 3). 
```js
  safewat: {
    symbol: 'WAT',
    address: {
      56: '0x...',
      97: '',
    },
  },
```

2. Create a warning component which will be passed into the body of the modal. These are super basic and could maybe even be spun up by non-FE engineers, i.e.
```js
const SafeWatWarning: React.FC<DefaultWarningProps> = () => {
  return (
    <>
      <Text mb="24px">A cluster of stuff about safewat</Text>
      <Text>Good project</Text>
    </>
  )
}
```

3. Add a new object to `TOKEN_WARNINGS` for the new warning
```js
    [getAddress(SwapWarningTokensConfig.safewat.address)]: {
      symbol: SwapWarningTokensConfig.safewat.symbol,
      component: <SafeWatWarning />,
    },

    // 0x...: {
    //   symbol: 'WAT',
    //   component: <SafeWatWarning/>,
    // },
```

Done. The `safewat` warning modal will now fire when a user tries to swap `0x...`
