### PR TITLE
refactor(nft): Move routes inside index

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,11 +49,7 @@ const PoolFinder = lazy(() => import('./views/PoolFinder'))
 const RemoveLiquidity = lazy(() => import('./views/RemoveLiquidity'))
 const Info = lazy(() => import('./views/Info'))
 const NftMarket = lazy(() => import('./views/Nft/market'))
-const NftProfile = lazy(() => import('./views/Nft/market/Profile'))
 const ProfileCreation = lazy(() => import('./views/ProfileCreation'))
-const Collectible = lazy(() => import('./views/Nft/market/Collectible'))
-const CollectibleOverview = lazy(() => import('./views/Nft/market/Collectibles'))
-const IndividualNFTPage = lazy(() => import('views/Nft/market/IndividualNFTPage'))
 
 // This config is required for number formatting
 BigNumber.config({
@@ -126,18 +122,6 @@ const App: React.FC = () => {
             </Route>
 
             {/* NFT */}
-            <Route exact path="/nft/market/collectibles">
-              <CollectibleOverview />
-            </Route>
-            <Route path="/nft/market/collectibles/:slug">
-              <Collectible />
-            </Route>
-            <Route path="/nft/market/profile">
-              <NftProfile />
-            </Route>
-            <Route exact path="/nft/market/item/:id">
-              <IndividualNFTPage />
-            </Route>
             <Route path="/nft/market">
               <NftMarket />
             </Route>

--- a/src/state/nftMarket/hooks.ts
+++ b/src/state/nftMarket/hooks.ts
@@ -14,8 +14,12 @@ export const useFetchCollections = () => {
   }, [dispatch])
 }
 
+export const useGetCollections = () => {
+  return useSelector((state: State) => state.nftMarket.data.collections)
+}
+
 export const useCollectionFromSlug = (slug: string) => {
-  const collections = useSelector((state: State) => state.nftMarket.data.collections)
+  const collections = useGetCollections()
   return find(collections, (collection) => slugify(collection.name) === slug)
 }
 
@@ -24,6 +28,6 @@ export const useNftsFromCollection = (collectionAddress: string) => {
   return collections
 }
 
-export const useGetNFTMarketLoadingState = () => {
-  return useSelector((state: State) => state.nftMarket.loadingState)
+export const useGetNFTInitializationState = () => {
+  return useSelector((state: State) => state.nftMarket.initializationState)
 }

--- a/src/state/nftMarket/hooks.ts
+++ b/src/state/nftMarket/hooks.ts
@@ -23,3 +23,7 @@ export const useNftsFromCollection = (collectionAddress: string) => {
   const collections = useSelector((state: State) => state.nftMarket.data.nfts[collectionAddress])
   return collections
 }
+
+export const useGetNFTMarketLoadingState = () => {
+  return useSelector((state: State) => state.nftMarket.loadingState)
+}

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -1,9 +1,9 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
 import { getNftsMetadata, getNftsMarketData, getCollectionsApi, getCollectionsSg } from './helpers'
-import { State, Collection, NFT, NFTMarketLoadingState } from './types'
+import { State, Collection, NFT, NFTMarketInitializationState } from './types'
 
 const initialState: State = {
-  loadingState: NFTMarketLoadingState.IDLE,
+  initializationState: NFTMarketInitializationState.UNINITIALIZED,
   data: {
     collections: {},
     nfts: {},
@@ -54,20 +54,13 @@ export const NftMarket = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(fetchCollections.pending, (state) => {
-      state.loadingState = NFTMarketLoadingState.LOADING
-    })
     builder.addCase(fetchCollections.fulfilled, (state, action) => {
       state.data.collections = action.payload
-      state.loadingState = NFTMarketLoadingState.IDLE
+      state.initializationState = NFTMarketInitializationState.INITIALIZED
     })
 
-    builder.addCase(fetchNftsFromCollections.pending, (state) => {
-      state.loadingState = NFTMarketLoadingState.LOADING
-    })
     builder.addCase(fetchNftsFromCollections.fulfilled, (state, action) => {
       state.data.nfts[action.meta.arg] = action.payload
-      state.loadingState = NFTMarketLoadingState.IDLE
     })
   },
 })

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -1,9 +1,9 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
-import { getCollectionsApi, getCollectionsSg, getNftsMetadata, getNftsMarketData } from './helpers'
-import { State, Collection, NFT } from './types'
+import { getNftsMetadata, getNftsMarketData, getCollectionsApi, getCollectionsSg } from './helpers'
+import { State, Collection, NFT, NFTMarketLoadingState } from './types'
 
 const initialState: State = {
-  isInitializing: true,
+  loadingState: NFTMarketLoadingState.IDLE,
   data: {
     collections: {},
     nfts: {},
@@ -54,12 +54,20 @@ export const NftMarket = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
+    builder.addCase(fetchCollections.pending, (state) => {
+      state.loadingState = NFTMarketLoadingState.LOADING
+    })
     builder.addCase(fetchCollections.fulfilled, (state, action) => {
       state.data.collections = action.payload
-      state.isInitializing = false
+      state.loadingState = NFTMarketLoadingState.IDLE
+    })
+
+    builder.addCase(fetchNftsFromCollections.pending, (state) => {
+      state.loadingState = NFTMarketLoadingState.LOADING
     })
     builder.addCase(fetchNftsFromCollections.fulfilled, (state, action) => {
       state.data.nfts[action.meta.arg] = action.payload
+      state.loadingState = NFTMarketLoadingState.IDLE
     })
   },
 })

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -4,14 +4,15 @@ import { Nft as NftMeta } from 'config/constants/nfts/types'
 // Collections -> Nfts -> Transactions
 // Users -> Nft tokens IDs
 
