### PR TITLE
chore(menu-items): Improve getActivesubMenuItem specificity

### DIFF
--- a/src/__tests__/utils/utils.test.ts
+++ b/src/__tests__/utils/utils.test.ts
@@ -60,4 +60,15 @@ describe('getActiveSubMenuItem', () => {
     // Then
     expect(result).toEqual(undefined)
   })
+
+  it('should return the item with the longest href when multiple items are found', () => {
+    // Given
+    const pathname = '/nfts/collections/0xDf7952B35f24aCF7fC0487D01c8d5690a60DBa07'
+
+    // When
+    const result = getActiveSubMenuItem({ pathname, menuItem: menuConfig(mockT)[3] })
+
+    // Then
+    expect(result).toEqual(menuConfig(mockT)[3].items[1])
+  })
 })

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -6,9 +6,9 @@ export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; 
 export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) => {
   const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.includes(subMenuItem.href))
 
-  // Pathname doesn't include any submenu item href - return null
+  // Pathname doesn't include any submenu item href - return undefined
   if (activeSubMenuItems.length === 0) {
-    return null
+    return undefined
   }
 
   // Pathname includes one sub menu item href - return it

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -3,5 +3,26 @@ import { ConfigMenuItemsType } from './config/config'
 export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
   menuConfig.find((menuItem) => pathname.includes(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
 
-export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) =>
-  menuItem?.items.find((subMenuItem) => pathname.includes(subMenuItem.href))
+export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) => {
+  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.includes(subMenuItem.href))
+
+  // Pathname doesn't include any submenu item href - return null
+  if (activeSubMenuItems.length === 0) {
+    return null
+  }
+
+  // Pathname includes one sub menu item href - return it
+  if (activeSubMenuItems.length === 1) {
+    return activeSubMenuItems[0]
+  }
+
+  // Pathname includes multiple sub menu item hrefs - find the most specific match
+  const splitIntoParts = activeSubMenuItems.map((subMenuItem) => {
+    return { label: subMenuItem.label, href: subMenuItem.href.split('/') }
+  })
+
+  const mostSpecificMatch = splitIntoParts.sort(
+    (subMenuItem1, subMenuItem2) => subMenuItem2.href.length - subMenuItem1.href.length,
+  )[0]
+  return { ...mostSpecificMatch, href: mostSpecificMatch.href.join('/') }
+}

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -17,12 +17,9 @@ export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string;
   }
 
   // Pathname includes multiple sub menu item hrefs - find the most specific match
-  const splitIntoParts = activeSubMenuItems.map((subMenuItem) => {
-    return { label: subMenuItem.label, href: subMenuItem.href.split('/') }
-  })
-
-  const mostSpecificMatch = splitIntoParts.sort(
+  const mostSpecificMatch = activeSubMenuItems.sort(
     (subMenuItem1, subMenuItem2) => subMenuItem2.href.length - subMenuItem1.href.length,
   )[0]
-  return { ...mostSpecificMatch, href: mostSpecificMatch.href.join('/') }
+
+  return mostSpecificMatch
 }

--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -1,10 +1,10 @@
 import { ConfigMenuItemsType } from './config/config'
 
 export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
-  menuConfig.find((menuItem) => pathname.includes(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
+  menuConfig.find((menuItem) => pathname.startsWith(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
 
 export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) => {
-  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.includes(subMenuItem.href))
+  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.startsWith(subMenuItem.href))
 
   // Pathname doesn't include any submenu item href - return undefined
   if (activeSubMenuItems.length === 0) {


### PR DESCRIPTION
Previous logic uses `.find()` & return the first match for `pathname.includes(menuItem.href)` which means that if you have an array of menuItems like `/nfts`, `/nfts/collection/0x...`, and a pathname  `/nfts/collection/0x...` - it returns `/nfts` as the active item.

This fixes it. Interested in what @0xCorgi thinks though. It doesn't feel particularly elegant.

<img width="646" alt="Screenshot 2021-09-27 at 12 31 44" src="https://user-images.githubusercontent.com/79279477/134900405-45288518-9f35-4c2b-8a0d-f385150b7999.png">