### PR TITLE
refactor: (lottery): Remove unused and broken reducer

### DIFF
--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -103,11 +103,7 @@ export const setLotteryIsTransitioning = createAsyncThunk<{ isTransitioning: boo
 export const LotterySlice = createSlice({
   name: 'Lottery',
   initialState,
-  reducers: {
-    setLotteryPublicData: (state, action) => {
-      state = action.payload
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder.addCase(fetchCurrentLottery.fulfilled, (state, action: PayloadAction<LotteryResponse>) => {
       state.currentRound = { ...state.currentRound, ...action.payload }
@@ -142,8 +138,5 @@ export const LotterySlice = createSlice({
     )
   },
 })
-
-// Actions
-export const { setLotteryPublicData } = LotterySlice.actions
 
 export default LotterySlice.reducer


### PR DESCRIPTION
@Chef-Cheems That reducer is not used anywhere and it could not set the state since it doesn't return the new one. Should we remove it or keep it fixed?

To review:

https://deploy-preview-2657--pancakeswap-dev.netlify.app/