### PR TITLE
fix: (farm auction): Unknown account error when accessing page directly with account

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -226,20 +226,12 @@ export const usePancakeSquadContract = () => {
   return useMemo(() => getPancakeSquadContract(library.getSigner()), [library])
 }
 
-export const useFarmAuctionContract = () => {
+export const useFarmAuctionContract = (withSignerIfPossible = true) => {
   const { account, library } = useActiveWeb3React()
-  // This hook is slightly different from others
-  // Calls were failing if unconnected user goes to farm auction page
-  // Using library instead of library.getSigner() fixes the problem for unconnected users
-  // However, this fix is not ideal, it currently has following behavior:
-  // - If you visit Farm Auction page coming from some other page there are no errors in console (unconnected or connected)
-  // - If you go directly to Farm Auction page
-  //   - as unconnected user you don't see any console errors
-  //   - as connected user you see `unknown account #0 (operation="getAddress", code=UNSUPPORTED_OPERATION, ...` errors
-  //     the functionality of the page is not affected, data is loading fine and you can interact with the contract
-  //
-  // Similar behavior was also noticed on Trading Competition page.
-  return useMemo(() => getFarmAuctionContract(account ? library.getSigner() : library), [library, account])
+  return useMemo(
+    () => getFarmAuctionContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [library, account, withSignerIfPossible],
+  )
 }
 
 export const useNftMarketContract = () => {

--- a/src/views/FarmAuction/components/AuctionCakeBurn.tsx
+++ b/src/views/FarmAuction/components/AuctionCakeBurn.tsx
@@ -19,7 +19,7 @@ const BurnedText = styled(Text)`
 const AuctionCakeBurn: React.FC = () => {
   const [burnedCakeAmount, setBurnedCakeAmount] = useState(0)
   const { t } = useTranslation()
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
   const cakePriceBusd = usePriceCakeBusd()
 
   const burnedAmountAsUSD = cakePriceBusd.times(burnedCakeAmount)

--- a/src/views/FarmAuction/hooks/useAuctionHistory.tsx
+++ b/src/views/FarmAuction/hooks/useAuctionHistory.tsx
@@ -14,7 +14,7 @@ interface AuctionHistoryMap {
 const useAuctionHistory = (auctionId: number) => {
   const [auctionHistory, setAuctionHistory] = useState<AuctionHistoryMap>({})
 
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
 
   // Get past auction data
   useEffect(() => {

--- a/src/views/FarmAuction/hooks/useCongratulateAuctionWinner.tsx
+++ b/src/views/FarmAuction/hooks/useCongratulateAuctionWinner.tsx
@@ -14,7 +14,7 @@ const useCongratulateAuctionWinner = (currentAuction: Auction, bidders: Bidder[]
 
   const { account } = useWeb3React()
 
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
 
   useEffect(() => {
     const checkIfWonPreviousAuction = async (previousAuctionId: number) => {

--- a/src/views/FarmAuction/hooks/useCurrentFarmAuction.ts
+++ b/src/views/FarmAuction/hooks/useCurrentFarmAuction.ts
@@ -18,7 +18,7 @@ export const useCurrentFarmAuction = (account: string) => {
 
   const fastRefresh = useFastFresh()
 
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
 
   // Get latest auction id and its data
   useEffect(() => {

--- a/src/views/FarmAuction/hooks/useReclaimAuctionBid.ts
+++ b/src/views/FarmAuction/hooks/useReclaimAuctionBid.ts
@@ -83,7 +83,7 @@ const useReclaimAuctionBid = (): [ReclaimableAuction | null, () => void] => {
 
   const [state, dispatch] = useReducer(reclaimReducer, initialState)
 
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
 
   const checkNextAuction = () => {
     dispatch({ type: 'checkNextAuction' })

--- a/src/views/FarmAuction/hooks/useWhitelistedAddresses.ts
+++ b/src/views/FarmAuction/hooks/useWhitelistedAddresses.ts
@@ -6,7 +6,7 @@ import { AUCTION_WHITELISTED_BIDDERS_TO_FETCH } from 'config'
 
 const useWhitelistedAddresses = () => {
   const [whitelistedAddresses, setWhitelistedAddresses] = useState<FarmAuctionBidderConfig[] | null>(null)
-  const farmAuctionContract = useFarmAuctionContract()
+  const farmAuctionContract = useFarmAuctionContract(false)
 
   useEffect(() => {
     const fetchWhitelistedAddresses = async () => {


### PR DESCRIPTION
To reproduce:

1. Go directly to Farm Auction page with account connected eagerly (https://pancakeswap.finance/farms/auction)
2. See `unknown account #0 (operation="getAddress", code=UNSUPPORTED_OPERATION, ...` errors

To review:

https://deploy-preview-2944--pancakeswap-dev.netlify.app/