### PR TITLE
chore: Only enable ErrorBoundary on prod

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -106,11 +106,13 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
+const ProductionErrorBoundary = process.env.NODE_ENV === 'production' ? ErrorBoundary : Fragment
+
 const App = ({ Component, pageProps }: AppPropsWithLayout) => {
   // Use the layout defined at the page level, if available
   const Layout = Component.Layout || Fragment
   return (
-    <ErrorBoundary>
+    <ProductionErrorBoundary>
       <Menu>
         <Layout>
           <Component {...pageProps} />
@@ -119,7 +121,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
       <EasterEgg iterations={2} />
       <ToastListener />
       <SubgraphHealthIndicator />
-    </ErrorBoundary>
+    </ProductionErrorBoundary>
   )
 }
 


### PR DESCRIPTION
Showing ErrorBoundary on development does not provide any help to debug