### PR TITLE
fix: (menu) Menu item active highlight for liquidity not working

### DIFF
--- a/src/components/Menu/config.ts
+++ b/src/components/Menu/config.ts
@@ -17,7 +17,7 @@ const config: (t: ContextApi['t']) => MenuEntry[] = (t) => [
       },
       {
         label: t('Liquidity'),
-        href: '/pool',
+        href: '/liquidity',
       },
       {
         label: t('LP Migration'),


### PR DESCRIPTION
To review:

https://deploy-preview-2048--pancakeswap-dev.netlify.app/

To reproduce:

1. Click trade in menu
2. Click Liquidity
3. See menu item doesn't indicate the active page.