### PR TITLE
[Ru-Translation] It is not a swimming pool

### DIFF
--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -27,7 +27,7 @@
   "Every time you stake and unstake CAKE tokens, the contract will automagically harvest CAKE rewards for you!": "Каждый раз, когда вы вкладываете или возвращаете токены CAKE, контракт автоматически собирает для вас награды CAKE!",
   "XVS Tokens Earned": "Заработано XVS токенов",
   "Rewards will be calculated per block and total rewards will be distributed automatically at the end of each project’s farming period.": "Награды будут рассчитываться для каждого блока, а общие награды будут распределяться автоматически в конце периода фарма каждого проекта.",
-  "Pool": "Бассейн",
+  "Pool": "Пул",
   "Coming Soon": "Скоро",
   "APY": "APY",
   "Total Liquidity": "Общая ликвидность",


### PR DESCRIPTION
The translation is swimming pool. I think if plural `"Pools": "Пулы"` then should be `"Pool": "Пул"`. This only make sense. I wanted to change this one the most because it is absolutely incorrect translation that does not make any sense. In Russian Бассейн из exactly Swimming pool. And when you read a translation you think, What!!!? What swimming pool?!!