### PR TITLE
fix(swap): Prevent crash on same token address

### DIFF
--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -409,9 +409,13 @@ export const useFetchPairPrices = ({
 
   useEffect(() => {
     const updatePairId = () => {
-      const pairAddress = getLpAddress(token0Address, token1Address)?.toLowerCase()
-      if (pairAddress !== pairId) {
-        setPairId(pairAddress)
+      try {
+        const pairAddress = getLpAddress(token0Address, token1Address)?.toLowerCase()
+        if (pairAddress !== pairId) {
+          setPairId(pairAddress)
+        }
+      } catch (error) {
+        setPairId(null)
       }
     }
 

--- a/src/views/Swap/components/Chart/PriceChartContainer.tsx
+++ b/src/views/Swap/components/Chart/PriceChartContainer.tsx
@@ -60,7 +60,7 @@ const PriceChartContainer: React.FC<PriceChartContainerProps> = ({
     )
 
   // If results did came back but as empty array - there is no data to display
-  if ((!!pairPrices && pairPrices.length === 0) || isBadData) {
+  if ((!!pairPrices && pairPrices.length === 0) || isBadData || !pairId) {
     return (
       <NoChartAvailable
         isDark={isDark}


### PR DESCRIPTION
`getLpAddress` throws error when tokens are same