### PR TITLE
fix: Translation key missing for connect modal component

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1382,6 +1382,7 @@
   "Search %subject%": "Search %subject%",
   "Address": "Address",
   "Learn How to Connect": "Learn How to Connect",
+  "Haven’t got a crypto wallet yet?": "Haven’t got a crypto wallet yet?",
   "Neither side wins this round": "Neither side wins this round",
   "The Locked Price & Closed Price are exactly the same (within 8 decimals), so neither side wins. All funds entered into UP and DOWN positions will go to the weekly CAKE burn.": "The Locked Price & Closed Price are exactly the same (within 8 decimals), so neither side wins. All funds entered into UP and DOWN positions will go to the weekly CAKE burn.",
   "To Burn": "To Burn",


### PR DESCRIPTION
It is removed by mistake in previous commits, cannot be detected with tests since that component is in toolkit :(