### PR TITLE
feat(nft-collections): Paginate collections frontend and requests

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/index.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/ForSaleTableCard/index.tsx
@@ -20,6 +20,7 @@ import { NftToken } from 'state/nftMarket/types'
 import ForSaleTableRows from './ForSaleTableRows'
 import { StyledSortButton } from './styles'
 import UpdateIndicator from './UpdateIndicator'
+import { Arrow, PageButtons } from '../../../components/PaginationButtons'
 
 const ITEMS_PER_PAGE_DESKTOP = 10
 const ITEMS_PER_PAGE_MOBILE = 5
@@ -38,23 +39,6 @@ const StyledCard = styled(Card)<{ hasManyPages: boolean }>`
 
 const TableHeading = styled(Grid)`
   border-bottom: ${({ theme }) => `1px solid ${theme.colors.cardBorder}`};
-`
-
-const PageButtons = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 16px;
-  margin-bottom: 16px;
-`
-
-const Arrow = styled.div`
-  color: ${({ theme }) => theme.colors.primary};
-  padding: 0 20px;
-  :hover {
-    cursor: pointer;
-  }
 `
 
 interface ForSaleTableCardProps {

--- a/src/views/Nft/market/Collection/Items/CollectionNfts.tsx
+++ b/src/views/Nft/market/Collection/Items/CollectionNfts.tsx
@@ -1,57 +1,169 @@
-import React, { useEffect } from 'react'
-import { Grid } from '@pancakeswap/uikit'
+import React, { useEffect, useState } from 'react'
+import { ArrowBackIcon, ArrowForwardIcon, AutoRenewIcon, Flex, Grid, Text } from '@pancakeswap/uikit'
 import { getAddress } from '@ethersproject/address'
 import orderBy from 'lodash/orderBy'
 import { useAppDispatch } from 'state'
 import { useNftsFromCollection } from 'state/nftMarket/hooks'
-import { Collection } from 'state/nftMarket/types'
+import { Collection, NftToken } from 'state/nftMarket/types'
 import { fetchNftsFromCollections } from 'state/nftMarket/reducer'
+import { useTranslation } from 'contexts/Localization'
 import GridPlaceholder from '../../components/GridPlaceholder'
 import { CollectibleLinkCard } from '../../components/CollectibleCard'
 import { pancakeBunniesAddress } from '../../constants'
 import useAllPancakeBunnyNfts from '../../hooks/useAllPancakeBunnyNfts'
+import { Arrow, PageButtons } from '../../components/PaginationButtons'
 
 interface CollectionNftsProps {
   collection: Collection
   sortBy?: string
+  scrollToTop: () => void
 }
 
-const CollectionNfts: React.FC<CollectionNftsProps> = ({ collection, sortBy = 'updatedAt' }) => {
-  const { address } = collection
-  const checksummedAddress = getAddress(address)
+const REQUEST_SIZE = 100
+const MAX_ITEMS_PER_PAGE = 100
+
+const CollectionNfts: React.FC<CollectionNftsProps> = ({ collection, sortBy = 'updatedAt', scrollToTop }) => {
   const dispatch = useAppDispatch()
 
-  const isPBCollection = address === pancakeBunniesAddress
+  const [currentPage, setCurrentPage] = useState(1)
+  const [maxPage, setMaxPages] = useState(1)
+  const [sortedNfts, setSortedNfts] = useState<NftToken[]>([])
+  const [nftsSlice, setNftsSlice] = useState<NftToken[]>([])
+  const { t } = useTranslation()
 
-  useEffect(() => {
-    dispatch(fetchNftsFromCollections(checksummedAddress))
-  }, [checksummedAddress, dispatch])
+  const { address, totalSupply } = collection
+
+  const checksummedAddress = getAddress(address)
+  const isPBCollection = address === pancakeBunniesAddress
 
   const nfts = useNftsFromCollection(checksummedAddress)
   const allPancakeBunnyNfts = useAllPancakeBunnyNfts(address)
 
   const currentNfts = isPBCollection ? allPancakeBunnyNfts : nfts
+  const shouldFetchMoreNfts = currentNfts?.length <= currentPage * MAX_ITEMS_PER_PAGE
+  const isArrowBackDisabled = currentPage === 1
+  const isArrowForwardDisabled = currentPage === maxPage || shouldFetchMoreNfts
 
-  if (!currentNfts) {
+  useEffect(() => {
+    // First fetch
+    dispatch(
+      fetchNftsFromCollections({
+        collectionAddress: checksummedAddress,
+        page: 1,
+        size: REQUEST_SIZE,
+      }),
+    )
+  }, [checksummedAddress, dispatch])
+
+  useEffect(() => {
+    // Additional fetches
+    const fetchMoreNftsFromCollections = () => {
+      const requestPage = Math.ceil(currentNfts.length / REQUEST_SIZE) + 1
+      dispatch(
+        fetchNftsFromCollections({
+          collectionAddress: checksummedAddress,
+          page: requestPage,
+          size: REQUEST_SIZE,
+        }),
+      )
+    }
+
+    // NB: TRAIT FILTERS - When trait filter is active, should probably prevent this from firing
+    if (!isPBCollection && currentNfts?.length > 0 && shouldFetchMoreNfts) {
+      fetchMoreNftsFromCollections()
+    }
+  }, [currentNfts, currentPage, checksummedAddress, shouldFetchMoreNfts, isPBCollection, dispatch])
+
+  useEffect(() => {
+    const getMaxPages = () => {
+      // NB: TRAIT FILTERS - changing the `totalSupply` here to the length of the data returned by the traits res should work well for FE pagination.
+      const max = Math.ceil(Number(totalSupply) / MAX_ITEMS_PER_PAGE)
+      setMaxPages(max)
+    }
+
+    if (!isPBCollection && totalSupply) {
+      getMaxPages()
+    }
+  }, [totalSupply, isPBCollection])
+
+  // Sort data returned from redux
+  useEffect(() => {
+    const applySortToNfts = () => {
+      const sorted = orderBy(
+        currentNfts,
+        (nft) => (isPBCollection ? nft.meta[sortBy] : nft.marketData ? Number(nft.marketData[sortBy]) : 0),
+        [sortBy === 'currentAskPrice' ? 'asc' : 'desc'],
+      )
+      setSortedNfts(sorted)
+    }
+
+    if (currentNfts?.length > 0) {
+      applySortToNfts()
+    }
+  }, [currentNfts, isPBCollection, sortBy])
+
+  // Slice sorted data to paginate in FE
+  useEffect(() => {
+    const getActivitiesSlice = () => {
+      const slice = sortedNfts.slice(MAX_ITEMS_PER_PAGE * (currentPage - 1), MAX_ITEMS_PER_PAGE * currentPage)
+      setNftsSlice(slice)
+    }
+
+    if (sortedNfts?.length > 0) {
+      getActivitiesSlice()
+    }
+  }, [sortedNfts, currentPage, isPBCollection, sortBy])
+
+  if (!nftsSlice.length) {
     return <GridPlaceholder />
   }
 
-  const nftsToShow = orderBy(
-    currentNfts,
-    (nft) => (isPBCollection ? nft.meta[sortBy] : nft.marketData ? Number(nft.marketData[sortBy]) : 0),
-    [sortBy === 'currentAskPrice' ? 'asc' : 'desc'],
-  )
-
   return (
-    <Grid
-      gridGap="16px"
-      gridTemplateColumns={['1fr', null, 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
-      alignItems="start"
-    >
-      {nftsToShow.map((nft) => {
-        return <CollectibleLinkCard key={`${nft.tokenId}-${nft.collectionName}`} nft={nft} />
-      })}
-    </Grid>
+    <>
+      <Grid
+        gridGap="16px"
+        gridTemplateColumns={['1fr', null, 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
+        alignItems="start"
+      >
+        {nftsSlice.map((nft) => {
+          return <CollectibleLinkCard key={`${nft.tokenId}-${nft.collectionName}`} nft={nft} />
+        })}
+      </Grid>
+      {nfts?.length > MAX_ITEMS_PER_PAGE && (
+        <Flex mt="24px">
+          <PageButtons>
+            <Arrow
+              onClick={() => {
+                setCurrentPage(isArrowBackDisabled ? currentPage : currentPage - 1)
+              }}
+            >
+              <ArrowBackIcon
+                color={isArrowBackDisabled ? 'textDisabled' : 'primary'}
+                cursor={isArrowBackDisabled ? 'not-allowed' : 'pointer'}
+              />
+            </Arrow>
+            <Text>{t('Page %page% of %maxPage%', { page: currentPage, maxPage })}</Text>
+            <Arrow
+              onClick={() => {
+                if (!isArrowForwardDisabled) {
+                  scrollToTop()
+                  setCurrentPage(currentPage + 1)
+                }
+              }}
+            >
+              {shouldFetchMoreNfts ? (
+                <AutoRenewIcon spin color="textDisabled" cursor="not-allowed" />
+              ) : (
+                <ArrowForwardIcon
+                  color={isArrowForwardDisabled ? 'textDisabled' : 'primary'}
+                  cursor={isArrowForwardDisabled ? 'not-allowed' : 'pointer'}
+                />
+              )}
+            </Arrow>
+          </PageButtons>
+        </Flex>
+      )}
+    </>
   )
 }
 

--- a/src/views/Nft/market/Collection/Items/PancakeBunniesCollectionNfts.tsx
+++ b/src/views/Nft/market/Collection/Items/PancakeBunniesCollectionNfts.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Grid } from '@pancakeswap/uikit'
+import orderBy from 'lodash/orderBy'
+import { Collection } from 'state/nftMarket/types'
+import { CollectibleLinkCard } from '../../components/CollectibleCard'
+import useAllPancakeBunnyNfts from '../../hooks/useAllPancakeBunnyNfts'
+
+interface CollectionNftsProps {
+  collection: Collection
+  sortBy?: string
+}
+
+const PancakeBunniesCollectionNfts: React.FC<CollectionNftsProps> = ({ collection, sortBy = 'updatedAt' }) => {
+  const { address } = collection
+  const allPancakeBunnyNfts = useAllPancakeBunnyNfts(address)
+  const sortedNfts = orderBy(allPancakeBunnyNfts, (nft) => (nft.meta[sortBy] ? Number(nft.marketData[sortBy]) : 0), [
+    sortBy === 'currentAskPrice' ? 'asc' : 'desc',
+  ])
+
+  return (
+    <>
+      <Grid
+        gridGap="16px"
+        gridTemplateColumns={['1fr', null, 'repeat(3, 1fr)', null, 'repeat(4, 1fr)']}
+        alignItems="start"
+      >
+        {sortedNfts.map((nft) => {
+          return <CollectibleLinkCard key={`${nft.tokenId}-${nft.collectionName}`} nft={nft} />
+        })}
+      </Grid>
+    </>
+  )
+}
+
+export default PancakeBunniesCollectionNfts

--- a/src/views/Nft/market/Collection/Items/index.tsx
+++ b/src/views/Nft/market/Collection/Items/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { Box, Flex, Text } from '@pancakeswap/uikit'
 import { useAppDispatch } from 'state'
@@ -7,16 +7,18 @@ import { useGetCollection } from 'state/nftMarket/hooks'
 import { useTranslation } from 'contexts/Localization'
 import Select, { OptionProps } from 'components/Select/Select'
 import Page from 'components/Layout/Page'
+import { pancakeBunniesAddress } from '../../constants'
 import CollectionNfts from './CollectionNfts'
+import PancakeBunniesCollectionNfts from './PancakeBunniesCollectionNfts'
 import Header from '../Header'
 
 const Items = () => {
   const { collectionAddress } = useParams<{ collectionAddress: string }>()
   const [sortBy, setSortBy] = useState('updatedAt')
-  const sortEl = useRef<HTMLDivElement>(null)
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const collection = useGetCollection(collectionAddress)
+  const isPBCollection = collectionAddress.toLowerCase() === pancakeBunniesAddress
 
   const { address } = collection || {}
 
@@ -24,12 +26,6 @@ const Items = () => {
     { label: t('Recently listed'), value: 'updatedAt' },
     { label: t('Lowest price'), value: 'currentAskPrice' },
   ]
-
-  const scrollToTop = (): void => {
-    sortEl.current.scrollIntoView({
-      behavior: 'smooth',
-    })
-  }
 
   const handleChange = (newOption: OptionProps) => {
     setSortBy(newOption.value)
@@ -45,16 +41,22 @@ const Items = () => {
     <>
       <Header collection={collection} />
       <Page>
-        <Flex ref={sortEl} alignItems="center" justifyContent={['flex-start', null, null, 'flex-end']} mb="24px">
-          {/* TODO: Current FE sorting logic may not be viable for squad as we have paginated, i.e. incomplete data. May need to remove sort for non-PB collection for now. */}
-          <Box minWidth="165px">
-            <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
-              {t('Sort By')}
-            </Text>
-            <Select options={sortByItems} onOptionChange={handleChange} />
-          </Box>
-        </Flex>
-        <CollectionNfts collection={collection} sortBy={sortBy} scrollToTop={scrollToTop} />
+        {/* Only PBs can return enough data to viably sort the entire collection */}
+        {isPBCollection && (
+          <Flex alignItems="center" justifyContent={['flex-start', null, null, 'flex-end']} mb="24px">
+            <Box minWidth="165px">
+              <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
+                {t('Sort By')}
+              </Text>
+              <Select options={sortByItems} onOptionChange={handleChange} />
+            </Box>
+          </Flex>
+        )}
+        {isPBCollection ? (
+          <PancakeBunniesCollectionNfts collection={collection} sortBy={sortBy} />
+        ) : (
+          <CollectionNfts collection={collection} />
+        )}
       </Page>
     </>
   )

--- a/src/views/Nft/market/Collection/Items/index.tsx
+++ b/src/views/Nft/market/Collection/Items/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 import { Box, Flex, Text } from '@pancakeswap/uikit'
 import { useAppDispatch } from 'state'
@@ -13,15 +13,23 @@ import Header from '../Header'
 const Items = () => {
   const { collectionAddress } = useParams<{ collectionAddress: string }>()
   const [sortBy, setSortBy] = useState('updatedAt')
+  const sortEl = useRef<HTMLDivElement>(null)
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const collection = useGetCollection(collectionAddress)
+
   const { address } = collection || {}
 
   const sortByItems = [
     { label: t('Recently listed'), value: 'updatedAt' },
     { label: t('Lowest price'), value: 'currentAskPrice' },
   ]
+
+  const scrollToTop = (): void => {
+    sortEl.current.scrollIntoView({
+      behavior: 'smooth',
+    })
+  }
 
   const handleChange = (newOption: OptionProps) => {
     setSortBy(newOption.value)
@@ -37,7 +45,8 @@ const Items = () => {
     <>
       <Header collection={collection} />
       <Page>
-        <Flex alignItems="center" justifyContent={['flex-start', null, null, 'flex-end']} mb="24px">
+        <Flex ref={sortEl} alignItems="center" justifyContent={['flex-start', null, null, 'flex-end']} mb="24px">
+          {/* TODO: Current FE sorting logic may not be viable for squad as we have paginated, i.e. incomplete data. May need to remove sort for non-PB collection for now. */}
           <Box minWidth="165px">
             <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
               {t('Sort By')}
@@ -45,7 +54,7 @@ const Items = () => {
             <Select options={sortByItems} onOptionChange={handleChange} />
           </Box>
         </Flex>
-        <CollectionNfts collection={collection} sortBy={sortBy} />
+        <CollectionNfts collection={collection} sortBy={sortBy} scrollToTop={scrollToTop} />
       </Page>
     </>
   )

--- a/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
+++ b/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import styled from 'styled-components'
 import { uniqBy } from 'lodash'
 import { Flex, Text, Card, ArrowBackIcon, ArrowForwardIcon, Table, Th, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { getNftsFromDifferentCollectionsApi } from 'state/nftMarket/helpers'
@@ -13,23 +12,7 @@ import useUserActivity, { Activity } from '../../hooks/useUserActivity'
 import ActivityRow from './ActivityRow'
 import TableLoader from './TableLoader'
 import NoNftsImage from '../NoNftsImage'
-
-const PageButtons = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 0.2em;
-  margin-bottom: 1.2em;
-`
-
-const Arrow = styled.div`
-  color: ${({ theme }) => theme.colors.primary};
-  padding: 0 20px;
-  :hover {
-    cursor: pointer;
-  }
-`
+import { Arrow, PageButtons } from '../../../components/PaginationButtons'
 
 const MAX_PER_PAGE = 8
 

--- a/src/views/Nft/market/components/PaginationButtons.tsx
+++ b/src/views/Nft/market/components/PaginationButtons.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+
+export const PageButtons = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  margin-bottom: 16px;
+`
+
+export const Arrow = styled.div`
+  color: ${({ theme }) => theme.colors.primary};
+  padding: 0 20px;
+  :hover {
+    cursor: pointer;
+  }
+`


### PR DESCRIPTION
- Split `CollectionNfts` into two as they have very distinctive logic - `PancakeBunniesCollectionNfts` & `CollectionNfts`
- Paginate API & NFT requests for `fetchNftsFromCollections`
- Paginate FE `CollectionNfts`

Compatible with existing collection setup in prod