### PR TITLE
fix: Should call _uniqueId in view ticket modal lottery

### DIFF
--- a/src/views/Lottery/components/TicketNumber.tsx
+++ b/src/views/Lottery/components/TicketNumber.tsx
@@ -52,7 +52,7 @@ const TicketNumber: React.FC<TicketNumberProps> = ({ localId, id, number, reward
       <StyledNumberWrapper>
         {rewardBracket >= 0 && <RewardHighlighter numberMatches={numberMatches} />}
         {numberAsArray.map((digit) => (
-          <Text key={`${localId || id}-${digit}-${_uniqueId}`} fontSize="16px">
+          <Text key={`${localId || id}-${digit}-${_uniqueId()}`} fontSize="16px">
             {digit}
           </Text>
         ))}


### PR DESCRIPTION
**Environment:**
Device and OS: Any
Browser: Any
Reproducibility rate: 100%

**Steps to reproduce:**
1. Open view your tickets modal on the lottery page
2. Check console in dev tool
![2021-08-10 00 10 31](https://user-images.githubusercontent.com/17973301/128746273-30841371-23aa-49e4-8540-822b6254dff1.jpg)

By calling `_uniqueId()` we will get rid of the same key problem. I think the devs forgot to call it. 
