### PR TITLE
fix: Round switcher input accepts non-numeric values

### DIFF
--- a/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
+++ b/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
@@ -43,18 +43,25 @@ const RoundSwitcher: React.FC<RoundSwitcherProps> = ({
   const { t } = useTranslation()
   const selectedRoundIdAsInt = parseInt(selectedRoundId, 10)
 
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.currentTarget.validity.valid) {
+      handleInputChange(e)
+    }
+  }
+
   return (
     <Flex alignItems="center" justifyContent="space-between">
       <Flex alignItems="center">
         <Heading mr="8px">{t('Round')}</Heading>
         <StyledInput
+          pattern="^[0-9]+$"
+          inputMode="numeric"
           disabled={isLoading}
           id="round-id"
           name="round-id"
-          type="number"
           value={selectedRoundId}
           scale="lg"
-          onChange={handleInputChange}
+          onChange={handleOnChange}
         />
       </Flex>
       <Flex alignItems="center">


### PR DESCRIPTION
To review:

https://deploy-preview-1932--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to lottery
2. Go to finished rounds section
3. Try to enter non-numeric values 

In mobile
1. Check which type of keyboard shown when typing input
2. It should show keyboard with number only