### PR TITLE
fix: (nft): PB nft media gets stuck and countdown has to be waited for sale data

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/MainNFTCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/MainNFTCard.tsx
@@ -113,7 +113,7 @@ const MainNFTCard: React.FC<MainNFTCardProps> = ({ nft, isOwnNft, nftIsProfilePi
             </Box>
           </Flex>
           <Flex flex="2" justifyContent={['center', null, 'flex-end']} alignItems="center" maxWidth={440}>
-            <NFTMedia nft={nft} width={440} height={440} />
+            <NFTMedia key={nft.tokenId} nft={nft} width={440} height={440} />
           </Flex>
         </Container>
       </CardBody>

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
@@ -93,7 +93,7 @@ const MainPancakeBunnyCard: React.FC<MainPancakeBunnyCardProps> = ({
             </Box>
           </Flex>
           <Flex flex="2" justifyContent={['center', null, 'flex-end']} alignItems="center" maxWidth={440}>
-            <NFTMedia nft={nftToDisplay} width={440} height={440} />
+            <NFTMedia key={nftToDisplay.tokenId} nft={nftToDisplay} width={440} height={440} />
           </Flex>
         </Container>
       </CardBody>

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/index.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/index.tsx
@@ -23,6 +23,7 @@ import { pancakeBunniesAddress } from '../../../constants'
 import { sortNFTsByPriceBuilder } from './ForSaleTableCard/utils'
 import { SortType } from '../../../types'
 import { TwoColumnsContainer } from '../shared/styles'
+import usePrevious from '../../../../../../hooks/usePreviousValue'
 
 interface IndividualPancakeBunnyPageProps {
   bunnyId: string
@@ -44,6 +45,7 @@ const IndividualPancakeBunnyPage: React.FC<IndividualPancakeBunnyPageProps> = ({
     : bunniesSortedByPrice
   const cheapestBunny = bunniesSortedByPrice[0]
   const cheapestBunnyFromOtherSellers = allBunniesFromOtherSellers[0]
+  const prevBunnyId = usePrevious(bunnyId)
 
   const { data: distributionData, isFetching: isFetchingDistribution } = useGetCollectionDistributionPB()
 
@@ -55,10 +57,15 @@ const IndividualPancakeBunnyPage: React.FC<IndividualPancakeBunnyPageProps> = ({
     // (it can't be reasonably wrapper in useCallback because the tokens are updated every time you call it, which is the whole point)
     // Since fastRefresh is 10 seconds and FETCH_NEW_NFTS_INTERVAL_MS is 8 seconds it fires every 10 seconds
     // The difference in 2 seconds is just to prevent some edge cases when request takes too long
-    if (msSinceLastUpdate > PANCAKE_BUNNIES_UPDATE_FREQUENCY && !isUpdatingPancakeBunnies && isWindowVisible) {
+    if (
+      prevBunnyId !== bunnyId ||
+      (msSinceLastUpdate > PANCAKE_BUNNIES_UPDATE_FREQUENCY && !isUpdatingPancakeBunnies && isWindowVisible)
+    ) {
       fetchMorePancakeBunnies(priceSort)
     }
   }, [
+    bunnyId,
+    prevBunnyId,
     priceSort,
     fetchMorePancakeBunnies,
     isUpdatingPancakeBunnies,


### PR DESCRIPTION
To reproduce:

Go to pb bunny details page
Then change to another one by using more from collection component
See nft media doesnt change and previous countdown has to be waited for for sale table and lowest price