### PR TITLE
fix: Wrong Tooltip placement in add liquidity in mobile

### DIFF
--- a/src/components/App/AppHeader.tsx
+++ b/src/components/App/AppHeader.tsx
@@ -39,7 +39,7 @@ const AppHeader: React.FC<Props> = ({ title, subtitle, helper, backTo, noConfig 
             {title}
           </Heading>
           <Flex alignItems="center">
-            {helper && <QuestionHelper text={helper} mr="4px" />}
+            {helper && <QuestionHelper text={helper} mr="4px" placement="top-start" />}
             <Text color="textSubtle" fontSize="14px">
               {subtitle}
             </Text>


### PR DESCRIPTION
To review:



To reproduce: 

1. Go to https://pancakeswap.finance/add in mobile (iphone 8 size)
2. Click tooltip question marker
3. See tooltip is off the screen