### PR TITLE
fix: Guard for possible undefined marketData

### DIFF
--- a/src/views/Nft/market/Profile/components/UserNfts.tsx
+++ b/src/views/Nft/market/Profile/components/UserNfts.tsx
@@ -86,7 +86,7 @@ const UserNfts = () => {
                 key={`${nft.tokenId}-${nft.collectionName}`}
                 nft={nft}
                 currentAskPrice={
-                  marketData.currentAskPrice && marketData.isTradable && parseFloat(marketData.currentAskPrice)
+                  marketData?.currentAskPrice && marketData?.isTradable && parseFloat(marketData.currentAskPrice)
                 }
                 nftLocation={location}
               />


### PR DESCRIPTION
If certain bunny id was never on sale seems like marketData can be undefined here and crash the page
