### PR TITLE
fix: (profile): Connected account path is shown when viewing other users profile in profile header

### DIFF
--- a/src/views/Nft/market/Profile/index.tsx
+++ b/src/views/Nft/market/Profile/index.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react'
-import { useWeb3React } from '@web3-react/core'
 import { useRouter } from 'next/router'
 import { isAddress } from 'utils'
 import { useAchievementsForAddress, useProfileForAddress } from 'state/profile/hooks'
@@ -27,7 +26,6 @@ const TabMenuWrapper = styled(Box)`
 `
 
 const NftProfile: FC = ({ children }) => {
-  const { account } = useWeb3React()
   const accountAddress = useRouter().query.accountAddress as string
   const { t } = useTranslation()
 
@@ -76,7 +74,7 @@ const NftProfile: FC = ({ children }) => {
     <>
       <MarketPageHeader position="relative">
         <ProfileHeader
-          accountPath={account}
+          accountPath={accountAddress}
           profile={profile}
           achievements={achievements}
           nftCollected={userNfts.length}


### PR DESCRIPTION
To reproduce:

1. Connect your account
2. Go to others users profile
3. See under the avatar connected user account address is shown