### PR TITLE
fix(unknown-account): Add account checks to Profile/Collectibles calls that require accounts 

### DIFF
--- a/src/state/collectibles/hooks.ts
+++ b/src/state/collectibles/hooks.ts
@@ -15,7 +15,7 @@ export const useGetCollectibles = () => {
 
   useEffect(() => {
     // Fetch nfts only if we have not done so already
-    if (!isInitialized) {
+    if (!isInitialized && account) {
       dispatch(fetchWalletNfts(account))
     }
   }, [isInitialized, account, dispatch])

--- a/src/state/collectibles/index.ts
+++ b/src/state/collectibles/index.ts
@@ -23,6 +23,12 @@ export const fetchWalletNfts = createAsyncThunk<NftSourceItem[], string>(
       const { address: addressObj } = collections[nftSourceType]
       const address = getAddress(addressObj)
       const contract = getErc721Contract(address)
+      const balanceOfResponse = await contract.balanceOf(account)
+      const balanceOf = balanceOfResponse.toNumber()
+
+      if (balanceOfResponse.eq(0)) {
+        return []
+      }
 
       const getTokenIdAndData = async (index: number) => {
         try {
@@ -35,13 +41,6 @@ export const fetchWalletNfts = createAsyncThunk<NftSourceItem[], string>(
           console.error('getTokenIdAndData', error)
           return null
         }
-      }
-
-      const balanceOfResponse = await contract.balanceOf(account)
-      const balanceOf = balanceOfResponse.toNumber()
-
-      if (balanceOf === 0) {
-        return []
       }
 
       const nftDataFetchPromises = []

--- a/src/state/profile/helpers.ts
+++ b/src/state/profile/helpers.ts
@@ -111,7 +111,8 @@ export const getProfile = async (address: string): Promise<GetProfileResponse> =
     } as Profile
 
     return { hasRegistered, profile }
-  } catch (error) {
+  } catch (e) {
+    console.error(e)
     return null
   }
 }

--- a/src/state/profile/hooks.ts
+++ b/src/state/profile/hooks.ts
@@ -11,7 +11,9 @@ export const useFetchProfile = () => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    dispatch(fetchProfile(account))
+    if (account) {
+      dispatch(fetchProfile(account))
+    }
   }, [account, dispatch])
 }
 

--- a/src/state/profile/index.tsx
+++ b/src/state/profile/index.tsx
@@ -94,7 +94,8 @@ export const fetchProfile = (address: string) => async (dispatch: AppDispatch) =
     dispatch(profileFetchStart())
     const response = await getProfile(address)
     dispatch(profileFetchSucceeded(response))
-  } catch (error) {
+  } catch (e) {
+    console.error(e)
     dispatch(profileFetchFailed())
   }
 }

--- a/src/views/Collectibles/components/NftCard/LotteryNftCard.tsx
+++ b/src/views/Collectibles/components/NftCard/LotteryNftCard.tsx
@@ -43,7 +43,9 @@ const LotteryNftCard: React.FC<NftCardProps> = ({ nft, ...props }) => {
   }
 
   const LotteryNftRefresh = () => {
-    dispatch(fetchWalletNfts(account))
+    if (account) {
+      dispatch(fetchWalletNfts(account))
+    }
     setIsClaimable(false)
   }
 

--- a/src/views/Collectibles/components/NftList.tsx
+++ b/src/views/Collectibles/components/NftList.tsx
@@ -20,7 +20,9 @@ const NftList = () => {
   const { account } = useWeb3React()
 
   const handleRefresh = useCallback(() => {
-    dispatch(fetchWalletNfts(account))
+    if (account) {
+      dispatch(fetchWalletNfts(account))
+    }
   }, [dispatch, account])
 
   useEffect(() => {


### PR DESCRIPTION
Fixes broken out of nft-market PR as they can go directly into master https://github.com/pancakeswap/pancake-frontend/pull/2154

A recurring 'unknown account' error fires in some pages in the app

```
Error: unknown account #0 (operation="getAddress", code=UNSUPPORTED_OPERATION, version=providers/5.4.1)
```

The impact is sometimes limited to a console error (farm auctions), but on occasion it causes an app crash. 

### Recent changes on the `nft-market` branch have led to this error preventing the `fetchWalletNfts` fetch from resolving. This resolves that