### PR TITLE
fix: (info): Order by liquidity in pools and token list

### DIFF
--- a/src/views/Info/components/InfoTables/PoolsTable.tsx
+++ b/src/views/Info/components/InfoTables/PoolsTable.tsx
@@ -57,7 +57,7 @@ const LinkWrapper = styled(Link)`
 
 const SORT_FIELD = {
   volumeUSD: 'volumeUSD',
-  tvlUSD: 'tvlUSD',
+  liquidityUSD: 'liquidityUSD',
   volumeUSDWeek: 'volumeUSDWeek',
   lpFees24h: 'lpFees24h',
   lpApr7d: 'lpApr7d',
@@ -206,10 +206,10 @@ const PoolTable: React.FC<PoolTableProps> = ({ poolDatas, loading }) => {
           color="secondary"
           fontSize="12px"
           bold
-          onClick={() => handleSort(SORT_FIELD.tvlUSD)}
+          onClick={() => handleSort(SORT_FIELD.liquidityUSD)}
           textTransform="uppercase"
         >
-          {t('Liquidity')} {arrow(SORT_FIELD.tvlUSD)}
+          {t('Liquidity')} {arrow(SORT_FIELD.liquidityUSD)}
         </ClickableColumnHeader>
       </ResponsiveGrid>
       <Break />

--- a/src/views/Info/components/InfoTables/TokensTable.tsx
+++ b/src/views/Info/components/InfoTables/TokensTable.tsx
@@ -118,7 +118,7 @@ const DataRow: React.FC<{ tokenData: TokenData; index: number }> = ({ tokenData,
 const SORT_FIELD = {
   name: 'name',
   volumeUSD: 'volumeUSD',
-  tvlUSD: 'tvlUSD',
+  liquidityUSD: 'liquidityUSD',
   priceUSD: 'priceUSD',
   priceUSDChange: 'priceUSDChange',
   priceUSDChangeWeek: 'priceUSDChangeWeek',
@@ -228,10 +228,10 @@ const TokenTable: React.FC<{
           color="secondary"
           fontSize="12px"
           bold
-          onClick={() => handleSort(SORT_FIELD.tvlUSD)}
+          onClick={() => handleSort(SORT_FIELD.liquidityUSD)}
           textTransform="uppercase"
         >
-          {t('Liquidity')} {arrow(SORT_FIELD.tvlUSD)}
+          {t('Liquidity')} {arrow(SORT_FIELD.liquidityUSD)}
         </ClickableColumnHeader>
       </ResponsiveGrid>
 


### PR DESCRIPTION
To reproduce

1. Go to info page
2. Order pools or token list by liquidity
3. See it doesn't order

To review: 

https://deploy-preview-2753--pancakeswap-dev.netlify.app/
