### PR TITLE
fix: (profile): Page title is wrong when viewing other account profile

### DIFF
--- a/src/config/constants/meta.ts
+++ b/src/config/constants/meta.ts
@@ -128,7 +128,7 @@ export const getCustomMeta = (path: string, t: ContextApi['t']): PageMeta => {
       }
     case '/nfts/profile':
       return {
-        title: `${t('Your Profile')} | ${t('PancakeSwap')}`,
+        title: `${t('Profile')} | ${t('PancakeSwap')}`,
       }
     case '/pancake-squad':
       return {


### PR DESCRIPTION
We could separate the pages, but it would be a overkill just for the title, therefore it is better to have generic title.

To review:
https://deploy-preview-2976--pancakeswap-dev.netlify.app/
