### PR TITLE
fix: (nft): Collection list stays at old scroll position when page changes

### DIFF
--- a/src/views/Nft/market/Collections/index.tsx
+++ b/src/views/Nft/market/Collections/index.tsx
@@ -56,6 +56,16 @@ const Collectible = () => {
   const [maxPage, setMaxPage] = useState(1)
 
   useEffect(() => {
+    setTimeout(() => {
+      window.scroll({
+        top: 0,
+        left: 0,
+        behavior: 'smooth',
+      })
+    }, 50)
+  }, [page])
+
+  useEffect(() => {
     let extraPages = 1
     const collectionValues = collections ? Object.values(collections) : []
     if (collectionValues.length % ITEMS_PER_PAGE === 0) {


### PR DESCRIPTION
To review: 

1. Go collections https://pancakeswap.finance/nfts/collections/
2. Go to second page by scrolling down first to reach pagination
3. Since it has less item than the first one, the item list is not visible you have to scroll up 

To review:

https://deploy-preview-2739--pancakeswap-dev.netlify.app/
