### PR TITLE
fix: Recents transactions modal shows empty when no wallet connected

### DIFF
--- a/src/components/App/Transactions/TransactionsModal.tsx
+++ b/src/components/App/Transactions/TransactionsModal.tsx
@@ -9,6 +9,7 @@ import { AppDispatch } from 'state'
 import { clearAllTransactions } from 'state/transactions/actions'
 import { AutoRow } from '../../Layout/Row'
 import Transaction from './Transaction'
+import ConnectWalletButton from '../../ConnectWalletButton'
 
 // we want the latest one to come first, so return negative if a is after b
 function newTransactionsFirst(a: TransactionDetails, b: TransactionDetails) {
@@ -46,7 +47,7 @@ const TransactionsModal: React.FC<InjectedModalProps> = ({ onDismiss }) => {
 
   return (
     <Modal title={t('Recent Transactions')} headerBackground="gradients.cardHeader" onDismiss={onDismiss}>
-      {account && (
+      {account ? (
         <ModalBody>
           {!!pending.length || !!confirmed.length ? (
             <>
@@ -63,6 +64,8 @@ const TransactionsModal: React.FC<InjectedModalProps> = ({ onDismiss }) => {
             <Text>{t('No recent transactions')}</Text>
           )}
         </ModalBody>
+      ) : (
+        <ConnectWalletButton />
       )}
     </Modal>
   )


### PR DESCRIPTION
To review:

https://deploy-preview-2247--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to https://pancakeswap.finance/swap without connecting your wallet
2. Click recent transaction icon
3. See it shows empty modal
4. Instead it should have connect wallet button