### PR TITLE
fix: (pools): Pools apr not shown for one slow refresh cycle although the farm data is available

### DIFF
--- a/src/state/farms/fetchFarmsPrices.ts
+++ b/src/state/farms/fetchFarmsPrices.ts
@@ -85,7 +85,7 @@ const getFarmQuoteTokenPrice = (
   return BIG_ZERO
 }
 
-const fetchFarmsPrices = async (farms: SerializedFarm[]) => {
+const fetchFarmsPrices = (farms: SerializedFarm[]) => {
   const bnbBusdFarm = farms.find((farm) => farm.pid === 252)
   const bnbPriceBusd = bnbBusdFarm.tokenPriceVsQuote ? BIG_ONE.div(bnbBusdFarm.tokenPriceVsQuote) : BIG_ZERO
 

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -40,7 +40,7 @@ export const fetchFarmsPublicDataAsync = createAsyncThunk<SerializedFarm[], numb
     const farmsWithPriceHelpers = farmsToFetch.concat(priceHelperLpsConfig)
 
     const farms = await fetchFarms(farmsWithPriceHelpers)
-    const farmsWithPrices = await fetchFarmsPrices(farms)
+    const farmsWithPrices = fetchFarmsPrices(farms)
 
     // Filter out price helper LP config farms
     const farmsWithoutHelperLps = farmsWithPrices.filter((farm: SerializedFarm) => {

--- a/src/state/pools/hooks.ts
+++ b/src/state/pools/hooks.ts
@@ -21,6 +21,7 @@ import {
 } from '.'
 import { State, DeserializedPool, VaultKey } from '../types'
 import { transformPool } from './helpers'
+import { fetchFarmsPublicDataAsync, nonArchivedFarms } from '../farms'
 
 export const useFetchPublicPoolsData = () => {
   const dispatch = useAppDispatch()
@@ -29,6 +30,8 @@ export const useFetchPublicPoolsData = () => {
   useEffect(() => {
     const fetchPoolsPublicData = async () => {
       const blockNumber = await simpleRpcProvider.getBlockNumber()
+      const activeFarms = nonArchivedFarms.filter((farm) => farm.pid !== 0)
+      await dispatch(fetchFarmsPublicDataAsync(activeFarms.map((farm) => farm.pid)))
       dispatch(fetchPoolsPublicDataAsync(blockNumber))
     }
 

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -18,7 +18,6 @@ import {
   useFetchIfoPool,
   useVaultPools,
 } from 'state/pools/hooks'
-import { usePollFarmsPublicData } from 'state/farms/hooks'
 import { latinise } from 'utils/latinise'
 import FlexLayout from 'components/Layout/Flex'
 import Page from 'components/Layout/Page'
@@ -130,7 +129,6 @@ const Pools: React.FC = () => {
   )
   const hasStakeInFinishedPools = stakedOnlyFinishedPools.length > 0
 
-  usePollFarmsPublicData()
   useFetchCakeVault()
   useFetchIfoPool()
   useFetchPublicPoolsData()


### PR DESCRIPTION
This is an intermittent issue, if at the time fetchPoolsPublicDataAsync called there is no farms data but comes after that short time, user has to wait one slowRefresh cycle (which is 1 minute) to see them

To reproduce:

1. Go to pools page
2. See apr's (except cake pools) not loading for 1 minute

To review:
https://deploy-preview-2863--pancakeswap-dev.netlify.app/
