### PR TITLE
fix: (nft): Image flickers in pb nft details page

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/MainPancakeBunnyCard.tsx
@@ -93,7 +93,7 @@ const MainPancakeBunnyCard: React.FC<MainPancakeBunnyCardProps> = ({
             </Box>
           </Flex>
           <Flex flex="2" justifyContent={['center', null, 'flex-end']} alignItems="center" maxWidth={440}>
-            <NFTMedia key={nftToDisplay.tokenId} nft={nftToDisplay} width={440} height={440} />
+            <NFTMedia key={nftToDisplay.name} nft={nftToDisplay} width={440} height={440} />
           </Flex>
         </Container>
       </CardBody>


### PR DESCRIPTION
Root cause: 

When cheapest nft being loaded (with valid tokenId), placeholder nft is used (nothingForSaleBunny) of which the tokenId is the token name. Cheapest nft with tokenId makes component rerender