### PR TITLE
fix: Trade battle shows live without account connected

### DIFF
--- a/src/views/TradingCompetition/index.tsx
+++ b/src/views/TradingCompetition/index.tsx
@@ -71,7 +71,7 @@ const TradingCompetition = () => {
   const { profile, isLoading } = useProfile()
   const { isDark, theme } = useTheme()
   const tradingCompetitionContract = useTradingCompetitionContract()
-  const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.LIVE)
+  const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.CLAIM)
   const [registrationSuccessful, setRegistrationSuccessful] = useState(false)
   const [claimSuccessful, setClaimSuccessful] = useState(false)
   const [userTradingInformation, setUserTradingInformation] = useState({
@@ -138,6 +138,7 @@ const TradingCompetition = () => {
 
     if (account) {
       fetchUserContract()
+      fetchCompetitionInfoContract()
     } else {
       setUserTradingInformation({
         hasRegistered: false,
@@ -148,7 +149,6 @@ const TradingCompetition = () => {
         canClaimNFT: false,
       })
     }
-    fetchCompetitionInfoContract()
   }, [account, registrationSuccessful, claimSuccessful, tradingCompetitionContract])
 
   useEffect(() => {


### PR DESCRIPTION
Contract cannot be called without an account. It gives an error. 

`Uncaught (in promise) Error: unknown account #0 (operation="getAddress", code=UNSUPPORTED_OPERATION, version=providers/5.4.1)`

It has to be set CLAIM by default for now until there has a new campaign

Fixes #2016 

To review: 

https://deploy-preview-2020--pancakeswap-dev.netlify.app/