### PR TITLE
fix: (poll block) Windows visible event triggers rerender app every time

### DIFF
--- a/src/contexts/RefreshContext.tsx
+++ b/src/contexts/RefreshContext.tsx
@@ -1,52 +1,34 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect } from 'react'
+import useIsWindowVisibleRef from 'hooks/useIsWindowVisibleRef'
 
 const FAST_INTERVAL = 10000
 const SLOW_INTERVAL = 60000
 
 const RefreshContext = React.createContext({ slow: 0, fast: 0 })
 
-// Check if the tab is active in the user browser
-const useIsBrowserTabActive = () => {
-  const isBrowserTabActiveRef = useRef(true)
-
-  useEffect(() => {
-    const onVisibilityChange = () => {
-      isBrowserTabActiveRef.current = !document.hidden
-    }
-
-    window.addEventListener('visibilitychange', onVisibilityChange)
-
-    return () => {
-      window.removeEventListener('visibilitychange', onVisibilityChange)
-    }
-  }, [])
-
-  return isBrowserTabActiveRef
-}
-
 // This context maintain 2 counters that can be used as a dependencies on other hooks to force a periodic refresh
 const RefreshContextProvider = ({ children }) => {
   const [slow, setSlow] = useState(0)
   const [fast, setFast] = useState(0)
-  const isBrowserTabActiveRef = useIsBrowserTabActive()
+  const isWindowVisibleRef = useIsWindowVisibleRef()
 
   useEffect(() => {
     const interval = setInterval(async () => {
-      if (isBrowserTabActiveRef.current) {
+      if (isWindowVisibleRef.current) {
         setFast((prev) => prev + 1)
       }
     }, FAST_INTERVAL)
     return () => clearInterval(interval)
-  }, [isBrowserTabActiveRef])
+  }, [isWindowVisibleRef])
 
   useEffect(() => {
     const interval = setInterval(async () => {
-      if (isBrowserTabActiveRef.current) {
+      if (isWindowVisibleRef.current) {
         setSlow((prev) => prev + 1)
       }
     }, SLOW_INTERVAL)
     return () => clearInterval(interval)
-  }, [isBrowserTabActiveRef])
+  }, [isWindowVisibleRef])
 
   return <RefreshContext.Provider value={{ slow, fast }}>{children}</RefreshContext.Provider>
 }

--- a/src/hooks/useIsWindowVisibleRef.ts
+++ b/src/hooks/useIsWindowVisibleRef.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+const VISIBILITY_STATE_SUPPORTED = 'visibilityState' in document
+
+// Check if the tab is active in the user browser
+export default function useIsWindowVisibleRef() {
+  const isBrowserTabActiveRef = useRef(true)
+
+  useEffect(() => {
+    if (!VISIBILITY_STATE_SUPPORTED) return undefined
+
+    const onVisibilityChange = () => {
+      isBrowserTabActiveRef.current = !document.hidden
+    }
+
+    window.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      window.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  return isBrowserTabActiveRef
+}

--- a/src/state/block/hooks.ts
+++ b/src/state/block/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 import { useAppDispatch } from 'state'
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
+import useIsWindowVisibleRef from 'hooks/useIsWindowVisibleRef'
 import { simpleRpcProvider } from 'utils/providers'
 import { setBlock } from '.'
 import { State } from '../types'
@@ -9,17 +9,15 @@ import { State } from '../types'
 export const usePollBlockNumber = () => {
   const timer = useRef(null)
   const dispatch = useAppDispatch()
-  const isWindowVisible = useIsWindowVisible()
+  const isWindowVisible = useIsWindowVisibleRef()
 
   useEffect(() => {
-    if (isWindowVisible) {
-      timer.current = setInterval(async () => {
+    timer.current = setInterval(async () => {
+      if (isWindowVisible.current) {
         const blockNumber = await simpleRpcProvider.getBlockNumber()
         dispatch(setBlock(blockNumber))
-      }, 6000)
-    } else {
-      clearInterval(timer.current)
-    }
+      }
+    }, 6000)
 
     return () => clearInterval(timer.current)
   }, [dispatch, timer, isWindowVisible])

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -6,8 +6,8 @@ import { useAllInactiveTokens } from 'hooks/Tokens'
 import { UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
 import useWeb3Provider from 'hooks/useActiveWeb3React'
 import useFetchListCallback from 'hooks/useFetchListCallback'
+import useIsWindowVisibleRef from 'hooks/useIsWindowVisibleRef'
 import useInterval from 'hooks/useInterval'
-import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { AppDispatch } from '../index'
 import { acceptListUpdate } from './actions'
 import { useActiveListUrls } from './hooks'
@@ -15,7 +15,7 @@ import { useActiveListUrls } from './hooks'
 export default function Updater(): null {
   const { library } = useWeb3Provider()
   const dispatch = useDispatch<AppDispatch>()
-  const isWindowVisible = useIsWindowVisible()
+  const isWindowVisible = useIsWindowVisibleRef()
 
   // get all loaded lists, and the active urls
   const lists = useAllLists()
@@ -26,7 +26,7 @@ export default function Updater(): null {
 
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {
-    if (!isWindowVisible) return
+    if (!isWindowVisible.current) return
     Object.keys(lists).forEach((url) =>
       fetchList(url).catch((error) => console.debug('interval list fetching error', error)),
     )


### PR DESCRIPTION
To review:

https://deploy-preview-1968--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to website (especially on desktop)
2. Switch between tabs
3. See when it switches, it renders the all app and sometimes makes it unresponsive