### PR TITLE
fix: (prediction): Charts button not visible at first sight on desktop

### DIFF
--- a/src/views/Predictions/Desktop.tsx
+++ b/src/views/Predictions/Desktop.tsx
@@ -63,7 +63,7 @@ const StyledDesktop = styled.div`
 
   ${({ theme }) => theme.mediaQueries.lg} {
     display: flex;
-    height: 100%;
+    height: calc(100vh - 100px);
   }
 `
 

--- a/src/views/Predictions/components/Container.tsx
+++ b/src/views/Predictions/components/Container.tsx
@@ -2,8 +2,7 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   background: ${({ theme }) => theme.colors.gradients.violetAlt};
-  height: calc(100vh - 64px);
-  min-height: calc(100vh - 64px);
+  height: calc(100vh - 100px);
   overflow: hidden;
   position: relative;
 `


### PR DESCRIPTION
To reproduce:

1. Go to prediction on desktop
2. See chart button and bar at the bottom not visible completely

To review:

https://deploy-preview-2798--pancakeswap-dev.netlify.app/