### PR TITLE
refactor: Rewrote views to use router hooks instead of props

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,21 +134,48 @@ const App: React.FC = () => {
               <Info />
             </Route>
 
-            {/* Using this format because these components use routes injected props. We need to rework them with hooks */}
-            <Route exact strict path="/swap" component={Swap} />
-            <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
-            <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-            <Route exact strict path="/find" component={PoolFinder} />
-            <Route exact strict path="/liquidity" component={Liquidity} />
-            <Route exact strict path="/create" component={RedirectToAddLiquidity} />
-            <Route exact path="/add" component={AddLiquidity} />
-            <Route exact path="/add/:currencyIdA" component={RedirectOldAddLiquidityPathStructure} />
-            <Route exact path="/add/:currencyIdA/:currencyIdB" component={RedirectDuplicateTokenIds} />
-            <Route exact path="/create" component={AddLiquidity} />
-            <Route exact path="/create/:currencyIdA" component={RedirectOldAddLiquidityPathStructure} />
-            <Route exact path="/create/:currencyIdA/:currencyIdB" component={RedirectDuplicateTokenIds} />
-            <Route exact strict path="/remove/:tokens" component={RedirectOldRemoveLiquidityPathStructure} />
-            <Route exact strict path="/remove/:currencyIdA/:currencyIdB" component={RemoveLiquidity} />
+            <Route exact strict path="/swap">
+              <Swap />
+            </Route>
+            <Route exact strict path="/swap/:outputCurrency">
+              <RedirectToSwap />
+            </Route>
+            <Route exact strict path="/send">
+              <RedirectPathToSwapOnly />
+            </Route>
+            <Route exact strict path="/find">
+              <PoolFinder />
+            </Route>
+            <Route exact strict path="/liquidity">
+              <Liquidity />
+            </Route>
+            <Route exact strict path="/create">
+              <RedirectToAddLiquidity />
+            </Route>
+            <Route exact path="/add">
+              <AddLiquidity />
+            </Route>
+            <Route exact path="/add/:currencyIdA">
+              <RedirectOldAddLiquidityPathStructure />
+            </Route>
+            <Route exact path="/add/:currencyIdA/:currencyIdB">
+              <RedirectDuplicateTokenIds />
+            </Route>
+            <Route exact path="/create">
+              <AddLiquidity />
+            </Route>
+            <Route exact path="/create/:currencyIdA">
+              <RedirectOldAddLiquidityPathStructure />
+            </Route>
+            <Route exact path="/create/:currencyIdA/:currencyIdB">
+              <RedirectDuplicateTokenIds />
+            </Route>
+            <Route exact strict path="/remove/:tokens">
+              <RedirectOldRemoveLiquidityPathStructure />
+            </Route>
+            <Route exact strict path="/remove/:currencyIdA/:currencyIdB">
+              <RemoveLiquidity />
+            </Route>
 
             {/* Redirect */}
             <Route path="/pool">

--- a/src/views/AddLiquidity/index.tsx
+++ b/src/views/AddLiquidity/index.tsx
@@ -3,7 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, currencyEquals, ETHER, TokenAmount, WETH } from '@pancakeswap/sdk'
 import { Button, Text, Flex, AddIcon, CardBody, Message, useModal } from '@pancakeswap/uikit'
-import { RouteComponentProps } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import { useTranslation } from 'contexts/Localization'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
@@ -39,13 +39,10 @@ import { currencyId } from '../../utils/currencyId'
 import PoolPriceBar from './PoolPriceBar'
 import Page from '../Page'
 
