### PR TITLE
fix(nft): Collection ssg redux state overrided

### DIFF
--- a/src/pages/nfts/collections/[collectionAddress].tsx
+++ b/src/pages/nfts/collections/[collectionAddress].tsx
@@ -30,6 +30,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     return {
       props: {
+        // Note: only include the data needed for the page, otherwise it will override the user preset data
         initialReduxState: {
           nftMarket: state.nftMarket,
         },

--- a/src/pages/nfts/collections/[collectionAddress].tsx
+++ b/src/pages/nfts/collections/[collectionAddress].tsx
@@ -26,9 +26,13 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
     await store.dispatch(fetchCollection(collectionAddress))
 
+    const state = store.getState()
+
     return {
       props: {
-        initialReduxState: store.getState(),
+        initialReduxState: {
+          nftMarket: state.nftMarket,
+        },
       },
       revalidate: 60 * 60 * 6, // 6 hours
     }


### PR DESCRIPTION
The whole `initialReduxState` will override the persist state