### PR TITLE
fix: Lottery bunny resize at footer in safari mobile

### DIFF
--- a/src/views/Lottery/components/HowToPlay.tsx
+++ b/src/views/Lottery/components/HowToPlay.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Box, Flex, Text, Heading, useMatchBreakpoints, Link } from '@pancakeswap/uikit'
+import { Box, Flex, Text, Heading, useMatchBreakpoints, Link, Image } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import useTheme from 'hooks/useTheme'
 import { BallWithNumber, MatchExampleA, MatchExampleB, PoolAllocationChart } from '../svgs'
@@ -338,9 +338,7 @@ const HowToPlay: React.FC = () => {
       </GappedFlex>
       <Divider />
       <Flex justifyContent="center" alignItems="center" flexDirection={['column', 'column', 'row']}>
-        <Flex maxWidth="240px" mr="8px" mb="16px">
-          <img src="/images/lottery/tombola.png" alt="tombola bunny" />
-        </Flex>
+        <Image width={240} height={172} src="/images/lottery/tombola.png" alt="tombola bunny" mr="8px" mb="16px" />
         <Flex maxWidth="300px" flexDirection="column">
           <Heading mb="16px" scale="md">
             {t('Still got questions?')}


### PR DESCRIPTION
Somehow safari mobile doesn't take the height proportions correctly that we have to manually define it

To review:

To reproduce:

1. Go to lottery with iOS Safari 
2. Check bottom
3. See bunny logo height is not correct and image looks stretched
