### PR TITLE
feat: Transaction Submitted Toast and tx link to Success toast for user transactions

### DIFF
--- a/src/hooks/useApproveConfirmTransaction.tsx
+++ b/src/hooks/useApproveConfirmTransaction.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useReducer, useRef } from 'react'
+import React, { useEffect, useReducer, useRef } from 'react'
 import { noop } from 'lodash'
 import { useWeb3React } from '@web3-react/core'
 import { ethers } from 'ethers'
 import useToast from 'hooks/useToast'
 import { useTranslation } from 'contexts/Localization'
 import { logError } from 'utils/sentry'
+import { ToastDescriptionWithTx } from 'components/Toast'
 
 type LoadingState = 'idle' | 'loading' | 'success' | 'fail'
 
@@ -93,7 +94,7 @@ const useApproveConfirmTransaction = ({
   const { account } = useWeb3React()
   const [state, dispatch] = useReducer(reducer, initialState)
   const handlePreApprove = useRef(onRequiresApproval)
-  const { toastError } = useToast()
+  const { toastSuccess, toastError } = useToast()
 
   // Check if approval is necessary, re-check if account changes
   useEffect(() => {
@@ -116,6 +117,7 @@ const useApproveConfirmTransaction = ({
     handleApprove: async () => {
       try {
         const tx = await onApprove()
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
         dispatch({ type: 'approve_sending' })
         const receipt = await tx.wait()
         if (receipt.status) {
@@ -132,6 +134,7 @@ const useApproveConfirmTransaction = ({
       dispatch({ type: 'confirm_sending' })
       try {
         const tx = await onConfirm(params)
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
         const receipt = await tx.wait()
         if (receipt.status) {
           dispatch({ type: 'confirm_receipt' })

--- a/src/utils/calls/farms.ts
+++ b/src/utils/calls/farms.ts
@@ -10,39 +10,27 @@ export const stakeFarm = async (masterChefContract, pid, amount) => {
   const gasPrice = getGasPrice()
   const value = new BigNumber(amount).times(DEFAULT_TOKEN_DECIMAL).toString()
   if (pid === 0) {
-    const tx = await masterChefContract.enterStaking(value, { ...options, gasPrice })
-    const receipt = await tx.wait()
-    return receipt.status
+    return masterChefContract.enterStaking(value, { ...options, gasPrice })
   }
 
-  const tx = await masterChefContract.deposit(pid, value, { ...options, gasPrice })
-  const receipt = await tx.wait()
-  return receipt.status
+  return masterChefContract.deposit(pid, value, { ...options, gasPrice })
 }
 
 export const unstakeFarm = async (masterChefContract, pid, amount) => {
   const gasPrice = getGasPrice()
   const value = new BigNumber(amount).times(DEFAULT_TOKEN_DECIMAL).toString()
   if (pid === 0) {
-    const tx = await masterChefContract.leaveStaking(value, { ...options, gasPrice })
-    const receipt = await tx.wait()
-    return receipt.status
+    return masterChefContract.leaveStaking(value, { ...options, gasPrice })
   }
 
-  const tx = await masterChefContract.withdraw(pid, value, { ...options, gasPrice })
-  const receipt = await tx.wait()
-  return receipt.status
+  return masterChefContract.withdraw(pid, value, { ...options, gasPrice })
 }
 
 export const harvestFarm = async (masterChefContract, pid) => {
   const gasPrice = getGasPrice()
   if (pid === 0) {
-    const tx = await masterChefContract.leaveStaking('0', { ...options, gasPrice })
-    const receipt = await tx.wait()
-    return receipt.status
+    return masterChefContract.leaveStaking('0', { ...options, gasPrice })
   }
 
-  const tx = await masterChefContract.deposit(pid, '0', { ...options, gasPrice })
-  const receipt = await tx.wait()
-  return receipt.status
+  return masterChefContract.deposit(pid, '0', { ...options, gasPrice })
 }

--- a/src/views/Farms/components/DepositModal.tsx
+++ b/src/views/Farms/components/DepositModal.tsx
@@ -52,7 +52,7 @@ const DepositModal: React.FC<DepositModalProps> = ({
   cakePrice,
 }) => {
   const [val, setVal] = useState('')
-  const { toastSuccess, toastError } = useToast()
+  const { toastError } = useToast()
   const [pendingTx, setPendingTx] = useState(false)
   const [showRoiCalculator, setShowRoiCalculator] = useState(false)
   const { t } = useTranslation()
@@ -154,7 +154,6 @@ const DepositModal: React.FC<DepositModalProps> = ({
             setPendingTx(true)
             try {
               await onConfirm(val)
-              toastSuccess(t('Staked!'), t('Your funds have been staked in the farm'))
               onDismiss()
             } catch (e) {
               logError(e)

--- a/src/views/Farms/components/FarmCard/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmCard/HarvestAction.tsx
@@ -3,6 +3,7 @@ import { useWeb3React } from '@web3-react/core'
 import BigNumber from 'bignumber.js'
 import Balance from 'components/Balance'
 import { useTranslation } from 'contexts/Localization'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import useToast from 'hooks/useToast'
 import React, { useState } from 'react'
 import { useAppDispatch } from 'state'
@@ -43,10 +44,26 @@ const HarvestAction: React.FC<FarmCardActionsProps> = ({ earnings, pid }) => {
         onClick={async () => {
           setPendingTx(true)
           try {
-            await onReward()
-            toastSuccess(
-              `${t('Harvested')}!`,
-              t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' }),
+            await onReward(
+              (tx) => {
+                toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+              },
+              (receipt) => {
+                toastSuccess(
+                  `${t('Harvested')}!`,
+                  <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                    {t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' })}
+                  </ToastDescriptionWithTx>,
+                )
+              },
+              (receipt) => {
+                toastError(
+                  t('Error'),
+                  <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                    {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+                  </ToastDescriptionWithTx>,
+                )
+              },
             )
           } catch (e) {
             toastError(

--- a/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -3,8 +3,10 @@ import { useWeb3React } from '@web3-react/core'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 import { Button, Flex, Heading, IconButton, AddIcon, MinusIcon, useModal } from '@pancakeswap/uikit'
+import useToast from 'hooks/useToast'
 import { useLocation } from 'react-router-dom'
 import Balance from 'components/Balance'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import { useTranslation } from 'contexts/Localization'
 import { useAppDispatch } from 'state'
 import { fetchFarmUserDataAsync } from 'state/farms'
@@ -54,14 +56,57 @@ const StakeAction: React.FC<FarmCardActionsProps> = ({
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
   const lpPrice = useLpTokenPrice(tokenName)
+  const { toastSuccess, toastError } = useToast()
 
   const handleStake = async (amount: string) => {
-    await onStake(amount)
+    await onStake(
+      amount,
+      (tx) => {
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+      },
+      (receipt) => {
+        toastSuccess(
+          `${t('Staked')}!`,
+          <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+            {t('Your funds have been staked in the farm')}
+          </ToastDescriptionWithTx>,
+        )
+      },
+      (receipt) => {
+        toastError(
+          t('Error'),
+          <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+            {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+          </ToastDescriptionWithTx>,
+        )
+      },
+    )
     dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
   }
 
   const handleUnstake = async (amount: string) => {
-    await onUnstake(amount)
+    await onUnstake(
+      amount,
+      (tx) => {
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+      },
+      (receipt) => {
+        toastSuccess(
+          `${t('Unstaked')}!`,
+          <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+            {t('Your earnings have also been harvested to your wallet')}
+          </ToastDescriptionWithTx>,
+        )
+      },
+      (receipt) => {
+        toastError(
+          t('Error'),
+          <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+            {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+          </ToastDescriptionWithTx>,
+        )
+      },
+    )
     dispatch(fetchFarmUserDataAsync({ account, pids: [pid] }))
   }
 

--- a/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
+++ b/src/views/Farms/components/FarmTable/Actions/HarvestAction.tsx
@@ -3,6 +3,7 @@ import { useWeb3React } from '@web3-react/core'
 import BigNumber from 'bignumber.js'
 import Balance from 'components/Balance'
 import { useTranslation } from 'contexts/Localization'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import useToast from 'hooks/useToast'
 import React, { useState } from 'react'
 import { useAppDispatch } from 'state'
@@ -62,10 +63,26 @@ const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({ pid, userD
           onClick={async () => {
             setPendingTx(true)
             try {
-              await onReward()
-              toastSuccess(
-                `${t('Harvested')}!`,
-                t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' }),
+              await onReward(
+                (tx) => {
+                  toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+                },
+                (receipt) => {
+                  toastSuccess(
+                    `${t('Harvested')}!`,
+                    <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                      {t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' })}
+                    </ToastDescriptionWithTx>,
+                  )
+                },
+                (receipt) => {
+                  toastError(
+                    t('Error'),
+                    <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                      {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+                    </ToastDescriptionWithTx>,
+                  )
+                },
               )
             } catch (e) {
               toastError(

--- a/src/views/Farms/components/WithdrawModal.tsx
+++ b/src/views/Farms/components/WithdrawModal.tsx
@@ -16,7 +16,7 @@ interface WithdrawModalProps {
 
 const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max, tokenName = '' }) => {
   const [val, setVal] = useState('')
-  const { toastSuccess, toastError } = useToast()
+  const { toastError } = useToast()
   const [pendingTx, setPendingTx] = useState(false)
   const { t } = useTranslation()
   const fullBalance = useMemo(() => {
@@ -59,7 +59,6 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({ onConfirm, onDismiss, max
             setPendingTx(true)
             try {
               await onConfirm(val)
-              toastSuccess(t('Unstaked!'), t('Your earnings have also been harvested to your wallet'))
               onDismiss()
             } catch (e) {
               logError(e)

--- a/src/views/Farms/hooks/useApproveFarm.ts
+++ b/src/views/Farms/hooks/useApproveFarm.ts
@@ -2,15 +2,31 @@ import { useCallback } from 'react'
 import { ethers, Contract } from 'ethers'
 import { useMasterchef } from 'hooks/useContract'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const useApproveFarm = (lpContract: Contract) => {
   const masterChefContract = useMasterchef()
   const { callWithGasPrice } = useCallWithGasPrice()
-  const handleApprove = useCallback(async () => {
-    const tx = await callWithGasPrice(lpContract, 'approve', [masterChefContract.address, ethers.constants.MaxUint256])
-    const receipt = await tx.wait()
-    return receipt.status
-  }, [lpContract, masterChefContract, callWithGasPrice])
+  const handleApprove = useCallback(
+    async (
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      const tx = await callWithGasPrice(lpContract, 'approve', [
+        masterChefContract.address,
+        ethers.constants.MaxUint256,
+      ])
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+      } else {
+        onError(receipt)
+      }
+    },
+    [lpContract, masterChefContract, callWithGasPrice],
+  )
 
   return { onApprove: handleApprove }
 }

--- a/src/views/Farms/hooks/useHarvestFarm.ts
+++ b/src/views/Farms/hooks/useHarvestFarm.ts
@@ -1,13 +1,29 @@
 import { useCallback } from 'react'
 import { harvestFarm } from 'utils/calls'
 import { useMasterchef } from 'hooks/useContract'
+import { TransactionResponse } from '@ethersproject/providers'
+import { TransactionReceipt } from '@ethersproject/abstract-provider/src.ts/index'
 
 const useHarvestFarm = (farmPid: number) => {
   const masterChefContract = useMasterchef()
 
-  const handleHarvest = useCallback(async () => {
-    await harvestFarm(masterChefContract, farmPid)
-  }, [farmPid, masterChefContract])
+  const handleHarvest = useCallback(
+    async (
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      const tx = await harvestFarm(masterChefContract, farmPid)
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+      } else {
+        onError(receipt)
+      }
+    },
+    [farmPid, masterChefContract],
+  )
 
   return { onReward: handleHarvest }
 }

--- a/src/views/Farms/hooks/useStakeFarms.ts
+++ b/src/views/Farms/hooks/useStakeFarms.ts
@@ -1,14 +1,26 @@
 import { useCallback } from 'react'
 import { stakeFarm } from 'utils/calls'
 import { useMasterchef } from 'hooks/useContract'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const useStakeFarms = (pid: number) => {
   const masterChefContract = useMasterchef()
 
   const handleStake = useCallback(
-    async (amount: string) => {
-      const txHash = await stakeFarm(masterChefContract, pid, amount)
-      console.info(txHash)
+    async (
+      amount: string,
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      const tx = await stakeFarm(masterChefContract, pid, amount)
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+      } else {
+        onError(receipt)
+      }
     },
     [masterChefContract, pid],
   )

--- a/src/views/Farms/hooks/useUnstakeFarms.ts
+++ b/src/views/Farms/hooks/useUnstakeFarms.ts
@@ -1,13 +1,26 @@
 import { useCallback } from 'react'
 import { unstakeFarm } from 'utils/calls'
 import { useMasterchef } from 'hooks/useContract'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const useUnstakeFarms = (pid: number) => {
   const masterChefContract = useMasterchef()
 
   const handleUnstake = useCallback(
-    async (amount: string) => {
-      await unstakeFarm(masterChefContract, pid, amount)
+    async (
+      amount: string,
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      const tx = await unstakeFarm(masterChefContract, pid, amount)
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+      } else {
+        onError(receipt)
+      }
     },
     [masterChefContract, pid],
   )

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ClaimButton.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ClaimButton.tsx
@@ -22,18 +22,14 @@ const ClaimButton: React.FC<Props> = ({ poolId, ifoVersion, walletIfoData }) => 
 
   const handleClaim = async () => {
     try {
-      let txHash
       setPendingTx(true)
-
-      if (ifoVersion === 1) {
-        const tx = await walletIfoData.contract.harvest()
-        const receipt = await tx.wait()
-        txHash = receipt.transactionHash
-      } else {
-        const tx = await walletIfoData.contract.harvestPool(poolId === PoolIds.poolBasic ? 0 : 1)
-        const receipt = await tx.wait()
-        txHash = receipt.transactionHash
-      }
+      const tx =
+        ifoVersion === 1
+          ? await walletIfoData.contract.harvest()
+          : await walletIfoData.contract.harvestPool(poolId === PoolIds.poolBasic ? 0 : 1)
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+      const receipt = await tx.wait()
+      const txHash = receipt.transactionHash
 
       walletIfoData.setIsClaimed(poolId)
       toastSuccess(

--- a/src/views/Ifos/hooks/useIfoApprove.ts
+++ b/src/views/Ifos/hooks/useIfoApprove.ts
@@ -1,13 +1,27 @@
 import { useCallback } from 'react'
 import { ethers, Contract } from 'ethers'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const useIfoApprove = (tokenContract: Contract, spenderAddress: string) => {
   const { callWithGasPrice } = useCallWithGasPrice()
-  const onApprove = useCallback(async (): Promise<ethers.providers.TransactionReceipt> => {
-    const tx = await callWithGasPrice(tokenContract, 'approve', [spenderAddress, ethers.constants.MaxUint256])
-    return tx.wait()
-  }, [spenderAddress, tokenContract, callWithGasPrice])
+  const onApprove = useCallback(
+    async (
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      const tx = await callWithGasPrice(tokenContract, 'approve', [spenderAddress, ethers.constants.MaxUint256])
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+      } else {
+        onError(receipt)
+      }
+    },
+    [spenderAddress, tokenContract, callWithGasPrice],
+  )
 
   return onApprove
 }

--- a/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
+++ b/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
@@ -90,6 +90,7 @@ const ClaimInnerContainer: React.FC<ClaimInnerProps> = ({ onSuccess, roundsToCla
       const tx = await callWithEstimateGas(lotteryContract, 'claimTickets', [lotteryId, ticketIds, brackets], {
         gasPrice,
       })
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(
@@ -124,6 +125,7 @@ const ClaimInnerContainer: React.FC<ClaimInnerProps> = ({ onSuccess, roundsToCla
           [lotteryId, ticketBatch.ticketIds, ticketBatch.brackets],
           { gasPrice },
         )
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
         const receipt = await tx.wait()
         /* eslint-enable no-await-in-loop */
         if (receipt.status) {

--- a/src/views/Nft/market/Profile/components/Achievements/AchievementRow/index.tsx
+++ b/src/views/Nft/market/Profile/components/Achievements/AchievementRow/index.tsx
@@ -62,6 +62,7 @@ const AchievementRow: React.FC<AchievementRowProps> = ({ achievement, onCollectS
   const handleCollectPoints = async () => {
     try {
       const tx = await callWithGasPrice(pointCenterContract, 'getPoints', [achievement.address])
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       setIsCollecting(true)
       const receipt = await tx.wait()
       if (receipt.status) {

--- a/src/views/Nft/market/Profile/components/EditProfileModal/PauseProfileView.tsx
+++ b/src/views/Nft/market/Profile/components/EditProfileModal/PauseProfileView.tsx
@@ -32,6 +32,7 @@ const PauseProfilePage: React.FC<PauseProfilePageProps> = ({ onDismiss }) => {
 
   const handleDeactivateProfile = async () => {
     const tx = await callWithGasPrice(pancakeProfileContract, 'pauseProfile')
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setIsConfirming(true)
     const receipt = await tx.wait()
     if (receipt.status) {

--- a/src/views/PancakeSquad/components/Buttons/Mint.tsx
+++ b/src/views/PancakeSquad/components/Buttons/Mint.tsx
@@ -3,6 +3,7 @@ import { BigNumber } from 'ethers'
 import React, { useEffect, useState } from 'react'
 import { AutoRenewIcon, Button, useModal } from '@pancakeswap/uikit'
 import { ContextApi } from 'contexts/Localization/types'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import { useNftSaleContract } from 'hooks/useContract'
 import useToast from 'hooks/useToast'
@@ -51,6 +52,7 @@ const MintButton: React.FC<PreEventProps> = ({ t, theme, saleStatus, numberTicke
     setIsLoading(true)
     try {
       const tx = await callWithGasPrice(nftSaleContract, 'mint', [ticketsOfUser])
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(t('Transaction has succeeded!'))

--- a/src/views/Pools/components/BountyModal.tsx
+++ b/src/views/Pools/components/BountyModal.tsx
@@ -63,6 +63,7 @@ const BountyModal: React.FC<BountyModalProps> = ({ onDismiss, TooltipComponent }
     setPendingTx(true)
     try {
       const tx = await callWithGasPrice(cakeVaultContract, 'harvest', undefined, { gasLimit: 300000 })
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -156,6 +156,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
     if (isWithdrawingAll) {
       try {
         const tx = await callWithGasPrice(vaultPoolContract, 'withdrawAll', undefined, callOptions)
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
         const receipt = await tx.wait()
         if (receipt.status) {
           toastSuccess(
@@ -183,6 +184,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
           [shareStakeToWithdraw.sharesAsBigNumber.toString()],
           callOptions,
         )
+        toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
         const receipt = await tx.wait()
         if (receipt.status) {
           toastSuccess(
@@ -209,6 +211,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
       // .toString() being called to fix a BigNumber error in prod
       // as suggested here https://github.com/ChainSafe/web3.js/issues/2077
       const tx = await callWithGasPrice(vaultPoolContract, 'deposit', [convertedStakeAmount.toString()], callOptions)
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       const receipt = await tx.wait()
       if (receipt.status) {
         toastSuccess(

--- a/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/CollectModal.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from 'contexts/Localization'
 import useTheme from 'hooks/useTheme'
 import useToast from 'hooks/useToast'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import { Token } from '@pancakeswap/sdk'
 import { formatNumber } from 'utils/formatBalance'
 import { logError } from 'utils/sentry'
@@ -61,11 +62,30 @@ const CollectModal: React.FC<CollectModalProps> = ({
     // compounding
     if (shouldCompound) {
       try {
-        await onStake(fullBalance, earningToken.decimals)
-        toastSuccess(
-          `${t('Compounded')}!`,
-          t('Your %symbol% earnings have been re-invested into the pool!', { symbol: earningToken.symbol }),
+        await onStake(
+          fullBalance,
+          earningToken.decimals,
+          (tx) => {
+            toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+          },
+          (receipt) => {
+            toastSuccess(
+              `${t('Compounded')}!`,
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Your %symbol% earnings have been re-invested into the pool!', { symbol: earningToken.symbol })}
+              </ToastDescriptionWithTx>,
+            )
+          },
+          (receipt) => {
+            toastError(
+              t('Error'),
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+              </ToastDescriptionWithTx>,
+            )
+          },
         )
+
         setPendingTx(false)
         onDismiss()
       } catch (e) {
@@ -76,11 +96,28 @@ const CollectModal: React.FC<CollectModalProps> = ({
     } else {
       // harvesting
       try {
-        await onReward()
-        toastSuccess(
-          `${t('Harvested')}!`,
-          t('Your %symbol% earnings have been sent to your wallet!', { symbol: earningToken.symbol }),
+        await onReward(
+          (tx) => {
+            toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+          },
+          (receipt) => {
+            toastSuccess(
+              `${t('Harvested')}!`,
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Your %symbol% earnings have been sent to your wallet!', { symbol: earningToken.symbol })}
+              </ToastDescriptionWithTx>,
+            )
+          },
+          (receipt) => {
+            toastError(
+              t('Error'),
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+              </ToastDescriptionWithTx>,
+            )
+          },
         )
+
         setPendingTx(false)
         onDismiss()
       } catch (e) {

--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -19,6 +19,7 @@ import useTheme from 'hooks/useTheme'
 import useToast from 'hooks/useToast'
 import BigNumber from 'bignumber.js'
 import RoiCalculatorModal from 'components/RoiCalculatorModal'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import { getFullDisplayBalance, formatNumber, getDecimalAmount } from 'utils/formatBalance'
 import { DeserializedPool } from 'state/types'
 import { getInterestBreakdown } from 'utils/compoundApyHelpers'
@@ -136,21 +137,57 @@ const StakeModal: React.FC<StakeModalProps> = ({
     try {
       if (isRemovingStake) {
         // unstaking
-        await onUnstake(stakeAmount, stakingToken.decimals)
-        toastSuccess(
-          `${t('Unstaked')}!`,
-          t('Your %symbol% earnings have also been harvested to your wallet!', {
-            symbol: earningToken.symbol,
-          }),
+        await onUnstake(
+          stakeAmount,
+          stakingToken.decimals,
+          (tx) => {
+            toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+          },
+          (receipt) => {
+            toastSuccess(
+              `${t('Unstaked')}!`,
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Your %symbol% earnings have also been harvested to your wallet!', {
+                  symbol: earningToken.symbol,
+                })}
+              </ToastDescriptionWithTx>,
+            )
+          },
+          (receipt) => {
+            toastError(
+              t('Error'),
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+              </ToastDescriptionWithTx>,
+            )
+          },
         )
       } else {
         // staking
-        await onStake(stakeAmount, stakingToken.decimals)
-        toastSuccess(
-          `${t('Staked')}!`,
-          t('Your %symbol% funds have been staked in the pool!', {
-            symbol: stakingToken.symbol,
-          }),
+        await onStake(
+          stakeAmount,
+          stakingToken.decimals,
+          (tx) => {
+            toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
+          },
+          (receipt) => {
+            toastSuccess(
+              `${t('Staked')}!`,
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Your %symbol% funds have been staked in the pool!', {
+                  symbol: stakingToken.symbol,
+                })}
+              </ToastDescriptionWithTx>,
+            )
+          },
+          (receipt) => {
+            toastError(
+              t('Error'),
+              <ToastDescriptionWithTx txHash={receipt.transactionHash}>
+                {t('Please try again. Confirm the transaction and make sure you are paying enough gas!')}
+              </ToastDescriptionWithTx>,
+            )
+          },
         )
       }
       setPendingTx(false)

--- a/src/views/Pools/hooks/useApprove.tsx
+++ b/src/views/Pools/hooks/useApprove.tsx
@@ -25,6 +25,7 @@ export const useApprovePool = (lpContract: Contract, sousId, earningTokenSymbol)
     try {
       setRequestedApproval(true)
       const tx = await callWithGasPrice(lpContract, 'approve', [sousChefContract.address, ethers.constants.MaxUint256])
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       const receipt = await tx.wait()
 
       dispatch(updateUserAllowance(sousId, account))
@@ -72,6 +73,7 @@ export const useVaultApprove = (vaultKey: VaultKey, setLastUpdated: () => void) 
 
   const handleApprove = async () => {
     const tx = await callWithGasPrice(cakeContract, 'approve', [vaultPoolContract.address, ethers.constants.MaxUint256])
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setRequestedApproval(true)
     const receipt = await tx.wait()
     if (receipt.status) {

--- a/src/views/Pools/hooks/useStakePool.ts
+++ b/src/views/Pools/hooks/useStakePool.ts
@@ -8,6 +8,7 @@ import { DEFAULT_TOKEN_DECIMAL, DEFAULT_GAS_LIMIT } from 'config'
 import { BIG_TEN } from 'utils/bigNumber'
 import { useMasterchef, useSousChef } from 'hooks/useContract'
 import getGasPrice from 'utils/getGasPrice'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const options = {
   gasLimit: DEFAULT_GAS_LIMIT,
@@ -15,22 +16,18 @@ const options = {
 
 const sousStake = async (sousChefContract, amount, decimals = 18) => {
   const gasPrice = getGasPrice()
-  const tx = await sousChefContract.deposit(new BigNumber(amount).times(BIG_TEN.pow(decimals)).toString(), {
+  return sousChefContract.deposit(new BigNumber(amount).times(BIG_TEN.pow(decimals)).toString(), {
     ...options,
     gasPrice,
   })
-  const receipt = await tx.wait()
-  return receipt.status
 }
 
 const sousStakeBnb = async (sousChefContract, amount) => {
   const gasPrice = getGasPrice()
-  const tx = await sousChefContract.deposit(new BigNumber(amount).times(DEFAULT_TOKEN_DECIMAL).toString(), {
+  return sousChefContract.deposit(new BigNumber(amount).times(DEFAULT_TOKEN_DECIMAL).toString(), {
     ...options,
     gasPrice,
   })
-  const receipt = await tx.wait()
-  return receipt.status
 }
 
 const useStakePool = (sousId: number, isUsingBnb = false) => {
@@ -40,16 +37,30 @@ const useStakePool = (sousId: number, isUsingBnb = false) => {
   const sousChefContract = useSousChef(sousId)
 
   const handleStake = useCallback(
-    async (amount: string, decimals: number) => {
+    async (
+      amount: string,
+      decimals: number,
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      let tx
       if (sousId === 0) {
-        await stakeFarm(masterChefContract, 0, amount)
+        tx = await stakeFarm(masterChefContract, 0, amount)
       } else if (isUsingBnb) {
-        await sousStakeBnb(sousChefContract, amount)
+        tx = await sousStakeBnb(sousChefContract, amount)
       } else {
-        await sousStake(sousChefContract, amount, decimals)
+        tx = await sousStake(sousChefContract, amount, decimals)
       }
-      dispatch(updateUserStakedBalance(sousId, account))
-      dispatch(updateUserBalance(sousId, account))
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+        dispatch(updateUserStakedBalance(sousId, account))
+        dispatch(updateUserBalance(sousId, account))
+      } else {
+        onError(receipt)
+      }
     },
     [account, dispatch, isUsingBnb, masterChefContract, sousChefContract, sousId],
   )

--- a/src/views/Pools/hooks/useUnstakePool.ts
+++ b/src/views/Pools/hooks/useUnstakePool.ts
@@ -6,6 +6,7 @@ import { updateUserStakedBalance, updateUserBalance, updateUserPendingReward } f
 import { unstakeFarm } from 'utils/calls'
 import { useMasterchef, useSousChef } from 'hooks/useContract'
 import getGasPrice from 'utils/getGasPrice'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 
 const sousUnstake = async (sousChefContract: any, amount: string, decimals: number) => {
   const gasPrice = getGasPrice()
@@ -32,17 +33,31 @@ const useUnstakePool = (sousId: number, enableEmergencyWithdraw = false) => {
   const sousChefContract = useSousChef(sousId)
 
   const handleUnstake = useCallback(
-    async (amount: string, decimals: number) => {
+    async (
+      amount: string,
+      decimals: number,
+      onTransactionSubmitted: (tx: TransactionResponse) => void,
+      onSuccess: (receipt: TransactionReceipt) => void,
+      onError: (receipt: TransactionReceipt) => void,
+    ) => {
+      let tx
       if (sousId === 0) {
-        await unstakeFarm(masterChefContract, 0, amount)
+        tx = await unstakeFarm(masterChefContract, 0, amount)
       } else if (enableEmergencyWithdraw) {
-        await sousEmergencyUnstake(sousChefContract)
+        tx = await sousEmergencyUnstake(sousChefContract)
       } else {
-        await sousUnstake(sousChefContract, amount, decimals)
+        tx = await sousUnstake(sousChefContract, amount, decimals)
       }
-      dispatch(updateUserStakedBalance(sousId, account))
-      dispatch(updateUserBalance(sousId, account))
-      dispatch(updateUserPendingReward(sousId, account))
+      onTransactionSubmitted(tx)
+      const receipt = await tx.wait()
+      if (receipt.status) {
+        onSuccess(receipt)
+        dispatch(updateUserStakedBalance(sousId, account))
+        dispatch(updateUserBalance(sousId, account))
+        dispatch(updateUserPendingReward(sousId, account))
+      } else {
+        onError(receipt)
+      }
     },
     [account, dispatch, enableEmergencyWithdraw, masterChefContract, sousChefContract, sousId],
   )

--- a/src/views/Predictions/components/CollectRoundWinningsModal.tsx
+++ b/src/views/Predictions/components/CollectRoundWinningsModal.tsx
@@ -101,6 +101,7 @@ const CollectRoundWinningsModal: React.FC<CollectRoundWinningsModalProps> = ({ o
   const handleClick = async () => {
     try {
       const tx = await callWithGasPrice(predictionsContract, 'claim', [epochs])
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       setIsPendingTx(true)
       const receipt = await tx.wait()
 

--- a/src/views/Predictions/components/ReclaimPositionButton.tsx
+++ b/src/views/Predictions/components/ReclaimPositionButton.tsx
@@ -21,6 +21,7 @@ const ReclaimPositionButton: React.FC<ReclaimPositionButtonProps> = ({ epoch, on
 
   const handleReclaim = async () => {
     const tx = await callWithGasPrice(predictionsContract, 'claim', [[epoch]])
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setIsPendingTx(true)
 
     const receipt = await tx.wait()

--- a/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
+++ b/src/views/Predictions/components/RoundCard/SetPositionCard.tsx
@@ -20,6 +20,7 @@ import { parseUnits } from 'ethers/lib/utils'
 import { useWeb3React } from '@web3-react/core'
 import { useGetMinBetAmount } from 'state/predictions/hooks'
 import { useTranslation } from 'contexts/Localization'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import { usePredictionsContract } from 'hooks/useContract'
 import { useGetBnbBalance } from 'hooks/useTokenBalance'
 import useToast from 'hooks/useToast'
@@ -82,7 +83,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
   const { balance: bnbBalance } = useGetBnbBalance()
   const minBetAmount = useGetMinBetAmount()
   const { t } = useTranslation()
-  const { toastError } = useToast()
+  const { toastSuccess, toastError } = useToast()
   const { callWithGasPrice } = useCallWithGasPrice()
   const predictionsContract = usePredictionsContract()
 
@@ -151,6 +152,7 @@ const SetPositionCard: React.FC<SetPositionCardProps> = ({ position, togglePosit
 
     try {
       const tx = await callWithGasPrice(predictionsContract, betMethod, [epoch], { value: valueAsBn.toString() })
+      toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
       setIsTxPending(true)
       const receipt = await tx.wait()
       onSuccess(receipt.transactionHash)

--- a/src/views/ProfileCreation/ProfilePicture.tsx
+++ b/src/views/ProfileCreation/ProfilePicture.tsx
@@ -7,6 +7,7 @@ import { getPancakeProfileAddress } from 'utils/addressHelpers'
 import { getErc721Contract } from 'utils/contractHelpers'
 import { useTranslation } from 'contexts/Localization'
 import { useUserNfts } from 'state/nftMarket/hooks'
+import { ToastDescriptionWithTx } from 'components/Toast'
 import useToast from 'hooks/useToast'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import useFetchUserNfts from 'views/Nft/market/Profile/hooks/useFetchUserNfts'
@@ -40,6 +41,7 @@ const ProfilePicture: React.FC = () => {
   const handleApprove = async () => {
     const contract = getErc721Contract(selectedNft.collectionAddress, library.getSigner())
     const tx = await callWithGasPrice(contract, 'approve', [getPancakeProfileAddress(), selectedNft.tokenId])
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setIsApproving(true)
     const receipt = await tx.wait()
     if (receipt.status) {

--- a/src/views/TradingCompetition/components/ClaimModal/index.tsx
+++ b/src/views/TradingCompetition/components/ClaimModal/index.tsx
@@ -45,6 +45,7 @@ const ClaimModal: React.FC<CompetitionProps> = ({ onDismiss, onClaimSuccess, use
 
   const handleClaimClick = async () => {
     const tx = await callWithGasPrice(tradingCompetitionContract, 'claimReward')
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setIsConfirming(true)
     const receipt = await tx.wait()
     if (receipt.status) {

--- a/src/views/TradingCompetition/components/RegisterModal/RegisterWithProfile.tsx
+++ b/src/views/TradingCompetition/components/RegisterModal/RegisterWithProfile.tsx
@@ -26,6 +26,7 @@ const RegisterWithProfile: React.FC<CompetitionProps> = ({ profile, onDismiss, o
 
   const handleConfirmClick = async () => {
     const tx = await callWithGasPrice(tradingCompetitionContract, 'register')
+    toastSuccess(`${t('Transaction Submitted')}!`, <ToastDescriptionWithTx txHash={tx.hash} />)
     setIsConfirming(true)
     const receipt = await tx.wait()
     if (receipt.status) {


### PR DESCRIPTION
User will see its transaction link immediately after confirming the transaction. It will help user to check its transaction status from chain explorer especially when bsc chain is congested.

To review:

1. Check Transaction Submitted toasts with tx link to bscscan on all user transactions
2. Check tx link to bscscan on Transaction success toasts

https://deploy-preview-2933--pancakeswap-dev.netlify.app/