### PR TITLE
fix: (pools table) Manual pools action panel components have excessive height

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -115,7 +115,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   }
 
   return (
-    <ActionContainer>
+    <ActionContainer isAutoVault={isAutoVault}>
       <ActionTitles>{actionTitle}</ActionTitles>
       <ActionContent>
         <Flex flex="1" pt="16px" flexDirection="column" alignSelf="flex-start">

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -181,7 +181,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
   // Wallet connected, user data loaded and approved
   if (isNotVaultAndHasStake || isVaultWithShares) {
     return (
-      <ActionContainer>
+      <ActionContainer isAutoVault={isAutoVault}>
         <ActionTitles>
           <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
             {stakingToken.symbol}{' '}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/styles.ts
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-export const ActionContainer = styled.div`
+export const ActionContainer = styled.div<{ isAutoVault?: boolean }>`
   padding: 16px;
   border: 2px solid ${({ theme }) => theme.colors.input};
   border-radius: 16px;
@@ -12,16 +12,13 @@ export const ActionContainer = styled.div`
     margin-left: 12px;
     margin-right: 12px;
     margin-bottom: 0;
-    height: 130px;
-    max-height: 130px;
+    height: ${({ isAutoVault }) => (isAutoVault ? '130px' : 'auto')};
   }
+}
 
   ${({ theme }) => theme.mediaQueries.xl} {
     margin-left: 32px;
     margin-right: 0;
-    margin-bottom: 0;
-    height: 130px;
-    max-height: 130px;
   }
 `
 


### PR DESCRIPTION
To review:

https://deploy-preview-1892--pancakeswap-dev.netlify.app/

To reproduce:

Go to pools table

Click details of a pool except auto cake

Check stake and harvest action components excessive height
