### PR TITLE
[Ru-Translation] The meaning is different as verb and noun

### DIFF
--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -10,7 +10,7 @@
   "Your %asset% Balance": "Ваш баланс",
   "Total %asset% Supply": "Общее предложение",
   "Locked": "Заблокировано",
-  "Pending harvest": "Ожидается урожай",
+  "Pending harvest": "Урожай в ожидании сбора",
   "New rewards per block": "Новые награды за блок",
   "Total CAKE burned since launch": "Общее число сожженных CAKE c момента запуска",
   "See the Kitchen": "Посмотреть кухню",


### PR DESCRIPTION
The word harvest in Russian as a noun is different than verb. 

The old translation "Ожидание урожай" means like we wait for crop to grow and ripe. There is not harvest ready to collect but we are waiting for harvest to be ready. 
My version say that there is already a harvest ready and we are waiting not for a harvest itself but for the action to collect it.
