### PR TITLE
fix: Add liquidity shows undefined in address bar when selecting token

### DIFF
--- a/src/views/AddLiquidity/index.tsx
+++ b/src/views/AddLiquidity/index.tsx
@@ -257,8 +257,10 @@ export default function AddLiquidity({
       const newCurrencyIdA = currencyId(currencyA_)
       if (newCurrencyIdA === currencyIdB) {
         history.push(`/add/${currencyIdB}/${currencyIdA}`)
-      } else {
+      } else if (currencyIdB) {
         history.push(`/add/${newCurrencyIdA}/${currencyIdB}`)
+      } else {
+        history.push(`/add/${newCurrencyIdA}`)
       }
     },
     [currencyIdB, history, currencyIdA],


### PR DESCRIPTION
To review:



To reproduce:

1. Go to add liquidity
2. Select token from first input panel
3. See undefined in browser address bar