### PR TITLE
fix: (lottery) How To Play Pool Allocation not shown properly in other languages

### DIFF
--- a/src/views/Lottery/components/HowToPlay.tsx
+++ b/src/views/Lottery/components/HowToPlay.tsx
@@ -134,8 +134,9 @@ const MatchExampleCard = () => {
 
 const AllocationGrid = styled.div`
   display: grid;
-  grid-template-columns: 2fr 1fr;
-  grid-auto-rows: 30px;
+  grid-template-columns: 4fr 1fr;
+  grid-auto-rows: max-content;
+  row-gap: 4px;
 `
 
 const AllocationColorCircle = styled.div<{ color: string }>`
@@ -159,7 +160,7 @@ const PoolAllocations = () => {
   const { t } = useTranslation()
   return (
     <StyledStepCard width={['280px', '330px', '380px']}>
-      <StepCardInner height="420px">
+      <StepCardInner height="auto">
         <Flex mb="32px" justifyContent="center">
           <PoolAllocationChart width="100px" height="100px" />
         </Flex>
@@ -167,7 +168,7 @@ const PoolAllocations = () => {
           <Text fontSize="12px" color="secondary" bold textTransform="uppercase">
             {t('Digits matched')}
           </Text>
-          <Text fontSize="12px" color="secondary" bold textTransform="uppercase">
+          <Text fontSize="12px" color="secondary" bold textAlign="right" textTransform="uppercase">
             {t('Prize pool allocation')}
           </Text>
         </Flex>


### PR DESCRIPTION
To review:

https://deploy-preview-1933--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to lottery
2. Go to prize funds section
3. Change language to french
4. Check pool allocation table

Before:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/2213635/129737986-cea0ad09-b66a-4abe-8cd1-1bb94302e9d4.png">

After:

<img width="412" alt="image" src="https://user-images.githubusercontent.com/2213635/129737885-fd45ab14-083a-455a-bada-cc27ea517ecf.png">
