### PR TITLE
fix: Global settings tooltips not visible correctly in mobile

### DIFF
--- a/src/components/Menu/GlobalSettings/GasSettings.tsx
+++ b/src/components/Menu/GlobalSettings/GasSettings.tsx
@@ -17,6 +17,7 @@ const GasSettings = () => {
           text={t(
             'Adjusts the gas price (transaction fee) for your transaction. Higher GWEI = higher speed = higher fees',
           )}
+          placement="top-start"
           ml="4px"
         />
       </Flex>

--- a/src/components/Menu/GlobalSettings/TransactionSettings.tsx
+++ b/src/components/Menu/GlobalSettings/TransactionSettings.tsx
@@ -79,6 +79,7 @@ const SlippageTabs = () => {
             text={t(
               'Setting a high slippage tolerance can help transactions succeed, but you may not get such a good price. Use with caution.',
             )}
+            placement="top-start"
             ml="4px"
           />
         </Flex>

--- a/src/components/QuestionHelper/index.tsx
+++ b/src/components/QuestionHelper/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { HelpIcon, useTooltip, Box, BoxProps } from '@pancakeswap/uikit'
+import { HelpIcon, useTooltip, Box, BoxProps, Placement } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 
 interface Props extends BoxProps {
   text: string | React.ReactNode
+  placement?: Placement
 }
 
 const QuestionWrapper = styled.div`
@@ -13,8 +14,8 @@ const QuestionWrapper = styled.div`
   }
 `
 
-const QuestionHelper: React.FC<Props> = ({ text, ...props }) => {
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(text, { placement: 'right-end', trigger: 'hover' })
+const QuestionHelper: React.FC<Props> = ({ text, placement = 'right-end', ...props }) => {
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(text, { placement, trigger: 'hover' })
 
   return (
     <Box {...props}>


### PR DESCRIPTION
To review: 

https://deploy-preview-1916--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to website in mobile
2. Open global settings
3. Check tooltips visibility