### PR TITLE
fix: (prediction) The results on house round shown differently between card panel and history tab

### DIFF
--- a/src/state/predictions/helpers.ts
+++ b/src/state/predictions/helpers.ts
@@ -34,6 +34,7 @@ export enum Result {
   WIN = 'win',
   LOSE = 'lose',
   CANCELED = 'canceled',
+  HOUSE = 'house',
   LIVE = 'live',
 }
 
@@ -193,6 +194,11 @@ export const getRoundResult = (bet: Bet, currentEpoch: number): Result => {
   if (round.epoch >= currentEpoch - 1) {
     return Result.LIVE
   }
+
+  if (bet.position === BetPosition.HOUSE) {
+    return Result.HOUSE
+  }
+
   const roundResultPosition = round.closePrice > round.lockPrice ? BetPosition.BULL : BetPosition.BEAR
 
   return bet.position === roundResultPosition ? Result.WIN : Result.LOSE

--- a/src/views/Predictions/components/History/BetResult.tsx
+++ b/src/views/Predictions/components/History/BetResult.tsx
@@ -61,6 +61,8 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
         return 'textSubtle'
       case Result.CANCELED:
         return 'textDisabled'
+      case Result.HOUSE:
+        return 'textDisabled'
       default:
         return 'text'
     }
@@ -74,6 +76,8 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
         return t('Lose')
       case Result.CANCELED:
         return t('Canceled')
+      case Result.HOUSE:
+        return t('To Burn')
       default:
         return ''
     }
@@ -98,6 +102,7 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
       case Result.LOSE:
         return 'failure'
       case Result.CANCELED:
+      case Result.HOUSE:
       default:
         return 'text'
     }

--- a/src/views/Predictions/components/History/HistoricalBet.tsx
+++ b/src/views/Predictions/components/History/HistoricalBet.tsx
@@ -5,8 +5,11 @@ import {
   ChevronUpIcon,
   Flex,
   IconButton,
+  InfoIcon,
   PlayCircleOutlineIcon,
   Text,
+  TooltipText,
+  useTooltip,
   WaitIcon,
 } from '@pancakeswap/uikit'
 import { useWeb3React } from '@web3-react/core'
@@ -40,8 +43,21 @@ const YourResult = styled(Box)`
 const HistoricalBet: React.FC<BetProps> = ({ bet }) => {
   const [isOpen, setIsOpen] = useState(false)
   const { amount, round } = bet
-
   const { t } = useTranslation()
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(
+    <>
+      <Text bold mb="4px">
+        {t('Neither side wins this round')}
+      </Text>
+      <Text>
+        {t(
+          'The Locked Price & Closed Price are exactly the same (within 8 decimals), so neither side wins. All funds entered into UP and DOWN positions will go to the weekly CAKE burn.',
+        )}
+      </Text>
+    </>,
+    { placement: 'right' },
+  )
+
   const currentEpoch = useGetCurrentEpoch()
   const status = useGetPredictionsStatus()
   const canClaim = useGetIsClaimable(bet.round.epoch)
@@ -57,6 +73,8 @@ const HistoricalBet: React.FC<BetProps> = ({ bet }) => {
       case Result.LOSE:
         return 'failure'
       case Result.CANCELED:
+        return 'textDisabled'
+      case Result.HOUSE:
         return 'textDisabled'
       default:
         return 'text'
@@ -113,7 +131,19 @@ const HistoricalBet: React.FC<BetProps> = ({ bet }) => {
           {t('Your Result')}
         </Text>
         <Text bold color={resultTextColor} lineHeight={1}>
-          {roundResult === Result.CANCELED ? t('Canceled') : `${resultTextPrefix}${formatBnb(payout)}`}
+          {roundResult === Result.CANCELED ? (
+            t('Canceled')
+          ) : roundResult === Result.HOUSE ? (
+            <>
+              {tooltipVisible && tooltip}
+              <Flex alignItems="center" ref={targetRef}>
+                {t('To Burn')}
+                <InfoIcon width="16px" ml="4px" color="secondary" />
+              </Flex>
+            </>
+          ) : (
+            `${resultTextPrefix}${formatBnb(payout)}`
+          )}
         </Text>
       </>
     )

--- a/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
+++ b/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
@@ -83,7 +83,7 @@ const getPnlSummary = (bets: Bet[], currentEpoch: number): PnlSummary => {
         lost: summary.lost,
       }
     }
-    if (roundResult === Result.LOSE) {
+    if (roundResult === Result.LOSE || roundResult === Result.HOUSE) {
       return {
         lost: {
           rounds: summary.lost.rounds + 1,


### PR DESCRIPTION
Fixes #2327 

To review:
