### PR TITLE
refactor: (price-chart): Reduce amount of render when props are the same

### DIFF
--- a/src/views/Swap/components/Chart/PriceChartContainer.tsx
+++ b/src/views/Swap/components/Chart/PriceChartContainer.tsx
@@ -97,4 +97,23 @@ const PriceChartContainer: React.FC<PriceChartContainerProps> = ({
   )
 }
 
-export default React.memo(PriceChartContainer)
+export default React.memo(PriceChartContainer, (prev, next) => {
+  const prevToken0Address = getTokenAddress(prev.inputCurrencyId)
+  const nextToken0Address = getTokenAddress(next.inputCurrencyId)
+  const prevToken1Address = getTokenAddress(prev.outputCurrencyId)
+  const nextToken1Address = getTokenAddress(next.outputCurrencyId)
+
+  return (
+    prev.inputCurrencyId === next.inputCurrencyId &&
+    prev.outputCurrencyId === next.outputCurrencyId &&
+    prev.isChartExpanded === next.isChartExpanded &&
+    prev.isChartDisplayed === next.isChartDisplayed &&
+    prev.isMobile === next.isMobile &&
+    prev.setIsChartExpanded === next.setIsChartExpanded &&
+    ((prev.currentSwapPrice !== null &&
+      next.currentSwapPrice !== null &&
+      prev.currentSwapPrice[prevToken0Address] === next.currentSwapPrice[nextToken0Address] &&
+      prev.currentSwapPrice[prevToken1Address] === next.currentSwapPrice[nextToken1Address]) ||
+      (prev.currentSwapPrice === null && next.currentSwapPrice === null))
+  )
+})


### PR DESCRIPTION
Although the price in currentSwapPrice object is the same, the object itself is different than the previous one, that causes rerender frequently unnecessarily.

To review: 
https://deploy-preview-2778--pancakeswap-dev.netlify.app/
