### PR TITLE
fix: (remove liquidity): Many lp tokens not visible by default in liquidity page

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -58,8 +58,8 @@ export function useDefaultTokens(): { [address: string]: Token } {
   return useTokensFromMap(defaultList, false)
 }
 
-export function useAllTokens(): { [address: string]: Token } {
-  const allTokens = useCombinedActiveList()
+export function useAllTokens(includeDefaultLists = false): { [address: string]: Token } {
+  const allTokens = useCombinedActiveList(includeDefaultLists)
   return useTokensFromMap(allTokens, true)
 }
 

--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -136,10 +136,14 @@ function useCombinedTokenMapFromUrls(urls: string[] | undefined): TokenAddressMa
 }
 
 // filter out unsupported lists
-export function useActiveListUrls(): string[] | undefined {
-  return useSelector<AppState, AppState['lists']['activeListUrls']>((state) => state.lists.activeListUrls)?.filter(
-    (url) => !UNSUPPORTED_LIST_URLS.includes(url),
-  )
+export function useActiveListUrls(includeDefaultLists = false): string[] | undefined {
+  const defaultList = includeDefaultLists
+    ? DEFAULT_LIST_OF_LISTS.filter((url) => !UNSUPPORTED_LIST_URLS.includes(url))
+    : []
+  const stateList = useSelector<AppState, AppState['lists']['activeListUrls']>(
+    (state) => state.lists.activeListUrls,
+  )?.filter((url) => !UNSUPPORTED_LIST_URLS.includes(url))
+  return [...new Set(defaultList.concat(stateList ?? []))]
 }
 
 export function useInactiveListUrls(): string[] {
@@ -149,8 +153,8 @@ export function useInactiveListUrls(): string[] {
 }
 
 // get all the tokens from active lists, combine with local default tokens
-export function useCombinedActiveList(): TokenAddressMap {
-  const activeListUrls = useActiveListUrls()
+export function useCombinedActiveList(includeDefaultLists = false): TokenAddressMap {
+  const activeListUrls = useActiveListUrls(includeDefaultLists)
   const activeTokens = useCombinedTokenMapFromUrls(activeListUrls)
   const defaultTokenMap = listToTokenMap(DEFAULT_TOKEN_LIST)
   return combineMaps(activeTokens, defaultTokenMap)

--- a/src/state/user/hooks/index.tsx
+++ b/src/state/user/hooks/index.tsx
@@ -408,7 +408,7 @@ export function toV2LiquidityToken([tokenA, tokenB]: [Token, Token]): Token {
  */
 export function useTrackedTokenPairs(): [Token, Token][] {
   const { chainId } = useActiveWeb3React()
-  const tokens = useAllTokens()
+  const tokens = useAllTokens(true)
 
   // pinned pairs
   const pinnedPairs = useMemo(() => (chainId ? PINNED_PAIRS[chainId] ?? [] : []), [chainId])


### PR DESCRIPTION
Default token lists should be added when searching user lp tokens in liquidity page