### PR TITLE
refactor: (ifo): Percentage of total when total amount 0

### DIFF
--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/PercentageOfTotal.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/PercentageOfTotal.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import BigNumber from 'bignumber.js'
 import { Text, TextProps } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
-import { BIG_ZERO } from 'utils/bigNumber'
 
 interface PercentageOfTotalProps extends TextProps {
   userAmount: BigNumber
@@ -11,9 +10,7 @@ interface PercentageOfTotalProps extends TextProps {
 
 const PercentageOfTotal: React.FC<PercentageOfTotalProps> = ({ userAmount, totalAmount, ...props }) => {
   const { t } = useTranslation()
-  const percentOfUserContribution = totalAmount.isGreaterThan(0)
-    ? userAmount.div(totalAmount).times(100).toNumber()
-    : BIG_ZERO
+  const percentOfUserContribution = totalAmount.isGreaterThan(0) ? userAmount.div(totalAmount).times(100).toNumber() : 0
   const percentOfUserDisplay = percentOfUserContribution.toLocaleString(undefined, { maximumFractionDigits: 5 })
 
   return (


### PR DESCRIPTION
When total amount is zero it falls back to big number 0 which calls toLocaleString with options object that bignumber's function doesn't have that parameters although it doesn't create problem on runtime, just to be on the safe side.

To review: 
https://deploy-preview-2700--pancakeswap-dev.netlify.app/

