### PR TITLE
fix: (info): Wrong page title of info tokens

### DIFF
--- a/src/config/constants/meta.ts
+++ b/src/config/constants/meta.ts
@@ -109,7 +109,7 @@ export const getCustomMeta = (path: string, t: ContextApi['t']): PageMeta => {
       }
     case '/info/tokens':
       return {
-        title: `${t('Pools')} | ${t('PancakeSwap Info & Analytics')}`,
+        title: `${t('Tokens')} | ${t('PancakeSwap Info & Analytics')}`,
         description: 'View statistics for Pancakeswap exchanges.',
       }
     case '/nfts/profile':


### PR DESCRIPTION
To review:

https://deploy-preview-2427--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to info
2. Go to tokens
3. Check page title