### PR TITLE
fix: Scrolling global settings in mobile 

### DIFF
--- a/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -58,7 +58,7 @@ const SettingsModal: React.FC<InjectedModalProps> = ({ onDismiss }) => {
       title={t('Settings')}
       headerBackground="gradients.cardHeader"
       onDismiss={onDismiss}
-      style={{ maxWidth: '420px' }}
+      style={{ maxWidth: '420px', overflowY: 'auto' }}
     >
       <Flex flexDirection="column">
         <Flex pb="24px" flexDirection="column">


### PR DESCRIPTION
To review:

https://deploy-preview-1921--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to global settings in mobile (iphone8 size phones and especially mobile safari)
2. Try to scroll down