### PR TITLE
fix(ifo): Avoid resize ifo section when loading

### DIFF
--- a/src/views/Ifos/components/IfoLayout.tsx
+++ b/src/views/Ifos/components/IfoLayout.tsx
@@ -2,7 +2,6 @@ import { Box } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 
 const IfoLayout = styled(Box)`
-  display: grid;
   > div:not(.sticky-header) {
     margin-bottom: 32px;
   }


### PR DESCRIPTION
when `grid` div contains `margin-x: auto`, it would resize the section somehow which leads to unexpected resize section.