### PR TITLE
fix: Global settings icon smaller than language icon

### DIFF
--- a/src/components/Menu/GlobalSettings/index.tsx
+++ b/src/components/Menu/GlobalSettings/index.tsx
@@ -8,7 +8,7 @@ const GlobalSettings = () => {
   return (
     <Flex>
       <IconButton onClick={onPresentSettingsModal} variant="text" scale="sm" mr="8px" id="open-settings-dialog-button">
-        <CogIcon height={22} width={22} color="textSubtle" />
+        <CogIcon height={24} width={24} color="textSubtle" />
       </IconButton>
     </Flex>
   )


### PR DESCRIPTION
It can be more noticeable in mobile. 

To review:

https://deploy-preview-2221--pancakeswap-dev.netlify.app/

Before:

<img width="274" alt="Screenshot 2021-09-16 at 15 17 18" src="https://user-images.githubusercontent.com/2213635/133619470-013c3657-c9e7-4ab1-bb75-890565314ae2.png">

After:

<img width="387" alt="Screenshot 2021-09-16 at 15 17 00" src="https://user-images.githubusercontent.com/2213635/133619475-2c0cdb57-4360-4d37-8602-6dce20a46063.png">
