### PR TITLE
fix: First Navigation to Swap and Pools page makes app frozen and page loader not shown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,6 @@ import PageLoader from './components/Loader/PageLoader'
 import EasterEgg from './components/EasterEgg'
 import GlobalCheckClaimStatus from './components/GlobalCheckClaimStatus'
 import history from './routerHistory'
-// Views included in the main bundle
-import Pools from './views/Pools'
-import Swap from './views/Swap'
 import {
   RedirectDuplicateTokenIds,
   RedirectOldAddLiquidityPathStructure,
@@ -33,9 +30,10 @@ import { useInactiveListener } from './hooks/useInactiveListener'
 import useSentryUser from './hooks/useSentryUser'
 
 // Route-based code splitting
-// Only pool is included in the main bundle because of it's the most visited page
 const Home = lazy(() => import('./views/Home'))
 const Farms = lazy(() => import('./views/Farms'))
+const Pools = lazy(() => import('./views/Pools'))
+const Swap = lazy(() => import('./views/Swap'))
 const FarmAuction = lazy(() => import('./views/FarmAuction'))
 const Lottery = lazy(() => import('./views/Lottery'))
 const Ifos = lazy(() => import('./views/Ifos'))


### PR DESCRIPTION
To reproduce:

1. Go to webpage (in mobile preferred)
2. Click pools
3. See app is frozen and there is no loading indicator (if there is a poor connection waiting time might be a lot)

To review:
https://deploy-preview-2847--pancakeswap-dev.netlify.app/
