### PR TITLE
fix: (nfts): Page crash on individual nft page after visiting an nft page that owned by user

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/index.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/index.tsx
@@ -57,6 +57,8 @@ const IndividualNFTPage: React.FC<IndividualNFTPageProps> = ({ collectionAddress
         setNft(nftOwnedByConnectedUser)
         setIsOwnNft(true)
       } else {
+        // reset to defaults
+        setIsOwnNft(false)
         // Get metadata and market data separately if connected user is not the owner
         fetchNftData()
       }


### PR DESCRIPTION
To review:

https://deploy-preview-2548--pancakeswap-dev.netlify.app/

To reproduce:

1. Go to an individual nft token page that owned by you
2. Then go to another token page (which the token is not owned by) from more from collection component
3. See page crashes

Reason is the component is rerendered with updated params but not remounted when we change the route params.  We have to clear the state.