### PR TITLE
chore: Change blog link to the publication landing page

### DIFF
--- a/src/components/Menu/config/config.ts
+++ b/src/components/Menu/config/config.ts
@@ -100,7 +100,7 @@ const config: (t: ContextApi['t']) => ConfigMenuItemsType[] = (t) => [
       },
       {
         label: t('Blog'),
-        href: 'https://pancakeswap.medium.com',
+        href: 'https://medium.com/pancakeswap',
         type: DropdownMenuItemType.EXTERNAL_LINK,
       },
       {

--- a/src/components/Menu/config/footerConfig.ts
+++ b/src/components/Menu/config/footerConfig.ts
@@ -11,7 +11,7 @@ export const footerLinks: (t: ContextApi['t']) => FooterLinkType[] = (t) => [
       },
       {
         label: t('Blog'),
-        href: 'https://pancakeswap.medium.com/',
+        href: 'https://medium.com/pancakeswap',
       },
       {
         label: t('Community'),


### PR DESCRIPTION
Change "Blog" link from Medium PancakeSwap domain (https://pancakeswap.medium.com/) to publication (https://medium.com/pancakeswap). Those links are available on top navigation and footer navigation. 

Reason: 
We maintain publication with multiple language supports now. Medium PancakeSwap domain can show only English articles.

Preview: 
https://pedantic-babbage-5efafb.netlify.app/
