### PR TITLE
chore(lottery): Restore original lottery history user notice

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1363,7 +1363,5 @@
   "Download your v0.1 Prediction history below.": "Download your v0.1 Prediction history below.",
   "Nothing to Collect": "Nothing to Collect",
   "From round %round%": "From round %round%",
-  "From rounds %rounds%": "From rounds %rounds%",
-  "Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.": "Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.",
-  "More information": "More information"
+  "From rounds %rounds%": "From rounds %rounds%"
 }

--- a/src/views/Lottery/components/YourHistoryCard/index.tsx
+++ b/src/views/Lottery/components/YourHistoryCard/index.tsx
@@ -12,7 +12,6 @@ import {
   Heading,
   Skeleton,
   Box,
-  Link,
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryStatus } from 'config/constants/types'
@@ -46,10 +45,6 @@ const StyledCardBody = styled(CardBody)`
   align-items: center;
   justify-content: center;
   min-height: 240px;
-`
-
-const StyledLink = styled(Link)`
-  display: inline;
 `
 
 const YourHistoryCard: React.FC<YourHistoryCardProps> = ({ handleShowMoreClick, numUserRoundsRequested }) => {
@@ -155,15 +150,7 @@ const YourHistoryCard: React.FC<YourHistoryCardProps> = ({ handleShowMoreClick, 
       <CardFooter>
         <Flex flexDirection="column" justifyContent="center" alignItems="center">
           <Text fontSize="12px" color="textSubtle">
-            {t(
-              'Note - due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.',
-            )}
-          </Text>
-          <Text display="inline" fontSize="12px" color="textSubtle">
-            {t('More information')}{' '}
-            <StyledLink fontSize="12px" external href="https://status.thegraph.com/">
-              status.thegraph.com
-            </StyledLink>
+            {t('Only showing data for Lottery V2')}
           </Text>
         </Flex>
       </CardFooter>


### PR DESCRIPTION
Only merge when the lottery subgraph is stable.

- Remove 'due to a delay in the BSC Subgraph, lotteries after round 108 may temporarily show incomplete data.' notice