### PR TITLE
fix: Links on homepage refreshes the website and firefox scroll to top

### DIFF
--- a/src/hooks/useScrollOnRouteChange.ts
+++ b/src/hooks/useScrollOnRouteChange.ts
@@ -4,11 +4,13 @@ import history from 'routerHistory'
 const useScrollOnRouteChange = () => {
   useEffect(() => {
     const unlisten = history.listen(() => {
-      window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: 'smooth',
-      })
+      setTimeout(() => {
+        window.scroll({
+          top: 0,
+          left: 0,
+          behavior: 'smooth',
+        })
+      }, 50)
     })
 
     return () => unlisten()

--- a/src/views/Home/components/Hero.tsx
+++ b/src/views/Home/components/Hero.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled, { keyframes } from 'styled-components'
-import { Flex, Heading, Link, Button } from '@pancakeswap/uikit'
+import { Link } from 'react-router-dom'
+import { Flex, Heading, Button } from '@pancakeswap/uikit'
 import { useWeb3React } from '@web3-react/core'
 import { useTranslation } from 'contexts/Localization'
 import ConnectWalletButton from 'components/ConnectWalletButton'
@@ -113,7 +114,7 @@ const Hero = () => {
           </Heading>
           <Flex>
             {!account && <ConnectWalletButton mr="8px" />}
-            <Link mr="16px" href="/swap">
+            <Link to="/swap">
               <Button variant={!account ? 'secondary' : 'primary'}>{t('Trade Now')}</Button>
             </Link>
           </Flex>

--- a/src/views/Home/components/SalesSection/index.tsx
+++ b/src/views/Home/components/SalesSection/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Flex, Text, Button, Link } from '@pancakeswap/uikit'
+import { Link as RouterLink } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
 import CompositeImage, { CompositeImageProps } from '../CompositeImage'
 import PurpleWordHeading from '../PurpleWordHeading'
@@ -46,16 +47,28 @@ const SalesSection: React.FC<SalesSectionProps> = (props) => {
             {bodyTranslatedText}
           </Text>
           <Flex>
-            <Link mr="16px" external={primaryButton.external} href={primaryButton.to}>
-              <Button>
-                <Text color="card" bold fontSize="16px">
-                  {t(primaryButton.text)}
-                </Text>
-              </Button>
-            </Link>
-            <Link external={secondaryButton.external} href={secondaryButton.to}>
-              {t(secondaryButton.text)}
-            </Link>
+            <Button mr="16px">
+              {primaryButton.external ? (
+                <Link external href={primaryButton.to}>
+                  <Text color="card" bold fontSize="16px">
+                    {t(primaryButton.text)}
+                  </Text>
+                </Link>
+              ) : (
+                <RouterLink to={primaryButton.to}>
+                  <Text color="card" bold fontSize="16px">
+                    {t(primaryButton.text)}
+                  </Text>
+                </RouterLink>
+              )}
+            </Button>
+            {secondaryButton.external ? (
+              <Link external href={secondaryButton.to}>
+                {t(secondaryButton.text)}
+              </Link>
+            ) : (
+              <RouterLink to={secondaryButton.to}>{t(secondaryButton.text)}</RouterLink>
+            )}
           </Flex>
         </Flex>
         <Flex

--- a/src/views/Home/components/WinSection/LotteryCardContent.tsx
+++ b/src/views/Home/components/WinSection/LotteryCardContent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { Flex, Text, Skeleton, Link, Button, ArrowForwardIcon } from '@pancakeswap/uikit'
+import { Flex, Text, Skeleton, Button, ArrowForwardIcon } from '@pancakeswap/uikit'
+import { Link } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
 import useRefresh from 'hooks/useRefresh'
 import useIntersectionObserver from 'hooks/useIntersectionObserver'
@@ -100,7 +101,7 @@ const LotteryCardContent = () => {
         </Text>
       </Flex>
       <Flex alignItems="center" justifyContent="center">
-        <StyledLink href="/lottery" id="homepage-prediction-cta">
+        <StyledLink to="/lottery" id="homepage-prediction-cta">
           <Button width="100%">
             <Text bold color="invertedContrast">
               {t('Buy Tickets')}

--- a/src/views/Home/components/WinSection/PredictionCardContent.tsx
+++ b/src/views/Home/components/WinSection/PredictionCardContent.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import { Flex, Text, Skeleton, Link, Button, ArrowForwardIcon, Heading } from '@pancakeswap/uikit'
+import { Flex, Text, Skeleton, Button, ArrowForwardIcon, Heading } from '@pancakeswap/uikit'
+import { Link } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
 import { formatLocalisedCompactNumber } from 'utils/formatBalance'
 import useRefresh from 'hooks/useRefresh'
@@ -68,7 +69,7 @@ const PredictionCardContent = () => {
         </Text>
       </Flex>
       <Flex alignItems="center" justifyContent="center">
-        <StyledLink href="/prediction" id="homepage-prediction-cta">
+        <StyledLink to="/prediction" id="homepage-prediction-cta">
           <Button width="100%">
             <Text bold color="invertedContrast">
               {t('Play')}


### PR DESCRIPTION
To review:

https://deploy-preview-2314--pancakeswap-dev.netlify.app/

To reproduce: 

1. Click trade now or play buttons on homepage and see the website refreshes completely
2. In firefox we have to give small timeout in order to scroll to work