### PR TITLE
feat(user-nfts): Add metadata fetch to fetchUserNfts reducer

### DIFF
--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -11,6 +11,9 @@ import {
   combineCollectionData,
   getCollectionSg,
   getCollectionApi,
+  getNftsFromDifferentCollectionsApi,
+  attachMarketDataToWalletNfts,
+  combineNftMarketAndMetadata,
 } from './helpers'
 import {
   State,
@@ -94,55 +97,41 @@ export const fetchNftsFromCollections = createAsyncThunk<NFT[], string>(
 )
 
 export const fetchUserNfts = createAsyncThunk<
-  NftTokenSg[],
+  NFT[],
   { account: string; profileNftWithCollectionAddress: TokenIdWithCollectionAddress; collections: ApiCollections }
 >('nft/fetchUserNfts', async ({ account, profileNftWithCollectionAddress, collections }) => {
-  const getCategoryForNftWithMarketData = (marketNft: NftTokenSg): NftLocation => {
-    if (profileNftWithCollectionAddress?.tokenId === marketNft.tokenId) {
-      return NftLocation.PROFILE
-    }
-    if (marketNft.isTradable && marketNft.currentSeller === account.toLowerCase()) {
-      return NftLocation.FORSALE
-    }
-    return NftLocation.WALLET
-  }
-
-  const nftsInWallet = await fetchWalletTokenIdsForCollections(account, collections)
-
+  const walletNftIds = await fetchWalletTokenIdsForCollections(account, collections)
   if (profileNftWithCollectionAddress?.tokenId) {
-    nftsInWallet.push(profileNftWithCollectionAddress)
+    walletNftIds.push(profileNftWithCollectionAddress)
   }
+  const tokenIds = walletNftIds.map((nft) => nft.tokenId)
 
-  const nftIdsInWallet = nftsInWallet.map((nft) => nft.tokenId)
-  const marketDataForNftsInWallet = await getNftsMarketData({ tokenId_in: nftIdsInWallet })
+  const marketDataForWalletNfts = await getNftsMarketData({ tokenId_in: tokenIds })
+  const walletNftsWithMarketData = attachMarketDataToWalletNfts(
+    walletNftIds,
+    marketDataForWalletNfts,
+    account,
+    profileNftWithCollectionAddress?.tokenId,
+  )
 
-  const walletNftsWithMarketData = nftsInWallet.map((walletNft) => {
-    const marketData = marketDataForNftsInWallet.find((marketNft) => marketNft.tokenId === walletNft.tokenId)
-    return marketData
-      ? { ...marketData, nftLocation: getCategoryForNftWithMarketData(marketData) }
-      : {
-          tokenId: walletNft.tokenId,
-          collection: {
-            id: walletNft.collectionAddress.toLowerCase(),
-          },
-          nftLocation: walletNft.nftLocation,
-          metadataUrl: null,
-          transactionHistory: null,
-          currentSeller: null,
-          isTradable: null,
-          currentAskPrice: null,
-          latestTradedPriceInBNB: null,
-          tradeVolumeBNB: null,
-          totalTrades: null,
-        }
-  })
-
-  const nftsForSale = await getNftsMarketData({ currentSeller: account.toLowerCase() })
-  const nftsForSaleWithCategory = nftsForSale.map((nft) => {
+  const marketDataForSaleNfts = await getNftsMarketData({ currentSeller: account.toLowerCase() })
+  const nftsForSaleWithCategory = marketDataForSaleNfts.map((nft) => {
     return { ...nft, nftLocation: NftLocation.FORSALE }
   })
 
-  return [...walletNftsWithMarketData, ...nftsForSaleWithCategory]
+  const forSaleNftIds = marketDataForSaleNfts.map((nft) => {
+    return { collectionAddress: nft.collection.id, tokenId: nft.tokenId }
+  })
+
+  const metadataForAllNfts = await getNftsFromDifferentCollectionsApi([...walletNftIds, ...forSaleNftIds])
+
+  const completeNftData = combineNftMarketAndMetadata(
+    metadataForAllNfts,
+    nftsForSaleWithCategory,
+    walletNftsWithMarketData,
+  )
+
+  return completeNftData
 })
 
 export const fetchUserActivity = createAsyncThunk<UserActivity, string>('nft/fetchUserActivity', async (address) => {

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -22,7 +22,7 @@ export interface State {
 
 export interface UserNftsState {
   userNftsInitialised: boolean
-  nfts: NftTokenSg[]
+  nfts: NFT[]
   activity: UserActivity
 }
 

--- a/src/views/Nft/market/Profile/components/UserNfts.tsx
+++ b/src/views/Nft/market/Profile/components/UserNfts.tsx
@@ -1,15 +1,12 @@
 import React from 'react'
 import { Grid } from '@pancakeswap/uikit'
-import { useGetCollections, useGetNftMetadata, useUserNfts } from 'state/nftMarket/hooks'
+import { useUserNfts } from 'state/nftMarket/hooks'
 import { NftLocation } from 'state/nftMarket/types'
-import { getAddress } from 'ethers/lib/utils'
 import { CollectibleCard } from '../../components/CollectibleCard'
 import GridPlaceholder from '../../components/GridPlaceholder'
 
 const UserNfts = () => {
-  const { nfts: userNfts } = useUserNfts()
-  const nftMetadata = useGetNftMetadata(userNfts)
-  const collections = useGetCollections()
+  const { nfts } = useUserNfts()
 
   const handleCollectibleClick = (nftLocation: NftLocation) => {
     switch (nftLocation) {
@@ -29,24 +26,25 @@ const UserNfts = () => {
 
   return (
     <>
-      {nftMetadata.length > 0 ? (
+      {nfts.length > 0 ? (
         <Grid
           gridGap="16px"
           gridTemplateColumns={['1fr', 'repeat(2, 1fr)', 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
           alignItems="start"
         >
-          {userNfts.map((userNft) => {
-            const nftDataForCard = nftMetadata.find((nft) => nft.tokenId === userNft.tokenId)
-            const checksummedAddress = getAddress(userNft.collection.id)
-            const collectionName = collections[checksummedAddress]?.name || '-'
+          {nfts.map((nft) => {
+            const marketData = nft.tokens[nft.tokenId]
+
             return (
               <CollectibleCard
-                onClick={() => handleCollectibleClick(userNft.nftLocation)}
-                key={nftDataForCard.id}
-                collectionName={collectionName}
-                nft={nftDataForCard}
-                currentAskPrice={userNft.currentAskPrice && userNft.isTradable && parseFloat(userNft.currentAskPrice)}
-                nftLocation={userNft.nftLocation}
+                onClick={() => handleCollectibleClick(marketData.nftLocation)}
+                key={nft.id}
+                collectionName={nft.collectionName}
+                nft={nft}
+                currentAskPrice={
+                  marketData.currentAskPrice && marketData.isTradable && parseFloat(marketData.currentAskPrice)
+                }
+                nftLocation={marketData.nftLocation}
               />
             )
           })}


### PR DESCRIPTION
- Return `NFT` from fetchUserNfts fetch (instead of `NftTokenSg`) and attach the `NftTokenSg` to the `NFT.tokens` object instead. So for each nft a user owns, an object like this is stored to `nftMarket.data.users.nfts` state:

![Frame 1](https://user-images.githubusercontent.com/79279477/133934946-029d93f8-e4dd-4b36-b307-714bc01f521e.png)


