### PR TITLE
feat: Auto update refinement

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,3 +33,5 @@ export const AUCTION_BIDDERS_TO_FETCH = 500
 export const RECLAIM_AUCTIONS_TO_FETCH = 500
 export const AUCTION_WHITELISTED_BIDDERS_TO_FETCH = 500
 export const IPFS_GATEWAY = 'https://ipfs.io/ipfs'
+// In reality its 10000 because of fast refresh, a bit less here to cover for possible long request times
+export const PANCAKE_BUNNIES_UPDATE_FREQUENCY = 8000

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1592,5 +1592,6 @@
   "Your NFT has been transferred to another wallet": "Your NFT has been transferred to another wallet",
   "Back": "Back",
   "Confirm transaction": "Confirm transaction",
-  "Collection": "Collection"
+  "Collection": "Collection",
+  "Items in the table update every 10 seconds": "Items in the table update every 10 seconds"
 }

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -17,6 +17,8 @@ import {
   CollectionMarketDataBaseFields,
   Transaction,
   AskOrder,
+  ApiSingleTokenData,
+  NftAttribute,
 } from './types'
 import { getBaseNftFields, getBaseTransactionFields, getCollectionBaseFields } from './queries'
 
@@ -259,7 +261,7 @@ export const getMarketDataForTokenIds = async (
       `,
       {
         collectionAddress: collectionAddress.toLowerCase(),
-        where: { tokenId_not_in: existingTokenIds },
+        where: { tokenId_in: existingTokenIds },
       },
     )
     return res.nfts
@@ -471,6 +473,50 @@ export const getLatestListedNfts = async (first: number): Promise<TokenMarketDat
 /**
  * OTHER HELPERS
  */
+
+export const getMetadataWithFallback = (apiMetadata: ApiResponseCollectionTokens['data'], bunnyId: string) => {
+  // The fallback is just for the testnet where some bunnies don't exist
+  return (
+    apiMetadata[bunnyId] ?? {
+      name: '',
+      description: '',
+      collection: { name: 'Pancake Bunnies' },
+      image: {
+        original: '',
+        thumbnail: '',
+      },
+    }
+  )
+}
+
+export const getPancakeBunniesAttributesField = (bunnyId: string) => {
+  // Generating attributes field that is not returned by API
+  // but can be "faked" since objects are keyed with bunny id
+  return [
+    {
+      traitType: 'bunnyId',
+      value: bunnyId,
+      displayType: null,
+    },
+  ]
+}
+
+export const combineApiAndSgResponseToNftToken = (
+  apiMetadata: ApiSingleTokenData,
+  marketData: TokenMarketData,
+  attributes: NftAttribute[],
+) => {
+  return {
+    tokenId: marketData.tokenId,
+    name: apiMetadata.name,
+    description: apiMetadata.description,
+    collectionName: apiMetadata.collection.name,
+    collectionAddress: pancakeBunniesAddress,
+    image: apiMetadata.image,
+    marketData,
+    attributes,
+  }
+}
 
 export const fetchWalletTokenIdsForCollections = async (
   account: string,

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -14,6 +14,9 @@ import {
   getCompleteAccountNftData,
   getNftsByBunnyIdSg,
   getMarketDataForTokenIds,
+  getMetadataWithFallback,
+  getPancakeBunniesAttributesField,
+  combineApiAndSgResponseToNftToken,
 } from './helpers'
 import {
   State,
@@ -25,8 +28,6 @@ import {
   NftToken,
   NftLocation,
   ApiSingleTokenData,
-  NftAttribute,
-  TokenMarketData,
 } from './types'
 
 const initialState: State = {
@@ -34,9 +35,10 @@ const initialState: State = {
   data: {
     collections: {},
     nfts: {},
-    isFetchingMoreNfts: false,
-    latestFetchAt: 0,
-    lastUpdateAt: Date.now(),
+    loadingState: {
+      isUpdatingPancakeBunnies: false,
+      latestPancakeBunniesUpdateAt: 0,
+    },
     users: {},
     user: {
       userNftsInitializationState: UserNftInitializationState.UNINITIALIZED,
@@ -83,6 +85,11 @@ export const fetchNftsFromCollections = createAsyncThunk(
   'nft/fetchNftsFromCollections',
   async (collectionAddress: string) => {
     try {
+      if (collectionAddress === pancakeBunniesAddress) {
+        // PancakeBunnies don't need to pre-fetch "all nfts" from the collection
+        // When user visits IndividualNFTPage required nfts will be fetched via bunny id
+        return []
+      }
       const [nfts, nftsMarket] = await Promise.all([
         getNftsFromCollectionApi(collectionAddress),
         getNftsFromCollectionSg(collectionAddress),
@@ -90,40 +97,6 @@ export const fetchNftsFromCollections = createAsyncThunk(
 
       if (!nfts?.data) {
         return []
-      }
-
-      if (collectionAddress === pancakeBunniesAddress) {
-        return nftsMarket.map((marketData) => {
-          // The fallback is just for the testnet where some bunnies don't exist
-          const apiMetadata = nfts.data[marketData.otherId] ?? {
-            name: '',
-            description: '',
-            collection: { name: 'Pancake Bunnies' },
-            image: {
-              original: '',
-              thumbnail: '',
-            },
-          }
-          // Generating attributes field that is not returned by API but can be "faked" since objects are keyed with bunny id
-          const attributes: NftAttribute[] = [
-            {
-              traitType: 'bunnyId',
-              value: marketData.otherId,
-              displayType: null,
-            },
-          ]
-          return {
-            tokenId: marketData.tokenId,
-            name: apiMetadata.name,
-
-            description: apiMetadata.description,
-            collectionName: apiMetadata.collection.name,
-            collectionAddress,
-            image: apiMetadata.image,
-            marketData,
-            attributes,
-          }
-        })
       }
 
       return Object.keys(nfts.data).map((id) => {
@@ -148,112 +121,62 @@ export const fetchNftsFromCollections = createAsyncThunk(
 )
 
 /**
- * Fetch fresh marketdata for existing tokens in the store
+ * This action keeps data on the individual PancakeBunny page up-to-date. Operation is a twofold
+ * 1. Update existing NFTs in the state in case some were sold or got price modified
+ * 2. Fetch 30 more NFTs with specified bunny id
  */
-export const updateNftTokensData = createAsyncThunk<
+export const fetchNewPBAndUpdateExisting = createAsyncThunk<
   NftToken[],
-  { collectionAddress: string; existingTokenIds: string[] }
->('nft/updateNftTokensData', async ({ collectionAddress, existingTokenIds }) => {
-  try {
-    // TODO: this kinda should work for other collections too, but doublecheck during Squad integration
-    const [nfts, nftsMarket] = await Promise.all([
-      getNftsFromCollectionApi(collectionAddress),
-      getMarketDataForTokenIds(collectionAddress, existingTokenIds),
-    ])
+  {
+    bunnyId: string
+    existingTokensWithBunnyId: string[]
+    allExistingPBTokenIds: string[]
+    existingMetadata: ApiSingleTokenData
+    orderDirection: 'asc' | 'desc'
+  }
+>(
+  'nft/fetchNewPBAndUpdateExisting',
+  async ({ bunnyId, existingTokensWithBunnyId, allExistingPBTokenIds, existingMetadata, orderDirection }) => {
+    try {
+      // 1. Update existing NFTs in the state in case some were sold or got price modified
+      const [updatedNfts, updatedNftsMarket] = await Promise.all([
+        getNftsFromCollectionApi(pancakeBunniesAddress),
+        getMarketDataForTokenIds(pancakeBunniesAddress, allExistingPBTokenIds),
+      ])
 
-    if (!nfts?.data) {
+      if (!updatedNfts?.data) {
+        return []
+      }
+      const updatedTokens = updatedNftsMarket.map((marketData) => {
+        const apiMetadata = getMetadataWithFallback(updatedNfts.data, marketData.otherId)
+        const attributes = getPancakeBunniesAttributesField(marketData.otherId)
+        return combineApiAndSgResponseToNftToken(apiMetadata, marketData, attributes)
+      })
+
+      // 2. Fetch 30 more NFTs with specified bunny id
+      let newNfts = { data: { [bunnyId]: existingMetadata } }
+
+      if (!existingMetadata) {
+        newNfts = await getNftsFromCollectionApi(pancakeBunniesAddress)
+      }
+      const nftsMarket = await getNftsByBunnyIdSg(bunnyId, existingTokensWithBunnyId, orderDirection)
+
+      if (!newNfts?.data) {
+        return updatedTokens
+      }
+
+      const moreTokensWithRequestedBunnyId = nftsMarket.map((marketData) => {
+        const apiMetadata = getMetadataWithFallback(newNfts.data, marketData.otherId)
+        const attributes = getPancakeBunniesAttributesField(marketData.otherId)
+        return combineApiAndSgResponseToNftToken(apiMetadata, marketData, attributes)
+      })
+      return [...updatedTokens, ...moreTokensWithRequestedBunnyId]
+    } catch (error) {
+      console.error(`Failed to update PancakeBunnies NFTs`, error)
       return []
     }
-
-    return nftsMarket.map((marketData) => {
-      // The fallback is just for the testnet where some bunnies don't exist
-      const apiMetadata = nfts.data[marketData.otherId] ?? {
-        name: '',
-        description: '',
-        collection: { name: 'Pancake Bunnies' },
-        image: {
-          original: '',
-          thumbnail: '',
-        },
-      }
-      // Generating attributes field that is not returned by API but can be "faked" since objects are keyed with bunny id
-      const attributes = [
-        {
-          traitType: 'bunnyId',
-          value: marketData.otherId,
-          displayType: null,
-        },
-      ]
-      return {
-        tokenId: marketData.tokenId,
-        name: apiMetadata.name,
-        description: apiMetadata.description,
-        collectionName: apiMetadata.collection.name,
-        collectionAddress: pancakeBunniesAddress,
-        image: apiMetadata.image,
-        marketData,
-        attributes,
-      }
-    })
-  } catch (error) {
-    console.error(`Failed to update collection NFTs for ${collectionAddress}`, error)
-    return []
-  }
-})
-
-/**
- * Fetch all 30 on sale NFTs with specified bunny id
- */
-export const fetchNftsByBunnyId = createAsyncThunk<
-  NftToken[],
-  { bunnyId: string; existingTokenIds: string[]; existingMetadata: ApiSingleTokenData; orderDirection: 'asc' | 'desc' }
->('nft/fetchNftsByBunnyId', async ({ bunnyId, existingTokenIds, existingMetadata, orderDirection }) => {
-  try {
-    let nfts = { data: { [bunnyId]: existingMetadata } }
-    if (!existingMetadata) {
-      nfts = await getNftsFromCollectionApi(pancakeBunniesAddress)
-    }
-    const nftsMarket = await getNftsByBunnyIdSg(bunnyId, existingTokenIds, orderDirection)
-
-    if (!nfts?.data) {
-      return []
-    }
-
-    return nftsMarket.map((marketData) => {
-      // The fallback is just for the testnet where some bunnies don't exist
-      const apiMetadata = nfts.data[marketData.otherId] ?? {
-        name: '',
-        description: '',
-        collection: { name: 'Pancake Bunnies' },
-        image: {
-          original: '',
-          thumbnail: '',
-        },
-      }
-      // Generating attributes field that is not returned by API but can be "faked" since objects are keyed with bunny id
-      const attributes = [
-        {
-          traitType: 'bunnyId',
-          value: marketData.otherId,
-          displayType: null,
-        },
-      ]
-      return {
-        tokenId: marketData.tokenId,
-        name: apiMetadata.name,
-        description: apiMetadata.description,
-        collectionName: apiMetadata.collection.name,
-        collectionAddress: pancakeBunniesAddress,
-        image: apiMetadata.image,
-        marketData,
-        attributes,
-      }
-    })
-  } catch (error) {
-    console.error(`Failed to fetch collection NFTs for bunny id ${bunnyId}`, error)
-    return []
-  }
-})
+  },
+)
 
 export const fetchUserNfts = createAsyncThunk<
   NftToken[],
@@ -310,28 +233,22 @@ export const NftMarket = createSlice({
       state.initializationState = NFTMarketInitializationState.INITIALIZED
     })
     builder.addCase(fetchNftsFromCollections.fulfilled, (state, action) => {
-      state.data.nfts[action.meta.arg] = action.payload
+      const existingNfts = state.data.nfts[action.meta.arg] ?? []
+      state.data.nfts[action.meta.arg] = [...existingNfts, ...action.payload]
     })
-    builder.addCase(updateNftTokensData.fulfilled, (state, action) => {
+    builder.addCase(fetchNewPBAndUpdateExisting.pending, (state) => {
+      state.data.loadingState.isUpdatingPancakeBunnies = true
+    })
+    builder.addCase(fetchNewPBAndUpdateExisting.fulfilled, (state, action) => {
       if (action.payload.length > 0) {
-        state.data.nfts[action.meta.arg.collectionAddress] = action.payload
-        state.data.lastUpdateAt = Date.now()
+        state.data.nfts[pancakeBunniesAddress] = action.payload
       }
+      state.data.loadingState.isUpdatingPancakeBunnies = false
+      state.data.loadingState.latestPancakeBunniesUpdateAt = Date.now()
     })
-    builder.addCase(updateNftTokensData.rejected, (state) => {
-      state.data.lastUpdateAt = Date.now()
-    })
-    builder.addCase(fetchNftsByBunnyId.pending, (state) => {
-      state.data.isFetchingMoreNfts = true
-    })
-    builder.addCase(fetchNftsByBunnyId.fulfilled, (state, action) => {
-      const existingNftsInState = state.data.nfts[pancakeBunniesAddress] || []
-      state.data.nfts[pancakeBunniesAddress] = [...existingNftsInState, ...action.payload]
-      state.data.isFetchingMoreNfts = false
-      state.data.latestFetchAt = Date.now()
-    })
-    builder.addCase(fetchNftsByBunnyId.rejected, (state) => {
-      state.data.isFetchingMoreNfts = false
+    builder.addCase(fetchNewPBAndUpdateExisting.rejected, (state) => {
+      state.data.loadingState.isUpdatingPancakeBunnies = false
+      state.data.loadingState.latestPancakeBunniesUpdateAt = Date.now()
     })
     builder.addCase(fetchUserNfts.rejected, (state) => {
       state.data.user.userNftsInitializationState = UserNftInitializationState.ERROR

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -22,9 +22,10 @@ export interface State {
   data: {
     collections: Record<string, Collection> // string is the address
     nfts: Record<string, NftToken[]> // string is the collection address
-    isFetchingMoreNfts: boolean
-    latestFetchAt: number
-    lastUpdateAt: number
+    loadingState: {
+      isUpdatingPancakeBunnies: boolean
+      latestPancakeBunniesUpdateAt: number
+    }
     users: Record<string, User> // string is the address
     user: UserNftsState
   }

--- a/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/CountdownCircle.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/CountdownCircle.tsx
@@ -1,0 +1,62 @@
+import { Spinner, Text } from '@pancakeswap/uikit'
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+
+const countdownAnimation = keyframes`
+  from {
+    stroke-dashoffset: 0px;
+  }
+  to {
+    stroke-dashoffset: 113px;
+  }
+`
+
+const CountdownContainer = styled.div`
+  position: relative;
+  margin: auto;
+  height: 40px;
+  width: 40px;
+  text-align: center;
+
+  & svg {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 40px;
+    height: 40px;
+    transform: rotateY(-180deg) rotateZ(-90deg);
+
+    & circle {
+      stroke-dasharray: 113px;
+      stroke-dashoffset: 0px;
+      stroke-linecap: round;
+      stroke-width: 2px;
+      stroke: ${({ theme }) => theme.colors.primaryBright};
+      fill: none;
+      animation: ${countdownAnimation} 10s linear infinite forwards;
+    }
+  }
+`
+
+interface CountdownCircleProps {
+  secondsRemaining: number
+  isUpdating: boolean
+}
+
+const CountdownCircle: React.FC<CountdownCircleProps> = ({ secondsRemaining, isUpdating }) => {
+  if (secondsRemaining < 1 || isUpdating) {
+    return <Spinner size={42} />
+  }
+  return (
+    <CountdownContainer>
+      <Text color="textSubtle" lineHeight="40px" display="inline-block">
+        {secondsRemaining}
+      </Text>
+      <svg>
+        <circle r="18" cx="20" cy="20" />
+      </svg>
+    </CountdownContainer>
+  )
+}
+
+export default CountdownCircle

--- a/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/UpdateIndicator.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/UpdateIndicator.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import { Flex, useTooltip } from '@pancakeswap/uikit'
+import { useLoadingState } from 'state/nftMarket/hooks'
+import { useTranslation } from 'contexts/Localization'
+import CountdownCircle from './CountdownCircle'
+
+const UpdateIndicator = () => {
+  const { t } = useTranslation()
+  const [secondsRemaining, setSecondsRemaining] = useState(10)
+  const { isUpdatingPancakeBunnies: isFetchingMorePancakeBunnies } = useLoadingState()
+  const { tooltip, tooltipVisible, targetRef } = useTooltip(t('Items in the table update every 10 seconds'), {
+    placement: 'auto',
+  })
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setSecondsRemaining((prev) => prev - 1)
+    }, 1000)
+
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isFetchingMorePancakeBunnies) {
+      setSecondsRemaining(10)
+    }
+  }, [isFetchingMorePancakeBunnies])
+
+  return (
+    <Flex justifyContent="center" ref={targetRef}>
+      <CountdownCircle secondsRemaining={secondsRemaining} isUpdating={isFetchingMorePancakeBunnies} />
+      {tooltipVisible && tooltip}
+    </Flex>
+  )
+}
+
+export default UpdateIndicator

--- a/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/index.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/index.tsx
@@ -19,6 +19,7 @@ import useTheme from 'hooks/useTheme'
 import { NftToken } from 'state/nftMarket/types'
 import ForSaleTableRows from './ForSaleTableRows'
 import { StyledSortButton } from './styles'
+import UpdateIndicator from './UpdateIndicator'
 
 const ITEMS_PER_PAGE_DESKTOP = 10
 const ITEMS_PER_PAGE_MOBILE = 5
@@ -118,7 +119,7 @@ const ForSaleTableCard: React.FC<ForSaleTableCardProps> = ({
     <StyledCard hasManyPages={maxPage > 1}>
       <Grid
         flex="0 1 auto"
-        gridTemplateColumns="34px 1fr"
+        gridTemplateColumns="34px 1fr 48px"
         alignItems="center"
         height="72px"
         px="24px"
@@ -126,6 +127,7 @@ const ForSaleTableCard: React.FC<ForSaleTableCardProps> = ({
       >
         <SellIcon width="24px" height="24px" />
         <Text bold>{t('For Sale (%num%)', { num: totalForSale.toLocaleString() })}</Text>
+        <UpdateIndicator />
       </Grid>
       {nftsOnCurrentPage.length > 0 ? (
         <>

--- a/src/views/Nft/market/Collection/IndividualNFTPage/MoreFromThisCollection.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/MoreFromThisCollection.tsx
@@ -44,7 +44,7 @@ const MoreFromThisCollection: React.FC<MoreFromThisCollectionProps> = ({ collect
 
   let nftsToShow = allPancakeBunnyNfts ? allPancakeBunnyNfts.filter((nft) => nft.name !== currentTokenName) : []
 
-  if (!nftsToShow) {
+  if (nftsToShow.length === 0) {
     return null
   }
 


### PR DESCRIPTION
- Adds update for existing NFTs in the state every 10 seconds (in case they get sold or price gets modified)
- Adds update indicator to the table
- Removes pre-fetching random pancake bunny NFTs into state as they are not used anywhere.