### PR TITLE
fix: (profile): Claimable achievements throws error when fetching

### DIFF
--- a/src/utils/achievements.ts
+++ b/src/utils/achievements.ts
@@ -71,7 +71,7 @@ export const getClaimableIfoData = async (account: string): Promise<Achievement[
       const [claimStatus] = claimStatusArr
 
       if (claimStatus === true) {
-        return [...accum, { address: getPointCenterIfoAddress(), name: 'ifos', params: [index] }]
+        return [...accum, { address: getPointCenterIfoAddress(), name: 'ifos', params: [ifoCampaigns[index].address] }]
       }
 
       return accum
@@ -80,18 +80,19 @@ export const getClaimableIfoData = async (account: string): Promise<Achievement[
 
   // Transform response to an Achievement
   return claimableIfoData.reduce((accum, claimableIfoDataItem) => {
-    if (!campaignMap.has(claimableIfoDataItem.campaignId)) {
+    const claimableCampaignId = claimableIfoDataItem.campaignId.toString()
+    if (!campaignMap.has(claimableCampaignId)) {
       return accum
     }
 
-    const campaignMeta = campaignMap.get(claimableIfoDataItem.campaignId)
-    const { address } = ifoCampaigns.find((ifoCampaign) => ifoCampaign.campaignId === claimableIfoDataItem.campaignId)
+    const campaignMeta = campaignMap.get(claimableCampaignId)
+    const { address } = ifoCampaigns.find((ifoCampaign) => ifoCampaign.campaignId === claimableCampaignId)
 
     return [
       ...accum,
       {
         address,
-        id: claimableIfoDataItem.campaignId,
+        id: claimableCampaignId,
         type: 'ifo',
         title: getAchievementTitle(campaignMeta),
         description: getAchievementDescription(campaignMeta),

--- a/src/views/Nft/market/Profile/components/Achievements/AchievementRow/index.tsx
+++ b/src/views/Nft/market/Profile/components/Achievements/AchievementRow/index.tsx
@@ -59,15 +59,19 @@ const AchievementRow: React.FC<AchievementRowProps> = ({ achievement, onCollectS
   const { callWithGasPrice } = useCallWithGasPrice()
 
   const handleCollectPoints = async () => {
-    const tx = await callWithGasPrice(pointCenterContract, 'getPoints', [achievement.address])
-    setIsCollecting(true)
-    const receipt = await tx.wait()
-    if (receipt.status) {
-      setIsCollecting(false)
-      onCollectSuccess(achievement)
-      toastSuccess(t('Points Collected!'), <ToastDescriptionWithTx txHash={receipt.transactionHash} />)
-    } else {
+    try {
+      const tx = await callWithGasPrice(pointCenterContract, 'getPoints', [achievement.address])
+      setIsCollecting(true)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onCollectSuccess(achievement)
+        toastSuccess(t('Points Collected!'), <ToastDescriptionWithTx txHash={receipt.transactionHash} />)
+      } else {
+        toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
+      }
+    } catch (error) {
       toastError(t('Error'), t('Please try again. Confirm the transaction and make sure you are paying enough gas!'))
+    } finally {
       setIsCollecting(false)
     }
   }


### PR DESCRIPTION
To review:

https://deploy-preview-2517--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to profile page
2. Connect an account that has claimable achievements
3. See the error on console when fetching claimable achievements

Uncaught (in promise) Error: invalid address (argument="address", value=5, code=INVALID_ARGUMENT, version=address/5.4.0) (argument=null, value=5, code=INVALID_ARGUMENT, version=abi/5.4.0)