### PR TITLE
perf(ethers): Use batch provider

### DIFF
--- a/src/utils/providers.ts
+++ b/src/utils/providers.ts
@@ -1,8 +1,35 @@
-import { ethers } from 'ethers'
+/* eslint-disable prefer-destructuring */
+import { ethers, logger } from 'ethers'
+import { Logger } from '@ethersproject/logger'
+import { Network } from '@ethersproject/networks'
+import { defineReadOnly } from '@ethersproject/properties'
 import getRpcUrl from 'utils/getRpcUrl'
 
 const RPC_URL = getRpcUrl()
 
-export const simpleRpcProvider = new ethers.providers.StaticJsonRpcProvider(RPC_URL)
+class JsonRpcProvider extends ethers.providers.JsonRpcBatchProvider implements ethers.providers.StaticJsonRpcProvider {
+  // from ethers.providers.StaticJsonRpcProvider
+  async detectNetwork(): Promise<Network> {
+    let network = this.network
+    if (network == null) {
+      network = await super.detectNetwork()
+
+      if (!network) {
+        logger.throwError('no network detected', Logger.errors.UNKNOWN_ERROR, {})
+      }
+
+      // If still not set, set it
+      if (this._network == null) {
+        // A static network does not support "any"
+        defineReadOnly(this, '_network', network)
+
+        this.emit('network', network, null)
+      }
+    }
+    return network
+  }
+}
+
+export const simpleRpcProvider = new JsonRpcProvider(RPC_URL)
 
 export default null


### PR DESCRIPTION
Split it from #2796 , reduce massive amount of network request, instead batching them into one request.
https://61a6f4bebe865d0008ef11d2--pcs-jojo.netlify.app/