### PR TITLE
refactor: Use relative path for exchange links

### DIFF
--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/GetLpModal.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/GetLpModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Modal, ModalBody, Text, Image, Button, Link, OpenNewIcon } from '@pancakeswap/uikit'
 import { Token } from '@pancakeswap/sdk'
-import { BASE_URL } from 'config'
 import { useTranslation } from 'contexts/Localization'
 
 interface Props {
@@ -26,7 +25,7 @@ const GetLpModal: React.FC<Partial<Props>> = ({ currency, onDismiss }) => {
         <Button
           as={Link}
           external
-          href={`${BASE_URL}/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82`}
+          href="/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
           endIcon={<OpenNewIcon color="white" />}
           minWidth="100%" // Bypass the width="fit-content" on Links
         >

--- a/src/views/Ifos/components/IfoSteps.tsx
+++ b/src/views/Ifos/components/IfoSteps.tsx
@@ -4,7 +4,6 @@ import every from 'lodash/every'
 import { Stepper, Step, StepStatus, Card, CardBody, Heading, Text, Button, Link, OpenNewIcon } from '@pancakeswap/uikit'
 import { Link as RouterLink } from 'react-router-dom'
 import { useWeb3React } from '@web3-react/core'
-import { BASE_URL } from 'config'
 import { Ifo } from 'config/constants/types'
 import { WalletIfoData } from 'views/Ifos/types'
 import { useTranslation } from 'contexts/Localization'
@@ -101,7 +100,7 @@ const IfoSteps: React.FC<Props> = ({ ifo, walletIfoData }) => {
             <Button
               as={Link}
               external
-              href={`${BASE_URL}/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82`}
+              href="/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82"
               endIcon={<OpenNewIcon color="white" />}
               mt="16px"
             >

--- a/src/views/Nft/market/components/BuySellModals/BuyModal/ReviewStage.tsx
+++ b/src/views/Nft/market/components/BuySellModals/BuyModal/ReviewStage.tsx
@@ -4,7 +4,6 @@ import ConnectWalletButton from 'components/ConnectWalletButton'
 import { Flex, Text, Button, ButtonMenu, ButtonMenuItem, Message, Link } from '@pancakeswap/uikit'
 import { FetchStatus } from 'hooks/useTokenBalance'
 import { useTranslation } from 'contexts/Localization'
-import { BASE_URL } from 'config'
 import { NftToken } from 'state/nftMarket/types'
 import { getBscScanLinkForNft } from 'utils'
 import { Divider, RoundedImage } from '../shared/styles'
@@ -113,7 +112,7 @@ const ReviewStage: React.FC<ReviewStageProps> = ({
             height="16px"
             external
             variant="text"
-            href={`${BASE_URL}/swap?inputCurrency=BNB&outputCurrency=0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c`}
+            href="/swap?inputCurrency=BNB&outputCurrency=0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c"
           >
             {t('Convert')}
           </Button>
@@ -128,13 +127,7 @@ const ReviewStage: React.FC<ReviewStageProps> = ({
         >
           {t('Checkout')}
         </Button>
-        <Button
-          as={Link}
-          external
-          style={{ width: '100%' }}
-          href={`${BASE_URL}/swap?outputCurrency=BNB`}
-          variant="secondary"
-        >
+        <Button as={Link} external style={{ width: '100%' }} href="/swap?outputCurrency=BNB" variant="secondary">
           {t('Get %symbol1% or %symbol2%', { symbol1: 'BNB', symbol2: 'WBNB' })}
         </Button>
       </Flex>


### PR DESCRIPTION
Mainly for development to not point to pancake website

To review:

https://deploy-preview-2655--pancakeswap-dev.netlify.app/