### PR TITLE
fix: Make subgraph health indicator text not selectable

### DIFF
--- a/src/components/SubgraphHealthIndicator/index.tsx
+++ b/src/components/SubgraphHealthIndicator/index.tsx
@@ -13,6 +13,7 @@ const StyledCard = styled(Card)`
   > div {
     border-radius: 8px;
   }
+  user-select: none;
 `
 
 const IndicatorWrapper = styled(Box)`


### PR DESCRIPTION
Issue mainly happens on mobile where user has to hold down pressing in order to see tooltip text.

1. Go to nfts on mobile
2. See subgraph indicator
3. Press down the component to see tooltip
4. It selects the text if you press down the text area and shows action menu depending on the browser
