### PR TITLE
fix: Missing translations in remove liquidity and swap

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1449,5 +1449,7 @@
   "Route": "Route",
   "Price Impact": "Price Impact",
   "This swap has a price impact of at least %amount%%. Please type the word \"%word%\" to continue with this swap.": "This swap has a price impact of at least %amount%%. Please type the word \"%word%\" to continue with this swap.",
-  "This swap has a price impact of at least %amount%%. Please confirm that you would like to continue with this swap.": "This swap has a price impact of at least %amount%%. Please confirm that you would like to continue with this swap."
+  "This swap has a price impact of at least %amount%%. Please confirm that you would like to continue with this swap.": "This swap has a price impact of at least %amount%%. Please confirm that you would like to continue with this swap.",
+  "To receive %assetA% and %assetB%": "To receive %assetA% and %assetB%",
+  "Price Impact Too High": "Price Impact Too High"
 }

--- a/src/state/burn/hooks.ts
+++ b/src/state/burn/hooks.ts
@@ -6,6 +6,7 @@ import { wrappedCurrency } from 'utils/wrappedCurrency'
 import { usePair } from 'hooks/usePairs'
 import useTotalSupply from 'hooks/useTotalSupply'
 
+import { useTranslation } from 'contexts/Localization'
 import { AppDispatch, AppState } from '../index'
 import { tryParseAmount } from '../swap/hooks'
 import { useTokenBalances } from '../wallet/hooks'
@@ -31,6 +32,8 @@ export function useDerivedBurnInfo(
   const { account, chainId } = useActiveWeb3React()
 
   const { independentField, typedValue } = useBurnState()
+
+  const { t } = useTranslation()
 
   // pair + totalsupply
   const [, pair] = usePair(currencyA, currencyB)
@@ -117,11 +120,11 @@ export function useDerivedBurnInfo(
 
   let error: string | undefined
   if (!account) {
-    error = 'Connect Wallet'
+    error = t('Connect Wallet')
   }
 
   if (!parsedAmounts[Field.LIQUIDITY] || !parsedAmounts[Field.CURRENCY_A] || !parsedAmounts[Field.CURRENCY_B]) {
-    error = error ?? 'Enter an amount'
+    error = error ?? t('Enter an amount')
   }
 
   return { pair, parsedAmounts, error }

--- a/src/views/RemoveLiquidity/index.tsx
+++ b/src/views/RemoveLiquidity/index.tsx
@@ -461,7 +461,10 @@ export default function RemoveLiquidity({
             assetA: currencyA?.symbol ?? '',
             assetB: currencyB?.symbol ?? '',
           })}
-          subtitle={`To receive ${currencyA?.symbol} and ${currencyB?.symbol}`}
+          subtitle={t('To receive %assetA% and %assetB%', {
+            assetA: currencyA?.symbol ?? '',
+            assetB: currencyB?.symbol ?? '',
+          })}
           noConfig
         />
 

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -475,7 +475,7 @@ export default function Swap({ history }: RouteComponentProps) {
               >
                 {swapInputError ||
                   (priceImpactSeverity > 3 && !isExpertMode
-                    ? `Price Impact Too High`
+                    ? t('Price Impact Too High')
                     : priceImpactSeverity > 2
                     ? t('Swap Anyway')
                     : t('Swap'))}


### PR DESCRIPTION
To review:

To reproduce:

1. Go to remove liquidity page (e.g https://pancakeswap.finance/remove/BNB/0xE0e514c71282b6f4e823703a39374Cf58dc3eA4f)
2. See To receive... header and button translations missing
3. Swap page button translation for price impact is missing too
