### PR TITLE
fix: (ifo): Reduce amount of requests on both live and past ifos

### DIFF
--- a/src/views/Ifos/hooks/v2/useGetWalletIfoData.ts
+++ b/src/views/Ifos/hooks/v2/useGetWalletIfoData.ts
@@ -15,6 +15,7 @@ import { WalletIfoState, WalletIfoData } from '../../types'
  */
 const useGetWalletIfoData = (ifo: Ifo): WalletIfoData => {
   const { fastRefresh } = useRefresh()
+  const fastRefreshOnlyActive = ifo.isActive ? fastRefresh : 0
   const [state, setState] = useState<WalletIfoState>({
     poolBasic: {
       amountTokenCommittedInLP: BIG_ZERO,
@@ -94,7 +95,7 @@ const useGetWalletIfoData = (ifo: Ifo): WalletIfoData => {
     if (account) {
       fetchIfoData()
     }
-  }, [account, fetchIfoData, fastRefresh])
+  }, [account, fetchIfoData, fastRefreshOnlyActive])
 
   return { ...state, allowance, contract, setPendingTx, setIsClaimed, fetchIfoData }
 }


### PR DESCRIPTION
To reproduce on past ifos:

1. Go to ifo
2. Go to past ifo
3. See amount of requests done that returns same result

To reproduce on live ifo:

Check the frequency of the requests. (See comment below) It is sufficent to have new request when we have a new block

To review:
https://deploy-preview-2795--pancakeswap-dev.netlify.app/
