### PR TITLE
fix: (nft-activity): Gif or Video thumbnails not shown in activity row

### DIFF
--- a/src/views/Nft/market/components/Activity/ActivityRow.tsx
+++ b/src/views/Nft/market/components/Activity/ActivityRow.tsx
@@ -1,20 +1,8 @@
 import React from 'react'
-import {
-  Image,
-  Flex,
-  Text,
-  Td,
-  IconButton,
-  Link,
-  OpenNewIcon,
-  useMatchBreakpoints,
-  useModal,
-  Box,
-} from '@pancakeswap/uikit'
+import { Flex, Text, Td, IconButton, Link, OpenNewIcon, useMatchBreakpoints, useModal, Box } from '@pancakeswap/uikit'
 import { Link as RouterLink } from 'react-router-dom'
 import { Activity, NftToken } from 'state/nftMarket/types'
 import { Price } from '@pancakeswap/sdk'
-import styled from 'styled-components'
 import { getBscScanLink } from 'utils'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import ProfileCell from 'views/Nft/market/components/ProfileCell'
@@ -22,12 +10,7 @@ import MobileModal from './MobileModal'
 import ActivityPrice from './ActivityPrice'
 import ActivityEventText from './ActivityEventText'
 import { nftsBaseUrl, pancakeBunniesAddress } from '../../constants'
-
-const RoundedImage = styled(Image)`
-  & > img {
-    border-radius: ${({ theme }) => theme.radii.default};
-  }
-`
+import NFTMedia from '../NFTMedia'
 
 interface ActivityRowProps {
   activity: Activity
@@ -85,7 +68,7 @@ const ActivityRow: React.FC<ActivityRowProps> = ({
           <Flex justifyContent="flex-start" alignItems="center" flexDirection={['column', null, 'row']}>
             <Box width={64} height={64} mr={[0, null, '16px']} mb={['8px', null, 0]}>
               <RouterLink to={nft ? `${nftsBaseUrl}/collections/${nft.collectionAddress}/${tokenId}` : ``}>
-                <RoundedImage src={nft?.image.thumbnail} alt={nft?.name} width={64} height={64} />
+                <NFTMedia nft={nft} width={64} height={64} />
               </RouterLink>
             </Box>
             <Flex flexDirection="column">

--- a/src/views/Nft/market/components/Activity/MobileModal.tsx
+++ b/src/views/Nft/market/components/Activity/MobileModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { InjectedModalProps, Modal, Flex, Text, Button, Image, Link, BinanceIcon } from '@pancakeswap/uikit'
+import { InjectedModalProps, Modal, Flex, Text, Button, Link, BinanceIcon, Box } from '@pancakeswap/uikit'
 import { Price } from '@pancakeswap/sdk'
 import useTheme from 'hooks/useTheme'
-import styled from 'styled-components'
 import { Activity, NftToken } from 'state/nftMarket/types'
 import { LightGreyCard } from 'components/Card'
 import { useTranslation } from 'contexts/Localization'
@@ -11,12 +10,7 @@ import { multiplyPriceByAmount } from 'utils/prices'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { getBscScanLink } from 'utils'
 import ActivityEventText from './ActivityEventText'
-
-const RoundedImage = styled(Image)`
-  & > img {
-    border-radius: ${({ theme }) => theme.radii.default};
-  }
-`
+import NFTMedia from '../NFTMedia'
 
 interface MobileModalProps extends InjectedModalProps {
   activity: Activity
@@ -44,12 +38,16 @@ const MobileModal: React.FC<MobileModalProps> = ({
     <Modal title={t('Transaction Details')} onDismiss={onDismiss} headerBackground={theme.colors.gradients.cardHeader}>
       <Flex flexDirection="column" maxWidth="350px">
         <Flex alignItems="center" mb="16px" justifyContent="space-between">
-          <RoundedImage src={nft.image.thumbnail} height={68} width={68} mr="16px" />
+          <Box width={68} mr="16px">
+            <NFTMedia nft={nft} width={68} height={68} />
+          </Box>
           <Flex flexDirection="column">
             <Text fontSize="12px" color="textSubtle" textAlign="right">
               {nft.collectionName}
             </Text>
-            <Text bold>{nft.name}</Text>
+            <Text bold textAlign="right">
+              {nft.name}
+            </Text>
           </Flex>
         </Flex>
         <LightGreyCard p="16px">

--- a/src/views/Nft/market/components/NFTMedia.tsx
+++ b/src/views/Nft/market/components/NFTMedia.tsx
@@ -18,7 +18,7 @@ export const AspectRatio = ({ ratio, children, ...props }) => (
 
 const NFTMedia: FC<
   {
-    nft: NftToken
+    nft?: NftToken
     as?: any
     width: number
     height: number
@@ -37,7 +37,7 @@ const NFTMedia: FC<
     }
   }, [isIntersecting])
 
-  if (nft.image.webm || nft.image.mp4) {
+  if (nft?.image.webm || nft?.image.mp4) {
     return (
       <AspectRatio ratio={width / height} {...props}>
         <div ref={observerRef} />
@@ -53,8 +53,8 @@ const NFTMedia: FC<
     <RoundedImage
       width={width}
       height={height}
-      src={nft.image.gif || nft.image.thumbnail}
-      alt={nft.name}
+      src={nft?.image.gif || nft?.image.thumbnail}
+      alt={nft?.name}
       as={as}
       {...props}
     />


### PR DESCRIPTION
1. Go to nft activities (https://pancakeswap.finance/nfts/collections/0xC448498DDC536ad6F5d437325725dCf504d2d964#activity)
2. See items thumbnails not shown if there is no image file

To review:
https://deploy-preview-2865--pancakeswap-dev.netlify.app/