### PR TITLE
fix(farms): Round farm staking balances below 0.0000001 to 10dp

### DIFF
--- a/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -57,6 +57,9 @@ const StakeAction: React.FC<FarmCardActionsProps> = ({
 
   const displayBalance = useCallback(() => {
     const stakedBalanceBigNumber = getBalanceAmount(stakedBalance)
+    if (stakedBalanceBigNumber.gt(0) && stakedBalanceBigNumber.lt(0.0000001)) {
+      return stakedBalanceBigNumber.toFixed(10, BigNumber.ROUND_DOWN)
+    }
     if (stakedBalanceBigNumber.gt(0) && stakedBalanceBigNumber.lt(0.0001)) {
       return getFullDisplayBalance(stakedBalance).toLocaleString()
     }

--- a/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -69,6 +69,9 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({
 
   const displayBalance = useCallback(() => {
     const stakedBalanceBigNumber = getBalanceAmount(stakedBalance)
+    if (stakedBalanceBigNumber.gt(0) && stakedBalanceBigNumber.lt(0.0000001)) {
+      return stakedBalanceBigNumber.toFixed(10, BigNumber.ROUND_DOWN)
+    }
     if (stakedBalanceBigNumber.gt(0) && stakedBalanceBigNumber.lt(0.0001)) {
       return getFullDisplayBalance(stakedBalance).toLocaleString()
     }


### PR DESCRIPTION

<img width="545" alt="Screenshot 2021-07-26 at 11 01 46" src="https://user-images.githubusercontent.com/79279477/126971244-a3fa2150-26f2-4fc6-bc14-f4aa89f701db.png">


Solved by rounding the staked balance to 10 decimal places when it's below `0.0000001`
![Screenshot 2021-07-26 at 11 00 56](https://user-images.githubusercontent.com/79279477/126971107-ee5ff8d8-f650-481d-b310-3b34d93e284e.png)
