### PR TITLE
fix: Add missing translation in footer of swap/liquidity pages

### DIFF
--- a/src/components/Menu/Footer.tsx
+++ b/src/components/Menu/Footer.tsx
@@ -42,7 +42,7 @@ const Footer = () => {
         <ButtonMenu variant="subtle" scale="sm" activeIndex={0}>
           <ButtonMenuItem>V2</ButtonMenuItem>
           <ButtonMenuItem as="a" href="https://v1exchange.pancakeswap.finance/#/">
-            V1 (old)
+            {t('V1 (old)')}
           </ButtonMenuItem>
         </ButtonMenu>
         <LinkExternal

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1463,5 +1463,6 @@
   "Audits": "Audits",
   "Careers": "Careers",
   "Dark mode": "Dark mode",
-  "Invalid pair": "Invalid pair"
+  "Invalid pair": "Invalid pair",
+  "V1 (old)": "V1 (old)"
 }


### PR DESCRIPTION
To review:

https://deploy-preview-2261--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to swap/liquidity
2. Change language
3. See V1(old) button in bottom left is not translated