### PR TITLE
fix: Prediction Leaderboard button missing in mobile

### DIFF
--- a/src/views/Predictions/components/Label.tsx
+++ b/src/views/Predictions/components/Label.tsx
@@ -40,6 +40,20 @@ const Title = styled(Text)`
   }
 `
 
+const ClosingTitle = styled(Text)`
+  font-size: 9px;
+  line-height: 21px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    font-size: 16px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    font-size: 20px;
+    line-height: 22px;
+  }
+`
+
 const Price = styled(Text)`
   height: 18px;
   justify-self: start;
@@ -119,9 +133,15 @@ export const TimerLabel: React.FC<TimerLabelProps> = ({ interval, unit }) => {
   return (
     <Box pr="24px" position="relative">
       <Label dir="right">
-        <Title bold color="secondary">
-          {secondsRemaining === 0 ? t('Closing') : countdown}
-        </Title>
+        {secondsRemaining !== 0 ? (
+          <Title bold color="secondary">
+            {countdown}
+          </Title>
+        ) : (
+          <ClosingTitle bold color="secondary">
+            {t('Closing')}
+          </ClosingTitle>
+        )}
         <Interval fontSize="12px">{`${interval}${t(unit)}`}</Interval>
       </Label>
       <Token right={0}>

--- a/src/views/Predictions/components/Menu.tsx
+++ b/src/views/Predictions/components/Menu.tsx
@@ -18,7 +18,7 @@ const SetCol = styled.div`
 
 const HelpButtonWrapper = styled.div`
   order: 1;
-  margin: 0 8px 0 0;
+  margin: 0 2px 0 8px;
 
   ${({ theme }) => theme.mediaQueries.lg} {
     order: 2;
@@ -27,10 +27,27 @@ const HelpButtonWrapper = styled.div`
 `
 
 const TimerLabelWrapper = styled.div`
-  order: 2;
+  order: 3;
+  max-width: 100px;
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    max-width: none;
+  }
 
   ${({ theme }) => theme.mediaQueries.lg} {
     order: 1;
+  }
+`
+
+const LeaderboardButtonWrapper = styled.div`
+  display: block;
+
+  order: 2;
+  margin: 0 8px 0 0;
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    order: 3;
+    margin: 0 0 0 8px;
   }
 `
 
@@ -69,11 +86,11 @@ const Menu = () => {
               <HelpIcon width="24px" color="white" />
             </Button>
           </HelpButtonWrapper>
-          <ButtonWrapper style={{ order: 3 }}>
+          <LeaderboardButtonWrapper>
             <Button as={Link} variant="subtle" to="/prediction/leaderboard" width="48px">
               <PrizeIcon color="white" />
             </Button>
-          </ButtonWrapper>
+          </LeaderboardButtonWrapper>
           <ButtonWrapper style={{ order: 4 }}>
             <HistoryButton />
           </ButtonWrapper>


### PR DESCRIPTION
To review: 

https://deploy-preview-2139--pancakeswap-dev.netlify.app/

1. Go to prediction in mobile
2. See leaderboard button is missing above the prediction cards