-export enum NFTMarketLoadingState {
-  IDLE,
-  LOADING,
+// TODO: Handle the error state on the UI
+export enum NFTMarketInitializationState {
+  UNINITIALIZED,
+  INITIALIZED,
   ERROR,
 }
 
 export interface State {
-  loadingState: NFTMarketLoadingState
+  initializationState: NFTMarketInitializationState
   data: {
     collections: Record<string, Collection> // string is the address
     nfts: Record<string, NFT[]> // string is the address

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -4,8 +4,14 @@ import { Nft as NftMeta } from 'config/constants/nfts/types'
 // Collections -> Nfts -> Transactions
 // Users -> Nft tokens IDs
 
+export enum NFTMarketLoadingState {
+  IDLE,
+  LOADING,
+  ERROR,
+}
+
 export interface State {
-  isInitializing: boolean
+  loadingState: NFTMarketLoadingState
   data: {
     collections: Record<string, Collection> // string is the address
     nfts: Record<string, NFT[]> // string is the address

--- a/src/views/Nft/market/Collectibles/index.tsx
+++ b/src/views/Nft/market/Collectibles/index.tsx
@@ -1,12 +1,39 @@
 import React from 'react'
+import { random } from 'lodash'
 import { Link } from 'react-router-dom'
+import { MinMaxFilter, ListFilter } from 'components/Filters'
 import Page from 'components/Layout/Page'
+import { Item } from 'components/Filters/ListFilter/styles'
+
+const exampleList: Item[] = [
+  { image: '/images/collections/pancake-bunnies-avatar.png', label: 'Collection Name', count: random(1, 50) },
+  { label: 'Smiley', count: random(1, 50) },
+  { label: 'Big', count: random(1, 50) },
+  { label: 'Teeth', count: random(1, 50) },
+  { label: 'Cigar', count: random(1, 50) },
+  { label: 'Lollipop', count: random(1, 50) },
+  { label: 'Ears', count: random(1, 50) },
+  { label: 'Glasses', count: random(1, 50) },
+  { label: 'Frown', count: random(1, 50) },
+  { label: 'Zombie', count: random(1, 50) },
+  { label: 'Bazooka', count: random(1, 50) },
+]
 
 const Collectible = () => {
+  const handleApply = (min: number, max: number) => {
+    console.log(min, max)
+  }
+
+  const handleListApply = (items: Item[]) => {
+    console.log(items)
+  }
+
   return (
     <>
       <Page>
         <Link to="/nft/market/collectibles/pancake-squad">Pancake Bunnies</Link>
+        <MinMaxFilter title="Price" min={1} max={100} onApply={handleApply} />
+        <ListFilter title="Attribute" items={exampleList} onApply={handleListApply} />
       </Page>
     </>
   )

--- a/src/views/Nft/market/Home/index.tsx
+++ b/src/views/Nft/market/Home/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import Page from 'components/Layout/Page'
+
+const Home = () => {
+  return (
+    <>
+      <Page>
+        <Link to="/nft/market/collectibles">Collectibles</Link>
+        <br />
+        <Link to="/nft/market/profile">Profile</Link>
+        <br />
+        <Link to="/nft/market/item/7">Individual NFT page</Link>
+      </Page>
+    </>
+  )
+}
+
+export default Home

--- a/src/views/Nft/market/index.tsx
+++ b/src/views/Nft/market/index.tsx
@@ -1,8 +1,8 @@
 import React, { lazy } from 'react'
 import { Route, useRouteMatch } from 'react-router-dom'
-import { useFetchCollections, useGetNFTMarketLoadingState } from 'state/nftMarket/hooks'
+import { useFetchCollections, useGetNFTInitializationState } from 'state/nftMarket/hooks'
 import PageLoader from 'components/Loader/PageLoader'
-import { NFTMarketLoadingState } from 'state/nftMarket/types'
+import { NFTMarketInitializationState } from 'state/nftMarket/types'
 
 const Home = lazy(() => import('./Home'))
 const NftProfile = lazy(() => import('./Profile'))
@@ -12,11 +12,11 @@ const IndividualNFTPage = lazy(() => import('./IndividualNFTPage'))
 
 const Market = () => {
   const { path } = useRouteMatch()
-  const nftMarketLoadingState = useGetNFTMarketLoadingState()
+  const initializationState = useGetNFTInitializationState()
 
   useFetchCollections()
 
-  if (nftMarketLoadingState === NFTMarketLoadingState.LOADING) {
+  if (initializationState !== NFTMarketInitializationState.INITIALIZED) {
     return <PageLoader />
   }
 

--- a/src/views/Nft/market/index.tsx
+++ b/src/views/Nft/market/index.tsx
@@ -1,48 +1,43 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { random } from 'lodash'
-import { useFetchCollections } from 'state/nftMarket/hooks'
-import Page from 'components/Layout/Page'
-import { MinMaxFilter, ListFilter } from 'components/Filters'
-import { Item } from 'components/Filters/ListFilter/styles'
+import React, { lazy } from 'react'
+import { Route, useRouteMatch } from 'react-router-dom'
+import { useFetchCollections, useGetNFTMarketLoadingState } from 'state/nftMarket/hooks'
+import PageLoader from 'components/Loader/PageLoader'
+import { NFTMarketLoadingState } from 'state/nftMarket/types'
 
-const exampleList: Item[] = [
-  { image: '/images/collections/pancake-bunnies-avatar.png', label: 'Collection Name', count: random(1, 50) },
-  { label: 'Smiley', count: random(1, 50) },
-  { label: 'Big', count: random(1, 50) },
-  { label: 'Teeth', count: random(1, 50) },
-  { label: 'Cigar', count: random(1, 50) },
-  { label: 'Lollipop', count: random(1, 50) },
-  { label: 'Ears', count: random(1, 50) },
-  { label: 'Glasses', count: random(1, 50) },
-  { label: 'Frown', count: random(1, 50) },
-  { label: 'Zombie', count: random(1, 50) },
-  { label: 'Bazooka', count: random(1, 50) },
-]
+const Home = lazy(() => import('./Home'))
+const NftProfile = lazy(() => import('./Profile'))
+const Collectible = lazy(() => import('./Collectible'))
+const CollectibleOverview = lazy(() => import('./Collectibles'))
+const IndividualNFTPage = lazy(() => import('./IndividualNFTPage'))
 
 const Market = () => {
-  const handleApply = (min: number, max: number) => {
-    console.log(min, max)
-  }
-
-  const handleListApply = (items: Item[]) => {
-    console.log(items)
-  }
+  const { path } = useRouteMatch()
+  const nftMarketLoadingState = useGetNFTMarketLoadingState()
 
   useFetchCollections()
 
+  if (nftMarketLoadingState === NFTMarketLoadingState.LOADING) {
+    return <PageLoader />
+  }
+
   return (
-    <Page>
-      <Link to="/nft/market/collectibles">Collectibles</Link>
-      <br />
-      <Link to="/nft/market/profile">Profile</Link>
-      <br />
-      <Link to="/nft/market/item/7">Individual NFT page</Link>
-      <br />
-      <br />
-      <MinMaxFilter title="Price" min={1} max={100} onApply={handleApply} />
-      <ListFilter title="Attribute" items={exampleList} onApply={handleListApply} />
-    </Page>
+    <>
+      <Route exact path={path}>
+        <Home />
+      </Route>
+      <Route exact path={`${path}/collectibles`}>
+        <CollectibleOverview />
+      </Route>
+      <Route path={`${path}/collectibles/:slug`}>
+        <Collectible />
+      </Route>
+      <Route path={`${path}/profile`}>
+        <NftProfile />
+      </Route>
+      <Route exact path={`${path}/item/:id`}>
+        <IndividualNFTPage />
+      </Route>
+    </>
   )
 }
 


### PR DESCRIPTION
- Adds a loading state so we can fetch the collections before rendering. This will ensure that it is available on all sub-routes
- Moved routes into the `views/Nft/market`
