### PR TITLE
fix: (nft): Nft details page price precision distorts display when too many

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/MainNFTCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/MainNFTCard.tsx
@@ -4,6 +4,7 @@ import { useBNBBusdPrice } from 'hooks/useBUSDPrice'
 import React from 'react'
 import { NftToken } from 'state/nftMarket/types'
 import { multiplyPriceByAmount } from 'utils/prices'
+import { formatNumber } from 'utils/formatBalance'
 import NFTMedia from 'views/Nft/market/components/NFTMedia'
 import EditProfileModal from 'views/Nft/market/Profile/components/EditProfileModal'
 import BuyModal from '../../../components/BuySellModals/BuyModal'
@@ -75,7 +76,7 @@ const MainNFTCard: React.FC<MainNFTCardProps> = ({ nft, isOwnNft, nftIsProfilePi
                 <Flex alignItems="center" mt="8px">
                   <BinanceIcon width={18} height={18} mr="4px" />
                   <Text fontSize="24px" bold mr="4px">
-                    {nft.marketData.currentAskPrice}
+                    {formatNumber(currentAskPriceAsNumber, 0, 5)}
                   </Text>
                   {bnbBusdPrice ? (
                     <Text color="textSubtle">{`(~${priceInUsd.toLocaleString(undefined, {

--- a/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/OwnerCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/OneOfAKindNftPage/OwnerCard.tsx
@@ -80,7 +80,7 @@ const OwnerCard: React.FC<OwnerCardProps> = ({ nft, isOwnNft, nftIsProfilePic })
                 <>
                   <Flex justifySelf="flex-start" alignItems="center" width="max-content">
                     <BinanceIcon width="24px" height="24px" mr="8px" />
-                    <Text bold>{formatNumber(parseFloat(nft.marketData.currentAskPrice), 0, 3)}</Text>
+                    <Text bold>{formatNumber(parseFloat(nft.marketData.currentAskPrice), 0, 5)}</Text>
                   </Flex>
                   {bnbBusdPrice ? (
                     <Text fontSize="12px" color="textSubtle">

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ForSaleTableCard/ForSaleTableRows.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ForSaleTableCard/ForSaleTableRows.tsx
@@ -43,7 +43,7 @@ const Row: React.FC<RowProps> = ({ t, nft, bnbBusdPrice, account }) => {
       <Box pl="24px">
         <Flex justifySelf="flex-start" alignItems="center" width="max-content">
           <BinanceIcon width="24px" height="24px" mr="8px" />
-          <Text bold>{formatNumber(parseFloat(nft.marketData.currentAskPrice), 0, 3)}</Text>
+          <Text bold>{formatNumber(parseFloat(nft.marketData.currentAskPrice), 0, 5)}</Text>
         </Flex>
         {bnbBusdPrice ? (
           <Text fontSize="12px" color="textSubtle">

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Flex, Box, Card, CardBody, Text, Button, BinanceIcon, Skeleton, useModal } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { formatNumber } from 'utils/formatBalance'
 import { multiplyPriceByAmount } from 'utils/prices'
 import { NftToken } from 'state/nftMarket/types'
 import NFTMedia from 'views/Nft/market/components/NFTMedia'
@@ -75,7 +76,7 @@ const MainPancakeBunnyCard: React.FC<MainPancakeBunnyCardProps> = ({
                   <Flex alignItems="center" mt="8px">
                     <BinanceIcon width={18} height={18} mr="4px" />
                     <Text fontSize="24px" bold mr="4px">
-                      {nftToDisplay.marketData.currentAskPrice}
+                      {formatNumber(parseFloat(nftToDisplay.marketData?.currentAskPrice), 0, 5)}
                     </Text>
                     {bnbBusdPrice ? (
                       <Text color="textSubtle">{`(~${priceInUsd.toLocaleString(undefined, {

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
@@ -16,6 +16,7 @@ import {
 import { useWeb3React } from '@web3-react/core'
 import { useUserNfts } from 'state/nftMarket/hooks'
 import { NftLocation, NftToken, UserNftInitializationState } from 'state/nftMarket/types'
+import { formatNumber } from 'utils/formatBalance'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { useTranslation } from 'contexts/Localization'
 import ExpandableCard from '../shared/ExpandableCard'
@@ -77,7 +78,7 @@ const CollectibleRow: React.FC<CollectibleRowProps> = ({ nft, lowestPrice }) => 
             </Text>
             <Flex justifySelf="flex-end" width="max-content">
               <BinanceIcon width="16px" height="16px" mr="4px" />
-              <Text small>{lowestPrice}</Text>
+              <Text small>{formatNumber(parseFloat(lowestPrice), 0, 5)}</Text>
             </Flex>
           </>
         )}

--- a/src/views/Nft/market/components/BuySellModals/BuyModal/styles.tsx
+++ b/src/views/Nft/market/components/BuySellModals/BuyModal/styles.tsx
@@ -56,7 +56,7 @@ export const BnbAmountCell: React.FC<BnbAmountCellProps> = ({ bnbAmount, isLoadi
         <BinanceIcon height={16} width={16} mr="4px" />
         <Text bold color={isInsufficient ? 'failure' : 'text'}>{`${bnbAmount.toLocaleString(undefined, {
           minimumFractionDigits: 3,
-          maximumFractionDigits: 3,
+          maximumFractionDigits: 5,
         })}`}</Text>
       </Flex>
       <Text small color="textSubtle" textAlign="right">

--- a/src/views/Nft/market/components/CollectibleCard/styles.tsx
+++ b/src/views/Nft/market/components/CollectibleCard/styles.tsx
@@ -33,7 +33,7 @@ export const BNBAmountLabel: React.FC<BNBAmountLabelProps> = ({ amount, ...props
     <Text fontWeight="600">
       {amount.toLocaleString(undefined, {
         minimumFractionDigits: 0,
-        maximumFractionDigits: 4,
+        maximumFractionDigits: 5,
       })}
     </Text>
   </Flex>


### PR DESCRIPTION
This pr will limit precision to 5 visually for all the places that price is represented

Before:

<img width="341" alt="image" src="https://user-images.githubusercontent.com/2213635/148402053-56e11624-ceaf-4216-b2ce-60444c260216.png">

After:

<img width="345" alt="image" src="https://user-images.githubusercontent.com/2213635/148402119-0e77b0c6-2e71-46a5-8eb4-7bcc281b5382.png">

