### PR TITLE
fix: Toggle correctly for path /liquidity

### DIFF
--- a/src/components/Menu/SubNav.tsx
+++ b/src/components/Menu/SubNav.tsx
@@ -13,7 +13,8 @@ const getActiveIndex = (pathname: string): number => {
     pathname.includes('/create') ||
     pathname.includes('/add') ||
     pathname.includes('/remove') ||
-    pathname.includes('/find')
+    pathname.includes('/find') ||
+    pathname.includes('/liquidity')
   ) {
     return 1
   }


### PR DESCRIPTION
Bug location: https://pancakeswap.finance/liquidity

**Button menu doesn't toggle to the correct item.**

### Current:
![Screen Shot 2021-07-17 at 3 43 07 PM](https://user-images.githubusercontent.com/6894325/126050866-888d3b5e-abce-494c-be68-8fbc171c0124.png)

### Fix:
![Screen Shot 2021-07-17 at 3 44 03 PM](https://user-images.githubusercontent.com/6894325/126050877-75df6e5b-35fc-4e8c-be53-88e148b4e267.png)
