### PR TITLE
fix: Put back xs check for help button for smaller devices

### DIFF
--- a/src/views/Pools/components/HelpButton.tsx
+++ b/src/views/Pools/components/HelpButton.tsx
@@ -3,6 +3,13 @@ import styled from 'styled-components'
 import { Text, Button, HelpIcon, Link } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 
+const ButtonText = styled(Text)`
+  display: none;
+  ${({ theme }) => theme.mediaQueries.xs} {
+    display: block;
+  }
+`
+
 const Container = styled.div`
   margin-right: 16px;
   display: flex;
@@ -25,9 +32,9 @@ const HelpButton = () => {
     <Container>
       <StyledLink external href="https://docs.pancakeswap.finance/syrup-pools/syrup-pool">
         <Button px={['14px', null, null, null, '20px']} variant="subtle">
-          <Text color="backgroundAlt" bold fontSize="16px">
+          <ButtonText color="backgroundAlt" bold fontSize="16px">
             {t('Help')}
-          </Text>
+          </ButtonText>
           <HelpIcon color="backgroundAlt" ml={[null, null, null, 0, '6px']} />
         </Button>
       </StyledLink>


### PR DESCRIPTION
My bad for removing this, that creates issues on iphone 5 size devices since xs min width is 370px and iphone 5 is 320px

To review: 

To reproduce: 

1. Check latest develop
2. Go to pools in iphone 5 size
3. Help should not show the text