### PR TITLE
[Ru-Translation] incorrect word.

### DIFF
--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -183,7 +183,7 @@
   "Liquidity": "Ликвидность",
   "Overview": "Обзор",
   "Token": "Токен",
-  "Pairs": "Пари",
+  "Pairs": "Пары",
   "Accounts": "Счета",
   "Stake LP tokens to earn CAKE": "Вкладывайте токены пула ликвидности, чтобы заработать CAKE",
   "Active": "Активно",


### PR DESCRIPTION
The word `bet` was used as translation.
