### PR TITLE
refactor: (Harvest Card): Use router link to not refresh page

### DIFF
--- a/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
-import { AutoRenewIcon, Button, Card, CardBody, Flex, Skeleton, Text, Link, ArrowForwardIcon } from '@pancakeswap/uikit'
+import { AutoRenewIcon, Button, Card, CardBody, Flex, Skeleton, Text, ArrowForwardIcon } from '@pancakeswap/uikit'
+import { Link } from 'react-router-dom'
 import BigNumber from 'bignumber.js'
 import { useTranslation } from 'contexts/Localization'
 import { usePriceCakeBusd } from 'state/farms/hooks'
@@ -77,7 +78,7 @@ const HarvestCard = () => {
             </Text>
           </Flex>
           {numTotalToCollect <= 0 ? (
-            <Link href="farms">
+            <Link to="farms">
               <Button width={['100%', null, null, 'auto']} variant="secondary">
                 <Text color="primary" bold>
                   {t('Start earning')}


### PR DESCRIPTION
To review:

https://deploy-preview-2430--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to main page
2. Connect account with no active pools or farms harvested
3. See Start earning button on harvest card
4. Clicking it refreshing the page completely