### PR TITLE
fix: (nft): Nft Media with video not shown when low power mode enabled in mobile

### DIFF
--- a/src/state/nftMarket/hooks.ts
+++ b/src/state/nftMarket/hooks.ts
@@ -158,6 +158,11 @@ export const useGetNftShowOnlyOnSale = (collectionAddress: string) => {
   return collectionFilter ? collectionFilter.showOnlyOnSale : true
 }
 
+export const useTryVideoNftMedia = () => {
+  const tryVideoNftMedia = useSelector((state: State) => state.nftMarket.data.tryVideoNftMedia)
+  return tryVideoNftMedia ?? true
+}
+
 export const useGetNftActivityFilters = (collectionAddress: string) => {
   const collectionFilter: NftActivityFilter = useSelector(
     (state: State) => state.nftMarket.data.activityFilters[collectionAddress],

--- a/src/state/nftMarket/reducer.ts
+++ b/src/state/nftMarket/reducer.ts
@@ -54,6 +54,7 @@ const initialState: State = {
     nfts: {},
     filters: {},
     activityFilters: {},
+    tryVideoNftMedia: true,
     loadingState: {
       isUpdatingPancakeBunnies: false,
       latestPancakeBunniesUpdateAt: 0,
@@ -348,6 +349,9 @@ export const NftMarket = createSlice({
         }
       }
     },
+    setTryVideoNftMedia: (state, action: PayloadAction<boolean>) => {
+      state.data.tryVideoNftMedia = action.payload
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(filterNftsFromCollection.pending, (state, action) => {
@@ -432,6 +436,7 @@ export const {
   addActivityCollectionFilters,
   setOrdering,
   setShowOnlyOnSale,
+  setTryVideoNftMedia,
 } = NftMarket.actions
 
 export default NftMarket.reducer

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -25,6 +25,7 @@ export interface State {
     nfts: Record<string, NftToken[]> // string is the collection address
     filters: Record<string, NftFilter> // string is the collection address
     activityFilters: Record<string, NftActivityFilter> // string is the collection address
+    tryVideoNftMedia: boolean
     loadingState: {
       isUpdatingPancakeBunnies: boolean
       latestPancakeBunniesUpdateAt: number


### PR DESCRIPTION
To reproduce: 

1. Set your phone to low power mode (iphone preferred)
2. Go to nft activity
3. Set collection to pancake bunnies (this is where the most video media )
4. See thumbnails are not shown