### PR TITLE
refactor: Separate auto pool row components to not make redundant calculations in manual pool rows

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -30,6 +30,7 @@ import { convertSharesToCake, getPoolBlockInfo } from 'views/Pools/helpers'
 import Harvest from './Harvest'
 import Stake from './Stake'
 import Apr from '../Apr'
+import AutoHarvest from './AutoHarvest'
 
 const expandAnimation = keyframes`
   from {
@@ -293,7 +294,11 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
             {isAutoVault ? t('Automatic restaking') : `${t('Earn')} CAKE ${t('Stake').toLocaleLowerCase()} CAKE`}
           </Text>
         )}
-        <Harvest {...pool} userDataLoaded={userDataLoaded} />
+        {pool.isAutoVault ? (
+          <AutoHarvest {...pool} userDataLoaded={userDataLoaded} />
+        ) : (
+          <Harvest {...pool} userDataLoaded={userDataLoaded} />
+        )}
         <Stake pool={pool} userDataLoaded={userDataLoaded} />
       </ActionContainer>
     </StyledActionPanel>

--- a/src/views/Pools/components/PoolsTable/ActionPanel/AutoHarvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/AutoHarvest.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { Text, Flex, TooltipText, useTooltip, Skeleton, Heading } from '@pancakeswap/uikit'
+import { useWeb3React } from '@web3-react/core'
+import { getCakeVaultEarnings } from 'views/Pools/helpers'
+import { useTranslation } from 'contexts/Localization'
+import Balance from 'components/Balance'
+import { useCakeVault } from 'state/pools/hooks'
+import { Pool } from 'state/types'
+
+import { ActionContainer, ActionTitles, ActionContent } from './styles'
+import UnstakingFeeCountdownRow from '../../CakeVaultCard/UnstakingFeeCountdownRow'
+
+interface AutoHarvestActionProps extends Pool {
+  userDataLoaded: boolean
+}
+
+const AutoHarvestAction: React.FunctionComponent<AutoHarvestActionProps> = ({ userDataLoaded, earningTokenPrice }) => {
+  const { t } = useTranslation()
+  const { account } = useWeb3React()
+
+  const {
+    userData: { cakeAtLastUserAction, userShares },
+    pricePerFullShare,
+    fees: { performanceFee },
+  } = useCakeVault()
+  const { hasAutoEarnings, autoCakeToDisplay, autoUsdToDisplay } = getCakeVaultEarnings(
+    account,
+    cakeAtLastUserAction,
+    userShares,
+    pricePerFullShare,
+    earningTokenPrice,
+  )
+
+  const earningTokenBalance = autoCakeToDisplay
+  const earningTokenDollarBalance = autoUsdToDisplay
+  const hasEarnings = hasAutoEarnings
+
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(
+    t('Subtracted automatically from each yield harvest and burned.'),
+    { placement: 'bottom-start' },
+  )
+
+  const actionTitle = (
+    <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
+      {t('Recent CAKE profit')}
+    </Text>
+  )
+
+  if (!account) {
+    return (
+      <ActionContainer>
+        <ActionTitles>{actionTitle}</ActionTitles>
+        <ActionContent>
+          <Heading>0</Heading>
+        </ActionContent>
+      </ActionContainer>
+    )
+  }
+
+  if (!userDataLoaded) {
+    return (
+      <ActionContainer>
+        <ActionTitles>{actionTitle}</ActionTitles>
+        <ActionContent>
+          <Skeleton width={180} height="32px" marginTop={14} />
+        </ActionContent>
+      </ActionContainer>
+    )
+  }
+
+  return (
+    <ActionContainer isAutoVault>
+      <ActionTitles>{actionTitle}</ActionTitles>
+      <ActionContent>
+        <Flex flex="1" pt="16px" flexDirection="column" alignSelf="flex-start">
+          <>
+            {hasEarnings ? (
+              <>
+                <Balance lineHeight="1" bold fontSize="20px" decimals={5} value={earningTokenBalance} />
+                {earningTokenPrice > 0 && (
+                  <Balance
+                    display="inline"
+                    fontSize="12px"
+                    color="textSubtle"
+                    decimals={2}
+                    prefix="~"
+                    value={earningTokenDollarBalance}
+                    unit=" USD"
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                <Heading color="textDisabled">0</Heading>
+                <Text fontSize="12px" color="textDisabled">
+                  0 USD
+                </Text>
+              </>
+            )}
+          </>
+        </Flex>
+        <Flex flex="1.3" flexDirection="column" alignSelf="flex-start" alignItems="flex-start">
+          <UnstakingFeeCountdownRow isTableVariant />
+          <Flex mb="2px" justifyContent="space-between" alignItems="center">
+            {tooltipVisible && tooltip}
+            <TooltipText ref={targetRef} small>
+              {t('Performance Fee')}
+            </TooltipText>
+            <Flex alignItems="center">
+              <Text ml="4px" small>
+                {performanceFee / 100}%
+              </Text>
+            </Flex>
+          </Flex>
+        </Flex>
+      </ActionContent>
+    </ActionContainer>
+  )
+}
+
+export default AutoHarvestAction

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -1,19 +1,16 @@
 import React from 'react'
-import { Button, Text, useModal, Flex, TooltipText, useTooltip, Skeleton, Heading } from '@pancakeswap/uikit'
+import { Button, Text, useModal, Flex, Skeleton, Heading } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useWeb3React } from '@web3-react/core'
-import { getCakeVaultEarnings } from 'views/Pools/helpers'
 import { PoolCategory } from 'config/constants/types'
 import { formatNumber, getBalanceNumber, getFullDisplayBalance } from 'utils/formatBalance'
 import { useTranslation } from 'contexts/Localization'
 import Balance from 'components/Balance'
-import { useCakeVault } from 'state/pools/hooks'
 import { BIG_ZERO } from 'utils/bigNumber'
 import { Pool } from 'state/types'
 
 import { ActionContainer, ActionTitles, ActionContent } from './styles'
 import CollectModal from '../../PoolCard/Modals/CollectModal'
-import UnstakingFeeCountdownRow from '../../CakeVaultCard/UnstakingFeeCountdownRow'
 
 interface HarvestActionProps extends Pool {
   userDataLoaded: boolean
@@ -25,39 +22,19 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   earningToken,
   userData,
   userDataLoaded,
-  isAutoVault,
   earningTokenPrice,
 }) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
 
   const earnings = userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO
-  // These will be reassigned later if its Auto CAKE vault
-  let earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
-  let earningTokenDollarBalance = getBalanceNumber(earnings.multipliedBy(earningTokenPrice), earningToken.decimals)
-  let hasEarnings = earnings.gt(0)
+  const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
+  const earningTokenDollarBalance = getBalanceNumber(earnings.multipliedBy(earningTokenPrice), earningToken.decimals)
+  const hasEarnings = earnings.gt(0)
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
   const isCompoundPool = sousId === 0
   const isBnbPool = poolCategory === PoolCategory.BINANCE
-
-  // Auto CAKE vault calculations
-  const {
-    userData: { cakeAtLastUserAction, userShares },
-    pricePerFullShare,
-    fees: { performanceFee },
-  } = useCakeVault()
-  const { hasAutoEarnings, autoCakeToDisplay, autoUsdToDisplay } = getCakeVaultEarnings(
-    account,
-    cakeAtLastUserAction,
-    userShares,
-    pricePerFullShare,
-    earningTokenPrice,
-  )
-
-  earningTokenBalance = isAutoVault ? autoCakeToDisplay : earningTokenBalance
-  hasEarnings = isAutoVault ? hasAutoEarnings : hasEarnings
-  earningTokenDollarBalance = isAutoVault ? autoUsdToDisplay : earningTokenDollarBalance
 
   const [onPresentCollect] = useModal(
     <CollectModal
@@ -71,16 +48,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
     />,
   )
 
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(
-    t('Subtracted automatically from each yield harvest and burned.'),
-    { placement: 'bottom-start' },
-  )
-
-  const actionTitle = isAutoVault ? (
-    <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
-      {t('Recent CAKE profit')}
-    </Text>
-  ) : (
+  const actionTitle = (
     <>
       <Text fontSize="12px" bold color="secondary" as="span" textTransform="uppercase">
         {earningToken.symbol}{' '}
@@ -115,7 +83,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
   }
 
   return (
-    <ActionContainer isAutoVault={isAutoVault}>
+    <ActionContainer>
       <ActionTitles>{actionTitle}</ActionTitles>
       <ActionContent>
         <Flex flex="1" pt="16px" flexDirection="column" alignSelf="flex-start">
@@ -145,26 +113,9 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
             )}
           </>
         </Flex>
-        {isAutoVault ? (
-          <Flex flex="1.3" flexDirection="column" alignSelf="flex-start" alignItems="flex-start">
-            <UnstakingFeeCountdownRow isTableVariant />
-            <Flex mb="2px" justifyContent="space-between" alignItems="center">
-              {tooltipVisible && tooltip}
-              <TooltipText ref={targetRef} small>
-                {t('Performance Fee')}
-              </TooltipText>
-              <Flex alignItems="center">
-                <Text ml="4px" small>
-                  {performanceFee / 100}%
-                </Text>
-              </Flex>
-            </Flex>
-          </Flex>
-        ) : (
-          <Button disabled={!hasEarnings} onClick={onPresentCollect}>
-            {isCompoundPool ? t('Collect') : t('Harvest')}
-          </Button>
-        )}
+        <Button disabled={!hasEarnings} onClick={onPresentCollect}>
+          {isCompoundPool ? t('Collect') : t('Harvest')}
+        </Button>
       </ActionContent>
     </ActionContainer>
   )

--- a/src/views/Pools/components/PoolsTable/PoolRow.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolRow.tsx
@@ -14,6 +14,7 @@ import TotalStakedCell from './Cells/TotalStakedCell'
 import EndsInCell from './Cells/EndsInCell'
 import ExpandActionCell from './Cells/ExpandActionCell'
 import ActionPanel from './ActionPanel/ActionPanel'
+import AutoEarningsCell from './Cells/AutoEarningsCell'
 
 interface PoolRowProps {
   pool: Pool
@@ -52,7 +53,11 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
     <>
       <StyledRow role="row" onClick={toggleExpanded}>
         <NameCell pool={pool} />
-        <EarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
+        {pool.isAutoVault ? (
+          <AutoEarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
+        ) : (
+          <EarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
+        )}
         <AprCell
           pool={pool}
           stakedBalance={isAutoVault ? cakeAsBigNumber : stakedBalance}


### PR DESCRIPTION
To review: 

https://deploy-preview-1913--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to pools table
2. Connect your account
3. You should not see any difference