### PR TITLE
(chore): Initial POC for use of SDK Token class

### DIFF
--- a/src/config/constants/farmAuctions.ts
+++ b/src/config/constants/farmAuctions.ts
@@ -1,19 +1,20 @@
 import { Token as SDKToken, Pair, ChainId } from '@pancakeswap/sdk'
-import tokens from './tokens'
-import { FarmAuctionBidderConfig, Token } from './types'
+import { coreTokens, getToken } from './tokens'
+import { FarmAuctionBidderConfig } from './types'
 
-const getLpAddress = (token: string, quoteToken: Token) => {
+const getLpAddress = (token: string, quoteToken: SDKToken) => {
   const tokenAsToken = new SDKToken(ChainId.MAINNET, token, 18)
-  const quoteTokenAsToken = new SDKToken(ChainId.MAINNET, quoteToken.address[56], 18)
-  return Pair.getAddress(tokenAsToken, quoteTokenAsToken)
+  return Pair.getAddress(tokenAsToken, quoteToken)
 }
 
-export const whitelistedBidders: FarmAuctionBidderConfig[] = [
+const { WBNB, BUSD } = coreTokens
+
+const whitelistedBidders: FarmAuctionBidderConfig[] = [
   {
     account: '0x9Ed5a62535A5Dd2dB2d9bB21bAc42035Af47F630',
     farmName: 'NAV-BNB',
     tokenAddress: '0xbfef6ccfc830d3baca4f6766a0d4aaa242ca9f3d',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Navcoin',
     projectSite: 'https://navcoin.org/en',
   },
@@ -21,7 +22,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x33723811B0FCa2a751f3912B80603Fe11499D894',
     farmName: 'WSG-BNB',
     tokenAddress: '0xa58950f05fea2277d2608748412bf9f802ea4901',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Wall Street Games',
     projectSite: 'https://wsg.gg/',
   },
@@ -29,7 +30,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xD1C35C3F5D9d373A3F7c0668Fbe75801886e060f',
     farmName: 'SWIRGE-BNB',
     tokenAddress: '0xe792f64C582698b8572AAF765bDC426AC3aEfb6B',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Swirge Network',
     projectSite: 'https://swirge.com/',
   },
@@ -37,7 +38,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x58092273a044D6e1d23B5095AE873F6E24E906ed',
     farmName: 'rUSD-BUSD',
     tokenAddress: '0x07663837218a003e66310a01596af4bf4e44623d',
-    quoteToken: tokens.busd,
+    quoteToken: getToken(BUSD),
     tokenName: 'RAMP DEFI',
     projectSite: 'https://www.rampdefi.com/',
   },
@@ -45,7 +46,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xfAd3B5FeAC1aAF86B3f66D105F2fa9607164D86b',
     farmName: 'FEED-BNB',
     tokenAddress: '0x67d66e8Ec1Fd25d98B3Ccd3B19B7dc4b4b7fC493',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Feeder Finance',
     projectSite: 'https://www.feeder.finance/',
   },
@@ -53,7 +54,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x6a2d41c87c3F28C2C0b466424DE8e08FC2E23eDc',
     farmName: 'BBT-BNB',
     tokenAddress: '0xd48474e7444727bf500a32d5abe01943f3a59a64',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'BitBook',
     projectSite: 'https://www.bitbook.network/',
   },
@@ -61,7 +62,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xAe126B90d2835c5A2D720b0687EC59f59b768183',
     farmName: 'WOW-BUSD',
     tokenAddress: '0x4da996c5fe84755c80e108cf96fe705174c5e36a',
-    quoteToken: tokens.busd,
+    quoteToken: getToken(BUSD),
     tokenName: 'WOWswap',
     projectSite: 'https://wowswap.io/',
   },
@@ -69,7 +70,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x88F0A6cb89909838d69E4E6e76eC21e2a7bdcA66',
     farmName: 'BREW-BNB',
     tokenAddress: '0x790be81c3ca0e53974be2688cdb954732c9862e1',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'CafeSwap Finance',
     projectSite: 'https://app.cafeswap.finance/',
   },
@@ -77,7 +78,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x0Cf86283ad1a1B7D04669696eD13BAE3d5925a0a',
     farmName: 'SAKE-BNB',
     tokenAddress: '0x8bd778b12b15416359a227f0533ce2d91844e1ed',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'SakeSwap',
     projectSite: 'https://bsc.sakeswap.finance/',
   },
