### PR TITLE
fix: Balance loading indicator missing when user selects token in swap input

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -96,8 +96,8 @@ export default function CurrencyInputPanel({
               <Text fontSize="14px">{translatedLabel}</Text>
               {account && (
                 <Text onClick={onMax} fontSize="14px" style={{ display: 'inline', cursor: 'pointer' }}>
-                  {!hideBalance && !!currency && selectedCurrencyBalance
-                    ? t('Balance: %amount%', { amount: selectedCurrencyBalance?.toSignificant(6) ?? '' })
+                  {!hideBalance && !!currency
+                    ? t('Balance: %balance%', { balance: selectedCurrencyBalance?.toSignificant(6) ?? t('Loading') })
                     : ' -'}
                 </Text>
               )}

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1124,7 +1124,6 @@
   "Your transaction will revert if it is pending for more than this long.": "Your transaction will revert if it is pending for more than this long.",
   "minutes": "minutes",
   "Token Amount": "Token Amount",
-  "Balance: %amount%": "Balance: %amount%",
   "LP tokens in your wallet": "LP tokens in your wallet",
   "Pooled %asset%": "Pooled %asset%",
   "By adding liquidity you'll earn 0.17% of all trades on this pair proportional to your share of the pool. Fees are added to the pool, accrue in real time and can be claimed by withdrawing your liquidity.": "By adding liquidity you'll earn 0.17% of all trades on this pair proportional to your share of the pool. Fees are added to the pool, accrue in real time and can be claimed by withdrawing your liquidity.",


### PR DESCRIPTION
To review:

https://deploy-preview-2160--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to swap with your account
2. Select token
3. See balance inside the input panel shows "-" a few time without loading indicator