### PR TITLE
fix: Changing the farm view setting affects view of pool or vice versa

### DIFF
--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -61,7 +61,7 @@ const Pools: React.FC = () => {
   const [numberOfPoolsVisible, setNumberOfPoolsVisible] = useState(NUMBER_OF_POOLS_VISIBLE)
   const [observerIsSet, setObserverIsSet] = useState(false)
   const loadMoreRef = useRef<HTMLDivElement>(null)
-  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, { localStorageKey: 'pancake_farm_view' })
+  const [viewMode, setViewMode] = usePersistState(ViewMode.TABLE, { localStorageKey: 'pancake_pool_view' })
   const [searchQuery, setSearchQuery] = useState('')
   const [sortOption, setSortOption] = useState('hot')
   const chosenPoolsLength = useRef(0)


### PR DESCRIPTION
To review: 

https://deploy-preview-1765--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to pools
2. Change view to card
3. Go to farms
4. See view changed to cards