### PR TITLE
fix: Staked only setting persistent storage missing in farms

### DIFF
--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -13,6 +13,12 @@ export interface SerializedPair {
   token1: SerializedToken
 }
 
+export enum FarmStakedOnly {
+  ON_FINISHED = 'onFinished',
+  TRUE = 'true',
+  FALSE = 'false',
+}
+
 export const updateUserExpertMode = createAction<{ userExpertMode: boolean }>('user/updateUserExpertMode')
 export const updateUserSingleHopOnly = createAction<{ userSingleHopOnly: boolean }>('user/updateUserSingleHopOnly')
 export const updateUserSlippageTolerance = createAction<{ userSlippageTolerance: number }>(
@@ -28,3 +34,6 @@ export const removeSerializedPair =
 export const muteAudio = createAction<void>('user/muteAudio')
 export const unmuteAudio = createAction<void>('user/unmuteAudio')
 export const toggleTheme = createAction<void>('user/toggleTheme')
+export const updateUserFarmStakedOnly = createAction<{ userFarmStakedOnly: FarmStakedOnly }>(
+  'user/updateUserFarmStakedOnly',
+)

--- a/src/state/user/hooks/index.tsx
+++ b/src/state/user/hooks/index.tsx
@@ -9,17 +9,19 @@ import { AppDispatch, AppState } from '../../index'
 import {
   addSerializedPair,
   addSerializedToken,
+  FarmStakedOnly,
+  muteAudio,
   removeSerializedToken,
   SerializedPair,
+  toggleTheme as toggleThemeAction,
+  unmuteAudio,
   updateUserDeadline,
   updateUserExpertMode,
-  updateUserSlippageTolerance,
+  updateUserFarmStakedOnly,
   updateUserSingleHopOnly,
-  muteAudio,
-  unmuteAudio,
-  toggleTheme as toggleThemeAction,
+  updateUserSlippageTolerance,
 } from '../actions'
-import { serializeToken, deserializeToken } from './helpers'
+import { deserializeToken, serializeToken } from './helpers'
 
 export function useAudioModeManager(): [boolean, () => void] {
   const dispatch = useDispatch<AppDispatch>()
@@ -93,6 +95,26 @@ export function useUserSlippageTolerance(): [number, (slippage: number) => void]
   )
 
   return [userSlippageTolerance, setUserSlippageTolerance]
+}
+
+export function useUserFarmStakedOnly(isActive: boolean): [boolean, (stakedOnly: boolean) => void] {
+  const dispatch = useDispatch<AppDispatch>()
+  const userFarmStakedOnly = useSelector<AppState, AppState['user']['userFarmStakedOnly']>((state) => {
+    return state.user.userFarmStakedOnly
+  })
+
+  const setUserFarmStakedOnly = useCallback(
+    (stakedOnly: boolean) => {
+      const farmStakedOnly = stakedOnly ? FarmStakedOnly.TRUE : FarmStakedOnly.FALSE
+      dispatch(updateUserFarmStakedOnly({ userFarmStakedOnly: farmStakedOnly }))
+    },
+    [dispatch],
+  )
+
+  return [
+    userFarmStakedOnly === FarmStakedOnly.ON_FINISHED ? !isActive : userFarmStakedOnly === FarmStakedOnly.TRUE,
+    setUserFarmStakedOnly,
+  ]
 }
 
 export function useUserTransactionTTL(): [number, (slippage: number) => void] {

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -15,6 +15,8 @@ import {
   muteAudio,
   unmuteAudio,
   toggleTheme,
+  updateUserFarmStakedOnly,
+  FarmStakedOnly,
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -50,6 +52,7 @@ export interface UserState {
   timestamp: number
   audioPlay: boolean
   isDark: boolean
+  userFarmStakedOnly: FarmStakedOnly
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -66,6 +69,7 @@ export const initialState: UserState = {
   timestamp: currentTimestamp(),
   audioPlay: true,
   isDark: false,
+  userFarmStakedOnly: FarmStakedOnly.ON_FINISHED,
 }
 
 export default createReducer(initialState, (builder) =>
@@ -143,5 +147,8 @@ export default createReducer(initialState, (builder) =>
     })
     .addCase(toggleTheme, (state) => {
       state.isDark = !state.isDark
+    })
+    .addCase(updateUserFarmStakedOnly, (state, { payload: { userFarmStakedOnly } }) => {
+      state.userFarmStakedOnly = userFarmStakedOnly
     }),
 )

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -16,6 +16,7 @@ import { getFarmApr } from 'utils/apr'
 import { orderBy } from 'lodash'
 import isArchivedPid from 'utils/farmHelpers'
 import { latinise } from 'utils/latinise'
+import { useUserFarmStakedOnly } from 'state/user/hooks'
 import PageHeader from 'components/PageHeader'
 import SearchInput from 'components/SearchInput'
 import Select, { OptionProps } from 'components/Select/Select'
@@ -133,10 +134,7 @@ const Farms: React.FC = () => {
   // Connected users should see loading indicator until first userData has loaded
   const userDataReady = !account || (!!account && userDataLoaded)
 
-  const [stakedOnly, setStakedOnly] = useState(!isActive)
-  useEffect(() => {
-    setStakedOnly(!isActive)
-  }, [isActive])
+  const [stakedOnly, setStakedOnly] = useUserFarmStakedOnly(isActive)
 
   const activeFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier !== '0X' && !isArchivedPid(farm.pid))
   const inactiveFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X' && !isArchivedPid(farm.pid))


### PR DESCRIPTION
To review: 

https://deploy-preview-1777--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to farms
2. Toggle staked only
3. Refresh the page
4. See the new setting is not persistent

This fix also keeps the feature of showing staked only farms when finished farms selected (until user toggles a new setting)