### PR TITLE
refactor: (nft owner): Use simple rpc provider even when account connected

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -203,11 +203,14 @@ export const useNftMarketContract = () => {
   return useMemo(() => getNftMarketContract(library.getSigner()), [library])
 }
 
-export const useErc721CollectionContract = (collectionAddress: string) => {
+export const useErc721CollectionContract = (collectionAddress: string, withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(() => {
-    return getErc721CollectionContract(getProviderOrSigner(library, account), collectionAddress)
-  }, [account, library, collectionAddress])
+    return getErc721CollectionContract(
+      withSignerIfPossible ? getProviderOrSigner(library, account) : null,
+      collectionAddress,
+    )
+  }, [account, library, collectionAddress, withSignerIfPossible])
 }
 
 // Code below migrated from Exchange useContract.ts

--- a/src/views/Nft/market/hooks/useNftOwner.tsx
+++ b/src/views/Nft/market/hooks/useNftOwner.tsx
@@ -7,7 +7,7 @@ const NOT_ON_SALE_SELLER = '0x0000000000000000000000000000000000000000'
 const useNftOwner = (nft: NftToken) => {
   const [owner, setOwner] = useState(null)
   const [isLoadingOwner, setIsLoadingOwner] = useState(true)
-  const collectionContract = useErc721CollectionContract(nft.collectionAddress)
+  const collectionContract = useErc721CollectionContract(nft.collectionAddress, false)
   const currentSeller = nft.marketData?.currentSeller
   const { tokenId } = nft
 


### PR DESCRIPTION
Currently it uses wallet rpc to check ntf ownership when account is connected