### PR TITLE
fix: (collections): All collections link points to overview instead of collection list

### DIFF
--- a/src/views/Nft/market/Collection/TopBar.tsx
+++ b/src/views/Nft/market/Collection/TopBar.tsx
@@ -18,7 +18,7 @@ const TopBar: React.FC = () => {
 
   return (
     <Flex alignItems="center" justifyContent="space-between" mb="24px">
-      <BackLink to={nftsBaseUrl}>
+      <BackLink to={`${nftsBaseUrl}/collections`}>
         <ChevronLeftIcon color="primary" width="24px" />
         {t('All Collections')}
       </BackLink>


### PR DESCRIPTION
To review:

https://deploy-preview-2546--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to https://pancakeswap.finance/nfts/collections/0x0a8901b0E25DEb55A87524f0cC164E9644020EBA
2. Click All Collections top right
3. See it points to Overview instead of Collection list