### PR TITLE
fix: (swap-chart): Add timeout when graphql server is unresponsive

### DIFF
--- a/src/state/swap/fetch/fetchPairPriceData.ts
+++ b/src/state/swap/fetch/fetchPairPriceData.ts
@@ -1,4 +1,5 @@
 import { INFO_CLIENT } from 'config/constants/endpoints'
+import requestWithTimeout from 'utils/requestWithTimeout'
 import { GraphQLClient } from 'graphql-request'
 import lastPairDayId from '../queries/lastPairDayId'
 import pairHourDatas from '../queries/pairHourDatas'
@@ -23,14 +24,14 @@ const fetchPairPriceData = async ({ pairId, timeWindow }: fetchPairDataParams) =
   try {
     switch (timeWindow) {
       case PairDataTimeWindowEnum.DAY: {
-        const data = await client.request<PairHoursDatasResponse>(pairHourDatas, {
+        const data = await requestWithTimeout<PairHoursDatasResponse>(client, pairHourDatas, {
           pairId,
           first: timeWindowIdsCountMapping[timeWindow],
         })
         return { data, error: false }
       }
       case PairDataTimeWindowEnum.WEEK: {
-        const lastPairHourIdData = await client.request<LastPairHourIdResponse>(lastPairHourId, { pairId })
+        const lastPairHourIdData = await requestWithTimeout<LastPairHourIdResponse>(client, lastPairHourId, { pairId })
         const lastId = lastPairHourIdData?.pairHourDatas ? lastPairHourIdData.pairHourDatas[0]?.id : null
         if (!lastId) {
           return { data: { pairHourDatas: [] }, error: false }
@@ -42,19 +43,21 @@ const fetchPairPriceData = async ({ pairId, timeWindow }: fetchPairDataParams) =
           timeWindow,
           idsCount: timeWindowIdsCountMapping[timeWindow],
         })
-        const pairHoursData = await client.request<PairHoursDatasResponse>(pairHourDatasByIds, { pairIds: pairHourIds })
 
+        const pairHoursData = await requestWithTimeout<PairHoursDatasResponse>(client, pairHourDatasByIds, {
+          pairIds: pairHourIds,
+        })
         return { data: pairHoursData, error: false }
       }
       case PairDataTimeWindowEnum.MONTH: {
-        const data = await client.request<PairHoursDatasResponse>(pairDayDatas, {
+        const data = await requestWithTimeout<PairHoursDatasResponse>(client, pairDayDatas, {
           pairId,
           first: timeWindowIdsCountMapping[timeWindow],
         })
         return { data, error: false }
       }
       case PairDataTimeWindowEnum.YEAR: {
-        const lastPairDayIdData = await client.request<LastPairDayIdResponse>(lastPairDayId, { pairId })
+        const lastPairDayIdData = await requestWithTimeout<LastPairDayIdResponse>(client, lastPairDayId, { pairId })
         const lastId = lastPairDayIdData?.pairDayDatas ? lastPairDayIdData.pairDayDatas[0]?.id : null
         if (!lastId) {
           return { data: { pairDayDatas: [] }, error: false }
@@ -66,7 +69,9 @@ const fetchPairPriceData = async ({ pairId, timeWindow }: fetchPairDataParams) =
           timeWindow,
           idsCount: timeWindowIdsCountMapping[timeWindow],
         })
-        const pairDayData = await client.request<PairDayDatasResponse>(pairDayDatasByIdsQuery, { pairIds: pairDayIds })
+        const pairDayData = await requestWithTimeout<PairDayDatasResponse>(client, pairDayDatasByIdsQuery, {
+          pairIds: pairDayIds,
+        })
         return { data: pairDayData, error: false }
       }
       default:

--- a/src/utils/requestWithTimeout.ts
+++ b/src/utils/requestWithTimeout.ts
@@ -1,0 +1,19 @@
+import { GraphQLClient } from 'graphql-request'
+
+const requestWithTimeout = <T extends any>(
+  graphQLClient: GraphQLClient,
+  request: string,
+  variables?: any,
+  timeout = 30000,
+): Promise<T> => {
+  return Promise.race([
+    variables ? graphQLClient.request<T>(request, variables) : graphQLClient.request<T>(request),
+    new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Request timed out after ${timeout} milliseconds`))
+      }, timeout)
+    }),
+  ]) as Promise<T>
+}
+
+export default requestWithTimeout

--- a/src/views/Info/utils/infoQueryHelpers.ts
+++ b/src/views/Info/utils/infoQueryHelpers.ts
@@ -1,6 +1,7 @@
 import { getUnixTime, subDays, subWeeks, startOfMinute } from 'date-fns'
 import { GraphQLClient } from 'graphql-request'
 import { getHeaders } from 'state/swap/fetch/constants'
+import requestWithTimeout from 'utils/requestWithTimeout'
 
 /**
  * Helper function to get large amount GraphQL subqueries
@@ -28,7 +29,7 @@ export const multiQuery = async (
       }
       const subqueriesSlice = subqueries.slice(skip, end)
       // eslint-disable-next-line no-await-in-loop
-      const result = await client.request(queryConstructor(subqueriesSlice))
+      const result: any = await requestWithTimeout(client, queryConstructor(subqueriesSlice))
       fetchedData = {
         ...fetchedData,
         ...result,


### PR DESCRIPTION
When graphql is unresponsive fetching operation keeps sending new request on each render, (possibly it is because heavy operation to keep all the function call data in memory) that makes browser hard to scroll or other things.

To review:
https://deploy-preview-2791--pancakeswap-dev.netlify.app/
