### PR TITLE
feat: (farms): Change harvest button text when there is pending transaction

### DIFF
--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -59,7 +59,7 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
           dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
         }}
       >
-        {t('Harvest')}
+        {pendingTx ? t('Harvesting') : t('Harvest')}
       </Button>
     </Flex>
   )

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -80,7 +80,7 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
           }}
           ml="4px"
         >
-          {t('Harvest')}
+          {pendingTx ? t('Harvesting') : t('Harvest')}
         </Button>
       </ActionContent>
     </ActionContainer>


### PR DESCRIPTION
To review: 

To reproduce:

1. Go to farms
2. Click one of the farms that staked
3. Click harvest button
4. See it is disabled but text still shows harvest when there is a pending transaction