### PR TITLE
fix: (ifo): Mobile Pool card staking component loading gets stuck and NaN in roi calculator balance

### DIFF
--- a/src/components/RoiCalculatorModal/index.tsx
+++ b/src/components/RoiCalculatorModal/index.tsx
@@ -179,7 +179,7 @@ const RoiCalculatorModal: React.FC<RoiCalculatorModalProps> = ({
               $1000
             </Button>
             <Button
-              disabled={stakingTokenBalance.lte(0) || !account}
+              disabled={!stakingTokenBalance.isFinite() || stakingTokenBalance.lte(0) || !account}
               scale="xs"
               p="4px 16px"
               width="128px"

--- a/src/state/pools/hooks.ts
+++ b/src/state/pools/hooks.ts
@@ -222,7 +222,7 @@ export const useIfoWithApr = () => {
   const {
     fees: { performanceFeeAsDecimal },
   } = useIfoPoolVault()
-  const { pool: poolZero, userDataLoaded } = usePool(0)
+  const { pool: poolZero } = usePool(0)
 
   const ifoPoolWithApr = useMemo(() => {
     const ifoPool = { ...poolZero }
@@ -234,6 +234,5 @@ export const useIfoWithApr = () => {
 
   return {
     pool: ifoPoolWithApr,
-    userDataLoaded,
   }
 }


### PR DESCRIPTION
Currently ifo card mobile staking loading indicator is using pool state userdata loading (which never gets false because all pools data fetch is not triggered), should use vault user data loading flag instead

To reproduce component issue:

1. Go to ifo page in mobile and connect account
2. See ifo card staking component loading gets stuck

To reproduce roi issue: 

1. Click apr calculator in mobile
2. Click my balance
3. See NaN

—————————-

Cake pool calls reduced from 4 to 2 multicall request

To review:

https://deploy-preview-3048--pancakeswap-dev.netlify.app/