### PR TITLE
fix: (pools & farms) To top shows the first row item under the fixed header

### DIFF
--- a/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -22,6 +22,7 @@ const Container = styled.div`
 
 const TableWrapper = styled.div`
   overflow: visible;
+  scroll-margin-top: 64px;
 
   &::-webkit-scrollbar {
     display: none;

--- a/src/views/Pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolsTable.tsx
@@ -13,6 +13,7 @@ interface PoolsTableProps {
 
 const StyledTable = styled.div`
   border-radius: ${({ theme }) => theme.radii.card};
+  scroll-margin-top: 64px;
 
   background-color: ${({ theme }) => theme.card.background};
   > div:not(:last-child) {


### PR DESCRIPTION
To reproduce:

1. Go to pools or farms table
2. Go to bottom of the table
3. Click "To top"
4. See the first row of the table is under the fixed header