### PR TITLE
Fix: Display the correct USD amount for the best round in PnL tab of the Prediction's History

### DIFF
--- a/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
+++ b/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
@@ -120,7 +120,7 @@ const PnlTab: React.FC<PnlTabProps> = ({ hasBetHistory, bets }) => {
 
   const netResultInUsd = multiplyPriceByAmount(bnbBusdPrice, netResultAmount)
   const avgBnbWonInUsd = multiplyPriceByAmount(bnbBusdPrice, avgBnbWonPerRound)
-  const betRoundInUsd = multiplyPriceByAmount(bnbBusdPrice, summary.won.bestRound.multiplier)
+  const betRoundInUsd = multiplyPriceByAmount(bnbBusdPrice, summary.won.bestRound.payout)
   const avgPositionEnteredInUsd = multiplyPriceByAmount(bnbBusdPrice, avgPositionEntered)
 
   return hasBetHistory ? (


### PR DESCRIPTION
In the PnL Tab of the history of predictions the USD value of the best round is displayed incorrectly. Instead of showing the USD value of the gains is showing the USD value of the multiplier. This PR fixes the problem.

<img width="259" alt="Captura de Pantalla 2021-09-18 a les 11 01 45" src="https://user-images.githubusercontent.com/17490809/133883312-5aeeabd0-7f91-4f03-8236-3019870b0deb.png">