-export default function AddLiquidity({
-  match: {
-    params: { currencyIdA, currencyIdB },
-  },
-  history,
-}: RouteComponentProps<{ currencyIdA?: string; currencyIdB?: string }>) {
+export default function AddLiquidity() {
   const { account, chainId, library } = useActiveWeb3React()
+  const { currencyIdA, currencyIdB } = useParams<{ currencyIdA: string; currencyIdB: string }>()
+  const history = useHistory()
   const dispatch = useDispatch<AppDispatch>()
   const { t } = useTranslation()
   const gasPrice = useGasPrice()

--- a/src/views/AddLiquidity/redirects.tsx
+++ b/src/views/AddLiquidity/redirects.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Redirect, RouteComponentProps } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 import AddLiquidity from './index'
 
 export function RedirectToAddLiquidity() {
@@ -7,28 +7,20 @@ export function RedirectToAddLiquidity() {
 }
 
 const OLD_PATH_STRUCTURE = /^(0x[a-fA-F0-9]{40}|BNB)-(0x[a-fA-F0-9]{40}|BNB)$/
-export function RedirectOldAddLiquidityPathStructure(props: RouteComponentProps<{ currencyIdA: string }>) {
-  const {
-    match: {
-      params: { currencyIdA },
-    },
-  } = props
+export function RedirectOldAddLiquidityPathStructure() {
+  const { currencyIdA } = useParams<{ currencyIdA: string }>()
   const match = currencyIdA.match(OLD_PATH_STRUCTURE)
   if (match?.length) {
     return <Redirect to={`/add/${match[1]}/${match[2]}`} />
   }
 
-  return <AddLiquidity {...props} />
+  return <AddLiquidity />
 }
 
-export function RedirectDuplicateTokenIds(props: RouteComponentProps<{ currencyIdA: string; currencyIdB: string }>) {
-  const {
-    match: {
-      params: { currencyIdA, currencyIdB },
-    },
-  } = props
+export function RedirectDuplicateTokenIds() {
+  const { currencyIdA, currencyIdB } = useParams<{ currencyIdA: string; currencyIdB: string }>()
   if (currencyIdA.toLowerCase() === currencyIdB.toLowerCase()) {
     return <Redirect to={`/add/${currencyIdA}`} />
   }
-  return <AddLiquidity {...props} />
+  return <AddLiquidity />
 }

--- a/src/views/RemoveLiquidity/index.tsx
+++ b/src/views/RemoveLiquidity/index.tsx
@@ -5,7 +5,7 @@ import { Contract } from '@ethersproject/contracts'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Currency, currencyEquals, ETHER, Percent, WETH } from '@pancakeswap/sdk'
 import { Button, Text, AddIcon, ArrowDownIcon, CardBody, Slider, Box, Flex, useModal } from '@pancakeswap/uikit'
-import { RouteComponentProps } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useTranslation } from 'contexts/Localization'
 import { AutoColumn, ColumnCenter } from '../../components/Layout/Column'
@@ -44,12 +44,9 @@ const BorderCard = styled.div`
   padding: 16px;
 `
 
-export default function RemoveLiquidity({
-  history,
-  match: {
-    params: { currencyIdA, currencyIdB },
-  },
-}: RouteComponentProps<{ currencyIdA: string; currencyIdB: string }>) {
+export default function RemoveLiquidity() {
+  const history = useHistory()
+  const { currencyIdA, currencyIdB } = useParams<{ currencyIdA: string; currencyIdB: string }>()
   const [currencyA, currencyB] = [useCurrency(currencyIdA) ?? undefined, useCurrency(currencyIdB) ?? undefined]
   const { account, chainId, library } = useActiveWeb3React()
   const [tokenA, tokenB] = useMemo(

--- a/src/views/RemoveLiquidity/redirects.tsx
+++ b/src/views/RemoveLiquidity/redirects.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
-import { RouteComponentProps, Redirect } from 'react-router-dom'
+import { Redirect, useParams } from 'react-router-dom'
 
 const OLD_PATH_STRUCTURE = /^(0x[a-fA-F0-9]{40})-(0x[a-fA-F0-9]{40})$/
 
-function RedirectOldRemoveLiquidityPathStructure({
-  match: {
-    params: { tokens },
-  },
-}: RouteComponentProps<{ tokens: string }>) {
+function RedirectOldRemoveLiquidityPathStructure() {
+  const { tokens } = useParams<{ tokens: string }>()
   if (!OLD_PATH_STRUCTURE.test(tokens)) {
     return <Redirect to="/pool" />
   }

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -4,9 +4,9 @@ import { CurrencyAmount, JSBI, Token, Trade } from '@pancakeswap/sdk'
 import { Button, Text, ArrowDownIcon, Box, useModal } from '@pancakeswap/uikit'
 import { useIsTransactionUnsupported } from 'hooks/Trades'
 import UnsupportedCurrencyFooter from 'components/UnsupportedCurrencyFooter'
-import { RouteComponentProps } from 'react-router-dom'
 import { useTranslation } from 'contexts/Localization'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
+import { useHistory } from 'react-router'
 import AddressInputPanel from './components/AddressInputPanel'
 import { GreyCard } from '../../components/Card'
 import Column, { AutoColumn } from '../../components/Layout/Column'
@@ -48,10 +48,11 @@ const Label = styled(Text)`
   color: ${({ theme }) => theme.colors.secondary};
 `
 
-export default function Swap({ history }: RouteComponentProps) {
+export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()
 
   const { t } = useTranslation()
+  const history = useHistory()
 
   // token warning stuff
   const [loadedInputCurrency, loadedOutputCurrency] = [
@@ -272,7 +273,7 @@ export default function Swap({ history }: RouteComponentProps) {
   const swapIsUnsupported = useIsTransactionUnsupported(currencies?.INPUT, currencies?.OUTPUT)
 
   const [onPresentImportTokenWarningModal] = useModal(
-    <ImportTokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap/')} />,
+    <ImportTokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap')} />,
   )
 
   useEffect(() => {

--- a/src/views/Swap/redirects.tsx
+++ b/src/views/Swap/redirects.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
-import { Redirect, RouteComponentProps } from 'react-router-dom'
+import { Redirect, useLocation, useParams } from 'react-router-dom'
 
 // Redirects to swap but only replace the pathname
-export function RedirectPathToSwapOnly({ location }: RouteComponentProps) {
+export function RedirectPathToSwapOnly() {
+  const location = useLocation()
   return <Redirect to={{ ...location, pathname: '/swap' }} />
 }
 
 // Redirects from the /swap/:outputCurrency path to the /swap?outputCurrency=:outputCurrency format
-export function RedirectToSwap(props: RouteComponentProps<{ outputCurrency: string }>) {
-  const {
-    location,
-    location: { search },
-    match: {
-      params: { outputCurrency },
-    },
-  } = props
+export function RedirectToSwap() {
+  const location = useLocation()
+  const { search } = location
+  const { outputCurrency } = useParams<{ outputCurrency: string }>()
 
   return (
     <Redirect


### PR DESCRIPTION
This is a small refactor on how views use router functions.
Now views inside App.tsx are using the router hooks instead of router props.