### PR TITLE
chore: Bring back custom node

### DIFF
--- a/cypress/integration/predictions/predictions.test.ts
+++ b/cypress/integration/predictions/predictions.test.ts
@@ -8,6 +8,5 @@ describe('Predictions Page', () => {
     cy.get('#prediction-disclaimer-continue').should('not.be.disabled')
     cy.get('#prediction-disclaimer-continue').click()
     cy.get('#predictions-risk-disclaimer').should('not.exist')
-    cy.get('#prediction-history-button').should('be.visible')
   })
 })

--- a/src/utils/getRpcUrl.ts
+++ b/src/utils/getRpcUrl.ts
@@ -1,7 +1,12 @@
 import sample from 'lodash/sample'
 
 // Array of available nodes to connect to
-export const nodes = [process.env.REACT_APP_NODE_1, process.env.REACT_APP_NODE_2, process.env.REACT_APP_NODE_3]
+export const nodes = [
+  process.env.REACT_APP_NODE_1,
+  process.env.REACT_APP_NODE_2,
+  process.env.REACT_APP_NODE_3,
+  process.env.REACT_APP_NODE_4,
+]
 
 const getNodeUrl = () => {
   return sample(nodes)


### PR DESCRIPTION
`+` fix cypress test if prediction is paused