### PR TITLE
fix: (pools): Finished pools shows apr skeleton instead of zero

### DIFF
--- a/src/views/Pools/components/PoolCard/AprRow.tsx
+++ b/src/views/Pools/components/PoolCard/AprRow.tsx
@@ -59,22 +59,24 @@ const AprRow: React.FC<AprRowProps> = ({ pool, stakedBalance, performanceFee = 0
     <Flex alignItems="center" justifyContent="space-between">
       {tooltipVisible && tooltip}
       <TooltipText ref={targetRef}>{isAutoVault ? `${t('APY')}:` : `${t('APR')}:`}</TooltipText>
-      {isFinished || !apr ? (
-        <Skeleton width="82px" height="32px" />
-      ) : (
+      {earningsPercentageToDisplay || isFinished ? (
         <ApyLabelContainer alignItems="center" onClick={onPresentApyModal}>
           <Balance
             fontSize="16px"
             isDisabled={isFinished}
-            value={earningsPercentageToDisplay}
+            value={isFinished ? 0 : earningsPercentageToDisplay}
             decimals={2}
             unit="%"
             onClick={onPresentApyModal}
           />
-          <IconButton variant="text" scale="sm">
-            <CalculateIcon color="textSubtle" width="18px" />
-          </IconButton>
+          {!isFinished && (
+            <IconButton variant="text" scale="sm">
+              <CalculateIcon color="textSubtle" width="18px" />
+            </IconButton>
+          )}
         </ApyLabelContainer>
+      ) : (
+        <Skeleton width="82px" height="32px" />
       )}
     </Flex>
   )


### PR DESCRIPTION
I followed the same logic that we have it in pools table

To review:

https://deploy-preview-2535--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to finished pools
2. See apr value shown skeleton