### PR TITLE
feat: Adding limit orders and stop losses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project contains the main features of the pancake application.
 
+This project integrates Autonomy Network (a decentralized automation protocol) to offer limit orders and stop losses for pancake.
+
 If you want to contribute, please refer to the [contributing guidelines](./CONTRIBUTING.md) of this project.
 
 ## Documentation

--- a/src/components/ReactMarkdown/styles.tsx
+++ b/src/components/ReactMarkdown/styles.tsx
@@ -14,6 +14,11 @@ const Table = styled.table`
     padding: 8px;
   }
 `
+const TableBox = styled.div`
+  width: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+`
 
 const ThemedComponent = styled.div`
   color: ${({ theme }) => theme.colors.text};
@@ -33,6 +38,10 @@ const Pre = styled.pre`
   overflow-x: auto;
 `
 
+const AStyle = styled.a`
+  word-break: break-all;
+`
+
 const Title = (props) => {
   return <Heading as="h4" scale="lg" my="16px" {...props} />
 }
@@ -47,7 +56,13 @@ const markdownComponents: Partial<NormalComponents & SpecialComponents> = {
   p: (props) => {
     return <Text as="p" my="16px" {...props} />
   },
-  table: Table,
+  table: ({ node, ...props }) => {
+    return (
+      <TableBox>
+        <Table>{props.children}</Table>
+      </TableBox>
+    )
+  },
   ol: (props) => {
     return <ThemedComponent as="ol" {...props} />
   },
@@ -55,6 +70,7 @@ const markdownComponents: Partial<NormalComponents & SpecialComponents> = {
     return <ThemedComponent as="ul" {...props} />
   },
   pre: Pre,
+  a: AStyle,
 }
 
 export default markdownComponents


### PR DESCRIPTION
# Limit orders and Stop losses using Autonomy  

Opening this draft PR to start a discussion about the implementation of limit orders and stop losses using Autonomy Network a decentralized automation protocol. Since Autonomy Contracts are already live and working on BSC, adding both features would just require a few changes to the Pancake UI. If the team likes the idea and the proposed UI (or proposes better ideas)  we could do a direct PR into Pancake or we could also have a stand-alone version to test the features with the community before doing a native integration.

**Website:** https://www.autonomynetwork.io

**Autonomy Contracts:** https://github.com/Autonomy-Network/autonomy-contracts
**Limit and Stop Loss Contracts:** https://github.com/Autonomy-Network/uniV2-limits-stops

**Audits:**
 - HashEx: https://github.com/HashEx/public_audits/blob/master/autonomy/Autonomy%20report.pdf
 - Certik: Will add link soon.

**Demo DEX on BSC with Limit orders:** https://app.sokuswap.finance/bsc/#/limit-order

**Example Pancake deployment with Limit Orders, Stop losses and Transaction histories:** Coming soon. 

**Example of proposed UI:**
<img width="1788" alt="Screen Shot 2021-12-09 at 11 49 25 PM" src="https://user-images.githubusercontent.com/17280488/145537282-57549cfa-4fc6-4b13-a34d-bdaf531ac79a.png">
 
