### PR TITLE
perf: (activity): Reduce nft metadata calls for PB nfts

### DIFF
--- a/src/views/Nft/market/ActivityHistory/ActivityHistory.tsx
+++ b/src/views/Nft/market/ActivityHistory/ActivityHistory.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { uniqBy } from 'lodash'
 import { isAddress } from 'utils'
 import { useAppDispatch } from 'state'
 import {
@@ -13,10 +12,10 @@ import {
   Th,
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
-import { getCollectionActivity, getNftsFromDifferentCollectionsApi } from 'state/nftMarket/helpers'
+import { getCollectionActivity } from 'state/nftMarket/helpers'
 import Container from 'components/Layout/Container'
 import TableLoader from 'components/TableLoader'
-import { Activity, Collection, NftToken, TokenIdWithCollectionAddress } from 'state/nftMarket/types'
+import { Activity, Collection, NftToken } from 'state/nftMarket/types'
 import { useTranslation } from 'contexts/Localization'
 import { useBNBBusdPrice } from 'hooks/useBUSDPrice'
 import useTheme from 'hooks/useTheme'
@@ -27,6 +26,7 @@ import NoNftsImage from '../components/Activity/NoNftsImage'
 import ActivityFilters from './ActivityFilters'
 import ActivityRow from '../components/Activity/ActivityRow'
 import { sortActivity } from './utils/sortActivity'
+import { fetchActivityNftMetadata } from './utils/fetchActivityNftMetadata'
 
 const MAX_PER_PAGE = 8
 
@@ -91,19 +91,13 @@ const ActivityHistory: React.FC<ActivityHistoryProps> = ({ collection }) => {
   }, [dispatch, collectionAddress, nftActivityFiltersString, lastUpdated])
 
   useEffect(() => {
-    const fetchActivityNftMetadata = async () => {
-      const activityNftTokenIds = uniqBy(
-        activitiesSlice.map((activity): TokenIdWithCollectionAddress => {
-          return { tokenId: activity.nft.tokenId, collectionAddress: activity.nft.collection.id }
-        }),
-        'tokenId',
-      )
-      const nfts = await getNftsFromDifferentCollectionsApi(activityNftTokenIds)
+    const fetchNftMetadata = async () => {
+      const nfts = await fetchActivityNftMetadata(activitiesSlice)
       setNftMetadata(nfts)
     }
 
     if (activitiesSlice.length > 0) {
-      fetchActivityNftMetadata()
+      fetchNftMetadata()
     }
   }, [activitiesSlice])
 

--- a/src/views/Nft/market/ActivityHistory/utils/fetchActivityNftMetadata.tsx
+++ b/src/views/Nft/market/ActivityHistory/utils/fetchActivityNftMetadata.tsx
@@ -1,0 +1,38 @@
+import { Activity, NftToken, TokenIdWithCollectionAddress } from 'state/nftMarket/types'
+import { getNftsFromCollectionApi, getNftsFromDifferentCollectionsApi } from 'state/nftMarket/helpers'
+import { uniqBy } from 'lodash'
+import { pancakeBunniesAddress } from '../../constants'
+
+export const fetchActivityNftMetadata = async (activities: Activity[]): Promise<NftToken[]> => {
+  const hasPBCollections = activities.some(
+    (activity) => activity.nft.collection.id.toLowerCase() === pancakeBunniesAddress.toLowerCase(),
+  )
+  let bunniesMetadata
+  if (hasPBCollections) {
+    bunniesMetadata = await getNftsFromCollectionApi(pancakeBunniesAddress)
+  }
+
+  const pbNfts = activities
+    .filter((activity) => activity.nft.collection.id.toLowerCase() === pancakeBunniesAddress.toLowerCase())
+    .map((activity) => {
+      const { name: collectionName } = bunniesMetadata.data[activity.nft.otherId].collection
+      return {
+        ...bunniesMetadata.data[activity.nft.otherId],
+        tokenId: activity.nft.tokenId,
+        attributes: [{ bunnyId: activity.nft.otherId }],
+        collectionAddress: activity.nft.collection.id,
+        collectionName,
+      }
+    })
+
+  const activityNftTokenIds = uniqBy(
+    activities
+      .filter((activity) => activity.nft.collection.id.toLowerCase() !== pancakeBunniesAddress.toLowerCase())
+      .map((activity): TokenIdWithCollectionAddress => {
+        return { tokenId: activity.nft.tokenId, collectionAddress: activity.nft.collection.id }
+      }),
+    'tokenId',
+  )
+  const nfts = await getNftsFromDifferentCollectionsApi(activityNftTokenIds)
+  return nfts.concat(pbNfts)
+}

--- a/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
+++ b/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { uniqBy } from 'lodash'
 import { isAddress } from 'utils'
 import { fetchUserActivity } from 'state/nftMarket/reducer'
 import { useAppDispatch } from 'state'
 import { useUserNfts } from 'state/nftMarket/hooks'
+import { getUserActivity } from 'state/nftMarket/helpers'
 import { ArrowBackIcon, ArrowForwardIcon, Card, Flex, Table, Text, Th, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { getNftsFromDifferentCollectionsApi, getUserActivity } from 'state/nftMarket/helpers'
-import { Activity, NftToken, TokenIdWithCollectionAddress, UserNftInitializationState } from 'state/nftMarket/types'
+import { Activity, NftToken, UserNftInitializationState } from 'state/nftMarket/types'
 import { useTranslation } from 'contexts/Localization'
 import TableLoader from 'components/TableLoader'
 import { useBNBBusdPrice } from 'hooks/useBUSDPrice'
@@ -17,6 +16,7 @@ import { sortUserActivity } from '../../utils/sortUserActivity'
 import NoNftsImage from '../../../components/Activity/NoNftsImage'
 import { Arrow, PageButtons } from '../../../components/PaginationButtons'
 import ActivityRow from '../../../components/Activity/ActivityRow'
+import { fetchActivityNftMetadata } from '../../../ActivityHistory/utils/fetchActivityNftMetadata'
 
 const MAX_PER_PAGE = 8
 
@@ -76,14 +76,8 @@ const ActivityHistory = () => {
   }, [account, accountAddress, dispatch])
 
   useEffect(() => {
-    const fetchActivityNftMetadata = async () => {
-      const activityNftTokenIds = uniqBy(
-        sortedUserActivities.map((activity): TokenIdWithCollectionAddress => {
-          return { tokenId: activity.nft.tokenId, collectionAddress: activity.nft.collection.id }
-        }),
-        'tokenId',
-      )
-      const nfts = await getNftsFromDifferentCollectionsApi(activityNftTokenIds)
+    const fetchNftMetadata = async () => {
+      const nfts = await fetchActivityNftMetadata(sortedUserActivities)
       setNftMetadata(nfts)
     }
 
@@ -94,7 +88,7 @@ const ActivityHistory = () => {
 
     if (sortedUserActivities.length > 0) {
       getMaxPages()
-      fetchActivityNftMetadata()
+      fetchNftMetadata()
     }
 
     return () => {


### PR DESCRIPTION
No need to fetch pb metadata for each nft in the list that have same type of nfts