### PR TITLE
feat(farm/pool): BTT

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -39,6 +39,16 @@ const farms: FarmConfig[] = [
    * V3 by order of release (some may be out of PID order due to multiplier boost)
    */
   {
+    pid: 367,
+    lpSymbol: 'BTT-BNB LP',
+    lpAddresses: {
+      97: '',
+      56: '0x946696344e7d4346b223e1cf77035a76690d6a73',
+    },
+    token: tokens.btt,
+    quoteToken: tokens.wbnb,
+  },
+  {
     pid: 434,
     lpSymbol: 'SKILL-BNB LP',
     lpAddresses: {
@@ -787,16 +797,6 @@ const farms: FarmConfig[] = [
     },
     token: tokens.mcoin,
     quoteToken: tokens.ust,
-  },
-  {
-    pid: 367,
-    lpSymbol: 'BTT-BNB LP',
-    lpAddresses: {
-      97: '',
-      56: '0x946696344e7d4346b223e1cf77035a76690d6a73',
-    },
-    token: tokens.btt,
-    quoteToken: tokens.wbnb,
   },
   {
     pid: 366,

--- a/src/config/constants/pools.ts
+++ b/src/config/constants/pools.ts
@@ -17,6 +17,19 @@ const pools: PoolConfig[] = [
     isFinished: false,
   },
   {
+    sousId: 207,
+    stakingToken: tokens.cake,
+    earningToken: tokens.btt,
+    contractAddress: {
+      97: '',
+      56: '0x3b804460c3c62f0f565af593984159f13b1ac976',
+    },
+    poolCategory: PoolCategory.CORE,
+    harvest: true,
+    sortOrder: 999,
+    tokenPerBlock: '263',
+  },
+  {
     sousId: 206,
     stakingToken: tokens.cake,
     earningToken: tokens.skill,


### PR DESCRIPTION
The Syrup Pool:
Stake CAKE tokens to earn BTT tokens!

Total Tokens: 454,500,000 BTT
Distribution duration: 60 days
Start block: 9677600 (approx. 5am UTC on August 2nd)
Finish block: 11405600 (approx. 5am UTC on October 3rd)
Token rewards per block: 263 BTT
