### PR TITLE
fix: Recents transactions can be seen from another account on the same device

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { useWeb3React, UnsupportedChainIdError } from '@web3-react/core'
+import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
 import { NoBscProviderError } from '@binance-chain/bsc-connector'
 import {
   NoEthereumProviderError,
@@ -16,11 +16,12 @@ import useToast from 'hooks/useToast'
 import { profileClear } from 'state/profile'
 import { useAppDispatch } from 'state'
 import { useTranslation } from 'contexts/Localization'
+import { clearAllTransactions } from 'state/transactions/actions'
 
 const useAuth = () => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const { activate, deactivate } = useWeb3React()
+  const { chainId, activate, deactivate } = useWeb3React()
   const { toastError } = useToast()
 
   const login = useCallback(
@@ -67,7 +68,10 @@ const useAuth = () => {
       connectorsByName.walletconnect.walletConnectProvider = null
     }
     window.localStorage.removeItem(connectorLocalStorageKey)
-  }, [deactivate, dispatch])
+    if (chainId) {
+      dispatch(clearAllTransactions({ chainId }))
+    }
+  }, [deactivate, dispatch, chainId])
 
   return { login, logout }
 }


### PR DESCRIPTION
To review:

https://deploy-preview-2245--pancakeswap-dev.netlify.app/

To reproduce:

1. Do some transactions
2. Logout
3. Login with another account
4. Go to recent transactions
5. See transactions from previous account still visible