### PR TITLE
fix: Page title stays the same when switch to Home page from Menu

### DIFF
--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -23,7 +23,7 @@ const StyledPage = styled(Container)`
   }
 `
 
-const PageMeta: React.FC<{ symbol?: string }> = ({ symbol }) => {
+export const PageMeta: React.FC<{ symbol?: string }> = ({ symbol }) => {
   const { t } = useTranslation()
   const { pathname } = useLocation()
   const cakePriceUsd = useCakeBusdPrice()

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -4,6 +4,7 @@ import PageSection from 'components/PageSection'
 import { useWeb3React } from '@web3-react/core'
 import useTheme from 'hooks/useTheme'
 import Container from 'components/Layout/Container'
+import { PageMeta } from 'components/Layout/Page'
 import Hero from './components/Hero'
 import { swapSectionData, earnSectionData, cakeSectionData } from './components/SalesSection/data'
 import MetricsSection from './components/MetricsSection'
@@ -47,6 +48,7 @@ const Home: React.FC = () => {
 
   return (
     <>
+      <PageMeta />
       <StyledHeroSection
         innerProps={{ style: { margin: '0', width: '100%' } }}
         background={


### PR DESCRIPTION
Fixes #2066 

To review: 

https://deploy-preview-2068--pancakeswap-dev.netlify.app/