### PR TITLE
fix: (ifo): Price per fee shown NaN in old ifos

### DIFF
--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -122,11 +122,13 @@ const IfoCardDetails: React.FC<IfoCardDetailsProps> = ({ poolId, ifo, publicIfoD
           <FooterEntry label={t('Total committed:')} value={currencyPriceInUSD.gt(0) ? totalCommitted : null} />
           <FooterEntry label={t('Funds to raise:')} value={ifo[poolId].raiseAmount} />
           {ifo[poolId].cakeToBurn !== '$0' && <FooterEntry label={t('CAKE to burn:')} value={ifo[poolId].cakeToBurn} />}
-          <FooterEntry
-            label={t('Price per %symbol%:', { symbol: ifo.token.symbol })}
-            value={`$${ifo.tokenOfferingPrice ? ifo.tokenOfferingPrice : '?'}`}
-          />
-          {poolId === PoolIds.poolUnlimited && (
+          {ifo.version > 1 && (
+            <FooterEntry
+              label={t('Price per %symbol%:', { symbol: ifo.token.symbol })}
+              value={`$${ifo.tokenOfferingPrice ? ifo.tokenOfferingPrice : '?'}`}
+            />
+          )}
+          {ifo.version > 1 && poolId === PoolIds.poolUnlimited && (
             <FooterEntry
               label={t('Price per %symbol% with fee:', { symbol: ifo.token.symbol })}
               value={pricePerTokenWithFee}


### PR DESCRIPTION
To reproduce:

1. Go to IFO
2. Go to past ifos
3. Click one that doesn't have basic pool unlimited pool distinction
4. See price per fee shown NaN

To review:
https://deploy-preview-2794--pancakeswap-dev.netlify.app/