### PR TITLE
fix: (nft overview): Remove placeholder on hot collections

### DIFF
--- a/src/views/Nft/market/Home/Collections.tsx
+++ b/src/views/Nft/market/Home/Collections.tsx
@@ -35,7 +35,7 @@ const Collections = () => {
         </Button>
       </Flex>
       <Grid gridGap="16px" gridTemplateColumns={['1fr', '1fr', 'repeat(2, 1fr)', 'repeat(3, 1fr)']} mb="64px">
-        {orderedCollections.slice(0, 5).map((collection) => {
+        {orderedCollections.slice(0, 6).map((collection) => {
           return (
             <HotCollectionCard
               key={collection.address}
@@ -53,15 +53,6 @@ const Collections = () => {
             </HotCollectionCard>
           )
         })}
-        <HotCollectionCard
-          disabled
-          bgSrc="/images/collections/no-collection-banner-sm.png"
-          collectionName={t('Coming Soon')}
-        >
-          <Text color="textDisabled" fontSize="12px">
-            {t('More Collections are on their way!')}
-          </Text>
-        </HotCollectionCard>
       </Grid>
     </>
   )


### PR DESCRIPTION
Since currently there are more collections than 5, we don't need that placeholder anymore imho

To review:
https://deploy-preview-2869--pancakeswap-dev.netlify.app/