### PR TITLE
fix: Scroll top behaviour

### DIFF
--- a/src/components/HashRoute.tsx
+++ b/src/components/HashRoute.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Route } from 'react-router'
+
+const HashRoute = ({ component: Component, hash, ...routeProps }) => (
+  <Route {...routeProps} component={({ location, ...props }) => location.hash === hash && <Component {...props} />} />
+)
+
+export default HashRoute

--- a/src/hooks/useScrollOnRouteChange.ts
+++ b/src/hooks/useScrollOnRouteChange.ts
@@ -3,14 +3,16 @@ import history from 'routerHistory'
 
 const useScrollOnRouteChange = () => {
   useEffect(() => {
-    const unlisten = history.listen(() => {
-      setTimeout(() => {
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: 'smooth',
-        })
-      }, 50)
+    const unlisten = history.listen((args) => {
+      if (args.hash === '') {
+        setTimeout(() => {
+          window.scroll({
+            top: 0,
+            left: 0,
+            behavior: 'smooth',
+          })
+        }, 50)
+      }
     })
 
     return () => unlisten()

--- a/src/views/Nft/market/Collection/Header.tsx
+++ b/src/views/Nft/market/Collection/Header.tsx
@@ -19,11 +19,13 @@ interface HeaderProps {
   collection: Collection
 }
 
+const DEFAULT_TABS = '#items'
+
 const Header: React.FC<HeaderProps> = ({ collection }) => {
   const { collectionAddress } = useParams<{ collectionAddress: string }>()
   const { totalSupply, numberTokensListed, totalVolumeBNB, banner, avatar } = collection
   const { t } = useTranslation()
-  const { pathname } = useLocation()
+  const { pathname, hash } = useLocation()
 
   const volume = parseFloat(totalVolumeBNB).toLocaleString(undefined, {
     minimumFractionDigits: 3,
@@ -33,11 +35,11 @@ const Header: React.FC<HeaderProps> = ({ collection }) => {
   const itemsConfig = [
     {
       label: t('Items'),
-      href: `${nftsBaseUrl}/collections/${collectionAddress}`,
+      href: `${nftsBaseUrl}/collections/${collectionAddress}#items`,
     },
     {
       label: t('Traits'),
-      href: `${nftsBaseUrl}/collections/${collectionAddress}/traits`,
+      href: `${nftsBaseUrl}/collections/${collectionAddress}#traits`,
     },
   ]
 
@@ -59,7 +61,7 @@ const Header: React.FC<HeaderProps> = ({ collection }) => {
         </MarketPageTitle>
       </MarketPageHeader>
       <Container>
-        <BaseSubMenu items={itemsConfig} activeItem={pathname} mt="24px" mb="8px" />
+        <BaseSubMenu items={itemsConfig} activeItem={`${pathname}${hash || DEFAULT_TABS}`} mt="24px" mb="8px" />
       </Container>
     </>
   )

--- a/src/views/Nft/market/Collection/index.tsx
+++ b/src/views/Nft/market/Collection/index.tsx
@@ -1,3 +1,4 @@
+import HashRoute from 'components/HashRoute'
 import React, { lazy } from 'react'
 import { Route, Switch, useRouteMatch } from 'react-router'
 
@@ -9,17 +10,14 @@ const Collection = () => {
   const { path } = useRouteMatch()
 
   return (
-    <Switch>
-      <Route exact path={path}>
-        <Items />
-      </Route>
-      <Route exact path={`${path}/traits`}>
-        <Traits />
-      </Route>
+    <>
+      <HashRoute exact path={path} hash="" component={Items} />
+      <HashRoute exact path={path} hash="#items" component={Items} />
+      <HashRoute exact path={path} hash="#traits" component={Traits} />
       <Route path={`${path}/:tokenId`}>
         <IndividualNFTPage />
       </Route>
-    </Switch>
+    </>
   )
 }
 


### PR DESCRIPTION
A proposition to use `#` for same page navigation.
It relies on a new component `HashRoute` that just wrap `Route` from react-router and check a `hash` prop to render its component.
This would allow us to keep the existing behavior while landing on a page and ignore it afterward while using internal tabs navigation.