### PR TITLE
chore: Remove duplicated helper function

### DIFF
--- a/src/__tests__/utils/index.test.ts
+++ b/src/__tests__/utils/index.test.ts
@@ -1,15 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { AddressZero } from '@ethersproject/constants'
 import { TokenAmount, Token, ChainId, Percent, JSBI } from '@pancakeswap/sdk'
-
-import {
-  getBscScanLink,
-  calculateSlippageAmount,
-  isAddress,
-  shortenAddress,
-  calculateGasMargin,
-  basisPointsToPercent,
-} from 'utils'
+import { getBscScanLink, calculateSlippageAmount, isAddress, calculateGasMargin, basisPointsToPercent } from 'utils'
 
 describe('utils', () => {
   describe('#getBscScanLink', () => {
@@ -58,24 +50,6 @@ describe('utils', () => {
     })
     it('fails if too long', () => {
       expect(isAddress('f164fc0ec4e93095b804a4795bbe1e041497b92a0')).toBe(false)
-    })
-  })
-
-  describe('#shortenAddress', () => {
-    it('throws on invalid address', () => {
-      expect(() => shortenAddress('abc')).toThrow("Invalid 'address'")
-    })
-
-    it('truncates middle characters', () => {
-      expect(shortenAddress('0xf164fc0ec4e93095b804a4795bbe1e041497b92a')).toBe('0xf164...b92a')
-    })
-
-    it('truncates middle characters even without prefix', () => {
-      expect(shortenAddress('f164fc0ec4e93095b804a4795bbe1e041497b92a')).toBe('0xf164...b92a')
-    })
-
-    it('renders checksummed address', () => {
-      expect(shortenAddress('0x2E1b342132A67Ea578e4E3B814bae2107dc254CC'.toLowerCase())).toBe('0x2E1b...54CC')
     })
   })
 

--- a/src/components/SearchModal/ImportToken.tsx
+++ b/src/components/SearchModal/ImportToken.tsx
@@ -4,6 +4,7 @@ import { Button, Text, ErrorIcon, Flex, Message, Checkbox, Link, Tag, Grid } fro
 import { AutoColumn } from 'components/Layout/Column'
 import { useAddUserToken } from 'state/user/hooks'
 import { getBscScanLink } from 'utils'
+import truncateHash from 'utils/truncateHash'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useCombinedInactiveList } from 'state/lists/hooks'
 import { ListLogo } from 'components/Logo'
@@ -41,9 +42,7 @@ function ImportToken({ tokens, handleCurrencySelect }: ImportProps) {
 
       {tokens.map((token) => {
         const list = chainId && inactiveTokenList?.[chainId]?.[token.address]?.list
-        const address = token.address
-          ? `${token.address.substring(0, 6)}...${token.address.substring(token.address.length - 4)}`
-          : null
+        const address = token.address ? `${truncateHash(token.address)}` : null
         return (
           <Grid key={token.address} gridTemplateRows="1fr 1fr 1fr" gridGap="4px">
             {list !== undefined ? (

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -6,10 +6,11 @@ import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useGasPrice } from 'state/user/hooks'
 import { BIPS_BASE, INITIAL_ALLOWED_SLIPPAGE } from '../config/constants'
 import { useTransactionAdder } from '../state/transactions/hooks'
-import { calculateGasMargin, getRouterContract, isAddress, shortenAddress } from '../utils'
+import { calculateGasMargin, getRouterContract, isAddress } from '../utils'
 import isZero from '../utils/isZero'
 import useTransactionDeadline from './useTransactionDeadline'
 import useENS from './ENS/useENS'
+import truncateHash from 'utils/truncateHash'
 
 export enum SwapCallbackState {
   INVALID,
@@ -189,7 +190,7 @@ export function useSwapCallback(
                 ? base
                 : `${base} to ${
                     recipientAddressOrName && isAddress(recipientAddressOrName)
-                      ? shortenAddress(recipientAddressOrName)
+                      ? truncateHash(recipientAddressOrName)
                       : recipientAddressOrName
                   }`
 

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -4,13 +4,13 @@ import { JSBI, Percent, Router, SwapParameters, Trade, TradeType } from '@pancak
 import { useMemo } from 'react'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useGasPrice } from 'state/user/hooks'
+import truncateHash from 'utils/truncateHash'
 import { BIPS_BASE, INITIAL_ALLOWED_SLIPPAGE } from '../config/constants'
 import { useTransactionAdder } from '../state/transactions/hooks'
 import { calculateGasMargin, getRouterContract, isAddress } from '../utils'
 import isZero from '../utils/isZero'
 import useTransactionDeadline from './useTransactionDeadline'
 import useENS from './ENS/useENS'
-import truncateHash from 'utils/truncateHash'
 
 export enum SwapCallbackState {
   INVALID,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -42,15 +42,6 @@ export function getBscScanLink(
   }
 }
 
-// shorten the checksummed version of the input address to have 0x + 4 characters at start and end
-export function shortenAddress(address: string, chars = 4): string {
-  const parsed = isAddress(address)
-  if (!parsed) {
-    throw Error(`Invalid 'address' parameter '${address}'.`)
-  }
-  return `${parsed.substring(0, chars + 2)}...${parsed.substring(42 - chars)}`
-}
-
 // add 10%
 export function calculateGasMargin(value: BigNumber): BigNumber {
   return value.mul(BigNumber.from(10000).add(BigNumber.from(1000))).div(BigNumber.from(10000))

--- a/src/views/Info/Tokens/TokenPage.tsx
+++ b/src/views/Info/Tokens/TokenPage.tsx
@@ -18,7 +18,8 @@ import {
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import Page from 'components/Layout/Page'
-import { shortenAddress, getBscScanLink } from 'utils'
+import { getBscScanLink } from 'utils'
+import truncateHash from 'utils/truncateHash'
 import useCMCLink from 'views/Info/hooks/useCMCLink'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import { formatAmount } from 'views/Info/utils/formatInfoNumbers'
@@ -136,7 +137,7 @@ const TokenPage: React.FC<RouteComponentProps<{ address: string }>> = ({
                 </Link>
                 <Flex>
                   <Text mr="8px">{tokenData.symbol}</Text>
-                  <Text>{`(${shortenAddress(address)})`}</Text>
+                  <Text>{`(${truncateHash(address)})`}</Text>
                 </Flex>
               </Breadcrumbs>
               <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>

--- a/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -5,7 +5,8 @@ import styled from 'styled-components'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { Text, Flex, Box, Radio, Skeleton, LinkExternal, ArrowForwardIcon, ArrowBackIcon } from '@pancakeswap/uikit'
 import { formatAmount } from 'views/Info/utils/formatInfoNumbers'
-import { shortenAddress, getBscScanLink } from 'utils'
+import { getBscScanLink } from 'utils'
+import truncateHash from 'utils/truncateHash'
 import { Transaction, TransactionType } from 'state/info/types'
 import { ITEMS_PER_INFO_TABLE_PAGE } from 'config/constants/info'
 import { useTranslation } from 'contexts/Localization'
@@ -117,7 +118,7 @@ const DataRow: React.FC<{ transaction: Transaction }> = ({ transaction }) => {
         <Text>{`${formatAmount(abs1)} ${transaction.token1Symbol}`}</Text>
       </Text>
       <LinkExternal href={getBscScanLink(transaction.sender, 'address')}>
-        {shortenAddress(transaction.sender)}
+        {truncateHash(transaction.sender)}
       </LinkExternal>
       <Text>{formatDistanceToNowStrict(parseInt(transaction.timestamp, 10) * 1000)}</Text>
     </ResponsiveGrid>

--- a/src/views/Swap/components/SwapModalHeader.tsx
+++ b/src/views/Swap/components/SwapModalHeader.tsx
@@ -2,13 +2,12 @@ import React, { useMemo } from 'react'
 import { Trade, TradeType } from '@pancakeswap/sdk'
 import { Button, Text, ErrorIcon, ArrowDownIcon } from '@pancakeswap/uikit'
 import { Field } from 'state/swap/actions'
-import { isAddress } from 'utils'
 import { computeSlippageAdjustedAmounts, computeTradePriceBreakdown, warningSeverity } from 'utils/prices'
 import { AutoColumn } from 'components/Layout/Column'
 import { CurrencyLogo } from 'components/Logo'
 import { RowBetween, RowFixed } from 'components/Layout/Row'
-import { TruncatedText, SwapShowAcceptChanges } from './styleds'
 import truncateHash from 'utils/truncateHash'
+import { TruncatedText, SwapShowAcceptChanges } from './styleds'
 
 export default function SwapModalHeader({
   trade,

--- a/src/views/Swap/components/SwapModalHeader.tsx
+++ b/src/views/Swap/components/SwapModalHeader.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from 'react'
 import { Trade, TradeType } from '@pancakeswap/sdk'
 import { Button, Text, ErrorIcon, ArrowDownIcon } from '@pancakeswap/uikit'
 import { Field } from 'state/swap/actions'
-import { isAddress, shortenAddress } from 'utils'
+import { isAddress } from 'utils'
 import { computeSlippageAdjustedAmounts, computeTradePriceBreakdown, warningSeverity } from 'utils/prices'
 import { AutoColumn } from 'components/Layout/Column'
 import { CurrencyLogo } from 'components/Logo'
 import { RowBetween, RowFixed } from 'components/Layout/Row'
 import { TruncatedText, SwapShowAcceptChanges } from './styleds'
+import truncateHash from 'utils/truncateHash'
 
 export default function SwapModalHeader({
   trade,
@@ -105,8 +106,7 @@ export default function SwapModalHeader({
       {recipient !== null ? (
         <AutoColumn justify="flex-start" gap="sm" style={{ padding: '12px 0 0 0px' }}>
           <Text color="textSubtle">
-            Output will be sent to{' '}
-            <b title={recipient}>{isAddress(recipient) ? shortenAddress(recipient) : recipient}</b>
+            Output will be sent to <b title={recipient}>{truncateHash(recipient)}</b>
           </Text>
         </AutoColumn>
       ) : null}


### PR DESCRIPTION
Remove duplicated function to shorten hex-string. One being more widely used (`truncateHash`), I choose to keep this one. The other one (`shortenAddress`) seems to have been added along .info migration. Both functions do have tests.