### PR TITLE
fix: (nft): PB Bunny total count shows old api data on page header

### DIFF
--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/index.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/index.tsx
@@ -3,7 +3,7 @@ import { useWeb3React } from '@web3-react/core'
 import { Flex } from '@pancakeswap/uikit'
 import orderBy from 'lodash/orderBy'
 import Page from 'components/Layout/Page'
-import { useFetchByBunnyIdAndUpdate, useGetAllBunniesByBunnyId } from 'state/nftMarket/hooks'
+import { useFetchByBunnyIdAndUpdate, useGetAllBunniesByBunnyId, useGetCollection } from 'state/nftMarket/hooks'
 import { getNftsFromCollectionApi } from 'state/nftMarket/helpers'
 import { NftToken } from 'state/nftMarket/types'
 import PageLoader from 'components/Loader/PageLoader'
@@ -30,6 +30,8 @@ interface IndividualPancakeBunnyPageProps {
 
 const IndividualPancakeBunnyPage: React.FC<IndividualPancakeBunnyPageProps> = ({ bunnyId }) => {
   const { account } = useWeb3React()
+  const collection = useGetCollection(pancakeBunniesAddress)
+  const totalBunnyCount = Number(collection.totalSupply)
   const [nothingForSaleBunny, setNothingForSaleBunny] = useState<NftToken>(null)
   const { lastUpdated, previousLastUpdated, setLastUpdated: refresh } = useLastUpdated()
   const allBunnies = useGetAllBunniesByBunnyId(bunnyId)
@@ -46,11 +48,7 @@ const IndividualPancakeBunnyPage: React.FC<IndividualPancakeBunnyPageProps> = ({
   const cheapestBunnyFromOtherSellers = allBunniesFromOtherSellers[0]
   const prevBunnyId = usePreviousValue(bunnyId)
 
-  const {
-    data: distributionData,
-    total: totalBunnyCount,
-    isFetching: isFetchingDistribution,
-  } = useGetCollectionDistributionPB()
+  const { data: distributionData, isFetching: isFetchingDistribution } = useGetCollectionDistributionPB()
 
   useFastRefreshEffect(() => {
     // Fetch first 30 NFTs on page load

--- a/src/views/Nft/market/Collection/Traits/PancakeBunniesTraits.tsx
+++ b/src/views/Nft/market/Collection/Traits/PancakeBunniesTraits.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { formatNumber } from 'utils/formatBalance'
 import { useTranslation } from 'contexts/Localization'
 import CollapsibleCard from 'components/CollapsibleCard'
+import { useGetCollection } from 'state/nftMarket/hooks'
 import { useGetLowestPriceFromBunnyId } from '../../hooks/useGetLowestPrice'
 import { BNBAmountLabel } from '../../components/CollectibleCard/styles'
 import { nftsBaseUrl } from '../../constants'
@@ -36,12 +37,10 @@ const LowestPriceCell: React.FC<{ bunnyId: string }> = ({ bunnyId }) => {
 
 const PancakeBunniesTraits: React.FC<PancakeBunniesTraitsProps> = ({ collectionAddress }) => {
   const [raritySort, setRaritySort] = useState<SortType>('asc')
+  const collection = useGetCollection(collectionAddress)
+  const totalBunnyCount = Number(collection.totalSupply)
   const { t } = useTranslation()
-  const {
-    data: distributionData,
-    total: totalBunnyCount,
-    isFetching: isFetchingDistribution,
-  } = useGetCollectionDistributionPB()
+  const { data: distributionData, isFetching: isFetchingDistribution } = useGetCollectionDistributionPB()
   const { push } = useRouter()
 
   const sortedTokenList = useMemo(() => {

--- a/src/views/Nft/market/hooks/useGetCollectionDistribution.tsx
+++ b/src/views/Nft/market/hooks/useGetCollectionDistribution.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { getCollectionDistributionApi, getNftsFromCollectionApi } from 'state/nftMarket/helpers'
-import sum from 'lodash/sum'
 import { ApiCollectionDistribution, ApiResponseCollectionTokens, ApiSingleTokenData } from 'state/nftMarket/types'
 import { getPancakeRabbitsAddress } from 'utils/addressHelpers'
 import { multicallv2 } from 'utils/multicall'
@@ -33,12 +32,11 @@ const useGetCollectionDistribution = (collectionAddress: string) => {
 
 interface StatePB {
   isFetching: boolean
-  total: number
   data: Record<string, ApiSingleTokenData & { tokenCount: number }>
 }
 
 export const useGetCollectionDistributionPB = () => {
-  const [state, setState] = useState<StatePB>({ isFetching: false, total: 0, data: null })
+  const [state, setState] = useState<StatePB>({ isFetching: false, data: null })
 
   useEffect(() => {
     const fetchTokens = async () => {
@@ -52,19 +50,14 @@ export const useGetCollectionDistributionPB = () => {
       }
       // Use on chain data to get most updated totalSupply and bunnyCount data. Nft Api Data not updated frequently.
       const tokenIds = Object.keys(apiResponse.attributesDistribution)
-      const totalCountCall = {
-        address: getPancakeRabbitsAddress(),
-        name: 'totalSupply',
-      }
       const bunnyCountCalls = tokenIds.map((tokenId) => ({
         address: getPancakeRabbitsAddress(),
         name: 'bunnyCount',
         params: [tokenId],
       }))
-      const bunnyContractCalls = [totalCountCall].concat(bunnyCountCalls)
       try {
-        const response = await multicallv2(pancakeRabbitsAbi, bunnyContractCalls)
-        const tokenListResponse = response.slice(1).reduce((obj, tokenCount, index) => {
+        const response = await multicallv2(pancakeRabbitsAbi, bunnyCountCalls)
+        const tokenListResponse = response.reduce((obj, tokenCount, index) => {
           return {
             ...obj,
             [tokenIds[index]]: { ...apiResponse.data[index], tokenCount: tokenCount[0].toNumber() },
@@ -72,19 +65,17 @@ export const useGetCollectionDistributionPB = () => {
         }, {})
         setState({
           isFetching: false,
-          total: response[0][0].toNumber(),
           data: tokenListResponse,
         })
       } catch (error) {
         // Use nft api data if on chain multicall fails
-        const total = sum(Object.values(apiResponse.attributesDistribution))
         const tokenListResponse = Object.entries(apiResponse.data).reduce((obj, [tokenId, tokenData]) => {
           return {
             ...obj,
             [tokenId]: { ...tokenData, tokenCount: apiResponse.attributesDistribution[tokenId] },
           }
         }, {})
-        setState({ isFetching: false, total, data: tokenListResponse })
+        setState({ isFetching: false, data: tokenListResponse })
       }
     }
 


### PR DESCRIPTION
To reproduce

1. Go to pb collection page
2. See total count on header
3. It shows old api data

![image](https://user-images.githubusercontent.com/2213635/150780865-d92cd0fc-4b2b-4d97-aa4d-0f3d69526e6f.png)
