### PR TITLE
fix(swap): SAFEMOON warning's misdirection

### DIFF
--- a/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
+++ b/src/views/Swap/components/SwapWarningModal/SafemoonWarning.tsx
@@ -23,7 +23,7 @@ const SafemoonWarning = () => {
         <Link
           style={{ display: 'inline' }}
           external
-          href="https://twitter.com/safemoon/status/1470078043469275141?s=20"
+          href="https://twitter.com/safemoon/status/1477770592031887360"
         >
           {t("Safemoon's announcement")}.
         </Link>


### PR DESCRIPTION
They yeeted old tweet & updated & shared again.

Was forwardin to blank space & updated with new one.

old tweet: https://twitter.com/safemoon/status/1470078043469275141?s=20
new tweet: https://twitter.com/safemoon/status/1477770592031887360