### PR TITLE
fix(lottery): Fix lottery page crash

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1363,5 +1363,7 @@
   "Download your v0.1 Prediction history below.": "Download your v0.1 Prediction history below.",
   "Nothing to Collect": "Nothing to Collect",
   "From round %round%": "From round %round%",
-  "From rounds %rounds%": "From rounds %rounds%"
+  "From rounds %rounds%": "From rounds %rounds%",
+  "Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.": "Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.",
+  "More information": "More information"
 }

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -47,7 +47,9 @@ const applyNodeDataToLotteriesGraphResponse = (
 
   // Return the rounds with combined node + subgraph data, plus all remaining subgraph rounds.
   const [lastCombinedDataRound] = nodeRoundsWithGraphData.slice(-1)
-  const lastCombinedDataRoundIndex = graphResponse.map((graphRound) => graphRound.id).indexOf(lastCombinedDataRound.id)
+  const lastCombinedDataRoundIndex = graphResponse
+    .map((graphRound) => graphRound?.id)
+    .indexOf(lastCombinedDataRound?.id)
 
   const remainingSubgraphRounds = graphResponse ? graphResponse.splice(lastCombinedDataRoundIndex + 1) : []
   const mergedResponse = [...nodeRoundsWithGraphData, ...remainingSubgraphRounds]

--- a/src/state/lottery/getLotteriesData.ts
+++ b/src/state/lottery/getLotteriesData.ts
@@ -48,8 +48,8 @@ const applyNodeDataToLotteriesGraphResponse = (
   // Return the rounds with combined node + subgraph data, plus all remaining subgraph rounds.
   const [lastCombinedDataRound] = nodeRoundsWithGraphData.slice(-1)
   const lastCombinedDataRoundIndex = graphResponse.map((graphRound) => graphRound.id).indexOf(lastCombinedDataRound.id)
-  const remainingSubgraphRounds =
-    lastCombinedDataRoundIndex >= 0 ? graphResponse.splice(lastCombinedDataRoundIndex + 1) : []
+
+  const remainingSubgraphRounds = graphResponse ? graphResponse.splice(lastCombinedDataRoundIndex + 1) : []
   const mergedResponse = [...nodeRoundsWithGraphData, ...remainingSubgraphRounds]
   return mergedResponse
 }

--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -49,8 +49,8 @@ const applyNodeDataToUserGraphResponse = (
   // Return the rounds with combined data, plus all remaining subgraph rounds.
   const [lastCombinedDataRound] = nodeRoundsWithGraphData.slice(-1)
   const lastCombinedDataRoundIndex = userGraphData
-    .map((graphRound) => graphRound.lotteryId)
-    .indexOf(lastCombinedDataRound.lotteryId)
+    .map((graphRound) => graphRound?.lotteryId)
+    .indexOf(lastCombinedDataRound?.lotteryId)
   const remainingSubgraphRounds = userGraphData ? userGraphData.splice(lastCombinedDataRoundIndex + 1) : []
   const mergedResponse = [...nodeRoundsWithGraphData, ...remainingSubgraphRounds]
   return mergedResponse

--- a/src/state/lottery/getUserLotteryData.ts
+++ b/src/state/lottery/getUserLotteryData.ts
@@ -41,7 +41,7 @@ const applyNodeDataToUserGraphResponse = (
       status: nodeRoundData.status,
       lotteryId: nodeRoundData.lotteryId.toString(),
       claimed: hasRoundBeenClaimed(userNodeRound.userTickets),
-      totalTickets: userGraphRound?.totalTickets,
+      totalTickets: userGraphRound?.totalTickets || userNodeRound.userTickets.length.toString(),
       tickets: userNodeRound.userTickets,
     }
   })
@@ -51,8 +51,7 @@ const applyNodeDataToUserGraphResponse = (
   const lastCombinedDataRoundIndex = userGraphData
     .map((graphRound) => graphRound.lotteryId)
     .indexOf(lastCombinedDataRound.lotteryId)
-  const remainingSubgraphRounds =
-    lastCombinedDataRoundIndex >= 0 ? userGraphData.splice(lastCombinedDataRoundIndex + 1) : []
+  const remainingSubgraphRounds = userGraphData ? userGraphData.splice(lastCombinedDataRoundIndex + 1) : []
   const mergedResponse = [...nodeRoundsWithGraphData, ...remainingSubgraphRounds]
   return mergedResponse
 }

