### PR TITLE
feat(lottery-history): Fetch additional data from graph when lottery history is missing rounds

### DIFF
--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -3,7 +3,7 @@ import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
 import { LotteryRoundGraphEntity, LotteryResponse } from 'state/types'
 import { getRoundIdsArray, fetchMultipleLotteries } from './helpers'
 
-const MAX_LOTTERIES_REQUEST_SIZE = 100
+export const MAX_LOTTERIES_REQUEST_SIZE = 5
 
 const applyNodeDataToLotteriesGraphResponse = (
   nodeData: LotteryResponse[],

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -3,7 +3,10 @@ import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
 import { LotteryRoundGraphEntity, LotteryResponse } from 'state/types'
 import { getRoundIdsArray, fetchMultipleLotteries } from './helpers'
 
-export const MAX_LOTTERIES_REQUEST_SIZE = 5
+export const MAX_LOTTERIES_REQUEST_SIZE = 100
+
+/* eslint-disable camelcase */
+type LotteriesWhere = { id_in?: string[] }
 
 const applyNodeDataToLotteriesGraphResponse = (
   nodeData: LotteryResponse[],
@@ -55,13 +58,14 @@ const applyNodeDataToLotteriesGraphResponse = (
 export const getGraphLotteries = async (
   first = MAX_LOTTERIES_REQUEST_SIZE,
   skip = 0,
+  where: LotteriesWhere = {},
 ): Promise<LotteryRoundGraphEntity[]> => {
   try {
     const response = await request(
       GRAPH_API_LOTTERY,
       gql`
-        query getLotteries($first: Int!, $skip: Int!) {
-          lotteries(first: $first, skip: $skip, orderDirection: desc, orderBy: block) {
+        query getLotteries($first: Int!, $skip: Int!, $where: Lottery_filter) {
+          lotteries(first: $first, skip: $skip, where: $where, orderDirection: desc, orderBy: block) {
             id
             totalUsers
             totalTickets
@@ -74,7 +78,7 @@ export const getGraphLotteries = async (
           }
         }
       `,
-      { skip, first },
+      { skip, first, where },
     )
     return response.lotteries
   } catch (error) {

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -11,7 +11,6 @@ import { ethersToSerializedBigNumber } from 'utils/bigNumber'
 import { NUM_ROUNDS_TO_FETCH_FROM_NODES } from 'config/constants/lottery'
 
 const lotteryContract = getLotteryV2Contract()
-// Variable used to determine how many past rounds should be populated by node data rather than subgraph
 
 const processViewLotterySuccessResponse = (response, lotteryId: string): LotteryResponse => {
   const {

--- a/src/state/lottery/hooks.ts
+++ b/src/state/lottery/hooks.ts
@@ -44,7 +44,7 @@ export const useFetchLottery = () => {
 
   useEffect(() => {
     if (currentLotteryId) {
-      // Get historical lottery data from nodes + subgraph
+      // Get historical lottery data from nodes +  last 100 subgraph entires
       dispatch(fetchPublicLotteries({ currentLotteryId }))
       // get public data for current lottery
       dispatch(fetchCurrentLottery({ currentLotteryId }))

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -3,7 +3,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { LotteryTicket, LotteryStatus } from 'config/constants/types'
 import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
 import { fetchLottery, fetchCurrentLotteryIdAndMaxBuy } from './helpers'
-import getLotteriesData, { getGraphLotteries } from './getLotteriesData'
+import getLotteriesData from './getLotteriesData'
 import getUserLotteryData from './getUserLotteryData'
 
 interface PublicLotteryData {
@@ -77,14 +77,6 @@ export const fetchPublicLotteries = createAsyncThunk<LotteryRoundGraphEntity[], 
   },
 )
 
-export const fetchAdditionalPublicLotteries = createAsyncThunk<LotteryRoundGraphEntity[], { skip: number }>(
-  'lottery/fetchAdditionalPublicLotteries',
-  async ({ skip }) => {
-    const lotteries = await getGraphLotteries(skip)
-    return lotteries
-  },
-)
-
 export const fetchUserLotteries = createAsyncThunk<
   LotteryUserGraphEntity,
   { account: string; currentLotteryId: string }
@@ -127,12 +119,6 @@ export const LotterySlice = createSlice({
     builder.addCase(fetchPublicLotteries.fulfilled, (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
       state.lotteriesData = action.payload
     })
-    builder.addCase(
-      fetchAdditionalPublicLotteries.fulfilled,
-      (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
-        state.lotteriesData = { ...state.lotteriesData, ...action.payload }
-      },
-    )
     builder.addCase(fetchUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {
       state.userLotteryData = action.payload
     })

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -3,7 +3,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { LotteryTicket, LotteryStatus } from 'config/constants/types'
 import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
 import { fetchLottery, fetchCurrentLotteryIdAndMaxBuy } from './helpers'
-import getLotteriesData from './getLotteriesData'
+import getLotteriesData, { getGraphLotteries } from './getLotteriesData'
 import getUserLotteryData from './getUserLotteryData'
 
 interface PublicLotteryData {
@@ -77,6 +77,14 @@ export const fetchPublicLotteries = createAsyncThunk<LotteryRoundGraphEntity[], 
   },
 )
 
+export const fetchAdditionalPublicLotteries = createAsyncThunk<LotteryRoundGraphEntity[], { skip: number }>(
+  'lottery/fetchAdditionalPublicLotteries',
+  async ({ skip }) => {
+    const lotteries = await getGraphLotteries(skip)
+    return lotteries
+  },
+)
+
 export const fetchUserLotteries = createAsyncThunk<
   LotteryUserGraphEntity,
   { account: string; currentLotteryId: string }
@@ -119,6 +127,12 @@ export const LotterySlice = createSlice({
     builder.addCase(fetchPublicLotteries.fulfilled, (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
       state.lotteriesData = action.payload
     })
+    builder.addCase(
+      fetchAdditionalPublicLotteries.fulfilled,
+      (state, action: PayloadAction<LotteryRoundGraphEntity[]>) => {
+        state.lotteriesData = { ...state.lotteriesData, ...action.payload }
+      },
+    )
     builder.addCase(fetchUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {
       state.userLotteryData = action.payload
     })

--- a/src/views/Lottery/components/AllHistoryCard/index.tsx
+++ b/src/views/Lottery/components/AllHistoryCard/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Card, Text, Skeleton, CardHeader, Box } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useAppDispatch } from 'state'
-import { fetchAdditionalPublicLotteries } from 'state/lottery'
 import { useLottery } from 'state/lottery/hooks'
 import { fetchLottery } from 'state/lottery/helpers'
 import { LotteryStatus } from 'config/constants/types'
@@ -36,10 +35,10 @@ const AllHistoryCard = () => {
   } = useLottery()
   const [latestRoundId, setLatestRoundId] = useState(null)
   const [selectedRoundId, setSelectedRoundId] = useState('')
-  const [selectedLotteryInfo, setSelectedLotteryInfo] = useState(null)
+  const [selectedLotteryNodeData, setSelectedLotteryNodeData] = useState(null)
   const timer = useRef(null)
 
-  const roundsFetched = lotteriesData?.length
+  const numRoundsFetched = lotteriesData?.length
 
   useEffect(() => {
     if (currentLotteryId) {
@@ -52,19 +51,12 @@ const AllHistoryCard = () => {
   }, [currentLotteryId, status])
 
   useEffect(() => {
-    setSelectedLotteryInfo(null)
+    setSelectedLotteryNodeData(null)
 
     const fetchLotteryData = async () => {
       const lotteryData = await fetchLottery(selectedRoundId)
       const processedLotteryData = processLotteryResponse(lotteryData)
-      setSelectedLotteryInfo(processedLotteryData)
-
-      if (roundsFetched) {
-        const hasSelectedRoundBeenFetched = parseInt(selectedRoundId) > parseInt(currentLotteryId) - roundsFetched
-        if (!hasSelectedRoundBeenFetched) {
-          dispatch(fetchAdditionalPublicLotteries({ skip: roundsFetched }))
-        }
-      }
+      setSelectedLotteryNodeData(processedLotteryData)
     }
 
     timer.current = setInterval(() => {
@@ -75,7 +67,7 @@ const AllHistoryCard = () => {
     }, 1000)
 
     return () => clearInterval(timer.current)
-  }, [selectedRoundId, currentLotteryId, roundsFetched, dispatch])
+  }, [selectedRoundId, currentLotteryId, numRoundsFetched, dispatch])
 
   const handleInputChange = (event) => {
     const {
@@ -114,17 +106,17 @@ const AllHistoryCard = () => {
           handleArrowButtonPress={handleArrowButtonPress}
         />
         <Box mt="8px">
-          {selectedLotteryInfo?.endTime ? (
+          {selectedLotteryNodeData?.endTime ? (
             <Text fontSize="14px">
-              {t('Drawn')} {getDrawnDate(selectedLotteryInfo.endTime)}
+              {t('Drawn')} {getDrawnDate(selectedLotteryNodeData.endTime)}
             </Text>
           ) : (
             <Skeleton width="185px" height="21px" />
           )}
         </Box>
       </StyledCardHeader>
-      <PreviousRoundCardBody lotteryData={selectedLotteryInfo} lotteryId={selectedRoundId} />
-      <PreviousRoundCardFooter lotteryData={selectedLotteryInfo} lotteryId={selectedRoundId} />
+      <PreviousRoundCardBody lotteryNodeData={selectedLotteryNodeData} lotteryId={selectedRoundId} />
+      <PreviousRoundCardFooter lotteryNodeData={selectedLotteryNodeData} lotteryId={selectedRoundId} />
     </StyledCard>
   )
 }

--- a/src/views/Lottery/components/NextDrawCard.tsx
+++ b/src/views/Lottery/components/NextDrawCard.tsx
@@ -195,7 +195,7 @@ const NextDrawCard = () => {
       <CardFooter p="0">
         {isExpanded && (
           <NextDrawWrapper>
-            <RewardBrackets lotteryData={currentRound} />
+            <RewardBrackets lotteryNodeData={currentRound} />
           </NextDrawWrapper>
         )}
         {(status === LotteryStatus.OPEN || status === LotteryStatus.CLOSE) && (

--- a/src/views/Lottery/components/PreviousRoundCard/Body.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Body.tsx
@@ -47,8 +47,8 @@ const StyedCardRibbon = styled(CardRibbon)`
   }
 `
 
-const PreviousRoundCardBody: React.FC<{ lotteryData: LotteryRound; lotteryId: string }> = ({
-  lotteryData,
+const PreviousRoundCardBody: React.FC<{ lotteryNodeData: LotteryRound; lotteryId: string }> = ({
+  lotteryNodeData,
   lotteryId,
 }) => {
   const { t } = useTranslation()
@@ -67,7 +67,7 @@ const PreviousRoundCardBody: React.FC<{ lotteryData: LotteryRound; lotteryId: st
   const isLatestRound = mostRecentFinishedRoundId.toString() === lotteryId
 
   const [onPresentViewTicketsModal] = useModal(
-    <ViewTicketsModal roundId={lotteryId} roundStatus={lotteryData?.status} />,
+    <ViewTicketsModal roundId={lotteryId} roundStatus={lotteryNodeData?.status} />,
   )
 
   return (
@@ -78,10 +78,10 @@ const PreviousRoundCardBody: React.FC<{ lotteryData: LotteryRound; lotteryId: st
           <Heading mb="24px">{t('Winning Number')}</Heading>
         </Flex>
         <Flex maxWidth={['240px', null, null, '100%']} justifyContent={['center', null, null, 'flex-start']}>
-          {lotteryData ? (
+          {lotteryNodeData ? (
             <WinningNumbers
               rotateText={isDesktop || false}
-              number={lotteryData?.finalNumber.toString()}
+              number={lotteryNodeData?.finalNumber.toString()}
               mr={[null, null, null, '32px']}
               size="100%"
               fontSize={isDesktop ? '42px' : '16px'}

--- a/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
@@ -5,17 +5,17 @@ import { LotteryRound } from 'state/types'
 import FooterExpanded from './FooterExpanded'
 
 interface PreviousRoundCardFooterProps {
-  lotteryData: LotteryRound
+  lotteryNodeData: LotteryRound
   lotteryId: string
 }
 
-const PreviousRoundCardFooter: React.FC<PreviousRoundCardFooterProps> = ({ lotteryData, lotteryId }) => {
+const PreviousRoundCardFooter: React.FC<PreviousRoundCardFooterProps> = ({ lotteryNodeData, lotteryId }) => {
   const { t } = useTranslation()
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
     <CardFooter p="0">
-      {isExpanded && <FooterExpanded lotteryData={lotteryData} lotteryId={lotteryId} />}
+      {isExpanded && <FooterExpanded lotteryNodeData={lotteryNodeData} lotteryId={lotteryId} />}
       <Flex p="8px 24px" alignItems="center" justifyContent="center">
         <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
           {isExpanded ? t('Hide') : t('Details')}

--- a/src/views/Lottery/components/RewardBrackets.tsx
+++ b/src/views/Lottery/components/RewardBrackets.tsx
@@ -23,7 +23,7 @@ const RewardsInner = styled.div`
 `
 
 interface RewardMatchesProps {
-  lotteryData: LotteryRound
+  lotteryNodeData: LotteryRound
   isHistoricRound?: boolean
 }
 
@@ -35,7 +35,7 @@ interface RewardsState {
   countWinnersPerBracket: string[]
 }
 
-const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricRound }) => {
+const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryNodeData, isHistoricRound }) => {
   const { t } = useTranslation()
   const [state, setState] = useState<RewardsState>({
     isLoading: true,
@@ -46,8 +46,8 @@ const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricR
   })
 
   useEffect(() => {
-    if (lotteryData) {
-      const { treasuryFee, amountCollectedInCake, rewardsBreakdown, countWinnersPerBracket } = lotteryData
+    if (lotteryNodeData) {
+      const { treasuryFee, amountCollectedInCake, rewardsBreakdown, countWinnersPerBracket } = lotteryNodeData
 
       const feeAsPercentage = new BigNumber(treasuryFee).div(100)
       const cakeToBurn = feeAsPercentage.div(100).times(new BigNumber(amountCollectedInCake))
@@ -68,7 +68,7 @@ const RewardBrackets: React.FC<RewardMatchesProps> = ({ lotteryData, isHistoricR
         countWinnersPerBracket: null,
       })
     }
-  }, [lotteryData])
+  }, [lotteryNodeData])
 
   const getCakeRewards = (bracket: number) => {
     const shareAsPercentage = new BigNumber(state.rewardsBreakdown[bracket]).div(100)

--- a/src/views/Lottery/components/YourHistoryCard/index.tsx
+++ b/src/views/Lottery/components/YourHistoryCard/index.tsx
@@ -46,7 +46,7 @@ const YourHistoryCard = () => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const [shouldShowRoundDetail, setShouldShowRoundDetail] = useState(false)
-  const [selectedLotteryInfo, setSelectedLotteryInfo] = useState<LotteryRound>(null)
+  const [selectedLotteryNodeData, setSelectedLotteryNodeData] = useState<LotteryRound>(null)
   const [selectedLotteryId, setSelectedLotteryId] = useState<string>(null)
 
   const {
@@ -61,12 +61,12 @@ const YourHistoryCard = () => {
     setSelectedLotteryId(lotteryId)
     const lotteryData = await fetchLottery(lotteryId)
     const processedLotteryData = processLotteryResponse(lotteryData)
-    setSelectedLotteryInfo(processedLotteryData)
+    setSelectedLotteryNodeData(processedLotteryData)
   }
 
   const clearState = () => {
     setShouldShowRoundDetail(false)
-    setSelectedLotteryInfo(null)
+    setSelectedLotteryNodeData(null)
     setSelectedLotteryId(null)
   }
 
@@ -79,9 +79,9 @@ const YourHistoryCard = () => {
             <Heading scale="md" mb="4px">
               {t('Round')} {selectedLotteryId || ''}
             </Heading>
-            {selectedLotteryInfo?.endTime ? (
+            {selectedLotteryNodeData?.endTime ? (
               <Text fontSize="14px">
-                {t('Drawn')} {getDrawnDate(selectedLotteryInfo.endTime)}
+                {t('Drawn')} {getDrawnDate(selectedLotteryNodeData.endTime)}
               </Text>
             ) : (
               <Skeleton width="185px" height="21px" />
@@ -96,7 +96,7 @@ const YourHistoryCard = () => {
 
   const getBody = () => {
     if (shouldShowRoundDetail) {
-      return <PreviousRoundCardBody lotteryData={selectedLotteryInfo} lotteryId={selectedLotteryId} />
+      return <PreviousRoundCardBody lotteryNodeData={selectedLotteryNodeData} lotteryId={selectedLotteryId} />
     }
 
     const claimableRounds = userLotteryData?.rounds.filter((round) => {
@@ -132,8 +132,8 @@ const YourHistoryCard = () => {
   }
 
   const getFooter = () => {
-    if (selectedLotteryInfo) {
-      return <PreviousRoundCardFooter lotteryData={selectedLotteryInfo} lotteryId={selectedLotteryId} />
+    if (selectedLotteryNodeData) {
+      return <PreviousRoundCardFooter lotteryNodeData={selectedLotteryNodeData} lotteryId={selectedLotteryId} />
     }
     return (
       <CardFooter>


### PR DESCRIPTION
Our lottery subgraph request returns the most recent 100 lotteries. Soon we'll have over 100 past rounds, which will cause issues in history when viewing rounds >100 ago

- Renamed variables throughout lottery so it's clear when it's node data vs graph data being used
- Add fetch for when graph data isn't found for a selected round