### PR TITLE
chore(sentry): Ignore global errors

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -17,6 +17,10 @@ Sentry.init({
     new Sentry.Integrations.Breadcrumbs({
       console: process.env.NODE_ENV === 'production',
     }),
+    new Sentry.Integrations.GlobalHandlers({
+      onerror: false,
+      onunhandledrejection: false,
+    }),
   ],
   environment: process.env.NODE_ENV,
   // Adjust this value in production, or use tracesSampler for greater control


### PR DESCRIPTION
Let's ignore global errors for reduce the noise. We are still capturing errors from `logError` and ErrorBoundary