### PR TITLE
fix: (pools): Blocks cell in rows shows infinite skeleton when starts in countdown

### DIFF
--- a/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EndsInCell.tsx
@@ -52,7 +52,8 @@ const EndsInCell: React.FC<FinishCellProps> = ({ pool }) => {
   // A bit hacky way to determine if public data is loading relying on totalStaked
   // Opted to go for this since we don't really need a separate publicDataLoaded flag
   // anywhere else
-  const isLoadingPublicData = !totalStaked.gt(0) || !currentBlock || (!blocksRemaining && !blocksUntilStart)
+  const isLoadingBlockData = !currentBlock || (!blocksRemaining && !blocksUntilStart)
+  const isLoadingPublicData = hasPoolStarted ? !totalStaked.gt(0) || isLoadingBlockData : isLoadingBlockData
   const showLoading = isLoadingPublicData && !isCakePool && !isFinished
   return (
     <StyledCell role="cell">


### PR DESCRIPTION
To reproduce:

1. Go to pools table
2. Check one pools that has starts in countdown
3. See it shows infinite skeleton until pool started

To review: 

