### PR TITLE
fix: Dark theme header on nft market

### DIFF
--- a/src/views/Nft/market/components/MarketPageHeader.tsx
+++ b/src/views/Nft/market/components/MarketPageHeader.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import PageHeader, { PageHeaderProps } from 'components/PageHeader'
+import useTheme from 'hooks/useTheme'
 
-const MarketPageHeader: React.FC<PageHeaderProps> = (props) => (
-  <PageHeader background="linear-gradient(111.68deg, #f2ecf2 0%, #e8f2f6 100%)" {...props} />
-)
+const MarketPageHeader: React.FC<PageHeaderProps> = (props) => {
+  const { theme } = useTheme()
+  const background = theme.isDark
+    ? 'linear-gradient(166.77deg, #3B4155 0%, #3A3045 100%)'
+    : 'linear-gradient(111.68deg, #f2ecf2 0%, #e8f2f6 100%)'
+  return <PageHeader background={background} {...props} />
+}
 
 export default MarketPageHeader


### PR DESCRIPTION
### Before: 
![Screenshot 2021-09-30 at 8 56 31](https://user-images.githubusercontent.com/81824236/135396358-920ce3f3-2b47-4e5d-a83d-0138f839d390.png)
![Screenshot 2021-09-30 at 8 57 24](https://user-images.githubusercontent.com/81824236/135396375-aa60a42b-a26b-4302-b98c-42fc6acc9630.png)

### After:
![Screenshot 2021-09-30 at 9 01 29](https://user-images.githubusercontent.com/81824236/135396434-20c1a3c0-97d2-4528-a171-7c309fca1666.png)
![Screenshot 2021-09-30 at 9 01 37](https://user-images.githubusercontent.com/81824236/135396437-02956bdf-73eb-46ea-9536-cfe563ec6779.png)
