### PR TITLE
feat(nft-market): Move lowestPriceToken logic into redux

### DIFF
--- a/src/state/nftMarket/hooks.ts
+++ b/src/state/nftMarket/hooks.ts
@@ -59,6 +59,15 @@ export const useUserActivity = (): (Transaction | AskOrder)[] => {
   return []
 }
 
+export const useGetLowestPricedPB = (nft: NFT): NftTokenSg => {
+  const nfts = useNftsFromCollection(nft.collectionAddress)
+
+  const bunnyId = nft.attributes.find((attribute) => attribute.traitType === 'bunnyId')?.value
+  const lowestPriceToken = nfts && nfts[bunnyId].lowestPricedToken
+
+  return lowestPriceToken
+}
+
 /**
  * Fetch metadata for a given array of Nft subgraph responses
  * @param sgNfts NftTokenSg[]

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -104,9 +104,10 @@ export interface NFT {
   collectionAddress: string
   description: string
   image: Image
-  tokens?: Record<number, NftTokenSg>
-  attributes?: any[]
   updatedAt: string
+  attributes?: any[]
+  tokens?: Record<number, NftTokenSg>
+  lowestPricedToken?: NftTokenSg
   meta?: Record<string, string | number>
 }
 

--- a/src/views/Nft/market/components/CollectibleCard/CardBody.tsx
+++ b/src/views/Nft/market/components/CollectibleCard/CardBody.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Box, CardBody, Flex, Text } from '@pancakeswap/uikit'
-import minBy from 'lodash/minBy'
 import { useTranslation } from 'contexts/Localization'
 import { useBNBBusdPrice } from 'hooks/useBUSDPrice'
+import { useGetLowestPricedPB } from 'state/nftMarket/hooks'
 import PreviewImage from './PreviewImage'
 import { CostLabel, MetaRow } from './styles'
 import LocationTag from './LocationTag'
@@ -10,11 +10,11 @@ import { CollectibleCardProps } from './types'
 
 const CollectibleCardBody: React.FC<CollectibleCardProps> = ({ nft, nftLocation, currentAskPrice }) => {
   const { t } = useTranslation()
-  const { name, image, tokens } = nft
+  const { name, image } = nft
+  const lowestPricedToken = useGetLowestPricedPB(nft)
   const bnbBusdPrice = useBNBBusdPrice()
 
-  const lowestPriceToken = tokens && minBy(Object.values(tokens), 'currentAskPrice')
-  const lowestPriceNum = lowestPriceToken ? parseFloat(lowestPriceToken.currentAskPrice) : 0
+  const lowestPriceNum = lowestPricedToken ? parseFloat(lowestPricedToken.currentAskPrice) : 0
 
   return (
     <CardBody p="8px">
@@ -30,9 +30,9 @@ const CollectibleCardBody: React.FC<CollectibleCardProps> = ({ nft, nftLocation,
       <Text as="h4" fontWeight="600" mb="8px">
         {name}
       </Text>
-      {(lowestPriceToken || currentAskPrice) && (
+      {(lowestPricedToken || currentAskPrice) && (
         <Box borderTop="1px solid" borderTopColor="cardBorder" pt="8px">
-          {lowestPriceToken && (
+          {lowestPricedToken && (
             <MetaRow title={t('Lowest price')}>
               <CostLabel cost={lowestPriceNum} bnbBusdPrice={bnbBusdPrice} />
             </MetaRow>


### PR DESCRIPTION
Proof of concept for how this could be stored in redux and accessed in components (for PBs).

It works, but it has two dependencies that won't scale well. 

1. It relies on us retrieving and storing an array of all token IDs for each NFT. As an example - Sleepy's tokens array will have 98k ids on mainnet.
2. It relies on sorting the market data for _all_ tokens of an NFT type. When thousands of tokens are on sale - we would need to gather this data over many requests.

And another thing:
 - The `useGetLowestPricedPB` hook will only work for PBs because it uses the PB attributes to access the nft in the `collections` redux.

Success:
<img width="1187" alt="Screenshot 2021-09-21 at 13 25 25" src="https://user-images.githubusercontent.com/79279477/134172657-520c1060-995e-451b-bbeb-2f7b85e54268.png">

But not scalable:
![Image from iOS (1)](https://user-images.githubusercontent.com/79279477/134173202-aeb4dd0a-69ee-45d6-b39f-4f2f9c91b84a.jpg)
