### PR TITLE
fix: Recent transaction modals discrepancy in transaction lists

### DIFF
--- a/src/components/App/Transactions/TransactionsModal.tsx
+++ b/src/components/App/Transactions/TransactionsModal.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useCallback } from 'react'
+import React, { useCallback } from 'react'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useDispatch } from 'react-redux'
 import { Modal, ModalBody, Text, Button, Flex, InjectedModalProps } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { orderBy } from 'lodash'
 import { isTransactionRecent, useAllTransactions } from 'state/transactions/hooks'
 import { TransactionDetails } from 'state/transactions/reducer'
 import { AppDispatch } from 'state'
@@ -10,11 +11,6 @@ import { clearAllTransactions } from 'state/transactions/actions'
 import { AutoRow } from '../../Layout/Row'
 import Transaction from './Transaction'
 import ConnectWalletButton from '../../ConnectWalletButton'
-
-// we want the latest one to come first, so return negative if a is after b
-function newTransactionsFirst(a: TransactionDetails, b: TransactionDetails) {
-  return b.addedTime - a.addedTime
-}
 
 function renderTransactions(transactions: TransactionDetails[]) {
   return (
@@ -33,10 +29,11 @@ const TransactionsModal: React.FC<InjectedModalProps> = ({ onDismiss }) => {
 
   const { t } = useTranslation()
 
-  const sortedRecentTransactions = useMemo(() => {
-    const txs = Object.values(allTransactions)
-    return txs.filter(isTransactionRecent).sort(newTransactionsFirst)
-  }, [allTransactions])
+  const sortedRecentTransactions = orderBy(
+    Object.values(allTransactions).filter(isTransactionRecent),
+    'addedTime',
+    'desc',
+  )
 
   const pending = sortedRecentTransactions.filter((tx) => !tx.receipt)
   const confirmed = sortedRecentTransactions.filter((tx) => tx.receipt)

--- a/src/components/Menu/UserMenu/WalletTransactions.tsx
+++ b/src/components/Menu/UserMenu/WalletTransactions.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useDispatch } from 'react-redux'
 import { Box, Button, Flex, Text } from '@pancakeswap/uikit'
 import { AppDispatch } from 'state'
-import { useAllTransactions } from 'state/transactions/hooks'
+import { isTransactionRecent, useAllTransactions } from 'state/transactions/hooks'
 import { useTranslation } from 'contexts/Localization'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { clearAllTransactions } from 'state/transactions/actions'
@@ -14,7 +14,7 @@ const WalletTransactions: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>()
   const { t } = useTranslation()
   const allTransactions = useAllTransactions()
-  const sortedTransactions = orderBy(allTransactions, 'addedTime', 'desc')
+  const sortedTransactions = orderBy(Object.values(allTransactions).filter(isTransactionRecent), 'addedTime', 'desc')
 
   const handleClearAll = () => {
     if (chainId) {


### PR DESCRIPTION
To review:

https://deploy-preview-2363--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to wallet modal -> transaction
2. See transactions
3. Go to liquidity or swap
4. Click transactions icon
5. See the discrepancy between this modal and the wallet one