### PR TITLE
feat(nft-metadata-api): Add nftMetadata fetch and update types

### DIFF
--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -3,7 +3,7 @@ import { GRAPH_API_NFTMARKET, API_NFT } from 'config/constants/endpoints'
 import { getErc721Contract } from 'utils/contractHelpers'
 import { ethers } from 'ethers'
 import map from 'lodash/map'
-import { NftToken, ApiCollections, TokenIdWithCollectionAddress } from './types'
+import { NftTokenSg, ApiCollections, TokenIdWithCollectionAddress, NFT } from './types'
 
 /**
  * Fetch static data from all collections using the API
@@ -67,7 +67,7 @@ export const getNftsFromCollectionApi = async (collectionAddress: string): Promi
  * @param collectionAddress
  * @returns
  */
-export const getNftsFromCollectionSg = async (collectionAddress: string): Promise<NftToken[]> => {
+export const getNftsFromCollectionSg = async (collectionAddress: string): Promise<NftTokenSg[]> => {
   try {
     const res = await request(
       GRAPH_API_NFTMARKET,
@@ -93,7 +93,23 @@ export const getNftsFromCollectionSg = async (collectionAddress: string): Promis
   }
 }
 
-export const getNftsMarketData = async (where = {}): Promise<NftToken[]> => {
+/**
+ * Fetch NFT metadata with a given collection and tokenId using the API
+ * @param collectionAddress
+ * @param tokenId
+ * @returns
+ */
+export const getNftMetadataFromTokenIdApi = async (collectionAddress: string, tokenId: string): Promise<NFT> => {
+  const res = await fetch(`${API_NFT}/collections/${collectionAddress}/tokens/${tokenId}`)
+  if (res.ok) {
+    const json = await res.json()
+    return json.data
+  }
+  console.error('Failed to fetch token', res.statusText)
+  return null
+}
+
+export const getNftsMarketData = async (where = {}): Promise<NftTokenSg[]> => {
   try {
     const res = await request(
       GRAPH_API_NFTMARKET,
@@ -127,7 +143,7 @@ export const getNftsMarketData = async (where = {}): Promise<NftToken[]> => {
       { where },
     )
 
-    return res.nfts.map((nftRes): NftToken => {
+    return res.nfts.map((nftRes): NftTokenSg => {
       return {
         tokenId: nftRes?.tokenId,
         metadataUrl: nftRes?.metadataUrl,

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -15,7 +15,7 @@ import {
   NFT,
   TokenIdWithCollectionAddress,
   NFTMarketInitializationState,
-  NftToken,
+  NftTokenSg,
 } from './types'
 
 const initialState: State = {
@@ -84,7 +84,7 @@ export const fetchNftsFromCollections = createAsyncThunk<NFT[], string>(
 )
 
 export const fetchUserNfts = createAsyncThunk<
-  NftToken[],
+  NftTokenSg[],
   { account: string; profileNftWithCollectionAddress: TokenIdWithCollectionAddress; collections: ApiCollections }
 >('nft/fetchUserNfts', async ({ account, profileNftWithCollectionAddress, collections }) => {
   const nftsInWallet = await fetchWalletTokenIdsForCollections(account, collections)

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -22,7 +22,7 @@ export interface State {
 
 export interface UserNftsState {
   isInitialized: boolean
-  nfts: NftToken[]
+  nfts: NftTokenSg[]
 }
 
 export interface Transaction {
@@ -39,10 +39,13 @@ export interface Transaction {
 interface Image {
   original: string
   thumbnail: string
+  mp4?: string
+  webm?: string
+  gif?: string
 }
 
 // Return type from subgraph
-export interface NftToken {
+export interface NftTokenSg {
   tokenId: BigNumberish
   currentSeller: string
   isTradable: boolean
@@ -56,7 +59,8 @@ export interface NFT {
   name: string
   description: string
   image: Image
-  tokens: Record<number, NftToken>
+  tokens?: Record<number, NftTokenSg>
+  attributes?: any[]
 }
 
 export interface TokenIdWithCollectionAddress {


### PR DESCRIPTION
- Add `getNftMetadataFromTokenIdApi` fetch for specific token metadata
- Rename `NftToken` subgraph response type -> `NftTokenSg`
- Add optional props `mp4`, `webm`, `gif` to the `Image` type
- Add optional prop `attributes` to the 'NFT' type to reflect the api response data, eg

https://nft.pancakeswap.com/api/v1/collections/0x60935F36e4631F73f0f407e68642144e07aC7f5E/tokens/60

```json
    "id": "123",
    "tokenId": "60",
    "name": "Pancake Bunnies #60 - Twinkle",
    "description": "Three guesses what's put that twinkle in those eyes! (Hint: it's CAKE)",
    "image": {
      "original": "ipfs://Qme6aiY9GLvaT6v5KY42VqLEUNNsNurYzVtSTr16HEAMmU/blur_twinkle.png",
      "thumbnail": "ipfs://Qme6aiY9GLvaT6v5KY42VqLEUNNsNurYzVtSTr16HEAMmU/blur_twinkle.png",
      "mp4": null,
      "webm": null,
      "gif": null
    },
    "attributes": [
      {
        "traitType": "bunnyId",
        "value": "7"
      }
    ]
```