### PR TITLE
fix: Remove farm schedule from farm auctions

### DIFF
--- a/src/config/constants/types.ts
+++ b/src/config/constants/types.ts
@@ -178,10 +178,6 @@ export interface Auction {
   endBlock: number
   endDate: Date
   auctionDuration: number
-  farmStartBlock: number
-  farmStartDate: Date
-  farmEndBlock: number
-  farmEndDate: Date
   initialBidAmount: number
   topLeaderboard: number
   leaderboardThreshold: BigNumber

--- a/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
+++ b/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Text, Flex, Box, CardFooter, ExpandableLabel } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { Auction, AuctionStatus } from 'config/constants/types'
-import { FarmSchedule } from './AuctionSchedule'
 import WhitelistedBiddersButton from '../WhitelistedBiddersButton'
 
 const FooterInner = styled(Box)`
@@ -38,7 +37,6 @@ const AuctionFooter: React.FC<{ auction: Auction }> = ({ auction }) => {
               <Text color="textSubtle">{t('Total whitelisted bidders')}</Text>
               <WhitelistedBiddersButton />
             </Flex>
-            <FarmSchedule auction={auction} />
           </Flex>
         </FooterInner>
       )}

--- a/src/views/FarmAuction/components/AuctionDetailsCard/AuctionSchedule.tsx
+++ b/src/views/FarmAuction/components/AuctionDetailsCard/AuctionSchedule.tsx
@@ -18,7 +18,7 @@ interface ScheduleProps {
   showForClosedAuction?: boolean
 }
 
-export const AuctionSchedule: React.FC<ScheduleProps> = ({ auction }) => {
+const AuctionSchedule: React.FC<ScheduleProps> = ({ auction }) => {
   const { startBlock, endBlock, auctionDuration, startDate, endDate, status } = auction
   const { t } = useTranslation()
 
@@ -73,59 +73,4 @@ export const AuctionSchedule: React.FC<ScheduleProps> = ({ auction }) => {
   )
 }
 
-export const FarmSchedule: React.FC<ScheduleProps> = ({ auction, showForClosedAuction }) => {
-  const { status, farmStartBlock, farmEndBlock, farmStartDate, farmEndDate } = auction
-  const { t } = useTranslation()
-
-  let scheduleToBeAnnounced = status === AuctionStatus.ToBeAnnounced || status === AuctionStatus.Closed
-  // Schedule for closed auction is shown in congratulation card but not shown in Next Auction card
-  if (showForClosedAuction) {
-    scheduleToBeAnnounced = false
-  }
-
-  return (
-    <Flex flexDirection="column" mt="24px">
-      <Text textTransform="uppercase" color="secondary" bold fontSize="12px" mb="8px">
-        {t('Farm schedule')}
-      </Text>
-      <ScheduleInner>
-        <Flex justifyContent="space-between" mb="8px">
-          <Text small color="textSubtle">
-            {t('Farm duration')}
-          </Text>
-          <Text small>{t('%num% days', { num: 7 })}</Text>
-        </Flex>
-        <Flex justifyContent="space-between" mb="8px">
-          <Text small color="textSubtle">
-            {t('Start')}
-          </Text>
-          {scheduleToBeAnnounced ? (
-            <Text small>{t('To be announced')}</Text>
-          ) : (
-            <Box>
-              <Text small>{format(farmStartDate, 'MMMM dd yyyy hh:mm aa')}</Text>
-              <Text small textAlign="right">
-                {t('Block %num%', { num: farmStartBlock })}
-              </Text>
-            </Box>
-          )}
-        </Flex>
-        <Flex justifyContent="space-between">
-          <Text small color="textSubtle">
-            {t('End')}
-          </Text>
-          {scheduleToBeAnnounced ? (
-            <Text small>{t('To be announced')}</Text>
-          ) : (
-            <Box>
-              <Text small>{format(farmEndDate, 'MMMM dd yyyy hh:mm aa')}</Text>
-              <Text small textAlign="right">
-                {t('Block %num%', { num: farmEndBlock })}
-              </Text>
-            </Box>
-          )}
-        </Flex>
-      </ScheduleInner>
-    </Flex>
-  )
-}
+export default AuctionSchedule

--- a/src/views/FarmAuction/components/AuctionDetailsCard/index.tsx
+++ b/src/views/FarmAuction/components/AuctionDetailsCard/index.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'contexts/Localization'
 import { Auction, AuctionStatus, ConnectedBidder } from 'config/constants/types'
 import { getBalanceNumber } from 'utils/formatBalance'
 import PlaceBidModal from '../PlaceBidModal'
-import { AuctionSchedule } from './AuctionSchedule'
+import AuctionSchedule from './AuctionSchedule'
 import CannotBidMessage from './CannotBidMessage'
 import AuctionFooter from './AuctionFooter'
 

--- a/src/views/FarmAuction/components/CongratulationsCard.tsx
+++ b/src/views/FarmAuction/components/CongratulationsCard.tsx
@@ -5,7 +5,6 @@ import { Auction, Bidder } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'
 import { getBalanceNumber } from 'utils/formatBalance'
 import useCongratulateAuctionWinner from '../hooks/useCongratulateAuctionWinner'
-import { FarmSchedule } from './AuctionDetailsCard/AuctionSchedule'
 import WhitelistedBiddersButton from './WhitelistedBiddersButton'
 
 const StyledReclaimBidCard = styled(Card)`
