### PR TITLE
fix: (ifo): Skeleton in ifo card not disappear when no account is connected

### DIFF
--- a/src/state/profile/index.tsx
+++ b/src/state/profile/index.tsx
@@ -5,7 +5,7 @@ import { getProfile, getProfileAvatar, getUsername } from './helpers'
 
 const initialState: ProfileState = {
   isInitialized: false,
-  isLoading: true,
+  isLoading: false,
   hasRegistered: false,
   data: null,
   profileAvatars: {},


### PR DESCRIPTION
To reproduce:

1. Open incognito browser with no account is connected at first
2. Go to ifo
3. See ifo cards skeletons doesn't disappear even after data loaded

To review: 

https://deploy-preview-2680--pancakeswap-dev.netlify.app/