### PR TITLE
Feature/lottery history loading

### DIFF
--- a/src/views/Lottery/components/HistoryTabMenu.tsx
+++ b/src/views/Lottery/components/HistoryTabMenu.tsx
@@ -7,8 +7,8 @@ const HistoryTabMenu = ({ setActiveIndex, activeIndex }) => {
 
   return (
     <ButtonMenu activeIndex={activeIndex} onItemClick={setActiveIndex} scale="sm" variant="subtle">
-      <ButtonMenuItem>{t('Your History')}</ButtonMenuItem>
       <ButtonMenuItem>{t('All History')}</ButtonMenuItem>
+      <ButtonMenuItem>{t('Your History')}</ButtonMenuItem>
     </ButtonMenu>
   )
 }

--- a/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { Flex, ExpandableLabel, CardFooter, Skeleton } from '@pancakeswap/uikit'
-import usePreviousValue from 'hooks/usePreviousValue'
+import React, { useState } from 'react'
+import { Flex, ExpandableLabel, CardFooter } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryRound } from 'state/types'
 import FooterExpanded from './FooterExpanded'
@@ -13,26 +12,14 @@ interface PreviousRoundCardFooterProps {
 const PreviousRoundCardFooter: React.FC<PreviousRoundCardFooterProps> = ({ lotteryData, lotteryId }) => {
   const { t } = useTranslation()
   const [isExpanded, setIsExpanded] = useState(false)
-  const previousLotteryId = usePreviousValue(lotteryId)
-
-  useEffect(() => {
-    // Close when changing lottery rounds
-    if (lotteryId !== previousLotteryId) {
-      setIsExpanded(false)
-    }
-  }, [lotteryId, previousLotteryId])
 
   return (
     <CardFooter p="0">
-      {isExpanded && lotteryData && <FooterExpanded lotteryData={lotteryData} lotteryId={lotteryId} />}
+      {isExpanded && <FooterExpanded lotteryData={lotteryData} lotteryId={lotteryId} />}
       <Flex p="8px 24px" alignItems="center" justifyContent="center">
-        {lotteryData ? (
-          <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
-            {isExpanded ? t('Hide') : t('Details')}
-          </ExpandableLabel>
-        ) : (
-          <Skeleton height="24px" width="83px" my="12px" />
-        )}
+        <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
+          {isExpanded ? t('Hide') : t('Details')}
+        </ExpandableLabel>
       </Flex>
     </CardFooter>
   )

--- a/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
@@ -38,7 +38,7 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
     return (
       <>
         {prizeInBusd.isNaN() ? (
-          <Skeleton my="7px" height={40} width={160} />
+          <Skeleton my="7px" height={40} width={200} />
         ) : (
           <Heading scale="xl" lineHeight="1" color="secondary">
             ~${formatNumber(getBalanceNumber(prizeInBusd), 0, 0)}
@@ -67,13 +67,16 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
           {getPrizeBalances()}
         </Box>
         <Box mb="24px">
-          {lotteryGraphData.totalUsers ? (
-            <Text fontSize="14px">
-              {t('Total players this round')}: {lotteryGraphData.totalUsers.toLocaleString()}
+          <Flex>
+            <Text fontSize="14px" display="inline">
+              {t('Total players this round')}:{' '}
+              {lotteryData && lotteryGraphData.totalUsers ? (
+                lotteryGraphData.totalUsers.toLocaleString()
+              ) : (
+                <Skeleton height={14} width={31} />
+              )}
             </Text>
-          ) : (
-            <Skeleton height={14} width={40} />
-          )}
+          </Flex>
         </Box>
       </Flex>
       <RewardBrackets lotteryData={lotteryData} isHistoricRound />

--- a/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import BigNumber from 'bignumber.js'
 import { Flex, Skeleton, Heading, Box, Text } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryRound } from 'state/types'
@@ -24,10 +25,14 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
   lotteryId,
 }) => {
   const { t } = useTranslation()
-  const { amountCollectedInCake } = lotteryData
   const lotteryGraphData = useGetLotteryGraphDataById(lotteryId)
   const cakePriceBusd = usePriceCakeBusd()
-  const prizeInBusd = amountCollectedInCake.times(cakePriceBusd)
+
+  let prizeInBusd = new BigNumber(NaN)
+  if (lotteryData) {
+    const { amountCollectedInCake } = lotteryData
+    prizeInBusd = amountCollectedInCake.times(cakePriceBusd)
+  }
 
   const getPrizeBalances = () => {
     return (
@@ -46,7 +51,7 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
             fontSize="14px"
             color="textSubtle"
             unit=" CAKE"
-            value={getBalanceNumber(amountCollectedInCake)}
+            value={getBalanceNumber(lotteryData?.amountCollectedInCake)}
             decimals={0}
           />
         )}
@@ -62,9 +67,13 @@ const PreviousRoundCardFooter: React.FC<{ lotteryData: LotteryRound; lotteryId: 
           {getPrizeBalances()}
         </Box>
         <Box mb="24px">
-          <Text fontSize="14px">
-            {t('Total players this round')}: {lotteryGraphData.totalUsers?.toLocaleString()}
-          </Text>
+          {lotteryGraphData.totalUsers ? (
+            <Text fontSize="14px">
+              {t('Total players this round')}: {lotteryGraphData.totalUsers.toLocaleString()}
+            </Text>
+          ) : (
+            <Skeleton height={14} width={40} />
+          )}
         </Box>
       </Flex>
       <RewardBrackets lotteryData={lotteryData} isHistoricRound />

--- a/src/views/Lottery/components/RewardBracketDetail.tsx
+++ b/src/views/Lottery/components/RewardBracketDetail.tsx
@@ -12,6 +12,7 @@ interface RewardBracketDetailProps {
   numberWinners?: string
   isBurn?: boolean
   isHistoricRound?: boolean
+  isLoading?: boolean
 }
 
 const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
@@ -20,10 +21,10 @@ const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
   numberWinners,
   isHistoricRound,
   isBurn,
+  isLoading,
 }) => {
   const { t } = useTranslation()
   const cakePriceBusd = usePriceCakeBusd()
-  const prizeInBusd = cakeAmount.times(cakePriceBusd)
 
   const getRewardText = () => {
     const numberMatch = rewardBracket + 1
@@ -38,30 +39,48 @@ const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
 
   return (
     <Flex flexDirection="column">
-      <Text bold color={isBurn ? 'failure' : 'secondary'}>
-        {getRewardText()}
-      </Text>
+      {isLoading ? (
+        <Skeleton my="4px" height={16} width={80} />
+      ) : (
+        <Text bold color={isBurn ? 'failure' : 'secondary'}>
+          {getRewardText()}
+        </Text>
+      )}
       <>
-        {prizeInBusd.isNaN() ? (
-          <Skeleton my="2px" height={12} width={90} />
+        {isLoading || cakeAmount.isNaN() ? (
+          <Skeleton my="4px" height={20} width={100} />
         ) : (
           <Balance fontSize="20px" bold unit=" CAKE" value={getBalanceNumber(cakeAmount)} decimals={0} />
         )}
-        {prizeInBusd.isNaN() ? (
+        {isLoading || cakeAmount.isNaN() ? (
           <Skeleton my="2px" height={12} width={70} />
         ) : (
-          <Balance fontSize="12px" color="textSubtle" prefix="~$" value={getBalanceNumber(prizeInBusd)} decimals={0} />
+          <Balance
+            fontSize="12px"
+            color="textSubtle"
+            prefix="~$"
+            value={getBalanceNumber(cakeAmount.times(cakePriceBusd))}
+            decimals={0}
+          />
         )}
         {isHistoricRound && cakeAmount && (
           <>
-            {numberWinners !== '0' && (
+            {isLoading ? (
+              <Skeleton my="2px" height={12} width={50} />
+            ) : (
+              numberWinners !== '0' && (
+                <Text fontSize="12px" color="textSubtle">
+                  {getFullDisplayBalance(cakeAmount.div(parseInt(numberWinners, 10)), 18, 2)} CAKE {t('each')}
+                </Text>
+              )
+            )}
+            {isLoading ? (
+              <Skeleton my="2px" height={12} width={40} />
+            ) : (
               <Text fontSize="12px" color="textSubtle">
-                {getFullDisplayBalance(cakeAmount.div(parseInt(numberWinners, 10)), 18, 2)} CAKE {t('each')}
+                {numberWinners} {t('Winners')}
               </Text>
             )}
-            <Text fontSize="12px" color="textSubtle">
-              {numberWinners} {t('Winners')}
-            </Text>
           </>
         )}
       </>

--- a/src/views/Lottery/components/RewardBracketDetail.tsx
+++ b/src/views/Lottery/components/RewardBracketDetail.tsx
@@ -40,7 +40,7 @@ const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
   return (
     <Flex flexDirection="column">
       {isLoading ? (
-        <Skeleton my="4px" height={16} width={80} />
+        <Skeleton mb="4px" mt="8px" height={16} width={80} />
       ) : (
         <Text bold color={isBurn ? 'failure' : 'secondary'}>
           {getRewardText()}
@@ -48,12 +48,14 @@ const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
       )}
       <>
         {isLoading || cakeAmount.isNaN() ? (
-          <Skeleton my="4px" height={20} width={100} />
+          <Skeleton my="4px" mr="10px" height={20} width={110} />
         ) : (
           <Balance fontSize="20px" bold unit=" CAKE" value={getBalanceNumber(cakeAmount)} decimals={0} />
         )}
         {isLoading || cakeAmount.isNaN() ? (
-          <Skeleton my="2px" height={12} width={70} />
+          <>
+            <Skeleton mt="4px" mb="16px" height={12} width={70} />
+          </>
         ) : (
           <Balance
             fontSize="12px"
@@ -65,22 +67,14 @@ const RewardBracketDetail: React.FC<RewardBracketDetailProps> = ({
         )}
         {isHistoricRound && cakeAmount && (
           <>
-            {isLoading ? (
-              <Skeleton my="2px" height={12} width={50} />
-            ) : (
-              numberWinners !== '0' && (
-                <Text fontSize="12px" color="textSubtle">
-                  {getFullDisplayBalance(cakeAmount.div(parseInt(numberWinners, 10)), 18, 2)} CAKE {t('each')}
-                </Text>
-              )
-            )}
-            {isLoading ? (
-              <Skeleton my="2px" height={12} width={40} />
-            ) : (
+            {numberWinners !== '0' && (
               <Text fontSize="12px" color="textSubtle">
-                {numberWinners} {t('Winners')}
+                {getFullDisplayBalance(cakeAmount.div(parseInt(numberWinners, 10)), 18, 2)} CAKE {t('each')}
               </Text>
             )}
+            <Text fontSize="12px" color="textSubtle">
+              {numberWinners} {t('Winners')}
+            </Text>
           </>
         )}
       </>

--- a/src/views/Lottery/components/RewardBrackets.tsx
+++ b/src/views/Lottery/components/RewardBrackets.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import BigNumber from 'bignumber.js'
 import { Flex, Text } from '@pancakeswap/uikit'
 import styled from 'styled-components'
+import { BIG_ZERO } from 'utils/bigNumber'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryRound } from 'state/types'
 import RewardBracketDetail from './RewardBracketDetail'
@@ -26,18 +27,57 @@ interface RewardMatchesProps {
   isHistoricRound?: boolean
 }
 
+interface RewardsState {
+  isLoading: boolean
+  cakeToBurn: BigNumber
+  rewardsLessTreasuryFee: BigNumber
+  rewardsBreakdown: string[]
+  countWinnersPerBracket: string[]
+}
+
 const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricRound }) => {
   const { t } = useTranslation()
-  const { treasuryFee, amountCollectedInCake, rewardsBreakdown, countWinnersPerBracket } = lotteryData
+  const [state, setState] = useState<RewardsState>({
+    isLoading: true,
+    cakeToBurn: BIG_ZERO,
+    rewardsLessTreasuryFee: BIG_ZERO,
+    rewardsBreakdown: null,
+    countWinnersPerBracket: null,
+  })
 
-  const feeAsPercentage = new BigNumber(treasuryFee).div(100)
-  const cakeToBurn = feeAsPercentage.div(100).times(new BigNumber(amountCollectedInCake))
-  const amountLessTreasuryFee = new BigNumber(amountCollectedInCake).minus(cakeToBurn)
+  useEffect(() => {
+    if (lotteryData) {
+      const { treasuryFee, amountCollectedInCake, rewardsBreakdown, countWinnersPerBracket } = lotteryData
+
+      const feeAsPercentage = new BigNumber(treasuryFee).div(100)
+      const cakeToBurn = feeAsPercentage.div(100).times(new BigNumber(amountCollectedInCake))
+      const amountLessTreasuryFee = new BigNumber(amountCollectedInCake).minus(cakeToBurn)
+      setState({
+        isLoading: false,
+        cakeToBurn,
+        rewardsLessTreasuryFee: amountLessTreasuryFee,
+        rewardsBreakdown,
+        countWinnersPerBracket,
+      })
+    } else {
+      setState({
+        isLoading: true,
+        cakeToBurn: BIG_ZERO,
+        rewardsLessTreasuryFee: BIG_ZERO,
+        rewardsBreakdown: null,
+        countWinnersPerBracket: null,
+      })
+    }
+  }, [lotteryData])
 
   const getCakeRewards = (bracket: number) => {
-    const shareAsPercentage = new BigNumber(rewardsBreakdown[bracket]).div(100)
-    return amountLessTreasuryFee.div(100).times(shareAsPercentage)
+    const shareAsPercentage = new BigNumber(state.rewardsBreakdown[bracket]).div(100)
+    return state.rewardsLessTreasuryFee.div(100).times(shareAsPercentage)
   }
+
+  const { isLoading, countWinnersPerBracket, cakeToBurn } = state
+
+  const rewardBrackets = [0, 1, 2, 3, 4, 5]
 
   return (
     <Wrapper>
@@ -46,42 +86,16 @@ const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricR
         {!isHistoricRound && t('Current prizes up for grabs:')}
       </Text>
       <RewardsInner>
-        <RewardBracketDetail
-          rewardBracket={5}
-          cakeAmount={getCakeRewards(5)}
-          numberWinners={countWinnersPerBracket[5]}
-          isHistoricRound={isHistoricRound}
-        />
-        <RewardBracketDetail
-          rewardBracket={4}
-          cakeAmount={getCakeRewards(4)}
-          numberWinners={countWinnersPerBracket[4]}
-          isHistoricRound={isHistoricRound}
-        />
-        <RewardBracketDetail
-          rewardBracket={3}
-          cakeAmount={getCakeRewards(3)}
-          numberWinners={countWinnersPerBracket[3]}
-          isHistoricRound={isHistoricRound}
-        />
-        <RewardBracketDetail
-          rewardBracket={2}
-          cakeAmount={getCakeRewards(2)}
-          numberWinners={countWinnersPerBracket[2]}
-          isHistoricRound={isHistoricRound}
-        />
-        <RewardBracketDetail
-          rewardBracket={1}
-          cakeAmount={getCakeRewards(1)}
-          numberWinners={countWinnersPerBracket[1]}
-          isHistoricRound={isHistoricRound}
-        />
-        <RewardBracketDetail
-          rewardBracket={0}
-          cakeAmount={getCakeRewards(0)}
-          numberWinners={countWinnersPerBracket[0]}
-          isHistoricRound={isHistoricRound}
-        />
+        {rewardBrackets.map((bracketIndex) => (
+          <RewardBracketDetail
+            key={bracketIndex}
+            rewardBracket={bracketIndex}
+            cakeAmount={!isLoading && getCakeRewards(bracketIndex)}
+            numberWinners={!isLoading && countWinnersPerBracket[bracketIndex]}
+            isHistoricRound={isHistoricRound}
+            isLoading={isLoading}
+          />
+        ))}
         <RewardBracketDetail rewardBracket={0} cakeAmount={cakeToBurn} isBurn />
       </RewardsInner>
     </Wrapper>

--- a/src/views/Lottery/components/RewardBrackets.tsx
+++ b/src/views/Lottery/components/RewardBrackets.tsx
@@ -96,7 +96,7 @@ const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricR
             isLoading={isLoading}
           />
         ))}
-        <RewardBracketDetail rewardBracket={0} cakeAmount={cakeToBurn} isBurn />
+        <RewardBracketDetail rewardBracket={0} cakeAmount={cakeToBurn} isBurn isLoading={isLoading} />
       </RewardsInner>
     </Wrapper>
   )

--- a/src/views/Lottery/index.tsx
+++ b/src/views/Lottery/index.tsx
@@ -92,7 +92,7 @@ const Lottery = () => {
               setActiveIndex={(index) => setHistoryTabMenuIndex(index)}
             />
           </Box>
-          {historyTabMenuIndex === 0 ? <YourHistoryCard /> : <AllHistoryCard />}
+          {historyTabMenuIndex === 0 ? <AllHistoryCard /> : <YourHistoryCard />}
         </Flex>
       </PageSection>
 


### PR DESCRIPTION
Add loading behaviour to each element within the lottery history footer - so that it can remain expanded as a user browses between rounds. 

- Use of effects and `isLoading` state where necessary to manage null data being passed to the component
- Lots of additional `<Skeleton>` components


https://user-images.githubusercontent.com/79279477/126335389-5e3cb3d1-f1af-48e1-bde8-e40c2d3b6542.mov