@@ -40,7 +39,6 @@ const CongratulationsCard: React.FC<{ currentAuction: Auction; bidders: Bidder[]
             <Text color="textSubtle">{t('Total whitelisted bidders')}</Text>
             <WhitelistedBiddersButton />
           </Flex>
-          <FarmSchedule auction={auction} showForClosedAuction />
         </Flex>
 
         <Flex justifyContent="space-between" mb="8px">

--- a/src/views/FarmAuction/helpers.tsx
+++ b/src/views/FarmAuction/helpers.tsx
@@ -1,4 +1,4 @@
-import { toDate, add, hoursToSeconds, differenceInHours } from 'date-fns'
+import { toDate, add, differenceInHours } from 'date-fns'
 import { BSC_BLOCK_TIME, DEFAULT_TOKEN_DECIMAL } from 'config'
 import { getBidderInfo } from 'config/constants/farmAuctions'
 import { simpleRpcProvider } from 'utils/providers'
@@ -117,12 +117,6 @@ export const processAuctionData = async (auctionId: number, auctionResponse: Auc
   const currentBlock = await simpleRpcProvider.getBlockNumber()
   const startDate = await getDateForBlock(currentBlock, processedAuctionData.startBlock)
   const endDate = await getDateForBlock(currentBlock, processedAuctionData.endBlock)
-  const farmStartDate = add(endDate, { hours: 12 })
-  const blocksToFarmStartDate = hoursToSeconds(12) / BSC_BLOCK_TIME
-  const farmStartBlock = processedAuctionData.endBlock + blocksToFarmStartDate
-  const farmDurationInBlocks = hoursToSeconds(7 * 24) / BSC_BLOCK_TIME
-  const farmEndBlock = farmStartBlock + farmDurationInBlocks
-  const farmEndDate = add(farmStartDate, { weeks: 1 })
 
   const auctionStatus = getAuctionStatus(
     currentBlock,
@@ -136,10 +130,6 @@ export const processAuctionData = async (auctionId: number, auctionResponse: Auc
     startDate,
     endDate,
     auctionDuration: differenceInHours(endDate, startDate),
-    farmStartBlock,
-    farmStartDate,
-    farmEndBlock,
-    farmEndDate,
     ...processedAuctionData,
     status: auctionStatus,
   }


### PR DESCRIPTION
We ended up launching farms ASAP instead of planned 12h after auction end, so farm schedule is not needed.