### PR TITLE
fix: User state still visible when wallet disconnects with Auto-Lock or WalletConnect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
 } from './views/AddLiquidity/redirects'
 import RedirectOldRemoveLiquidityPathStructure from './views/RemoveLiquidity/redirects'
 import { RedirectPathToSwapOnly, RedirectToSwap } from './views/Swap/redirects'
+import { useInactiveListener } from './hooks/useInactiveListener'
 
 // Route-based code splitting
 // Only pool is included in the main bundle because of it's the most visited page
@@ -70,6 +71,7 @@ const App: React.FC = () => {
   usePollCoreFarmData()
   useScrollOnRouteChange()
   useUserAgent()
+  useInactiveListener()
 
   return (
     <Router history={history}>

--- a/src/hooks/useInactiveListener.ts
+++ b/src/hooks/useInactiveListener.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { useWeb3React } from '@web3-react/core'
+import { connectorLocalStorageKey } from '@pancakeswap/uikit'
+import { profileClear } from '../state/profile'
+import { resetUserNftState } from '../state/nftMarket/reducer'
+import { clearAllTransactions } from '../state/transactions/actions'
+import { useAppDispatch } from '../state'
+import { connectorsByName } from '../utils/web3React'
+
+export const useInactiveListener = () => {
+  const { account, chainId, connector } = useWeb3React()
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    if (account && connector) {
+      const handleDeactivate = () => {
+        dispatch(profileClear())
+        dispatch(resetUserNftState())
+        // This localStorage key is set by @web3-react/walletconnect-connector
+        if (window.localStorage.getItem('walletconnect')) {
+          connectorsByName.walletconnect.close()
+          connectorsByName.walletconnect.walletConnectProvider = null
+        }
+        window.localStorage.removeItem(connectorLocalStorageKey)
+        if (chainId) {
+          dispatch(clearAllTransactions({ chainId }))
+        }
+      }
+
+      connector.addListener('Web3ReactDeactivate', handleDeactivate)
+
+      return () => {
+        connector.removeListener('Web3ReactDeactivate', handleDeactivate)
+      }
+    }
+    return undefined
+  }, [account, chainId, dispatch, connector])
+}


### PR DESCRIPTION
To reproduce:

With injected wallet

1. Go to your wallet settings (i.e Metamask) set Auto - Lock timer (Settings -> Advanced)
2. Connect to website
3. Wait idle
4. Check redux state from browser that user profile and nft state still visible

With walletconnect

1. Connect to website via WalletConnect
2. Disconnect from the device that you use to scan qr code
3. Check redux state from browser that user profile and nft state still visible

To review:

https://deploy-preview-2732--pancakeswap-dev.netlify.app/
