### PR TITLE
fix: Pools card performance fee shows 0 when loading

### DIFF
--- a/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
+++ b/src/views/Pools/components/PoolCard/CardFooter/ExpandedFooter.tsx
@@ -140,9 +140,13 @@ const ExpandedFooter: React.FC<ExpandedFooterProps> = ({ pool, account }) => {
             {t('Performance Fee')}
           </TooltipText>
           <Flex alignItems="center">
-            <Text ml="4px" small>
-              {performanceFee / 100}%
-            </Text>
+            {performanceFee ? (
+              <Text ml="4px" small>
+                {performanceFee / 100}%
+              </Text>
+            ) : (
+              <Skeleton width="90px" height="21px" />
+            )}
           </Flex>
         </Flex>
       )}


### PR DESCRIPTION
To review:

https://deploy-preview-2049--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to pools card
2. Go to auto vault card
3. Click details
4. See performance fee shows 0 when data loading