### PR TITLE
refactor: Separate pools row manual apr cell from auto one to not make redundant calculations

### DIFF
--- a/src/views/Pools/components/PoolsTable/Cells/AutoAprCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/AutoAprCell.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import styled from 'styled-components'
-import { BIG_ZERO } from 'utils/bigNumber'
 import { Text, useMatchBreakpoints } from '@pancakeswap/uikit'
-import BigNumber from 'bignumber.js'
 import { Pool } from 'state/types'
+import { useCakeVault } from 'state/pools/hooks'
 import { useTranslation } from 'contexts/Localization'
 import BaseCell, { CellContent } from './BaseCell'
 import Apr from '../Apr'
+import { convertSharesToCake } from '../../../helpers'
 
 interface AprCellProps {
   pool: Pool
@@ -19,22 +19,34 @@ const StyledCell = styled(BaseCell)`
   }
 `
 
-const AprCell: React.FC<AprCellProps> = ({ pool }) => {
+const AutoAprCell: React.FC<AprCellProps> = ({ pool }) => {
   const { t } = useTranslation()
   const { isXs, isSm } = useMatchBreakpoints()
-  const { userData } = pool
-  const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
+
+  const {
+    userData: { userShares },
+    fees: { performanceFee },
+    pricePerFullShare,
+  } = useCakeVault()
+
+  const { cakeAsBigNumber } = convertSharesToCake(userShares, pricePerFullShare)
+  const performanceFeeAsDecimal = performanceFee && performanceFee / 100
 
   return (
     <StyledCell role="cell">
       <CellContent>
         <Text fontSize="12px" color="textSubtle" textAlign="left">
-          {t('APR')}
+          {t('APY')}
         </Text>
-        <Apr pool={pool} stakedBalance={stakedBalance} showIcon={!isXs && !isSm} />
+        <Apr
+          pool={pool}
+          stakedBalance={cakeAsBigNumber}
+          performanceFee={performanceFeeAsDecimal}
+          showIcon={!isXs && !isSm}
+        />
       </CellContent>
     </StyledCell>
   )
 }
 
-export default AprCell
+export default AutoAprCell

--- a/src/views/Pools/components/PoolsTable/PoolRow.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolRow.tsx
@@ -1,12 +1,8 @@
 import React, { useState } from 'react'
 import styled from 'styled-components'
 import { useMatchBreakpoints } from '@pancakeswap/uikit'
-import BigNumber from 'bignumber.js'
 import { Pool } from 'state/types'
-import { useCakeVault } from 'state/pools/hooks'
 import useDelayedUnmount from 'hooks/useDelayedUnmount'
-import { convertSharesToCake } from 'views/Pools/helpers'
-import { BIG_ZERO } from 'utils/bigNumber'
 import NameCell from './Cells/NameCell'
 import EarningsCell from './Cells/EarningsCell'
 import AprCell from './Cells/AprCell'
@@ -15,6 +11,7 @@ import EndsInCell from './Cells/EndsInCell'
 import ExpandActionCell from './Cells/ExpandActionCell'
 import ActionPanel from './ActionPanel/ActionPanel'
 import AutoEarningsCell from './Cells/AutoEarningsCell'
+import AutoAprCell from './Cells/AutoAprCell'
 
 interface PoolRowProps {
   pool: Pool
@@ -37,18 +34,6 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
     setExpanded((prev) => !prev)
   }
 
-  const { isAutoVault, userData } = pool
-
-  const {
-    userData: { userShares },
-    fees: { performanceFee },
-    pricePerFullShare,
-  } = useCakeVault()
-
-  const { cakeAsBigNumber } = convertSharesToCake(userShares, pricePerFullShare)
-  const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO
-  const performanceFeeAsDecimal = performanceFee && performanceFee / 100
-
   return (
     <>
       <StyledRow role="row" onClick={toggleExpanded}>
@@ -58,11 +43,7 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
         ) : (
           <EarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
         )}
-        <AprCell
-          pool={pool}
-          stakedBalance={isAutoVault ? cakeAsBigNumber : stakedBalance}
-          performanceFee={performanceFeeAsDecimal}
-        />
+        {pool.isAutoVault ? <AutoAprCell pool={pool} /> : <AprCell pool={pool} />}
         {(isLg || isXl) && <TotalStakedCell pool={pool} />}
         {isXl && <EndsInCell pool={pool} />}
         <ExpandActionCell expanded={expanded} isFullLayout={isMd || isLg || isXl} />


### PR DESCRIPTION
Currently each pool row has to deal with auto cake vault calculations

To review:

https://deploy-preview-1925--pancakeswap-dev.netlify.app/
