### PR TITLE
fix: (pools) Help button can be clicked beyond its size

### DIFF
--- a/src/views/Pools/components/HelpButton.tsx
+++ b/src/views/Pools/components/HelpButton.tsx
@@ -3,37 +3,35 @@ import styled from 'styled-components'
 import { Text, Button, HelpIcon, Link } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 
-const ButtonText = styled(Text)`
-  display: none;
-  ${({ theme }) => theme.mediaQueries.xs} {
-    display: block;
-  }
-`
-
-const StyledLink = styled(Link)`
+const Container = styled.div`
   margin-right: 16px;
   display: flex;
   justify-content: flex-end;
 
-  &:hover {
-    text-decoration: none;
-  }
   ${({ theme }) => theme.mediaQueries.sm} {
     flex: 1;
+  }
+`
+
+const StyledLink = styled(Link)`
+  &:hover {
+    text-decoration: none;
   }
 `
 
 const HelpButton = () => {
   const { t } = useTranslation()
   return (
-    <StyledLink external href="https://docs.pancakeswap.finance/syrup-pools/syrup-pool">
-      <Button px={['14px', null, null, null, '20px']} variant="subtle">
-        <ButtonText color="backgroundAlt" bold fontSize="16px">
-          {t('Help')}
-        </ButtonText>
-        <HelpIcon color="backgroundAlt" ml={[null, null, null, 0, '6px']} />
-      </Button>
-    </StyledLink>
+    <Container>
+      <StyledLink external href="https://docs.pancakeswap.finance/syrup-pools/syrup-pool">
+        <Button px={['14px', null, null, null, '20px']} variant="subtle">
+          <Text color="backgroundAlt" bold fontSize="16px">
+            {t('Help')}
+          </Text>
+          <HelpIcon color="backgroundAlt" ml={[null, null, null, 0, '6px']} />
+        </Button>
+      </StyledLink>
+    </Container>
   )
 }
 


### PR DESCRIPTION
To review:

https://deploy-preview-2227--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to pools
2. See Help button in the header can be clicked beyond its size to the left