### PR TITLE
fix: (import token):  Cancel button on Import token modal redirects to 404 not found page

### DIFF
--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -307,7 +307,7 @@ export default function Swap({ history }: RouteComponentProps) {
   const swapIsUnsupported = useIsTransactionUnsupported(currencies?.INPUT, currencies?.OUTPUT)
 
   const [onPresentImportTokenWarningModal] = useModal(
-    <ImportTokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap/')} />,
+    <ImportTokenWarningModal tokens={importTokensNotInDefault} onCancel={() => history.push('/swap')} />,
   )
 
   useEffect(() => {


### PR DESCRIPTION
1. Go to (https://pancakeswap.finance/swap/0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d) (USDC Token)
2. See import warning modal
3. Click x button
4. See 404 Page

It should return to default swap page.