### PR TITLE
fix: Farm auction banner text not visible overlaps with background image

### DIFF
--- a/src/views/Home/components/Banners/FarmAuctionsBanner.tsx
+++ b/src/views/Home/components/Banners/FarmAuctionsBanner.tsx
@@ -5,10 +5,17 @@ import { useTranslation } from 'contexts/Localization'
 
 const StyledSubheading = styled(Heading)`
   background: -webkit-linear-gradient(#ffd800, #eb8c00);
-  font-size: 24px;
+  font-size: 20px;
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.5);
+  ${({ theme }) => theme.mediaQueries.xs} {
+    font-size: 24px;
+  }
+  ${({ theme }) => theme.mediaQueries.sm} {
+    -webkit-text-stroke: unset;
+  }
   margin-bottom: 8px;
 `
 
@@ -44,7 +51,7 @@ const LeftWrapper = styled(Flex)`
   flex-direction: column;
   justify-content: center;
 
-  ${({ theme }) => theme.mediaQueries.sm} {
+  ${({ theme }) => theme.mediaQueries.md} {
     padding-top: 40px;
     padding-bottom: 40px;
   }
@@ -60,7 +67,7 @@ const RightWrapper = styled.div`
     height: 200px;
   }
 
-  ${({ theme }) => theme.mediaQueries.sm} {
+  ${({ theme }) => theme.mediaQueries.md} {
     position: relative;
     display: flex;
     align-items: center;


### PR DESCRIPTION
To review:

https://deploy-preview-1923--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to homepage in mobile
2. See farm auction text last part overlaps with background image and it is hard to read

Before:

<img width="354" alt="image" src="https://user-images.githubusercontent.com/2213635/129551881-2e31861d-e91f-409e-8465-978215acc0b1.png">

After:

<img width="359" alt="image" src="https://user-images.githubusercontent.com/2213635/129551940-5b556607-ac69-4307-a495-bb4c30ac02b6.png">

It also fixes the formatting issue when browser width is around 576px (sm breakpoint)

<img width="596" alt="image" src="https://user-images.githubusercontent.com/2213635/129551825-106bd6d9-a702-4463-a56d-01f2a232f4a9.png">