### PR TITLE
feat(lottery): Add 'See More' button & request additional lotteries when user has hit subgraph lottery limit

### DIFF
--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -5,7 +5,7 @@ import { LotteryUserGraphEntity, LotteryResponse, UserRound } from 'state/types'
 import { getRoundIdsArray, fetchMultipleLotteries, hasRoundBeenClaimed } from './helpers'
 import { fetchUserTicketsForMultipleRounds } from './getUserTicketsData'
 
-const MAX_USER_LOTTERIES_REQUEST_SIZE = 100
+export const MAX_USER_LOTTERIES_REQUEST_SIZE = 100
 
 /* eslint-disable camelcase */
 type UserLotteriesWhere = { lottery_in?: string[] }

--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -4,7 +4,7 @@ import { LotteryTicket, LotteryStatus } from 'config/constants/types'
 import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
 import { fetchLottery, fetchCurrentLotteryIdAndMaxBuy } from './helpers'
 import getLotteriesData from './getLotteriesData'
-import getUserLotteryData from './getUserLotteryData'
+import getUserLotteryData, { getGraphLotteryUser } from './getUserLotteryData'
 
 interface PublicLotteryData {
   currentLotteryId: string
@@ -85,6 +85,14 @@ export const fetchUserLotteries = createAsyncThunk<
   return userLotteries
 })
 
