### PR TITLE
feat(ifo): Show estimated token price with fee when live

### DIFF
--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -51,6 +51,16 @@ const IfoCardDetails: React.FC<IfoCardDetailsProps> = ({ poolId, ifo, publicIfoD
   const totalLPCommittedInUSD = currencyPriceInUSD.times(totalLPCommitted)
   const totalCommitted = `~$${formatNumber(totalLPCommittedInUSD.toNumber(), 0, 0)} (${totalCommittedPercent}%)`
 
+  const PricePerTokenWithFeeToOriginalRaio = poolCharacteristic.sumTaxesOverflow
+    .plus(poolCharacteristic.raisingAmountPool)
+    .div(poolCharacteristic.offeringAmountPool)
+    .div(poolCharacteristic.raisingAmountPool.div(poolCharacteristic.offeringAmountPool))
+  const PricePerTokenWithFee = `~$${formatNumber(
+    PricePerTokenWithFeeToOriginalRaio.times(ifo.tokenOfferingPrice).toNumber(),
+    0,
+    2,
+  )}`
+
   /* Format end */
 
   const renderBasedOnIfoStatus = () => {
@@ -72,6 +82,12 @@ const IfoCardDetails: React.FC<IfoCardDetailsProps> = ({ poolId, ifo, publicIfoD
         <>
           {poolId === PoolIds.poolBasic && <FooterEntry label={t('Max. LP token entry')} value={maxLpTokens} />}
           {poolId === PoolIds.poolUnlimited && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
+          {poolId === PoolIds.poolUnlimited && (
+            <FooterEntry
+              label={t('Price per %symbol% with fee:', { symbol: ifo.token.symbol })}
+              value={PricePerTokenWithFee}
+            />
+          )}
           <FooterEntry label={t('Total committed:')} value={currencyPriceInUSD.gt(0) ? totalCommitted : null} />
         </>
       )


### PR DESCRIPTION
Show estimated token price with participation fee (real cost) when an IFO is live

It uses `sumTaxesOverflow`, `raisingAmountPool`, `offeringAmountPool` from `poolCharacteristic` (SC) to work out an ratio between the "cost with fee" and "bare cost". Then use that ratio on `tokenOfferingPrice` to get the cost in USD

It should better help users to make decisions before joining unlimited sales