@@ -85,7 +86,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xCe059E8af96a654d4afe630Fa325FBF70043Ab11',
     farmName: 'XBLZD-BNB',
     tokenAddress: '0x9a946c3cb16c08334b69ae249690c236ebd5583e',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Blizzard',
     projectSite: 'https://www.blizzard.money/',
   },
@@ -93,7 +94,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x7A4BAE68836f486e2c99dca0fBda1845d4532194',
     farmName: 'HERO-BNB',
     tokenAddress: '0xD40bEDb44C081D2935eebA6eF5a3c8A31A1bBE13',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Metahero',
     projectSite: 'https://metahero.io/',
   },
@@ -101,7 +102,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x46D8e47b9A6487FDAB0a700b269A452cFeED49Aa',
     farmName: 'MCRN-BNB',
     tokenAddress: '0xacb2d47827c9813ae26de80965845d80935afd0b',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'MacaronSwap',
     projectSite: 'https://www.macaronswap.finance/',
   },
@@ -109,7 +110,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x1bA962acab22Be9e49C4cEBE7710c9201A72dFcc',
     farmName: 'BABYCAKE-BNB',
     tokenAddress: '0xdb8d30b74bf098af214e862c90e647bbb1fcc58c',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Babycake',
     projectSite: 'https://babycake.app/',
   },
@@ -117,7 +118,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xCCcC0b22799E82A79007814Dbc6A194410DCcEA5',
     farmName: 'BMON-BNB',
     tokenAddress: '0x08ba0619b1e7A582E0BCe5BBE9843322C954C340',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Binamon',
     projectSite: 'https://binamon.org/',
   },
@@ -125,7 +126,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x6cfA3ff4e96abe93a290dc3d7A911A483C194758',
     farmName: 'ANY-BNB',
     tokenAddress: '0xf68c9df95a18b2a5a5fa1124d79eeeffbad0b6fa',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Anyswap',
     projectSite: 'https://anyswap.exchange/',
   },
@@ -133,7 +134,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0xe596470D291Cb2D32ec111afC314B07006690c72',
     farmName: 'PHX-BNB',
     tokenAddress: '0xac86e5f9bA48d680516df50C72928c2ec50F3025',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'Phoenix Finance',
     projectSite: 'https://www.phoenixprotocol.net/',
   },
@@ -141,7 +142,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x8f8c77987C0ea9dd2400383b623d9cbcBbAf98CF',
     farmName: 'GMR-BNB',
     tokenAddress: '0x0523215dcafbf4e4aa92117d13c6985a3bef27d7',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'GMR Finance',
     projectSite: 'https://www.gmr.finance/',
   },
@@ -149,7 +150,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x786B313b01A25eddbF7f7461b48D60AF680d758C',
     farmName: 'BP-BNB',
     tokenAddress: '0xacb8f52dc63bb752a51186d1c55868adbffee9c1',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'BunnyPark',
     projectSite: 'https://www.bunnypark.com/',
   },
@@ -157,7 +158,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x70d7eCEE276Ad5fDFc91B3C30d2c1cDb9dD442Fb',
     farmName: 'DPET-BNB',
     tokenAddress: '0xfb62ae373aca027177d1c18ee0862817f9080d08',
-    quoteToken: tokens.wbnb,
+    quoteToken: getToken(WBNB),
     tokenName: 'MyDefiPet',
     projectSite: 'https://mydefipet.com/',
   },
@@ -165,7 +166,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
     account: '0x8aC06b55C9812e3E574CF5A5F3b49619dF33099C',
     farmName: 'NMX-BUSD',
     tokenAddress: '0xd32d01a43c869edcd1117c640fbdcfcfd97d9d65',
-    quoteToken: tokens.busd,
+    quoteToken: getToken(BUSD),
     tokenName: 'Nominex',
     projectSite: 'https://nominex.io/',
   },
