### PR TITLE
feat: Adapt wallet modal hook usage for translation support

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1373,7 +1373,6 @@
   "Net Winnings": "Net Winnings",
   "Total BNB": "Total BNB",
   "%num%m": "%num%m",
-  "View More": "View More",
   "Rounds Played": "Rounds Played",
   "Winnings (BNB)": "Winnings (BNB)",
   "Direction": "Direction",
@@ -1381,5 +1380,7 @@
   "View Stats": "View Stats",
   "Last %num% Bets": "Last %num% Bets",
   "Search %subject%": "Search %subject%",
-  "Address": "Address"
+  "Address": "Address",
+  "Learn How to Connect": "Learn How to Connect",
+  "Haven’t got a crypto wallet yet?": "Haven’t got a crypto wallet yet?"
 }


### PR DESCRIPTION
can be merged after https://github.com/pancakeswap/pancake-toolkit/pull/257 merged to toolkit and bumped version up in frontend

To reproduce: 

1. Go to homepage without connecting your account
2. Change language
3. Click connect wallet
4. See the modal is not translated