+export const fetchAdditionalUserLotteries = createAsyncThunk<
+  LotteryUserGraphEntity,
+  { account: string; skip?: number }
+>('lottery/fetchAdditionalUserLotteries', async ({ account, skip }) => {
+  const additionalUserLotteries = await getGraphLotteryUser(account, undefined, skip)
+  return additionalUserLotteries
+})
+
 export const setLotteryIsTransitioning = createAsyncThunk<{ isTransitioning: boolean }, { isTransitioning: boolean }>(
   `lottery/setIsTransitioning`,
   async ({ isTransitioning }) => {
@@ -121,6 +129,10 @@ export const LotterySlice = createSlice({
     })
     builder.addCase(fetchUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {
       state.userLotteryData = action.payload
+    })
+    builder.addCase(fetchAdditionalUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {
+      const mergedRounds = [...state.userLotteryData.rounds, ...action.payload.rounds]
+      state.userLotteryData.rounds = mergedRounds
     })
     builder.addCase(
       setLotteryIsTransitioning.fulfilled,

--- a/src/views/Lottery/components/YourHistoryCard/FinishedRoundTable.tsx
+++ b/src/views/Lottery/components/YourHistoryCard/FinishedRoundTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Text, Box, Flex } from '@pancakeswap/uikit'
+import { Text, Box, Flex, Button } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryStatus } from 'config/constants/types'
 import { useGetUserLotteriesGraphData } from 'state/lottery/hooks'
@@ -13,9 +13,15 @@ const Grid = styled(Box)`
 
 interface FinishedRoundTableProps {
   handleHistoryRowClick: (string) => void
+  handleShowMoreClick: () => void
+  numUserRoundsRequested: number
 }
 
-const FinishedRoundTable: React.FC<FinishedRoundTableProps> = ({ handleHistoryRowClick }) => {
+const FinishedRoundTable: React.FC<FinishedRoundTableProps> = ({
+  handleShowMoreClick,
+  numUserRoundsRequested,
+  handleHistoryRowClick,
+}) => {
   const { t } = useTranslation()
   const userLotteryData = useGetUserLotteriesGraphData()
 
@@ -53,6 +59,13 @@ const FinishedRoundTable: React.FC<FinishedRoundTableProps> = ({ handleHistoryRo
               onClick={handleHistoryRowClick}
             />
           ))}
+        {userLotteryData?.rounds?.length === numUserRoundsRequested && (
+          <Flex justifyContent="center">
+            <Button mt="12px" variant="text" width="fit-content" onClick={handleShowMoreClick}>
+              {t('Show More')}
+            </Button>
+          </Flex>
+        )}
       </Flex>
     </>
   )

--- a/src/views/Lottery/components/YourHistoryCard/index.tsx
+++ b/src/views/Lottery/components/YourHistoryCard/index.tsx
@@ -26,6 +26,11 @@ import PreviousRoundCardBody from '../PreviousRoundCard/Body'
 import { processLotteryResponse, getDrawnDate } from '../../helpers'
 import PreviousRoundCardFooter from '../PreviousRoundCard/Footer'
 
+interface YourHistoryCardProps {
+  handleShowMoreClick: () => void
+  numUserRoundsRequested: number
+}
+
 const StyledCard = styled(Card)`
   width: 100%;
 
@@ -42,7 +47,7 @@ const StyledCardBody = styled(CardBody)`
   min-height: 240px;
 `
 
-const YourHistoryCard = () => {
+const YourHistoryCard: React.FC<YourHistoryCardProps> = ({ handleShowMoreClick, numUserRoundsRequested }) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const [shouldShowRoundDetail, setShouldShowRoundDetail] = useState(false)
@@ -128,7 +133,13 @@ const YourHistoryCard = () => {
         </StyledCardBody>
       )
     }
-    return <FinishedRoundTable handleHistoryRowClick={handleHistoryRowClick} />
+    return (
+      <FinishedRoundTable
+        handleHistoryRowClick={handleHistoryRowClick}
+        handleShowMoreClick={handleShowMoreClick}
+        numUserRoundsRequested={numUserRoundsRequested}
+      />
+    )
   }
 
   const getFooter = () => {

--- a/src/views/Lottery/hooks/useShowMoreUserRounds.ts
+++ b/src/views/Lottery/hooks/useShowMoreUserRounds.ts
@@ -1,0 +1,20 @@
+import { useWeb3React } from '@web3-react/core'
+import { useState } from 'react'
+import { useAppDispatch } from 'state'
+import { fetchAdditionalUserLotteries } from 'state/lottery'
+import { MAX_USER_LOTTERIES_REQUEST_SIZE } from 'state/lottery/getUserLotteryData'
+
+const useShowMoreUserRounds = () => {
+  const { account } = useWeb3React()
+  const dispatch = useAppDispatch()
+  const [numUserRoundsRequested, setNumUserRoundsRequested] = useState(MAX_USER_LOTTERIES_REQUEST_SIZE)
+
+  const handleShowMoreUserRounds = () => {
+    dispatch(fetchAdditionalUserLotteries({ account, skip: numUserRoundsRequested }))
+    setNumUserRoundsRequested(numUserRoundsRequested + MAX_USER_LOTTERIES_REQUEST_SIZE)
+  }
+
+  return { numUserRoundsRequested, handleShowMoreUserRounds }
+}
+
+export default useShowMoreUserRounds

--- a/src/views/Lottery/index.tsx
+++ b/src/views/Lottery/index.tsx
@@ -23,6 +23,7 @@ import YourHistoryCard from './components/YourHistoryCard'
 import AllHistoryCard from './components/AllHistoryCard'
 import CheckPrizesSection from './components/CheckPrizesSection'
 import HowToPlay from './components/HowToPlay'
+import useShowMoreUserHistory from './hooks/useShowMoreUserRounds'
 
 const LotteryPage = styled.div`
   min-height: calc(100vh - 64px);
@@ -39,6 +40,7 @@ const Lottery = () => {
   const [historyTabMenuIndex, setHistoryTabMenuIndex] = useState(0)
   const endTimeAsInt = parseInt(endTime, 10)
   const { nextEventTime, postCountdownText, preCountdownText } = useGetNextLotteryEvent(endTimeAsInt, status)
+  const { numUserRoundsRequested, handleShowMoreUserRounds } = useShowMoreUserHistory()
 
   return (
     <LotteryPage>
@@ -92,7 +94,14 @@ const Lottery = () => {
               setActiveIndex={(index) => setHistoryTabMenuIndex(index)}
             />
           </Box>
-          {historyTabMenuIndex === 0 ? <AllHistoryCard /> : <YourHistoryCard />}
+          {historyTabMenuIndex === 0 ? (
+            <AllHistoryCard />
+          ) : (
+            <YourHistoryCard
+              handleShowMoreClick={handleShowMoreUserRounds}
+              numUserRoundsRequested={numUserRoundsRequested}
+            />
+          )}
         </Flex>
       </PageSection>
       <PageSection


### PR DESCRIPTION
- Conditionally render a 'See More' button within Finished Rounds > Your History when the max number of lotteries returned by the subgraph is equal to the number of lotteries being displayed.

![Screenshot 2021-08-24 at 15 50 30](https://user-images.githubusercontent.com/79279477/130638817-eeebe2c1-0710-49f6-a906-24bf1bb120d5.png)

- Currently will only appear for users who have entered 100+ rounds
- On click, an additional 100 are fetched. 'See More' will continue to display while the total number of lottery rounds shown matches the max number of lotteries requested.
- As the `numUserRoundsRequested` needs to be persisted outwith the component - I made a small hook to handle the logic and keep the `lottery/index.tsx` file clean.