### PR TITLE
fix: (info): Click listener stays active after unmount

### DIFF
--- a/src/views/Info/components/InfoSearch/index.tsx
+++ b/src/views/Info/components/InfoSearch/index.tsx
@@ -182,6 +182,10 @@ const Search = () => {
       document.removeEventListener('click', handleOutsideClick)
       document.querySelector('body').style.overflow = 'visible'
     }
+
+    return () => {
+      document.removeEventListener('click', handleOutsideClick)
+    }
   }, [showMenu])
 
   // watchlist


### PR DESCRIPTION
To review:


To reproduce:

1. Go to info page
2. Click search pools or tokens input
3. Then click another page from menu without closing the dropdown 
4. See click listener stays active by getEventListeners(document) on console