### PR TITLE
fix: (lottery): Skeleton shown when round number is empty in history

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1750,5 +1750,6 @@
   "Go to IFO": "Go to IFO",
   "Phishing warning: ": "Phishing warning: ",
   "please make sure you're visiting https://pancakeswap.finance - check the URL carefully.": "please make sure you're visiting https://pancakeswap.finance - check the URL carefully.",
-  "No bids yet": "No bids yet"
+  "No bids yet": "No bids yet",
+  "Please specify Round": "Please specify Round"
 }

--- a/src/views/Lottery/components/AllHistoryCard/index.tsx
+++ b/src/views/Lottery/components/AllHistoryCard/index.tsx
@@ -109,13 +109,15 @@ const AllHistoryCard = () => {
           handleArrowButtonPress={handleArrowButtonPress}
         />
         <Box mt="8px">
-          {selectedLotteryNodeData?.endTime ? (
-            <Text fontSize="14px">
-              {t('Drawn')} {getDrawnDate(locale, selectedLotteryNodeData.endTime)}
-            </Text>
-          ) : (
-            <Skeleton width="185px" height="21px" />
-          )}
+          {selectedRoundId ? (
+            selectedLotteryNodeData?.endTime ? (
+              <Text fontSize="14px">
+                {t('Drawn')} {getDrawnDate(locale, selectedLotteryNodeData.endTime)}
+              </Text>
+            ) : (
+              <Skeleton width="185px" height="21px" />
+            )
+          ) : null}
         </Box>
       </StyledCardHeader>
       <PreviousRoundCardBody lotteryNodeData={selectedLotteryNodeData} lotteryId={selectedRoundId} />

--- a/src/views/Lottery/components/PreviousRoundCard/Body.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Body.tsx
@@ -11,6 +11,7 @@ import {
   useModal,
   CardRibbon,
   useMatchBreakpoints,
+  BunnyPlaceholderIcon,
 } from '@pancakeswap/uikit'
 import { LotteryRound } from 'state/types'
 import { useGetUserLotteriesGraphData, useLottery } from 'state/lottery/hooks'
@@ -85,20 +86,29 @@ const PreviousRoundCardBody: React.FC<{ lotteryNodeData: LotteryRound; lotteryId
           <Heading mb="24px">{t('Winning Number')}</Heading>
         </Flex>
         <Flex maxWidth={['240px', null, null, '100%']} justifyContent={['center', null, null, 'flex-start']}>
-          {lotteryNodeData ? (
-            <WinningNumbers
-              rotateText={isLargerScreen || false}
-              number={lotteryNodeData?.finalNumber.toString()}
-              mr={[null, null, null, '32px']}
-              size="100%"
-              fontSize={isLargerScreen ? '42px' : '16px'}
-            />
+          {lotteryId ? (
+            lotteryNodeData ? (
+              <WinningNumbers
+                rotateText={isLargerScreen || false}
+                number={lotteryNodeData?.finalNumber.toString()}
+                mr={[null, null, null, '32px']}
+                size="100%"
+                fontSize={isLargerScreen ? '42px' : '16px'}
+              />
+            ) : (
+              <Skeleton
+                width={['240px', null, null, '450px']}
+                height={['34px', null, null, '71px']}
+                mr={[null, null, null, '32px']}
+              />
+            )
           ) : (
-            <Skeleton
-              width={['240px', null, null, '450px']}
-              height={['34px', null, null, '71px']}
-              mr={[null, null, null, '32px']}
-            />
+            <>
+              <Flex flexDirection="column" alignItems="center" width={['240px', null, null, '480px']}>
+                <Text mb="8px">{t('Please specify Round')}</Text>
+                <BunnyPlaceholderIcon height="64px" width="64px" />
+              </Flex>
+            </>
           )}
         </Flex>
         {userDataForRound && (

--- a/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
+++ b/src/views/Lottery/components/PreviousRoundCard/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Flex, ExpandableLabel, CardFooter } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { LotteryRound } from 'state/types'
@@ -13,11 +13,24 @@ const PreviousRoundCardFooter: React.FC<PreviousRoundCardFooterProps> = ({ lotte
   const { t } = useTranslation()
   const [isExpanded, setIsExpanded] = useState(false)
 
+  useEffect(() => {
+    if (!lotteryId) {
+      setIsExpanded(false)
+    }
+  }, [lotteryId])
+
   return (
     <CardFooter p="0">
       {isExpanded && <FooterExpanded lotteryNodeData={lotteryNodeData} lotteryId={lotteryId} />}
       <Flex p="8px 24px" alignItems="center" justifyContent="center">
-        <ExpandableLabel expanded={isExpanded} onClick={() => setIsExpanded(!isExpanded)}>
+        <ExpandableLabel
+          expanded={isExpanded}
+          onClick={() => {
+            if (lotteryId) {
+              setIsExpanded(!isExpanded)
+            }
+          }}
+        >
           {isExpanded ? t('Hide') : t('Details')}
         </ExpandableLabel>
       </Flex>


### PR DESCRIPTION
To reproduce: 

1. Go to lottery 
2. Go to history
3. Remove round number to make it empty
4. See skeleton stays there

To review:

https://deploy-preview-2749--pancakeswap-dev.netlify.app/
