### PR TITLE
fix: (auth) Eager connection happens even after successful logout

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -66,6 +66,7 @@ const useAuth = () => {
       connectorsByName.walletconnect.close()
       connectorsByName.walletconnect.walletConnectProvider = null
     }
+    window.localStorage.removeItem(connectorLocalStorageKey)
   }, [deactivate, dispatch])
 
   return { login, logout }


### PR DESCRIPTION
To review: 

To reproduce: 

1. Go to webpage
2. Connect your account
3. Disconnect from dropdown menu
4. Refresh page
5. See eager connection happens