### PR TITLE
fix: (farms) Empty multiplier tag in farms card when loading

### DIFF
--- a/src/views/Farms/components/FarmCard/CardHeading.tsx
+++ b/src/views/Farms/components/FarmCard/CardHeading.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Tag, Flex, Heading } from '@pancakeswap/uikit'
+import { Tag, Flex, Heading, Skeleton } from '@pancakeswap/uikit'
 import { CommunityTag, CoreTag } from 'components/Tags'
 import { Token } from 'config/constants/types'
 import { TokenPairImage } from 'components/TokenImage'
@@ -31,7 +31,11 @@ const CardHeading: React.FC<ExpandableSectionProps> = ({ lpLabel, multiplier, is
         <Heading mb="4px">{lpLabel.split(' ')[0]}</Heading>
         <Flex justifyContent="center">
           {isCommunityFarm ? <CommunityTag /> : <CoreTag />}
-          <MultiplierTag variant="secondary">{multiplier}</MultiplierTag>
+          {multiplier ? (
+            <MultiplierTag variant="secondary">{multiplier}</MultiplierTag>
+          ) : (
+            <Skeleton ml="4px" width={42} height={28} />
+          )}
         </Flex>
       </Flex>
     </Wrapper>


### PR DESCRIPTION
To review:

https://deploy-preview-2047--pancakeswap-dev.netlify.app/

To reproduce:

1. Go farms card
2. Check empty purple multiplier tag when loading

Before: 

<img width="776" alt="image" src="https://user-images.githubusercontent.com/2213635/131490229-324b6480-199f-4935-bc86-e5ca71b2a228.png">

After: 

<img width="784" alt="image" src="https://user-images.githubusercontent.com/2213635/131490088-c1ede36a-8da3-4fa0-a432-cbcb168715bf.png">
