### PR TITLE
fix: Fix hidden profile header

### DIFF
--- a/src/views/Profile/components/HeaderWrapper.tsx
+++ b/src/views/Profile/components/HeaderWrapper.tsx
@@ -4,6 +4,7 @@ const HeaderWrapper = styled.div`
   border-bottom: 2px solid ${({ theme }) => theme.colors.textSubtle};
   margin-bottom: 24px;
   padding-bottom: 24px;
+  margin-top: 57px;
 `
 
 export default HeaderWrapper


### PR DESCRIPTION
Currently part of the profile header is hidden under the navigation bar:

<img width="400" alt="" src="https://user-images.githubusercontent.com/1091472/133705528-ea943fe3-d1da-4844-ba2a-573dfb80b532.png">

And here's where that 57 number comes:

<img src='https://user-images.githubusercontent.com/1091472/133705596-d7584ce4-08f8-4e2d-b89f-01eef8567ae4.png' alt='' width='400' />

Here's how It looks like after:

<img width="500" alt="" src="https://user-images.githubusercontent.com/1091472/133705732-ea3eb5e0-4bf2-4754-b39e-2924e06d9489.png">

