### PR TITLE
fix: (liquidity) Missing translations in add liquidity

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1462,5 +1462,6 @@
   "Bug Bounty": "Bug Bounty",
   "Audits": "Audits",
   "Careers": "Careers",
-  "Dark mode": "Dark mode"
+  "Dark mode": "Dark mode",
+  "Invalid pair": "Invalid pair"
 }

--- a/src/state/mint/hooks.ts
+++ b/src/state/mint/hooks.ts
@@ -5,6 +5,7 @@ import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { PairState, usePair } from 'hooks/usePairs'
 import useTotalSupply from 'hooks/useTotalSupply'
 
+import { useTranslation } from 'contexts/Localization'
 import { wrappedCurrency, wrappedCurrencyAmount } from 'utils/wrappedCurrency'
 import { AppDispatch, AppState } from '../index'
 import { tryParseAmount } from '../swap/hooks'
@@ -59,6 +60,8 @@ export function useDerivedMintInfo(
   error?: string
 } {
   const { account, chainId } = useActiveWeb3React()
+
+  const { t } = useTranslation()
 
   const { independentField, typedValue, otherTypedValue } = useMintState()
 
@@ -159,25 +162,25 @@ export function useDerivedMintInfo(
 
   let error: string | undefined
   if (!account) {
-    error = 'Connect Wallet'
+    error = t('Connect Wallet')
   }
 
   if (pairState === PairState.INVALID) {
-    error = error ?? 'Invalid pair'
+    error = error ?? t('Invalid pair')
   }
 
   if (!parsedAmounts[Field.CURRENCY_A] || !parsedAmounts[Field.CURRENCY_B]) {
-    error = error ?? 'Enter an amount'
+    error = error ?? t('Enter an amount')
   }
 
   const { [Field.CURRENCY_A]: currencyAAmount, [Field.CURRENCY_B]: currencyBAmount } = parsedAmounts
 
   if (currencyAAmount && currencyBalances?.[Field.CURRENCY_A]?.lessThan(currencyAAmount)) {
-    error = `Insufficient ${currencies[Field.CURRENCY_A]?.symbol} balance`
+    error = t('Insufficient %symbol% balance', { symbol: currencies[Field.CURRENCY_A]?.symbol })
   }
 
   if (currencyBAmount && currencyBalances?.[Field.CURRENCY_B]?.lessThan(currencyBAmount)) {
-    error = `Insufficient ${currencies[Field.CURRENCY_B]?.symbol} balance`
+    error = t('Insufficient %symbol% balance', { symbol: currencies[Field.CURRENCY_B]?.symbol })
   }
 
   return {


### PR DESCRIPTION
To review:

https://deploy-preview-2200--pancakeswap-dev.netlify.app/

To reproduce: 

1. Go to trade>liquidity
2. Click add liquidity
3. Change language
4. Do some invalid operations like adding insufficient amount or selecting invalid pair.
5. See button translation is not working