### PR TITLE
[Ru-Translation] P in LP is not pool but provider

### DIFF
--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -20,7 +20,7 @@
   "Twitter": "Twitter",
   "Deposit": "Вложить",
   "Earn": "Награда",
-  "Stake LP tokens to stack CAKE": "Вкладывайте токены пула ликвидности для накопления CAKE",
+  "Stake LP tokens to stack CAKE": "Вкладывайте токены поставщика ликвидности для накопления CAKE",
   "You can swap back anytime": "Вы можете совершить обратный обмен в любое время",
   "%asset% Earned": "%asset% Заработано",
   "Tokens Staked": "Токенов вложено",


### PR DESCRIPTION
The translation say "Stake tokens of liquidity pool". But in fact LP means Liquidity Provider. So I changed word pool in translation to provider, because there is not word pool in source text.
