### PR TITLE
Revert "fix: Claim button is visible even after the claiming deadline passed (#2103)" for lottery nfts

### DIFF
--- a/src/views/Collectibles/components/NftList.tsx
+++ b/src/views/Collectibles/components/NftList.tsx
@@ -6,13 +6,18 @@ import { fetchWalletNfts } from 'state/collectibles'
 import { useGetCollectibles } from 'state/collectibles/hooks'
 import NftCard from './NftCard'
 import NftGrid from './NftGrid'
+import LotteryNftCard from './NftCard/LotteryNftCard'
 
 /**
  * A map of bunnyIds to special campaigns (NFT distribution)
  * Each NftCard is responsible for checking it's own claim status
  *
  */
-const nftComponents = {}
+const nftComponents = {
+  lottie: LotteryNftCard,
+  lucky: LotteryNftCard,
+  baller: LotteryNftCard,
+}
 
 const NftList = () => {
   const { tokenIds } = useGetCollectibles()


### PR DESCRIPTION
This will revert the fix for the issue https://github.com/pancakeswap/pancake-frontend/issues/2098 since the claim period is extended. 

@Chef-Cheems @ChefNina @0xCorgi Can you confirm this is the issue?