@@ -177,7 +178,7 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] = [
 const UNKNOWN_BIDDER: FarmAuctionBidderConfig = {
   account: '',
   tokenAddress: '',
-  quoteToken: tokens.wbnb,
+  quoteToken: getToken(WBNB),
   farmName: 'Unknown',
   tokenName: 'Unknown',
 }

--- a/src/config/constants/index.ts
+++ b/src/config/constants/index.ts
@@ -1,5 +1,7 @@
 import { ChainId, JSBI, Percent, Token, WETH } from '@pancakeswap/sdk'
-import { BUSD, DAI, USDT, BTCB, CAKE, WBNB, UST, ETH, USDC } from './tokens'
+import { coreTokens } from './tokens'
+
+const { BUSD, DAI, USDT, BTCB, CAKE, WBNB, UST, ETH, USDC } = coreTokens
 
 export const ROUTER_ADDRESS = '0x10ED43C718714eb63d5aA57B78B54704E256024E'
 
@@ -10,7 +12,16 @@ type ChainTokenList = {
 
 // used to construct intermediary pairs for trading
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
-  [ChainId.MAINNET]: [WETH[ChainId.MAINNET], CAKE[ChainId.MAINNET], BUSD[ChainId.MAINNET], USDT, BTCB, UST, ETH, USDC],
+  [ChainId.MAINNET]: [
+    WETH[ChainId.MAINNET],
+    CAKE[ChainId.MAINNET],
+    BUSD[ChainId.MAINNET],
+    USDT[ChainId.MAINNET],
+    BTCB[ChainId.MAINNET],
+    UST[ChainId.MAINNET],
+    ETH[ChainId.MAINNET],
+    USDC[ChainId.MAINNET],
+  ],
   [ChainId.TESTNET]: [WETH[ChainId.TESTNET], CAKE[ChainId.TESTNET], BUSD[ChainId.TESTNET]],
 }
 
@@ -33,21 +44,21 @@ export const CUSTOM_BASES: { [chainId in ChainId]?: { [tokenAddress: string]: To
 
 // used for display in the default list when adding liquidity
 export const SUGGESTED_BASES: ChainTokenList = {
-  [ChainId.MAINNET]: [BUSD[ChainId.MAINNET], CAKE[ChainId.MAINNET], BTCB],
+  [ChainId.MAINNET]: [BUSD[ChainId.MAINNET], CAKE[ChainId.MAINNET], BTCB[ChainId.MAINNET]],
   [ChainId.TESTNET]: [WETH[ChainId.TESTNET], CAKE[ChainId.TESTNET], BUSD[ChainId.TESTNET]],
 }
 
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
-  [ChainId.MAINNET]: [WETH[ChainId.MAINNET], DAI, BUSD[ChainId.MAINNET], USDT],
+  [ChainId.MAINNET]: [WETH[ChainId.MAINNET], DAI[ChainId.MAINNET], BUSD[ChainId.MAINNET], USDT[ChainId.MAINNET]],
   [ChainId.TESTNET]: [WETH[ChainId.TESTNET], CAKE[ChainId.TESTNET], BUSD[ChainId.TESTNET]],
 }
 
 export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } = {
   [ChainId.MAINNET]: [
-    [CAKE[ChainId.MAINNET], WBNB],
-    [BUSD[ChainId.MAINNET], USDT],
-    [DAI, USDT],
+    [CAKE[ChainId.MAINNET], WBNB[ChainId.MAINNET]],
+    [BUSD[ChainId.MAINNET], USDT[ChainId.MAINNET]],
+    [DAI[ChainId.MAINNET], USDT[ChainId.MAINNET]],
   ],
 }
 

--- a/src/config/constants/tokens.ts
+++ b/src/config/constants/tokens.ts
@@ -4,34 +4,66 @@ const { MAINNET, TESTNET } = ChainId
 
 interface TokenConfig {
   [MAINNET]: Token
-  [TESTNET]: Token
+  [TESTNET]?: Token
   projectLink?: string
 }
 
-export const CAKE: TokenConfig = {
-  [MAINNET]: new Token(MAINNET, '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82', 18, 'CAKE', 'PancakeSwap Token'),
-  [TESTNET]: new Token(TESTNET, '0xa35062141Fa33BCA92Ce69FeD37D0E8908868AAe', 18, 'CAKE', 'PancakeSwap Token'),
-}
-export const BUSD: { [chainId: number]: Token } = {
-  [MAINNET]: new Token(MAINNET, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'Binance USD'),
-  [TESTNET]: new Token(TESTNET, '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', 18, 'BUSD', 'Binance USD'),
+export const getToken = (token: TokenConfig): Token => {
+  const chainId = process.env.REACT_APP_CHAIN_ID
+  return token[chainId] ? token[chainId] : token[ChainId.MAINNET]
 }
 
-export const WBNB = new Token(MAINNET, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'WBNB', 'Wrapped BNB')
-export const DAI = new Token(MAINNET, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'Dai Stablecoin')
-export const USDT = new Token(MAINNET, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'Tether USD')
-export const BTCB = new Token(MAINNET, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'Binance BTC')
-export const UST = new Token(MAINNET, '0x23396cF899Ca06c4472205fC903bDB4de249D6fC', 18, 'UST', 'Wrapped UST Token')
-export const ETH = new Token(
-  MAINNET,
-  '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
-  18,
-  'ETH',
-  'Binance-Peg Ethereum Token',
-)
-export const USDC = new Token(MAINNET, '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', 18, 'USDC', 'Binance-Peg USD Coin')
+export const coreTokens: { [symbol: string]: TokenConfig } = {
+  CAKE: {
+    [MAINNET]: new Token(MAINNET, '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82', 18, 'CAKE', 'PancakeSwap Token'),
+    [TESTNET]: new Token(TESTNET, '0xa35062141Fa33BCA92Ce69FeD37D0E8908868AAe', 18, 'CAKE', 'PancakeSwap Token'),
+    projectLink: 'https://pancakeswap.finance/',
+  },
+  BUSD: {
+    [MAINNET]: new Token(MAINNET, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'Binance USD'),
+    [TESTNET]: new Token(TESTNET, '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', 18, 'BUSD', 'Binance USD'),
+    projectLink: 'https://www.paxos.com/busd/',
+  },
+  WBNB: {
+    [MAINNET]: new Token(MAINNET, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'WBNB', 'Wrapped BNB'),
+    [TESTNET]: new Token(TESTNET, '0xae13d989dac2f0debff460ac112a837c89baa7cd', 18, 'WBNB', 'Wrapped BNB'),
+    projectLink: 'https://pancakeswap.finance/',
+  },
+  DAI: {
+    [MAINNET]: new Token(MAINNET, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'Dai Stablecoin'),
+    projectLink: 'https://www.makerdao.com/',
+  },
+  USDT: {
+    [MAINNET]: new Token(MAINNET, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'Tether USD'),
+    [TESTNET]: new Token(TESTNET, '0xE02dF9e3e622DeBdD69fb838bB799E3F168902c5', 18, 'USDT', 'Tether USD'),
+    projectLink: 'https://tether.to/',
+  },
+  BTCB: {
+    [MAINNET]: new Token(MAINNET, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'Binance BTC'),
+    [TESTNET]: new Token(TESTNET, '0xE02dF9e3e622DeBdD69fb838bB799E3F168902c5', 18, 'BTCB', 'Binance BTC'),
+    projectLink: 'https://bitcoin.org/',
+  },
+  UST: {
+    [MAINNET]: new Token(MAINNET, '0x23396cf899ca06c4472205fc903bdb4de249d6fc', 18, 'UST', 'Wrapped UST Token'),
+    projectLink: 'https://mirror.finance/',
+  },
+  ETH: {
+    [MAINNET]: new Token(
+      MAINNET,
+      '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
+      18,
+      'WBNB',
+      'Binance-Peg Ethereum Token',
+    ),
+    projectLink: 'https://ethereum.org/en/',
+  },
+  USDC: {
+    [MAINNET]: new Token(MAINNET, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'USDC', 'Binance-Peg USD Coin'),
+    projectLink: 'https://www.centre.io/usdc',
+  },
+}
 
-const tokens: TokenConfig[] = {
+const tokens = {
   bnb: {
     symbol: 'BNB',
     projectLink: 'https://www.binance.com/',

--- a/src/config/constants/tokens.ts
+++ b/src/config/constants/tokens.ts
@@ -1,63 +1,31 @@
 import { ChainId, Token } from '@pancakeswap/sdk'
 
-export const CAKE: { [chainId: number]: Token } = {
-  [ChainId.MAINNET]: new Token(
-    ChainId.MAINNET,
-    '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
-    18,
-    'CAKE',
-    'PancakeSwap Token',
-  ),
-  [ChainId.TESTNET]: new Token(
-    ChainId.TESTNET,
-    '0xa35062141Fa33BCA92Ce69FeD37D0E8908868AAe',
-    18,
-    'CAKE',
-    'PancakeSwap Token',
-  ),
+const { MAINNET, TESTNET } = ChainId
+
+type TokenConfig = { [chainId: number]: Token }
+
+export const CAKE: TokenConfig = {
+  [MAINNET]: new Token(MAINNET, '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82', 18, 'CAKE', 'PancakeSwap Token'),
+  [TESTNET]: new Token(TESTNET, '0xa35062141Fa33BCA92Ce69FeD37D0E8908868AAe', 18, 'CAKE', 'PancakeSwap Token'),
 }
-export const BUSD: { [chainId: number]: Token } = {
-  [ChainId.MAINNET]: new Token(
-    ChainId.MAINNET,
-    '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
-    18,
-    'BUSD',
-    'Binance USD',
-  ),
-  [ChainId.TESTNET]: new Token(
-    ChainId.TESTNET,
-    '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee',
-    18,
-    'BUSD',
-    'Binance USD',
-  ),
+export const BUSD: TokenConfig = {
+  [MAINNET]: new Token(MAINNET, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'Binance USD'),
+  [TESTNET]: new Token(TESTNET, '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', 18, 'BUSD', 'Binance USD'),
 }
 
-export const WBNB = new Token(ChainId.MAINNET, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'WBNB', 'Wrapped BNB')
-export const DAI = new Token(ChainId.MAINNET, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'Dai Stablecoin')
-export const USDT = new Token(ChainId.MAINNET, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'Tether USD')
-export const BTCB = new Token(ChainId.MAINNET, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'Binance BTC')
-export const UST = new Token(
-  ChainId.MAINNET,
-  '0x23396cF899Ca06c4472205fC903bDB4de249D6fC',
-  18,
-  'UST',
-  'Wrapped UST Token',
-)
+export const WBNB = new Token(MAINNET, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'WBNB', 'Wrapped BNB')
+export const DAI = new Token(MAINNET, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'Dai Stablecoin')
+export const USDT = new Token(MAINNET, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'Tether USD')
+export const BTCB = new Token(MAINNET, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'Binance BTC')
+export const UST = new Token(MAINNET, '0x23396cF899Ca06c4472205fC903bDB4de249D6fC', 18, 'UST', 'Wrapped UST Token')
 export const ETH = new Token(
-  ChainId.MAINNET,
+  MAINNET,
   '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
   18,
   'ETH',
   'Binance-Peg Ethereum Token',
 )
-export const USDC = new Token(
-  ChainId.MAINNET,
-  '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-  18,
-  'USDC',
-  'Binance-Peg USD Coin',
-)
+export const USDC = new Token(MAINNET, '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', 18, 'USDC', 'Binance-Peg USD Coin')
 
 const tokens = {
   bnb: {

--- a/src/config/constants/tokens.ts
+++ b/src/config/constants/tokens.ts
@@ -2,13 +2,17 @@ import { ChainId, Token } from '@pancakeswap/sdk'
 
 const { MAINNET, TESTNET } = ChainId
 
-type TokenConfig = { [chainId: number]: Token }
+interface TokenConfig {
+  [MAINNET]: Token
+  [TESTNET]: Token
+  projectLink?: string
+}
 
 export const CAKE: TokenConfig = {
   [MAINNET]: new Token(MAINNET, '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82', 18, 'CAKE', 'PancakeSwap Token'),
   [TESTNET]: new Token(TESTNET, '0xa35062141Fa33BCA92Ce69FeD37D0E8908868AAe', 18, 'CAKE', 'PancakeSwap Token'),
 }
-export const BUSD: TokenConfig = {
+export const BUSD: { [chainId: number]: Token } = {
   [MAINNET]: new Token(MAINNET, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'Binance USD'),
   [TESTNET]: new Token(TESTNET, '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', 18, 'BUSD', 'Binance USD'),
 }
@@ -27,7 +31,7 @@ export const ETH = new Token(
 )
 export const USDC = new Token(MAINNET, '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', 18, 'USDC', 'Binance-Peg USD Coin')
 
-const tokens = {
+const tokens: TokenConfig[] = {
   bnb: {
     symbol: 'BNB',
     projectLink: 'https://www.binance.com/',

--- a/src/config/constants/types.ts
+++ b/src/config/constants/types.ts
@@ -1,5 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { SerializedBigNumber, TranslatableText } from 'state/types'
+import { Token as SDKToken } from '@pancakeswap/sdk'
 
 export interface Address {
   97?: string
@@ -183,7 +184,7 @@ export interface FarmAuctionBidderConfig {
   account: string
   farmName: string
   tokenAddress: string
-  quoteToken: Token
+  quoteToken: SDKToken
   tokenName: string
   projectSite?: string
   lpAddress?: string

--- a/src/hooks/useBUSDPrice.ts
+++ b/src/hooks/useBUSDPrice.ts
@@ -1,9 +1,11 @@
 import { ChainId, Currency, currencyEquals, JSBI, Price, WETH } from '@pancakeswap/sdk'
 import { useMemo } from 'react'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
-import { BUSD, CAKE } from '../config/constants/tokens'
+import { coreTokens } from '../config/constants/tokens'
 import { PairState, usePairs } from './usePairs'
 import { wrappedCurrency } from '../utils/wrappedCurrency'
+
+const { BUSD, CAKE } = coreTokens
 
 const BUSD_MAINNET = BUSD[ChainId.MAINNET]
 

--- a/src/utils/addressHelpers.ts
+++ b/src/utils/addressHelpers.ts
@@ -1,7 +1,9 @@
 import { ChainId } from '@pancakeswap/sdk'
 import addresses from 'config/constants/contracts'
-import tokens from 'config/constants/tokens'
+import { getToken, coreTokens } from 'config/constants/tokens'
 import { Address } from 'config/constants/types'
+
+const { CAKE, WBNB } = coreTokens
 
 export const getAddress = (address: Address): string => {
   const chainId = process.env.REACT_APP_CHAIN_ID
@@ -9,7 +11,7 @@ export const getAddress = (address: Address): string => {
 }
 
 export const getCakeAddress = () => {
-  return getAddress(tokens.cake.address)
+  return getToken(CAKE).address
 }
 export const getMasterChefAddress = () => {
   return getAddress(addresses.masterChef)
@@ -18,7 +20,7 @@ export const getMulticallAddress = () => {
   return getAddress(addresses.multiCall)
 }
 export const getWbnbAddress = () => {
-  return getAddress(tokens.wbnb.address)
+  return getToken(WBNB).address
 }
 export const getLotteryV2Address = () => {
   return getAddress(addresses.lotteryV2)

--- a/src/views/Pools/components/CakeVaultCard/CakeVaultTokenPairImage.tsx
+++ b/src/views/Pools/components/CakeVaultCard/CakeVaultTokenPairImage.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { TokenPairImage, ImageProps } from '@pancakeswap/uikit'
-import tokens from 'config/constants/tokens'
-import { getAddress } from 'utils/addressHelpers'
+import { coreTokens, getToken } from 'config/constants/tokens'
 
 const CakeVaultTokenPairImage: React.FC<Omit<ImageProps, 'src'>> = (props) => {
-  const primaryTokenSrc = `/images/tokens/${getAddress(tokens.cake.address)}.svg`
+  const primaryTokenSrc = `/images/tokens/${getToken(coreTokens.cake).address}.svg`
 
   return <TokenPairImage primarySrc={primaryTokenSrc} secondarySrc="/images/tokens/autorenew.svg" {...props} />
 }


### PR DESCRIPTION
- Initial POC (that can actually be safely merged as a first step in the refactor) for the impact of using the SDK Token class for `tokens.ts`, testing it on a limited number of tokens - `coreTokens`.
- The main difference between the entities is that the entire token is segmented by chainId, rather than just the address as is currently. This small difference actually has far-reaching impacts. 

Note the extent to which information is now duplicated. Is _this_ Token entity preferable to our current FE one?

From (current):

```js
  wbnb: {
    symbol: 'wBNB',
    address: {
      56: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
      97: '0xae13d989dac2f0debff460ac112a837c89baa7cd',
    },
    decimals: 18,
    projectLink: 'https://pancakeswap.finance/',
  },
```

to (SDK entity):

```js
wbnb: {
    '56': {
      decimals: 18,
      symbol: 'WBNB',
      name: 'Wrapped BNB',
      chainId: 56,
      address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
    },
    '97': {
      decimals: 18,
      symbol: 'WBNB',
      name: 'Wrapped BNB',
      chainId: 97,
      address: '0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd',
    },
    projectLink: 'https://pancakeswap.finance/',
  }
```
