### PR TITLE
chore(nft-market-sg): Remove data transformation of NFT entity's collection address

### DIFF
--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -138,20 +138,7 @@ export const getNftsMarketData = async (where = {}): Promise<NftTokenSg[]> => {
       { where },
     )
 
-    return res.nfts.map((nftRes): NftTokenSg => {
-      return {
-        tokenId: nftRes?.tokenId,
-        metadataUrl: nftRes?.metadataUrl,
-        transactionHistory: nftRes?.transactionHistory,
-        currentSeller: nftRes?.currentSeller,
-        isTradable: nftRes?.isTradable,
-        collectionAddress: nftRes?.collection.id,
-        currentAskPrice: nftRes?.currentAskPrice,
-        latestTradedPriceInBNB: nftRes?.latestTradedPriceInBNB,
-        tradeVolumeBNB: nftRes?.tradeVolumeBNB,
-        totalTrades: nftRes?.totalTrades,
-      }
-    })
+    return res.nfts
   } catch (error) {
     console.error('Failed to fetch NFTs market data', error)
     return []

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -107,6 +107,19 @@ export const getNftMetadataFromTokenIdApi = async (collectionAddress: string, to
   return null
 }
 
+/**
+ * Fetch NFT metadata for an array of tokenIds and collection addresses
+ * @param tokens TokenIdWithCollectionAddress[]
+ * @returns
+ */
+export const getMultipleNftsMetadataFromApi = async (tokens: TokenIdWithCollectionAddress[]) => {
+  const metaDataPromises = tokens.map((token) => {
+    return getNftMetadataFromTokenIdApi(token.collectionAddress, token.tokenId)
+  })
+  const nftMetaData = await Promise.all(metaDataPromises)
+  return nftMetaData
+}
+
 export const getNftsMarketData = async (where = {}): Promise<NftTokenSg[]> => {
   try {
     const res = await request(

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -104,7 +104,9 @@ export const fetchUserNfts = createAsyncThunk<
     return (
       marketData || {
         tokenId: walletNft.tokenId,
-        collectionAddress: walletNft.collectionAddress,
+        collection: {
+          id: walletNft.collectionAddress.toLowerCase(),
+        },
         metadataUrl: null,
         transactionHistory: null,
         currentSeller: null,

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -62,6 +62,7 @@ export interface NftTokenSg {
 
 export interface NFT {
   id: string
+  tokenId: string
   name: string
   collectionName: string
   description: string

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -54,7 +54,9 @@ export interface NftTokenSg {
   tradeVolumeBNB: string
   totalTrades: string
   isTradable: boolean
-  collectionAddress?: string
+  collection?: {
+    id: string
+  }
   transactionHistory?: Transaction[]
 }
 

--- a/src/views/Nft/market/Profile/index.tsx
+++ b/src/views/Nft/market/Profile/index.tsx
@@ -51,7 +51,7 @@ const NftProfile = () => {
             const tokenId = ethers.BigNumber.from(nft.tokenId).toString()
             return (
               <Text key={tokenId}>
-                {tokenId} - {nft.collectionAddress}
+                {tokenId} - {nft.collection.id}
               </Text>
             )
           })}


### PR DESCRIPTION
- Remove data transformation for NFT collection id (previously `NFT.collectionAddress`, now `NFT.collection.id`)
- Add `tokenId` to NFT type - the 'id' returned by the API isn't the tokenId
- Add fetch to return multiple NFTs' metadata