### PR TITLE
fix: Numberformat compact not shown properly in mobile safari (below 14.7)

### DIFF
--- a/src/views/Home/components/MetricsSection/StatCardContent.tsx
+++ b/src/views/Home/components/MetricsSection/StatCardContent.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { Heading, Flex, Text } from '@pancakeswap/uikit'
+import { Heading, Flex, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 
 const StatCardContent: React.FC<{ headingText: string; bodyText: string; highlightColor: string }> = ({
   headingText,
   bodyText,
   highlightColor,
 }) => {
+  const { isXl } = useMatchBreakpoints()
+  const isMobile = !isXl
   const split = headingText.split(' ')
   const lastWord = split.pop()
   const remainingWords = split.slice(0, split.length).join(' ')
@@ -19,7 +21,11 @@ const StatCardContent: React.FC<{ headingText: string; bodyText: string; highlig
       justifyContent="flex-end"
       mt={[null, null, null, '64px']}
     >
-      <Heading scale="xl">{remainingWords}</Heading>
+      {isMobile && remainingWords.length > 13 ? (
+        <Heading scale="lg">{remainingWords}</Heading>
+      ) : (
+        <Heading scale="xl">{remainingWords}</Heading>
+      )}
       <Heading color={highlightColor} scale="xl" mb="24px">
         {lastWord}
       </Heading>


### PR DESCRIPTION
To review:

https://deploy-preview-1803--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to homepage with mobile Safari
2. Check the numbers in Used by millions. Trusted with billions.
3. See that compact option could not be applied there

It is not supported in mobile safari until 14.7
https://caniuse.com/?search=numberformat%20notation

Before:

![CF8DEAE6-D94B-4CC4-9D60-A0D5DCB9F4A1](https://user-images.githubusercontent.com/2213635/127503592-54b37126-0a82-43c4-8833-9bb1f535b671.jpeg)

After:

![image](https://user-images.githubusercontent.com/2213635/129026770-fb889c39-6d52-483a-bbc8-bb0875c1fc4f.png)

