### PR TITLE
[Ru-Translation] change term for balance

### DIFF
--- a/public/locales/ru-RU.json
+++ b/public/locales/ru-RU.json
@@ -241,7 +241,7 @@
   "Confirming": "Подтверждение",
   "Enabled": "Активировано",
   "Confirmed": "Подтверждено",
-  "Insufficient CAKE balance": "Недостаточный запас CAKE",
+  "Insufficient CAKE balance": "Недостаточно CAKE на балансе",
   "Step 2": "Шаг 2",
   "Choose collectible": "Выберите коллекционный токен",
   "Choose a profile picture from the eligible collectibles (NFT) in your wallet, shown below.": "Выберите изображение профиля из коллекционных уникальных токенов NFT, доступных в вашем кошельке ниже.",


### PR DESCRIPTION
The word used in Russian was something like stash. Not enough in stash.  Although it Souds more or less ok, and perhaps even fit, the word Balance is more clear here. For запас there might be a question, what zapas? Where is that zapas? Because it is a new term. And term balance is clear.