--- a/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
@@ -27,7 +27,7 @@ const PreviousRoundCardFooter: React.FC<{ lotteryNodeData: LotteryRound; lottery
 }) => {
   const { t } = useTranslation()
   const [fetchedLotteryGraphData, setFetchedLotteryGraphData] = useState<LotteryRoundGraphEntity>()
-  const lotteryGraphData = useGetLotteryGraphDataById(lotteryId)
+  const lotteryGraphDataFromState = useGetLotteryGraphDataById(lotteryId)
   const cakePriceBusd = usePriceCakeBusd()
 
   useEffect(() => {
@@ -35,10 +35,10 @@ const PreviousRoundCardFooter: React.FC<{ lotteryNodeData: LotteryRound; lottery
       const fetchedGraphData = await getGraphLotteries(undefined, undefined, { id_in: [lotteryId] })
       setFetchedLotteryGraphData(fetchedGraphData[0])
     }
-    if (!lotteryGraphData) {
+    if (!lotteryGraphDataFromState) {
       getGraphData()
     }
-  }, [lotteryGraphData, lotteryId])
+  }, [lotteryGraphDataFromState, lotteryId])
 
   let prizeInBusd = new BigNumber(NaN)
   if (lotteryNodeData) {
@@ -47,12 +47,12 @@ const PreviousRoundCardFooter: React.FC<{ lotteryNodeData: LotteryRound; lottery
   }
 
   const getTotalUsers = (): string => {
-    if (!lotteryGraphData && fetchedLotteryGraphData) {
-      return fetchedLotteryGraphData.totalUsers.toLocaleString()
+    if (!lotteryGraphDataFromState && fetchedLotteryGraphData) {
+      return fetchedLotteryGraphData?.totalUsers?.toLocaleString()
     }
 
-    if (lotteryGraphData) {
-      return lotteryGraphData.totalUsers.toLocaleString()
+    if (lotteryGraphDataFromState) {
+      return lotteryGraphDataFromState?.totalUsers?.toLocaleString()
     }
 
     return null
@@ -94,7 +94,7 @@ const PreviousRoundCardFooter: React.FC<{ lotteryNodeData: LotteryRound; lottery
           <Flex>
             <Text fontSize="14px" display="inline">
               {t('Total players this round')}:{' '}
-              {lotteryNodeData && (lotteryGraphData || fetchedLotteryGraphData) ? (
+              {lotteryNodeData && (lotteryGraphDataFromState || fetchedLotteryGraphData) ? (
                 getTotalUsers()
               ) : (
                 <Skeleton height={14} width={31} />

--- a/src/views/Lottery/components/YourHistoryCard/index.tsx
+++ b/src/views/Lottery/components/YourHistoryCard/index.tsx
@@ -12,6 +12,7 @@ import {
   Heading,
   Skeleton,
   Box,
+  Link,
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryStatus } from 'config/constants/types'
@@ -45,6 +46,10 @@ const StyledCardBody = styled(CardBody)`
   align-items: center;
   justify-content: center;
   min-height: 240px;
+`
+
+const StyledLink = styled(Link)`
+  display: inline;
 `
 
 const YourHistoryCard: React.FC<YourHistoryCardProps> = ({ handleShowMoreClick, numUserRoundsRequested }) => {
@@ -150,7 +155,15 @@ const YourHistoryCard: React.FC<YourHistoryCardProps> = ({ handleShowMoreClick, 
       <CardFooter>
         <Flex flexDirection="column" justifyContent="center" alignItems="center">
           <Text fontSize="12px" color="textSubtle">
-            {t('Only showing data for Lottery V2')}
+            {t(
+              'Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.',
+            )}
+          </Text>
+          <Text display="inline" fontSize="12px" color="textSubtle">
+            {t('More information')}{' '}
+            <StyledLink fontSize="12px" external href="https://status.thegraph.com/">
+              status.thegraph.com
+            </StyledLink>
           </Text>
         </Flex>
       </CardFooter>


### PR DESCRIPTION
Preview https://adoring-golick-c9fee3.netlify.app/lottery

- Fix crash when expanding details of a past round without `totalUsers` data
- Improve logic appending subgraph data to node data for user-entered and public lotteries
- Add notice for subgraph delay to user history
<img width="803" alt="Screenshot 2021-08-27 at 13 22 22" src="https://user-images.githubusercontent.com/79279477/131126950-c8d21da1-99c2-44c2-865d-8dad46376129.png">
