### PR TITLE
fix(user-menu): Catch for when user doesn't have an nft profile pic

### DIFF
--- a/src/components/Menu/UserMenu/index.tsx
+++ b/src/components/Menu/UserMenu/index.tsx
@@ -26,7 +26,7 @@ const UserMenu = () => {
   const [onPresentWalletModal] = useModal(<WalletModal initialView={WalletView.WALLET_INFO} />)
   const [onPresentTransactionModal] = useModal(<WalletModal initialView={WalletView.TRANSACTIONS} />)
   const hasProfile = isInitialized && !!profile
-  const avatarSrc = profile ? `/images/nfts/${profile.nft.images.sm}` : undefined
+  const avatarSrc = profile && profile.nft ? `/images/nfts/${profile.nft.images.sm}` : undefined
   const hasLowBnbBalance = fetchStatus === FetchStatus.SUCCESS && balance.lte(LOW_BNB_BALANCE)
 
   if (!account) {


### PR DESCRIPTION
- Users without nft profile pictures will now experience an app crash as it attempts to access `.nft.images` which is undefined
- Add `profile.nft` to the avatarSrc ternary