### PR TITLE
fix: (ifo): Ifo card width is narrower than it should be in mobile devices

### DIFF
--- a/src/views/Ifos/CurrentIfo.tsx
+++ b/src/views/Ifos/CurrentIfo.tsx
@@ -27,7 +27,7 @@ const Ifo = () => {
 
   return (
     <IfoLayout id="current-ifo" py={['24px', '24px', '40px']}>
-      <Container>
+      <Container width={['100%', null, null, 'auto']} px={['24px', '24px']}>
         <IfoLayoutWrapper>
           <IfoPoolVaultCard />
           <IfoCurrentCard ifo={activeIfo} publicIfoData={publicIfoData} walletIfoData={walletIfoData} />


### PR DESCRIPTION
Iphone 8 size 

Before:
<img width="417" alt="image" src="https://user-images.githubusercontent.com/2213635/149136442-4b72db26-30b6-4331-a0cd-4599d0eb6818.png">

After: 
<img width="412" alt="image" src="https://user-images.githubusercontent.com/2213635/149136517-daf4ec1b-a054-4650-a913-7e9cd5579777.png">
