### PR TITLE
Add GalaxyGoggle Whitelist for PancakeSwap

### DIFF
--- a/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -129,6 +129,14 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://pancakeswap.finance/images/tokens/0xa7f552078dcc247c2684336020c03648500c6d9f.png"
+    },
+    {
+      "name": "Galaxy Goggle",
+      "symbol": "GG",
+      "address": "0xcAf23964Ca8db16D816eB314a56789F58fE0e10e",
+      "chainId": 56,
+      "decimals": 9,
+      "logoURI": "https://app.galaxygoggle.money/static/media/pancakeswapgglogo.png"
     }
   ]
 }

--- a/src/config/constants/tokens.ts
+++ b/src/config/constants/tokens.ts
@@ -1085,6 +1085,14 @@ export const mainnetTokens = defineTokens({
     'EASY Token',
     'https://easyfi.network/',
   ),
+  gg: new Token(
+    MAINNET,
+    '0xcAf23964Ca8db16D816eB314a56789F58fE0e10e',
+    9,
+    'GG',
+    'Galaxy Goggle',
+    'https://galaxygoggle.money',
+  ),
   oddz: new Token(MAINNET, '0xCD40F2670CF58720b694968698A5514e924F742d', 18, 'ODDZ', 'Oddz Token', 'https://oddz.fi/'),
   hoo: new Token(MAINNET, '0xE1d1F66215998786110Ba0102ef558b22224C016', 8, 'HOO', 'Hoo Token', 'https://hoo.com/'),
   apys: new Token(


### PR DESCRIPTION
PR adds GalaxyGoggle into the token default list. Galaxy Goggle has tons of volume on pancakeswap with large liquidity our large community of 30k + users wanted us to push this to PCS. This will allow our users to find GG easier without addition of contract address in search. 