### PR TITLE
fix: (collections): More from this collection swiper sometimes get stuck

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/shared/MoreFromThisCollection.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/shared/MoreFromThisCollection.tsx
@@ -101,14 +101,14 @@ const MoreFromThisCollection: React.FC<MoreFromThisCollectionProps> = ({
 
   const nextSlide = () => {
     if (activeIndex < maxPageIndex - 1) {
-      setActiveIndex(activeIndex + 1)
+      setActiveIndex((index) => index + 1)
       swiperRef.slideNext()
     }
   }
 
   const previousSlide = () => {
     if (activeIndex > 0) {
-      setActiveIndex(activeIndex - 1)
+      setActiveIndex((index) => index - 1)
       swiperRef.slidePrev()
     }
   }


### PR DESCRIPTION
To review:

https://deploy-preview-2488--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to one of the nft's detail page
2. Go to bottom
3. Move more from collection swiper to back and front 
4. Sometimes it gets stuck when page is rerendered because i think it uses obsolete data