### PR TITLE
fix: Top farms by apr shows finished farms and cake pool

### DIFF
--- a/src/views/Home/hooks/useGetTopFarmsByApr.tsx
+++ b/src/views/Home/hooks/useGetTopFarmsByApr.tsx
@@ -25,7 +25,7 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
   useEffect(() => {
     const fetchFarmData = async () => {
       setFetchStatus(FetchStatus.FETCHING)
-      const activeFarms = nonArchivedFarms.filter((farm) => farm.pid !== 0 && farm.multiplier !== '0X')
+      const activeFarms = nonArchivedFarms.filter((farm) => farm.pid !== 0)
       try {
         await dispatch(fetchFarmsPublicDataAsync(activeFarms.map((farm) => farm.pid)))
         setFetchStatus(FetchStatus.SUCCESS)
@@ -42,7 +42,14 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
 
   useEffect(() => {
     const getTopFarmsByApr = (farmsState: DeserializedFarm[]) => {
-      const farmsWithPrices = farmsState.filter((farm) => farm.lpTotalInQuoteToken && farm.quoteTokenPriceBusd)
+      const farmsWithPrices = farmsState.filter(
+        (farm) =>
+          farm.lpTotalInQuoteToken &&
+          farm.quoteTokenPriceBusd &&
+          farm.pid !== 0 &&
+          farm.multiplier &&
+          farm.multiplier !== '0X',
+      )
       const farmsWithApr: FarmWithStakedValue[] = farmsWithPrices.map((farm) => {
         const totalLiquidity = farm.lpTotalInQuoteToken.times(farm.quoteTokenPriceBusd)
         const { cakeRewardsApr, lpRewardsApr } = getFarmApr(


### PR DESCRIPTION
To review:

https://deploy-preview-2283--pancakeswap-dev.netlify.app/

To reproduce cake pool error:

<img width="1107" alt="Screenshot 2021-09-21 at 10 34 45" src="https://user-images.githubusercontent.com/2213635/134149473-b3359a8a-75d3-4f0a-9b29-2487a79cc928.png">

1. Go to main page
2. Check top farms by apr
3. Then go to farms (which fetches the cake pool public data)
4. Go back to main page and check top farms 

To reproduce finished farms error:

1. Go to main page
2. Check top farms by apr
3. See finished farms in the list