### PR TITLE
fix(swap): Remove SAFEMOON from frontend default list

### DIFF
--- a/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -1,8 +1,8 @@
 {
   "name": "PancakeSwap Default List",
-  "timestamp": "2021-05-06T00:00:00Z",
+  "timestamp": "2022-01-26T11:45:09Z",
   "version": {
-    "major": 3,
+    "major": 4,
     "minor": 0,
     "patch": 0
   },
@@ -81,14 +81,6 @@
       "chainId": 56,
       "decimals": 18,
       "logoURI": "https://pancakeswap.finance/images/tokens/0xc9849e6fdb743d08faee3e34dd2d1bc69ea11a51.png"
-    },
-    {
-      "name": "SafeMoon",
-      "symbol": "SAFEMOON",
-      "address": "0x8076C74C5e3F5852037F31Ff0093Eeb8c8ADd8D3",
-      "chainId": 56,
-      "decimals": 9,
-      "logoURI": "https://pancakeswap.finance/images/tokens/0x8076c74c5e3f5852037f31ff0093eeb8c8add8d3.png"
     },
     {
       "name": "Alpaca",


### PR DESCRIPTION
we yeeted from /toolkit https://github.com/pancakeswap/pancake-toolkit/pull/388

but still in default token list, please yeet from also here

![Screen Shot 2022-01-26 at 2 49 28 PM](https://user-images.githubusercontent.com/96993464/151158244-c2ad2eee-3be6-412a-9fe1-9a7f22033dd7.png)


from preview:

no safemoon finally

![Screen Shot 2022-01-26 at 2 55 28 PM](https://user-images.githubusercontent.com/96993464/151158963-f54d5481-e762-47aa-ab02-7db7cc8411ec.png)

if you import, you will see 2 warnin (anyone create and special safemoon warnn)
![Screen Shot 2022-01-26 at 2 55 37 PM](https://user-images.githubusercontent.com/96993464/151158989-7c5f4a8d-cb14-48b7-ae81-36577c8ed775.png)


seems fine.
