### PR TITLE
fix: (nft): Sorting by token id with trait filter

### DIFF
--- a/src/views/Nft/market/Collection/Items/FilteredCollectionNfts.tsx
+++ b/src/views/Nft/market/Collection/Items/FilteredCollectionNfts.tsx
@@ -47,6 +47,10 @@ const FilteredCollectionNfts: React.FC<FilteredCollectionNftsProps> = ({ collect
             }
             return selectedOrder.direction === 'asc' ? Infinity : -Infinity
           }
+          if (selectedOrder.field === 'tokenId') {
+            const tokenIdNumber = Number(nft.tokenId)
+            return Number.isFinite(tokenIdNumber) ? tokenIdNumber : 0
+          }
           // recently listed sorting
           return nft.marketData ? parseInt(nft.marketData[selectedOrder.field], 10) : 0
         },


### PR DESCRIPTION
To review:

https://deploy-preview-2533--pancakeswap-dev.netlify.app/

To reproduce:

1. Go squad nft collections
2. Select all and select trait filter
3. Select order by token id
4. See order is wrong that is first shows non listed items then shows tradable items