### PR TITLE
fix: (harvestcard) NaN shown in harvest card when earnings being loaded

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1228,7 +1228,7 @@
   "%earningsBusd% to collect from %count% farm and CAKE pool": "%earningsBusd% to collect from %count% farm and CAKE pool",
   "%earningsBusd% to collect from %count% farms and CAKE pool": "%earningsBusd% to collect from %count% farms and CAKE pool",
   "%earningsBusd% to collect from CAKE pool": "%earningsBusd% to collect from CAKE pool",
-  "0 to collect": "0 to collect",
+  "%earningsBusd% to collect": "%earningsBusd% to collect",
   "Harvest all": "Harvest all",
   "Start in seconds.": "Start in seconds.",
   "Used by millions.": "Used by millions.",

--- a/src/views/Home/components/UserBanner/EarningsText.tsx
+++ b/src/views/Home/components/UserBanner/EarningsText.tsx
@@ -12,7 +12,7 @@ export const getEarningsText = (
     count: numFarmsToCollect,
   }
 
-  let earningsText = t('0 to collect', data)
+  let earningsText = t('%earningsBusd% to collect', data)
 
   if (numFarmsToCollect > 0 && hasCakePoolToCollect) {
     if (numFarmsToCollect > 1) {

--- a/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -30,7 +30,7 @@ const HarvestCard = () => {
   const hasCakePoolToCollect = numTotalToCollect - numFarmsToCollect > 0
 
   const earningsText = getEarningsText(numFarmsToCollect, hasCakePoolToCollect, earningsBusd, t)
-  const [preText, toCollectText] = earningsText.split(earningsBusd.isNaN() ? '0' : earningsBusd.toString())
+  const [preText, toCollectText] = earningsText.split(earningsBusd.toString())
 
   const harvestAllFarms = useCallback(async () => {
     setPendingTx(true)
@@ -60,7 +60,7 @@ const HarvestCard = () => {
                 {preText}
               </Text>
             )}
-            {earningsBusd && !earningsBusd.isNaN() ? (
+            {!earningsBusd.isNaN() ? (
               <Balance
                 decimals={earningsBusd.gt(0) ? 2 : 0}
                 fontSize="24px"


### PR DESCRIPTION
When earnings amount is being loaded but user staked farms data available, depending on the time that query returns, user will see NaN on the screen. (usually it is couple of milliseconds but it can be noticed)

To review: 

https://deploy-preview-1937--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to homepage
2. Restart the page
3. Check harvest card NaN is visible couple of seconds or half a second