### PR TITLE
fix: (info): Wrong tab bar in info

### DIFF
--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -26,6 +26,17 @@ describe('getActiveMenuItem', () => {
     expect(result).toEqual(menuConfig(mockT)[1])
   })
 
+  it('should not return an item that only includes pathname but not starts with', () => {
+    // Given
+    const pathname = '/info/pools'
+
+    // When
+    const result = getActiveMenuItem({ pathname, menuConfig: menuConfig(mockT) })
+
+    // Then
+    expect(result).toEqual(menuConfig(mockT)[4])
+  })
+
   it('should return undefined if item is not found', () => {
     // Given
     const pathname = '/corgi'
@@ -39,6 +50,17 @@ describe('getActiveMenuItem', () => {
 })
 
 describe('getActiveSubMenuItem', () => {
+  it('should return undefined', () => {
+    // Given
+    const pathname = '/'
+
+    // When
+    const result = getActiveSubMenuItem({ pathname, menuItem: menuConfig(mockT)[1] })
+
+    // Then
+    expect(result).toEqual(undefined)
+  })
+
   it('should return an active sub item', () => {
     // Given
     const pathname = '/pools'
@@ -48,6 +70,17 @@ describe('getActiveSubMenuItem', () => {
 
     // Then
     expect(result).toEqual(menuConfig(mockT)[1].items[1])
+  })
+
+  it('should return the item with the longest href when multiple items are found', () => {
+    // Given
+    const pathname = '/nfts/collections/0xDf7952B35f24aCF7fC0487D01c8d5690a60DBa07'
+
+    // When
+    const result = getActiveSubMenuItem({ pathname, menuItem: menuConfig(mockT)[3] })
+
+    // Then
+    expect(result).toEqual(menuConfig(mockT)[3].items[1])
   })
 
   it('should return undefined if item is not found', () => {

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -1,7 +1,7 @@
 import { ConfigMenuItemsType } from './config/config'
 
 export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
-  menuConfig.find((menuItem) => pathname.includes(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
+  menuConfig.find((menuItem) => pathname.startsWith(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
 
 export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) =>
-  menuItem?.items.find((subMenuItem) => pathname.includes(subMenuItem.href))
+  menuItem?.items.find((subMenuItem) => pathname.startsWith(subMenuItem.href))

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -3,5 +3,23 @@ import { ConfigMenuItemsType } from './config/config'
 export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
   menuConfig.find((menuItem) => pathname.startsWith(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
 
-export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) =>
-  menuItem?.items.find((subMenuItem) => pathname.startsWith(subMenuItem.href))
+export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) => {
+  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.startsWith(subMenuItem.href))
+
+  // Pathname doesn't include any submenu item href - return undefined
+  if (!activeSubMenuItems || activeSubMenuItems.length === 0) {
+    return undefined
+  }
+
+  // Pathname includes one sub menu item href - return it
+  if (activeSubMenuItems.length === 1) {
+    return activeSubMenuItems[0]
+  }
+
+  // Pathname includes multiple sub menu item hrefs - find the most specific match
+  const mostSpecificMatch = activeSubMenuItems.sort(
+    (subMenuItem1, subMenuItem2) => subMenuItem2.href.length - subMenuItem1.href.length,
+  )[0]
+
+  return mostSpecificMatch
+}


### PR DESCRIPTION
This fix also contains https://github.com/pancakeswap/pancake-frontend/pull/2355 fixes by @ChefHutch to nftmarket branch.

Fixes #2214 as well

To review:

https://deploy-preview-2354--pancakeswap-dev.netlify.app/

1. Go to info https://pancakeswap.finance/info
2. Click pools on its own tab bar
3. See farms pools(which is syrup pools) tab bar shown above that
