### PR TITLE
fix: Annual roi calculation shows NaN when apr is loading in stake modal

### DIFF
--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import React, { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
-import { Flex, Text, Button, Modal, LinkExternal, CalculateIcon, IconButton } from '@pancakeswap/uikit'
+import { Flex, Text, Button, Modal, LinkExternal, CalculateIcon, IconButton, Skeleton } from '@pancakeswap/uikit'
 import { ModalActions, ModalInput } from 'components/Modal'
 import RoiCalculatorModal from 'components/RoiCalculatorModal'
 import { useTranslation } from 'contexts/Localization'
@@ -124,12 +124,21 @@ const DepositModal: React.FC<DepositModalProps> = ({
         <Text mr="8px" color="textSubtle">
           {t('Annual ROI at current rates')}:
         </Text>
-        <AnnualRoiContainer alignItems="center" onClick={() => setShowRoiCalculator(true)}>
-          <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
-          <IconButton variant="text" scale="sm">
-            <CalculateIcon color="textSubtle" width="18px" />
-          </IconButton>
-        </AnnualRoiContainer>
+        {Number.isFinite(annualRoi) ? (
+          <AnnualRoiContainer
+            alignItems="center"
+            onClick={() => {
+              setShowRoiCalculator(true)
+            }}
+          >
+            <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
+            <IconButton variant="text" scale="sm">
+              <CalculateIcon color="textSubtle" width="18px" />
+            </IconButton>
+          </AnnualRoiContainer>
+        ) : (
+          <Skeleton width={60} />
+        )}
       </Flex>
       <ModalActions>
         <Button variant="secondary" onClick={onDismiss} width="100%" disabled={pendingTx}>

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -11,6 +11,7 @@ import {
   AutoRenewIcon,
   CalculateIcon,
   IconButton,
+  Skeleton,
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useWeb3React } from '@web3-react/core'
@@ -288,12 +289,21 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
           <Text mr="8px" color="textSubtle">
             {t('Annual ROI at current rates')}:
           </Text>
-          <AnnualRoiContainer alignItems="center" onClick={() => setShowRoiCalculator(true)}>
-            <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
-            <IconButton variant="text" scale="sm">
-              <CalculateIcon color="textSubtle" width="18px" />
-            </IconButton>
-          </AnnualRoiContainer>
+          {Number.isFinite(annualRoi) ? (
+            <AnnualRoiContainer
+              alignItems="center"
+              onClick={() => {
+                setShowRoiCalculator(true)
+              }}
+            >
+              <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
+              <IconButton variant="text" scale="sm">
+                <CalculateIcon color="textSubtle" width="18px" />
+              </IconButton>
+            </AnnualRoiContainer>
+          ) : (
+            <Skeleton width={60} />
+          )}
         </Flex>
       )}
       <Button

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   CalculateIcon,
   IconButton,
+  Skeleton,
 } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import useTheme from 'hooks/useTheme'
@@ -247,12 +248,21 @@ const StakeModal: React.FC<StakeModalProps> = ({
           <Text mr="8px" color="textSubtle">
             {t('Annual ROI at current rates')}:
           </Text>
-          <AnnualRoiContainer alignItems="center" onClick={() => setShowRoiCalculator(true)}>
-            <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
-            <IconButton variant="text" scale="sm">
-              <CalculateIcon color="textSubtle" width="18px" />
-            </IconButton>
-          </AnnualRoiContainer>
+          {Number.isFinite(annualRoi) ? (
+            <AnnualRoiContainer
+              alignItems="center"
+              onClick={() => {
+                setShowRoiCalculator(true)
+              }}
+            >
+              <AnnualRoiDisplay>${formattedAnnualRoi}</AnnualRoiDisplay>
+              <IconButton variant="text" scale="sm">
+                <CalculateIcon color="textSubtle" width="18px" />
+              </IconButton>
+            </AnnualRoiContainer>
+          ) : (
+            <Skeleton width={60} />
+          )}
         </Flex>
       )}
       <Button


### PR DESCRIPTION
To reproduce:

1. Go to pools
2. Click stake button when apr is loading
3. See NaN on annual roi calculation