### PR TITLE
fix: (competition): Competition page without account shows to start battle

### DIFF
--- a/src/views/TradingCompetition/index.tsx
+++ b/src/views/TradingCompetition/index.tsx
@@ -167,9 +167,9 @@ const TradingCompetition = () => {
       }
     }
 
+    fetchCompetitionInfoContract()
     if (account) {
       fetchUserContract()
-      fetchCompetitionInfoContract()
     } else {
       setUserTradingInformation({
         hasRegistered: false,


### PR DESCRIPTION
To reproduce:

1. Go to https://pancakeswap.finance/competition without account connected
2. See Starting Soon although competition finished

To review:

https://deploy-preview-2922--pancakeswap-dev.netlify.app/