### PR TITLE
chore: Fix typo at NFT marketplace

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1529,7 +1529,7 @@
   "Continue?": "Continue?",
   "Paste BSC address": "Paste BSC address",
   "That’s not a Binance Smart Chain wallet address.": "That’s not a Binance Smart Chain wallet address.",
-  "This action will send your wallet to the address you have indicated above. Make sure it’s the correct": "This action will send your wallet to the address you have indicated above. Make sure it’s the correct",
+  "This action will send your NFT to the address you have indicated above. Make sure it’s the correct": "This action will send your NFT to the address you have indicated above. Make sure it’s the correct",
   "This address is the one that is currently connected": "This address is the one that is currently connected",
   "Recently Listed": "Recently Listed",
   "Please progress to the next step.": "Please progress to the next step.",

--- a/src/views/Nft/market/components/BuySellModals/SellModal/TransferStage.tsx
+++ b/src/views/Nft/market/components/BuySellModals/SellModal/TransferStage.tsx
@@ -83,7 +83,7 @@ const TransferStage: React.FC<TransferStageProps> = ({
           <ErrorIcon width={24} height={24} color="textSubtle" />
         </Flex>
         <Text small color="textSubtle">
-          {t('This action will send your wallet to the address you have indicated above. Make sure it’s the correct')}
+          {t('This action will send your NFT to the address you have indicated above. Make sure it’s the correct')}
         </Text>
       </Grid>
       <Divider />


### PR DESCRIPTION
Fix  typo in the text in NFT transfer modal:

[typo] This action will send your wallet to the address you have indicated above.
[fixed] This action will send your NFT to the address you have indicated above.