### PR TITLE
fix: (pools) Pools table layout in larger screens

### DIFF
--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -90,6 +90,7 @@ type MediaBreakpoints = {
   isMd: boolean
   isLg: boolean
   isXl: boolean
+  isXxl: boolean
 }
 
 interface ActionPanelProps {

--- a/src/views/Pools/components/PoolsTable/PoolRow.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolRow.tsx
@@ -26,7 +26,8 @@ const StyledRow = styled.div`
 `
 
 const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
-  const { isXs, isSm, isMd, isLg, isXl } = useMatchBreakpoints()
+  const { isXs, isSm, isMd, isLg, isXl, isXxl, isTablet, isDesktop } = useMatchBreakpoints()
+  const isLargerScreen = isLg || isXl || isXxl
   const [expanded, setExpanded] = useState(false)
   const shouldRenderActionPanel = useDelayedUnmount(expanded, 300)
 
@@ -44,9 +45,9 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
           <EarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
         )}
         {pool.isAutoVault ? <AutoAprCell pool={pool} /> : <AprCell pool={pool} />}
-        {(isLg || isXl) && <TotalStakedCell pool={pool} />}
-        {isXl && <EndsInCell pool={pool} />}
-        <ExpandActionCell expanded={expanded} isFullLayout={isMd || isLg || isXl} />
+        {isLargerScreen && <TotalStakedCell pool={pool} />}
+        {isDesktop && <EndsInCell pool={pool} />}
+        <ExpandActionCell expanded={expanded} isFullLayout={isTablet || isDesktop} />
       </StyledRow>
       {shouldRenderActionPanel && (
         <ActionPanel
@@ -54,7 +55,7 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
           pool={pool}
           userDataLoaded={userDataLoaded}
           expanded={expanded}
-          breakpoints={{ isXs, isSm, isMd, isLg, isXl }}
+          breakpoints={{ isXs, isSm, isMd, isLg, isXl, isXxl }}
         />
       )}
     </>


### PR DESCRIPTION
To review:



To reproduce:

1. Open pools in larger screen (width> 1080px)
2. See columns are missing