### PR TITLE
fix: Pagination and auto-fetching of NFTs

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1587,5 +1587,6 @@
   "Click to view NFT": "Click to view NFT",
   "Asking price": "Asking price",
   "Please enter a valid address, or connect your wallet to view your profile": "Please enter a valid address, or connect your wallet to view your profile",
-  "No items for sale": "No items for sale"
+  "No items for sale": "No items for sale",
+  "Load more": "Load more"
 }

--- a/src/state/nftMarket/hooks.ts
+++ b/src/state/nftMarket/hooks.ts
@@ -1,11 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useAppDispatch } from 'state'
 import { pancakeBunniesAddress } from 'views/Nft/market/constants'
 import { isAddress } from 'utils'
-import { fetchCollections, fetchNftsFromCollections } from './reducer'
+import useRefresh from 'hooks/useRefresh'
+import { fetchCollections, fetchNftsByBunnyId, fetchNftsFromCollections, updateNftTokensData } from './reducer'
 import { State } from '../types'
-import { UserNftsState } from './types'
+import { NftToken, UserNftsState } from './types'
 
 export const useFetchCollections = () => {
   const dispatch = useAppDispatch()
@@ -13,6 +14,58 @@ export const useFetchCollections = () => {
     dispatch(fetchCollections())
     dispatch(fetchNftsFromCollections(pancakeBunniesAddress))
   }, [dispatch])
+}
+
+// Returns a function that fetches more NFTs when called and puts them into redux state.
+// Also returns loading flag and time of latest successful fetch
+export const useFetchByBunnyId = (bunnyId: string) => {
+  const dispatch = useAppDispatch()
+
+  const isFetchingMoreNfts = useSelector((state: State) => state.nftMarket.data.isFetchingMoreNfts)
+  const latestFetchAt = useSelector((state: State) => state.nftMarket.data.latestFetchAt)
+
+  // Extra guard in case market data shifts
+  // we don't wanna fetch same tokens multiple times
+  const existingBunniesInState = useGetAllBunniesByBunnyId(bunnyId)
+  const existingTokenIds = existingBunniesInState ? existingBunniesInState.map((nft) => nft.tokenId) : []
+
+  const firstBunny = existingBunniesInState.length > 0 ? existingBunniesInState[0] : null
+
+  // If we already have NFT with this bunny id in state - we can reuse its metadata without making API request
+  const existingMetadata = useMemo(() => {
+    return firstBunny
+      ? {
+          name: firstBunny.name,
+          description: firstBunny.description,
+          collection: { name: firstBunny.collectionName },
+          image: firstBunny.image,
+        }
+      : null
+  }, [firstBunny])
+
+  const fetchMorePancakeBunnies = (orderDirection: 'asc' | 'desc') => {
+    dispatch(fetchNftsByBunnyId({ bunnyId, existingTokenIds, existingMetadata, orderDirection }))
+  }
+  return { isFetchingMoreNfts, latestFetchAt, fetchMorePancakeBunnies }
+}
+
+// This hook gets all token ids stored in redux and periodically checks subgraph in case the data we have is staled
+// e.g. NFT gets sold - must be changed form isTradable: true to isTradable: false
+export const useUpdateNftInfo = (collectionAddress: string) => {
+  const dispatch = useAppDispatch()
+  const { fastRefresh } = useRefresh()
+
+  const lastUpdateAt = useSelector((state: State) => state.nftMarket.data.lastUpdateAt)
+
+  const existingNfts = useNftsFromCollection(collectionAddress)
+
+  useEffect(() => {
+    const msSinceLastUpdate = Date.now() - lastUpdateAt
+    const existingTokenIds = existingNfts ? existingNfts.map((nft) => nft.tokenId) : []
+    if (msSinceLastUpdate > 10000) {
+      dispatch(updateNftTokensData({ collectionAddress, existingTokenIds }))
+    }
+  }, [dispatch, fastRefresh, collectionAddress, existingNfts, lastUpdateAt])
 }
 
 export const useGetCollections = () => {
@@ -27,12 +80,12 @@ export const useGetCollection = (collectionAddress: string) => {
 
 export const useNftsFromCollection = (collectionAddress: string) => {
   const checksummedCollectionAddress = isAddress(collectionAddress) || ''
-  const nfts = useSelector((state: State) => state.nftMarket.data.nfts[checksummedCollectionAddress])
+  const nfts: NftToken[] = useSelector((state: State) => state.nftMarket.data.nfts[checksummedCollectionAddress])
   return nfts
 }
 
 export const useGetAllBunniesByBunnyId = (bunnyId: string) => {
-  const nfts = useSelector((state: State) => state.nftMarket.data.nfts[pancakeBunniesAddress])
+  const nfts: NftToken[] = useSelector((state: State) => state.nftMarket.data.nfts[pancakeBunniesAddress])
   return nfts ? nfts.filter((nft) => nft.attributes[0].value === bunnyId && nft.marketData.isTradable) : []
 }
 

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -22,6 +22,9 @@ export interface State {
   data: {
     collections: Record<string, Collection> // string is the address
     nfts: Record<string, NftToken[]> // string is the collection address
+    isFetchingMoreNfts: boolean
+    latestFetchAt: number
+    lastUpdateAt: number
     users: Record<string, User> // string is the address
     user: UserNftsState
   }
@@ -191,22 +194,21 @@ export interface ApiSingleCollectionResponse {
   data: ApiCollection
 }
 
+export interface ApiSingleTokenData {
+  name: string
+  description: string
+  image: Image
+  collection: {
+    name: string
+  }
+}
+
 // Get tokens within collection
 // ${API_NFT}/collections/${collectionAddress}/tokens
 export interface ApiResponseCollectionTokens {
   total: number
   attributesDistribution: Record<string, number>
-  data: Record<
-    string,
-    {
-      name: string
-      description: string
-      image: Image
-      collection: {
-        name: string
-      }
-    }
-  >
+  data: Record<string, ApiSingleTokenData>
 }
 
 // Get specific token data


### PR DESCRIPTION
- Allow users to scroll pages of NFTs (load more on click)
- Every 10 seconds check for new NFTs with the bunny id that you're looking at
- Every 10 seconds update information about displayed NFTs (in case they change price or get bought)