### PR TITLE
fix: (nft): Sort and order options defaulted when clicking filter clear button

### DIFF
--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -266,8 +266,18 @@ export const NftMarket = createSlice({
   name: 'NftMarket',
   initialState,
   reducers: {
-    removeAllFilters: (state, action: PayloadAction<string>) => {
-      state.data.filters[action.payload] = { ...initialNftFilterState }
+    removeAllItemFilters: (state, action: PayloadAction<string>) => {
+      if (state.data.filters[action.payload]) {
+        const { ordering, showOnlyOnSale } = state.data.filters[action.payload]
+        state.data.filters[action.payload] = {
+          ...initialNftFilterState,
+          ordering,
+          showOnlyOnSale,
+        }
+      } else {
+        state.data.filters[action.payload] = { ...initialNftFilterState }
+      }
+
       state.data.nfts[action.payload] = []
     },
     addActivityTypeFilters: (state, action: PayloadAction<{ collection: string; field: MarketEvent }>) => {
@@ -413,7 +423,7 @@ export const NftMarket = createSlice({
 
 // Actions
 export const {
-  removeAllFilters,
+  removeAllItemFilters,
   removeAllActivityFilters,
   removeActivityTypeFilters,
   removeActivityCollectionFilters,

--- a/src/views/Nft/market/Collection/Items/ClearAllButton.tsx
+++ b/src/views/Nft/market/Collection/Items/ClearAllButton.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, ButtonProps } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useAppDispatch } from 'state'
-import { removeAllFilters } from 'state/nftMarket/reducer'
+import { removeAllItemFilters } from 'state/nftMarket/reducer'
 import { useGetNftFilterLoadingState } from 'state/nftMarket/hooks'
 import { FetchStatus } from 'config/constants/types'
 
@@ -16,7 +16,7 @@ const ClearAllButton: React.FC<ClearAllButtonProps> = ({ collectionAddress, ...p
   const nftFilterState = useGetNftFilterLoadingState(collectionAddress)
 
   const clearAll = () => {
-    dispatch(removeAllFilters(collectionAddress))
+    dispatch(removeAllItemFilters(collectionAddress))
   }
 
   return (

--- a/src/views/Nft/market/Collection/Items/Filters.tsx
+++ b/src/views/Nft/market/Collection/Items/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { Box, ButtonMenu, ButtonMenuItem, Flex, Grid, Text } from '@pancakeswap/uikit'
 import capitalize from 'lodash/capitalize'
@@ -92,9 +92,12 @@ const Filters: React.FC<FiltersProps> = ({ collection }) => {
   const showOnlyNftsOnSale = useGetNftShowOnlyOnSale(address)
   const [activeButtonIndex, setActiveButtonIndex] = useState(showOnlyNftsOnSale ? 1 : 0)
 
+  useEffect(() => {
+    setActiveButtonIndex(showOnlyNftsOnSale ? 1 : 0)
+  }, [showOnlyNftsOnSale])
+
   const onActiveButtonChange = (newIndex: number) => {
     dispatch(setShowOnlyOnSale({ collection: address, showOnlyOnSale: newIndex === 1 }))
-    setActiveButtonIndex(newIndex)
   }
 
   const nftFilters = useGetNftFilters(address)

--- a/src/views/Nft/market/Collection/Items/SortSelect.tsx
+++ b/src/views/Nft/market/Collection/Items/SortSelect.tsx
@@ -29,6 +29,7 @@ const SortSelect: React.FC<{ collectionAddress: string }> = ({ collectionAddress
     <Select
       options={sortByItems}
       onOptionChange={handleChange}
+      key={defaultOptionIndex !== -1 ? defaultOptionIndex : undefined}
       defaultOptionIndex={defaultOptionIndex !== -1 ? defaultOptionIndex : undefined}
     />
   )


### PR DESCRIPTION
To reproduce:

1. Go collection items page
2. Change filter by all and order by
3. Filter by trait
4. Click clear
5. See sort and order options defaulted although it is not visible to user on options
