### PR TITLE
fix: (nft): Owner info not available for unconnected users when nft is not listed

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -43,7 +43,7 @@ import { ERC20_BYTES32_ABI } from '../config/abi/erc20'
 import ERC20_ABI from '../config/abi/erc20.json'
 import WETH_ABI from '../config/abi/weth.json'
 import multiCallAbi from '../config/abi/Multicall.json'
-import { getContract } from '../utils'
+import { getContract, getProviderOrSigner } from '../utils'
 
 /**
  * Helper hooks to get specific contracts (by ABI)
@@ -204,10 +204,10 @@ export const useNftMarketContract = () => {
 }
 
 export const useErc721CollectionContract = (collectionAddress: string) => {
-  const { library } = useActiveWeb3React()
+  const { library, account } = useActiveWeb3React()
   return useMemo(() => {
-    return getErc721CollectionContract(library.getSigner(), collectionAddress)
-  }, [library, collectionAddress])
+    return getErc721CollectionContract(getProviderOrSigner(library, account), collectionAddress)
+  }, [account, library, collectionAddress])
 }
 
 // Code below migrated from Exchange useContract.ts

--- a/src/utils/contractHelpers.ts
+++ b/src/utils/contractHelpers.ts
@@ -63,7 +63,7 @@ import anniversaryAchievementAbi from 'config/abi/anniversaryAchievement.json'
 import nftMarketAbi from 'config/abi/nftMarket.json'
 import nftSaleAbi from 'config/abi/nftSale.json'
 import pancakeSquadAbi from 'config/abi/pancakeSquad.json'
-import erc721CollctionAbi from 'config/abi/erc721collection.json'
+import erc721CollectionAbi from 'config/abi/erc721collection.json'
 import { ChainLinkOracleContract, FarmAuctionContract, PancakeProfileContract, PredictionsContract } from './types'
 
 const getContract = (abi: any, address: string, signer?: ethers.Signer | ethers.providers.Provider) => {
@@ -167,5 +167,5 @@ export const getPancakeSquadContract = (signer?: ethers.Signer | ethers.provider
   return getContract(pancakeSquadAbi, getPancakeSquadAddress(), signer)
 }
 export const getErc721CollectionContract = (signer?: ethers.Signer | ethers.providers.Provider, address?: string) => {
-  return getContract(erc721CollctionAbi, address, signer)
+  return getContract(erc721CollectionAbi, address, signer)
 }


### PR DESCRIPTION
To reproduce:

1. Go to webpage without connecting wallet
2. Go to an individual token page on which token is not listed
3. See it shows owner information not available

To review: 

https://deploy-preview-2740--pancakeswap-dev.netlify.app/
