### PR TITLE
refactor: Move reader cake contract calls to pcs nodes for better ux

### DIFF
--- a/src/hooks/useApproveConfirmTransaction.tsx
+++ b/src/hooks/useApproveConfirmTransaction.tsx
@@ -7,7 +7,7 @@ import useCatchTxError from './useCatchTxError'
 type LoadingState = 'idle' | 'loading' | 'success' | 'fail'
 
 type Action =
-  | { type: 'requires_approval' }
+  | { type: 'has_approval' }
   | { type: 'approve_sending' }
   | { type: 'approve_receipt' }
   | { type: 'approve_error' }
@@ -27,7 +27,7 @@ const initialState: State = {
 
 const reducer = (state: State, actions: Action): State => {
   switch (actions.type) {
-    case 'requires_approval':
+    case 'has_approval':
       return {
         ...state,
         approvalState: 'success',
@@ -124,9 +124,9 @@ const useApproveConfirmTransaction = ({
   // Check if approval is necessary, re-check if account changes
   useEffect(() => {
     if (account && handlePreApprove.current) {
-      handlePreApprove.current().then((result) => {
-        if (result) {
-          dispatch({ type: 'requires_approval' })
+      handlePreApprove.current().then((requiresApproval) => {
+        if (!requiresApproval) {
+          dispatch({ type: 'has_approval' })
         }
       })
     }

--- a/src/hooks/useApproveConfirmTransaction.tsx
+++ b/src/hooks/useApproveConfirmTransaction.tsx
@@ -7,7 +7,6 @@ import useCatchTxError from './useCatchTxError'
 type LoadingState = 'idle' | 'loading' | 'success' | 'fail'
 
 type Action =
-  | { type: 'has_approval' }
   | { type: 'approve_sending' }
   | { type: 'approve_receipt' }
   | { type: 'approve_error' }
@@ -27,11 +26,6 @@ const initialState: State = {
 
 const reducer = (state: State, actions: Action): State => {
   switch (actions.type) {
-    case 'has_approval':
-      return {
-        ...state,
-        approvalState: 'success',
-      }
     case 'approve_sending':
       return {
         ...state,
@@ -126,7 +120,7 @@ const useApproveConfirmTransaction = ({
     if (account && handlePreApprove.current) {
       handlePreApprove.current().then((requiresApproval) => {
         if (!requiresApproval) {
-          dispatch({ type: 'has_approval' })
+          dispatch({ type: 'approve_receipt' })
         }
       })
     }

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -44,6 +44,7 @@ import {
   IfoPool,
   Multicall,
   Weth,
+  Cake,
 } from 'config/abi/types'
 
 // Imports below migrated from Exchange useContract.ts
@@ -90,11 +91,14 @@ export const useERC721 = (address: string) => {
   return useMemo(() => getErc721Contract(address, library.getSigner()), [address, library])
 }
 
-export const useCake = (withSignerIfPossible = true) => {
+export const useCake = (): { reader: Cake; signer: Cake } => {
   const { account, library } = useActiveWeb3React()
   return useMemo(
-    () => getCakeContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [account, library, withSignerIfPossible],
+    () => ({
+      reader: getCakeContract(null),
+      signer: getCakeContract(getProviderOrSigner(library, account)),
+    }),
+    [account, library],
   )
 }
 

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -45,6 +45,7 @@ import {
   Multicall,
   Weth,
   Cake,
+  Erc721collection,
 } from 'config/abi/types'
 
 // Imports below migrated from Exchange useContract.ts
@@ -248,14 +249,17 @@ export const useNftMarketContract = () => {
   return useMemo(() => getNftMarketContract(library.getSigner()), [library])
 }
 
-export const useErc721CollectionContract = (collectionAddress: string, withSignerIfPossible = true) => {
+export const useErc721CollectionContract = (
+  collectionAddress: string,
+): { reader: Erc721collection; signer: Erc721collection } => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(() => {
-    return getErc721CollectionContract(
-      withSignerIfPossible ? getProviderOrSigner(library, account) : null,
-      collectionAddress,
-    )
-  }, [account, library, collectionAddress, withSignerIfPossible])
+  return useMemo(
+    () => ({
+      reader: getErc721CollectionContract(null, collectionAddress),
+      signer: getErc721CollectionContract(getProviderOrSigner(library, account), collectionAddress),
+    }),
+    [account, library, collectionAddress],
+  )
 }
 
 // Code below migrated from Exchange useContract.ts

--- a/src/hooks/useTokenBalance.ts
+++ b/src/hooks/useTokenBalance.ts
@@ -35,7 +35,7 @@ const useTokenBalance = (tokenAddress: string) => {
 }
 
 export const useTotalSupply = () => {
-  const cakeContract = useCake(false)
+  const { reader: cakeContract } = useCake()
   const { data } = useSWRContract([cakeContract, 'totalSupply'], {
     refreshInterval: SLOW_INTERVAL,
   })

--- a/src/utils/requiresApproval.ts
+++ b/src/utils/requiresApproval.ts
@@ -1,0 +1,22 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { Cake, Erc20 } from 'config/abi/types'
+
+export const requiresApproval = async (
+  contract: Erc20 | Cake,
+  account: string,
+  spenderAddress: string,
+  minimumRequired: number | BigNumber = 0,
+) => {
+  try {
+    const response = await contract.allowance(account, spenderAddress)
+    const hasMinimumRequired =
+      (typeof minimumRequired === 'number' && minimumRequired > 0) ||
+      (BigNumber.isBigNumber(minimumRequired) && minimumRequired.gt(0))
+    if (hasMinimumRequired) {
+      return response.lt(minimumRequired)
+    }
+    return response.lte(0)
+  } catch (error) {
+    return true
+  }
+}

--- a/src/views/FarmAuction/components/PlaceBidModal.tsx
+++ b/src/views/FarmAuction/components/PlaceBidModal.tsx
@@ -69,8 +69,7 @@ const PlaceBidModal: React.FC<PlaceBidModalProps> = ({
 
   const cakePriceBusd = usePriceCakeBusd()
   const farmAuctionContract = useFarmAuctionContract()
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
 
   const { toastSuccess } = useToast()
 

--- a/src/views/FarmAuction/components/PlaceBidModal.tsx
+++ b/src/views/FarmAuction/components/PlaceBidModal.tsx
@@ -6,7 +6,6 @@ import { Modal, Text, Flex, BalanceInput, Box, Button, LogoRoundIcon } from '@pa
 import { useTranslation } from 'contexts/Localization'
 import { useWeb3React } from '@web3-react/core'
 import { formatNumber, getBalanceAmount, getBalanceNumber } from 'utils/formatBalance'
-import { ethersToBigNumber } from 'utils/bigNumber'
 import useTheme from 'hooks/useTheme'
 import useTokenBalance from 'hooks/useTokenBalance'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
@@ -20,6 +19,7 @@ import { usePriceCakeBusd } from 'state/farms/hooks'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import tokens from 'config/constants/tokens'
+import { requiresApproval } from 'utils/requiresApproval'
 
 const StyledModal = styled(Modal)`
   min-width: 280px;
@@ -69,7 +69,8 @@ const PlaceBidModal: React.FC<PlaceBidModalProps> = ({
 
   const cakePriceBusd = usePriceCakeBusd()
   const farmAuctionContract = useFarmAuctionContract()
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
 
   const { toastSuccess } = useToast()
 
@@ -103,16 +104,10 @@ const PlaceBidModal: React.FC<PlaceBidModalProps> = ({
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await cakeContract.allowance(account, farmAuctionContract.address)
-          const currentAllowance = ethersToBigNumber(response)
-          return currentAllowance.gt(0)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(cakeContractReader, account, farmAuctionContract.address)
       },
       onApprove: () => {
-        return callWithGasPrice(cakeContract, 'approve', [farmAuctionContract.address, MaxUint256])
+        return callWithGasPrice(cakeContractApprover, 'approve', [farmAuctionContract.address, MaxUint256])
       },
       onApproveSuccess: async ({ receipt }) => {
         toastSuccess(

--- a/src/views/FarmAuction/components/ReclaimBidCard.tsx
+++ b/src/views/FarmAuction/components/ReclaimBidCard.tsx
@@ -26,8 +26,7 @@ const ReclaimBidCard: React.FC = () => {
 
   const [reclaimableAuction, checkForNextReclaimableAuction] = useReclaimAuctionBid()
 
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
   const farmAuctionContract = useFarmAuctionContract()
 
   const { toastSuccess } = useToast()

--- a/src/views/FarmAuction/components/ReclaimBidCard.tsx
+++ b/src/views/FarmAuction/components/ReclaimBidCard.tsx
@@ -3,7 +3,7 @@ import { Text, Heading, Card, CardHeader, CardBody, Flex } from '@pancakeswap/ui
 import { useTranslation } from 'contexts/Localization'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
 import { useCake, useFarmAuctionContract } from 'hooks/useContract'
-import { ethersToBigNumber } from 'utils/bigNumber'
+import { requiresApproval } from 'utils/requiresApproval'
 import { useWeb3React } from '@web3-react/core'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import useToast from 'hooks/useToast'
@@ -26,23 +26,18 @@ const ReclaimBidCard: React.FC = () => {
 
   const [reclaimableAuction, checkForNextReclaimableAuction] = useReclaimAuctionBid()
 
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
   const farmAuctionContract = useFarmAuctionContract()
 
   const { toastSuccess } = useToast()
 
   const { isApproving, isApproved, isConfirming, handleApprove, handleConfirm } = useApproveConfirmTransaction({
     onRequiresApproval: async () => {
-      try {
-        const response = await cakeContract.allowance(account, farmAuctionContract.address)
-        const currentAllowance = ethersToBigNumber(response)
-        return currentAllowance.gt(0)
-      } catch (error) {
-        return false
-      }
+      return requiresApproval(cakeContractReader, account, farmAuctionContract.address)
     },
     onApprove: () => {
-      return callWithGasPrice(cakeContract, 'approve', [farmAuctionContract.address, MaxUint256])
+      return callWithGasPrice(cakeContractApprover, 'approve', [farmAuctionContract.address, MaxUint256])
     },
     onApproveSuccess: async ({ receipt }) => {
       toastSuccess(

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
@@ -30,6 +30,7 @@ import useToast from 'hooks/useToast'
 import { DEFAULT_TOKEN_DECIMAL } from 'config'
 import { useERC20 } from 'hooks/useContract'
 import tokens from 'config/constants/tokens'
+import { requiresApproval } from 'utils/requiresApproval'
 
 interface Props {
   poolId: PoolIds
@@ -91,13 +92,7 @@ const ContributeModal: React.FC<Props> = ({
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await raisingTokenContractReader.allowance(account, contract.address)
-          const currentAllowance = new BigNumber(response.toString())
-          return currentAllowance.gt(0)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(raisingTokenContractReader, account, contract.address)
       },
       onApprove: () => {
         return callWithGasPrice(raisingTokenContractApprover, 'approve', [contract.address, MaxUint256], {

--- a/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -298,7 +298,7 @@ const IfoCard: React.FC<IfoFoldableCardProps> = ({ ifo, publicIfoData, walletIfo
 
   useEffect(() => {
     const checkAllowance = async () => {
-      const approvalRequired = requiresApproval(raisingTokenContract, account, contract.address)
+      const approvalRequired = await requiresApproval(raisingTokenContract, account, contract.address)
       setEnableStatus(approvalRequired ? EnableStatus.DISABLED : EnableStatus.ENABLED)
     }
 

--- a/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -9,7 +9,6 @@ import {
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import { useWeb3React } from '@web3-react/core'
-import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { Ifo, PoolIds } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'

--- a/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -18,6 +18,7 @@ import useToast from 'hooks/useToast'
 import { useEffect, useState } from 'react'
 import { useCurrentBlock } from 'state/block/hooks'
 import styled from 'styled-components'
+import { requiresApproval } from 'utils/requiresApproval'
 import { useFastRefreshEffect } from 'hooks/useRefreshEffect'
 import useCatchTxError from 'hooks/useCatchTxError'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
@@ -297,13 +298,8 @@ const IfoCard: React.FC<IfoFoldableCardProps> = ({ ifo, publicIfoData, walletIfo
 
   useEffect(() => {
     const checkAllowance = async () => {
-      try {
-        const response = await raisingTokenContract.allowance(account, contract.address)
-        const currentAllowance = new BigNumber(response.toString())
-        setEnableStatus(currentAllowance.lte(0) ? EnableStatus.DISABLED : EnableStatus.ENABLED)
-      } catch (error) {
-        setEnableStatus(EnableStatus.DISABLED)
-      }
+      const approvalRequired = requiresApproval(raisingTokenContract, account, contract.address)
+      setEnableStatus(approvalRequired ? EnableStatus.DISABLED : EnableStatus.ENABLED)
     }
 
     if (account) {

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -82,8 +82,7 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
   const [maxTicketPurchaseExceeded, setMaxTicketPurchaseExceeded] = useState(false)
   const [userNotEnoughCake, setUserNotEnoughCake] = useState(false)
   const lotteryContract = useLotteryV2Contract()
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
   const { toastSuccess } = useToast()
   const { balance: userCake, fetchStatus } = useTokenBalance(tokens.cake.address)
   // balance from useTokenBalance causes rerenders in effects as a new BigNumber is instantiated on each render, hence memoising it using the stringified value below.

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
+import { requiresApproval } from 'utils/requiresApproval'
 import { MaxUint256 } from '@ethersproject/constants'
 import {
   Modal,
@@ -18,7 +19,7 @@ import { useTranslation } from 'contexts/Localization'
 import { useWeb3React } from '@web3-react/core'
 import tokens from 'config/constants/tokens'
 import { getFullDisplayBalance } from 'utils/formatBalance'
-import { BIG_ZERO, ethersToBigNumber } from 'utils/bigNumber'
+import { BIG_ZERO } from 'utils/bigNumber'
 import { useAppDispatch } from 'state'
 import { usePriceCakeBusd } from 'state/farms/hooks'
 import { useLottery } from 'state/lottery/hooks'
@@ -81,7 +82,8 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
   const [maxTicketPurchaseExceeded, setMaxTicketPurchaseExceeded] = useState(false)
   const [userNotEnoughCake, setUserNotEnoughCake] = useState(false)
   const lotteryContract = useLotteryV2Contract()
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
   const { toastSuccess } = useToast()
   const { balance: userCake, fetchStatus } = useTokenBalance(tokens.cake.address)
   // balance from useTokenBalance causes rerenders in effects as a new BigNumber is instantiated on each render, hence memoising it using the stringified value below.
@@ -242,16 +244,10 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await cakeContract.allowance(account, lotteryContract.address)
-          const currentAllowance = ethersToBigNumber(response)
-          return currentAllowance.gt(0)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(cakeContractReader, account, lotteryContract.address)
       },
       onApprove: () => {
-        return callWithGasPrice(cakeContract, 'approve', [lotteryContract.address, MaxUint256])
+        return callWithGasPrice(cakeContractApprover, 'approve', [lotteryContract.address, MaxUint256])
       },
       onApproveSuccess: async ({ receipt }) => {
         toastSuccess(

--- a/src/views/Nft/market/Profile/components/EditProfileModal/ApproveCakeView.tsx
+++ b/src/views/Nft/market/Profile/components/EditProfileModal/ApproveCakeView.tsx
@@ -19,7 +19,7 @@ const ApproveCakePage: React.FC<ApproveCakePageProps> = ({ goToChange, onDismiss
   const {
     costs: { numberCakeToUpdate, numberCakeToReactivate },
   } = useGetProfileCosts()
-  const cakeContract = useCake()
+  const { signer: cakeContract } = useCake()
 
   if (!profile) {
     return null

--- a/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
+++ b/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
@@ -12,6 +12,7 @@ import { FetchStatus } from 'config/constants/types'
 import { useProfile } from 'state/profile/hooks'
 import ProfileAvatarWithTeam from 'components/ProfileAvatarWithTeam'
 import { UseEditProfileResponse } from './reducer'
+import { requiresApproval } from '../../../../../../utils/requiresApproval'
 
 interface StartPageProps extends InjectedModalProps {
   goToChange: UseEditProfileResponse['goToChange']
@@ -43,7 +44,7 @@ const AvatarWrapper = styled.div`
 const StartPage: React.FC<StartPageProps> = ({ goToApprove, goToChange, goToRemove, onDismiss }) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
-  const cakeContract = useCake()
+  const cakeContract = useCake(false)
   const { profile } = useProfile()
   const { balance: cakeBalance, fetchStatus } = useGetCakeBalance()
   const {
@@ -60,8 +61,13 @@ const StartPage: React.FC<StartPageProps> = ({ goToApprove, goToChange, goToRemo
    */
   useEffect(() => {
     const checkApprovalStatus = async () => {
-      const response = await cakeContract.allowance(account, getPancakeProfileAddress())
-      setNeedsApproval(response.lt(minimumCakeRequired))
+      const approvalNeeded = await requiresApproval(
+        cakeContract,
+        account,
+        getPancakeProfileAddress(),
+        minimumCakeRequired,
+      )
+      setNeedsApproval(approvalNeeded)
     }
 
     if (account && !isProfileCostsLoading) {

--- a/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
+++ b/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
@@ -9,10 +9,10 @@ import { useGetCakeBalance } from 'hooks/useTokenBalance'
 import { useTranslation } from 'contexts/Localization'
 import useGetProfileCosts from 'views/Nft/market/Profile/hooks/useGetProfileCosts'
 import { FetchStatus } from 'config/constants/types'
+import { requiresApproval } from 'utils/requiresApproval'
 import { useProfile } from 'state/profile/hooks'
 import ProfileAvatarWithTeam from 'components/ProfileAvatarWithTeam'
 import { UseEditProfileResponse } from './reducer'
-import { requiresApproval } from '../../../../../../utils/requiresApproval'
 
 interface StartPageProps extends InjectedModalProps {
   goToChange: UseEditProfileResponse['goToChange']

--- a/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
+++ b/src/views/Nft/market/Profile/components/EditProfileModal/StartView.tsx
@@ -44,7 +44,7 @@ const AvatarWrapper = styled.div`
 const StartPage: React.FC<StartPageProps> = ({ goToApprove, goToChange, goToRemove, onDismiss }) => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
-  const cakeContract = useCake(false)
+  const { reader: cakeContract } = useCake()
   const { profile } = useProfile()
   const { balance: cakeBalance, fetchStatus } = useGetCakeBalance()
   const {

--- a/src/views/Nft/market/components/BuySellModals/BuyModal/index.tsx
+++ b/src/views/Nft/market/components/BuySellModals/BuyModal/index.tsx
@@ -12,6 +12,7 @@ import { useERC20, useNftMarketContract } from 'hooks/useContract'
 import { useWeb3React } from '@web3-react/core'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
+import { requiresApproval } from 'utils/requiresApproval'
 import useToast from 'hooks/useToast'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { NftToken } from 'state/nftMarket/types'
@@ -76,12 +77,7 @@ const BuyModal: React.FC<BuyModalProps> = ({ nftToBuy, onDismiss }) => {
 
   const { isApproving, isApproved, isConfirming, handleApprove, handleConfirm } = useApproveConfirmTransaction({
     onRequiresApproval: async () => {
-      try {
-        const currentAllowance = await wbnbContractReader.allowance(account, nftMarketContract.address)
-        return currentAllowance.gt(0)
-      } catch (error) {
-        return false
-      }
+      return requiresApproval(wbnbContractReader, account, nftMarketContract.address)
     },
     onApprove: () => {
       return callWithGasPrice(wbnbContractApprover, 'approve', [nftMarketContract.address, MaxUint256])

--- a/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
+++ b/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
@@ -93,8 +93,9 @@ const SellModal: React.FC<SellModalProps> = ({
   const { account } = useWeb3React()
   const { callWithGasPrice } = useCallWithGasPrice()
   const { toastSuccess } = useToast()
-  const collectionContractReader = useErc721CollectionContract(nftToSell.collectionAddress, false)
-  const collectionContractSigner = useErc721CollectionContract(nftToSell.collectionAddress)
+  const { reader: collectionContractReader, signer: collectionContractSigner } = useErc721CollectionContract(
+    nftToSell.collectionAddress,
+  )
   const nftMarketContract = useNftMarketContract()
 
   const isInvalidTransferAddress = transferAddress.length > 0 && !isAddress(transferAddress)

--- a/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
+++ b/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
@@ -171,9 +171,9 @@ const SellModal: React.FC<SellModalProps> = ({
     onRequiresApproval: async () => {
       try {
         const approvedForContract = await collectionContractReader.isApprovedForAll(account, nftMarketContract.address)
-        return approvedForContract
+        return approvedForContract ? !approvedForContract : true
       } catch (error) {
-        return false
+        return true
       }
     },
     onApprove: () => {

--- a/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
+++ b/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
@@ -93,7 +93,8 @@ const SellModal: React.FC<SellModalProps> = ({
   const { account } = useWeb3React()
   const { callWithGasPrice } = useCallWithGasPrice()
   const { toastSuccess } = useToast()
-  const collectionContract = useErc721CollectionContract(nftToSell.collectionAddress)
+  const collectionContractReader = useErc721CollectionContract(nftToSell.collectionAddress, false)
+  const collectionContractSigner = useErc721CollectionContract(nftToSell.collectionAddress)
   const nftMarketContract = useNftMarketContract()
 
   const isInvalidTransferAddress = transferAddress.length > 0 && !isAddress(transferAddress)
@@ -168,14 +169,14 @@ const SellModal: React.FC<SellModalProps> = ({
   const { isApproving, isApproved, isConfirming, handleApprove, handleConfirm } = useApproveConfirmTransaction({
     onRequiresApproval: async () => {
       try {
-        const approvedForContract = await collectionContract.isApprovedForAll(account, nftMarketContract.address)
+        const approvedForContract = await collectionContractReader.isApprovedForAll(account, nftMarketContract.address)
         return approvedForContract
       } catch (error) {
         return false
       }
     },
     onApprove: () => {
-      return callWithGasPrice(collectionContract, 'setApprovalForAll', [nftMarketContract.address, true])
+      return callWithGasPrice(collectionContractSigner, 'setApprovalForAll', [nftMarketContract.address, true])
     },
     onApproveSuccess: async ({ receipt }) => {
       toastSuccess(
@@ -188,7 +189,7 @@ const SellModal: React.FC<SellModalProps> = ({
         return callWithGasPrice(nftMarketContract, 'cancelAskOrder', [nftToSell.collectionAddress, nftToSell.tokenId])
       }
       if (stage === SellingStage.CONFIRM_TRANSFER) {
-        return callWithGasPrice(collectionContract, 'safeTransferFrom(address,address,uint256)', [
+        return callWithGasPrice(collectionContractSigner, 'safeTransferFrom(address,address,uint256)', [
           account,
           transferAddress,
           nftToSell.tokenId,

--- a/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
+++ b/src/views/Nft/market/components/BuySellModals/SellModal/index.tsx
@@ -171,7 +171,7 @@ const SellModal: React.FC<SellModalProps> = ({
     onRequiresApproval: async () => {
       try {
         const approvedForContract = await collectionContractReader.isApprovedForAll(account, nftMarketContract.address)
-        return approvedForContract ? !approvedForContract : true
+        return approvedForContract || true
       } catch (error) {
         return true
       }

--- a/src/views/Nft/market/hooks/useCompleteNft.tsx
+++ b/src/views/Nft/market/hooks/useCompleteNft.tsx
@@ -11,7 +11,7 @@ const NOT_ON_SALE_SELLER = '0x0000000000000000000000000000000000000000'
 
 const useNftOwn = (collectionAddress: string, tokenId: string, marketData?: TokenMarketData) => {
   const { account } = useWeb3React()
-  const collectionContract = useErc721CollectionContract(collectionAddress, false)
+  const { reader: collectionContract } = useErc721CollectionContract(collectionAddress)
   const { isInitialized: isProfileInitialized, profile } = useProfile()
   return useSWR(
     account && isProfileInitialized && collectionContract

--- a/src/views/Nft/market/hooks/useNftOwner.tsx
+++ b/src/views/Nft/market/hooks/useNftOwner.tsx
@@ -10,7 +10,7 @@ const useNftOwner = (nft: NftToken, isOwnNft = false) => {
   const { account } = useWeb3React()
   const [owner, setOwner] = useState(null)
   const [isLoadingOwner, setIsLoadingOwner] = useState(true)
-  const collectionContract = useErc721CollectionContract(nft.collectionAddress, false)
+  const { reader: collectionContract } = useErc721CollectionContract(nftToSell.collectionAddress)
   const currentSeller = nft.marketData?.currentSeller
   const pancakeProfileAddress = getPancakeProfileAddress()
   const { tokenId } = nft

--- a/src/views/Nft/market/hooks/useNftOwner.tsx
+++ b/src/views/Nft/market/hooks/useNftOwner.tsx
@@ -10,7 +10,7 @@ const useNftOwner = (nft: NftToken, isOwnNft = false) => {
   const { account } = useWeb3React()
   const [owner, setOwner] = useState(null)
   const [isLoadingOwner, setIsLoadingOwner] = useState(true)
-  const { reader: collectionContract } = useErc721CollectionContract(nftToSell.collectionAddress)
+  const { reader: collectionContract } = useErc721CollectionContract(nft.collectionAddress)
   const currentSeller = nft.marketData?.currentSeller
   const pancakeProfileAddress = getPancakeProfileAddress()
   const { tokenId } = nft

--- a/src/views/PancakeSquad/components/Buttons/BuyTickets.tsx
+++ b/src/views/PancakeSquad/components/Buttons/BuyTickets.tsx
@@ -10,7 +10,7 @@ import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import { useCake, useNftSaleContract } from 'hooks/useContract'
 import useToast from 'hooks/useToast'
 import { DefaultTheme } from 'styled-components'
-import { ethersToBigNumber } from 'utils/bigNumber'
+import { requiresApproval } from 'utils/requiresApproval'
 import { PancakeSquadContext } from 'views/PancakeSquad/context'
 import { SaleStatusEnum, UserStatusEnum } from '../../types'
 import BuyTicketsModal from '../Modals/BuyTickets'
@@ -57,7 +57,8 @@ const BuyTicketsButtons: React.FC<BuyTicketsProps> = ({
   const { callWithGasPrice } = useCallWithGasPrice()
   const nftSaleContract = useNftSaleContract()
   const { toastSuccess } = useToast()
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
   const { isUserEnabled, setIsUserEnabled } = useContext(PancakeSquadContext)
 
   const canBuySaleTicket =
@@ -71,16 +72,10 @@ const BuyTicketsButtons: React.FC<BuyTicketsProps> = ({
   const { isApproving, isApproved, isConfirming, handleApprove, handleConfirm, hasApproveFailed, hasConfirmFailed } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await cakeContract.allowance(account, nftSaleContract.address)
-          const currentAllowance = ethersToBigNumber(response)
-          return currentAllowance.gt(0)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(cakeContractReader, account, nftSaleContract.address)
       },
       onApprove: () => {
-        return callWithGasPrice(cakeContract, 'approve', [nftSaleContract.address, MaxUint256])
+        return callWithGasPrice(cakeContractApprover, 'approve', [nftSaleContract.address, MaxUint256])
       },
       onApproveSuccess: async ({ receipt }) => {
         toastSuccess(t('Transaction has succeeded!'), <ToastDescriptionWithTx txHash={receipt.transactionHash} />)

--- a/src/views/PancakeSquad/components/Buttons/BuyTickets.tsx
+++ b/src/views/PancakeSquad/components/Buttons/BuyTickets.tsx
@@ -57,8 +57,7 @@ const BuyTicketsButtons: React.FC<BuyTicketsProps> = ({
   const { callWithGasPrice } = useCallWithGasPrice()
   const nftSaleContract = useNftSaleContract()
   const { toastSuccess } = useToast()
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
   const { isUserEnabled, setIsUserEnabled } = useContext(PancakeSquadContext)
 
   const canBuySaleTicket =

--- a/src/views/Pools/hooks/useApprove.tsx
+++ b/src/views/Pools/hooks/useApprove.tsx
@@ -58,7 +58,7 @@ export const useVaultApprove = (vaultKey: VaultKey, setLastUpdated: () => void) 
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
   const vaultPoolContract = useVaultPoolContract(vaultKey)
   const { callWithGasPrice } = useCallWithGasPrice()
-  const cakeContract = useCake()
+  const { signer: cakeContract } = useCake()
 
   const handleApprove = async () => {
     const receipt = await fetchWithCatchTxError(() => {

--- a/src/views/Pools/hooks/useApprove.tsx
+++ b/src/views/Pools/hooks/useApprove.tsx
@@ -80,7 +80,7 @@ export const useVaultApprove = (vaultKey: VaultKey, setLastUpdated: () => void) 
 
 export const useCheckVaultApprovalStatus = (vaultKey: VaultKey) => {
   const { account } = useWeb3React()
-  const cakeContract = useCake(false)
+  const { reader: cakeContract } = useCake()
   const vaultPoolContract = useVaultPoolContract(vaultKey)
 
   const key = useMemo<UseSWRContractKey>(

--- a/src/views/ProfileCreation/ConfirmProfileCreationModal.tsx
+++ b/src/views/ProfileCreation/ConfirmProfileCreationModal.tsx
@@ -6,6 +6,7 @@ import { useCake, useProfileContract } from 'hooks/useContract'
 import useApproveConfirmTransaction from 'hooks/useApproveConfirmTransaction'
 import { useProfile } from 'state/profile/hooks'
 import useToast from 'hooks/useToast'
+import { requiresApproval } from 'utils/requiresApproval'
 import { useCallWithGasPrice } from 'hooks/useCallWithGasPrice'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import ApproveConfirmButtons from 'components/ApproveConfirmButtons'
@@ -34,21 +35,17 @@ const ConfirmProfileCreationModal: React.FC<Props> = ({
   const profileContract = useProfileContract()
   const { refresh: refreshProfile } = useProfile()
   const { toastSuccess } = useToast()
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
   const { callWithGasPrice } = useCallWithGasPrice()
 
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        try {
-          const response = await cakeContract.allowance(account, profileContract.address)
-          return response.gte(minimumCakeRequired)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(cakeContractReader, account, profileContract.address, minimumCakeRequired)
       },
       onApprove: () => {
-        return callWithGasPrice(cakeContract, 'approve', [profileContract.address, allowance.toJSON()])
+        return callWithGasPrice(cakeContractApprover, 'approve', [profileContract.address, allowance.toJSON()])
       },
       onConfirm: () => {
         return callWithGasPrice(profileContract, 'createProfile', [

--- a/src/views/ProfileCreation/ConfirmProfileCreationModal.tsx
+++ b/src/views/ProfileCreation/ConfirmProfileCreationModal.tsx
@@ -35,8 +35,7 @@ const ConfirmProfileCreationModal: React.FC<Props> = ({
   const profileContract = useProfileContract()
   const { refresh: refreshProfile } = useProfile()
   const { toastSuccess } = useToast()
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
   const { callWithGasPrice } = useCallWithGasPrice()
 
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =

--- a/src/views/ProfileCreation/Mint.tsx
+++ b/src/views/ProfileCreation/Mint.tsx
@@ -12,6 +12,7 @@ import useToast from 'hooks/useToast'
 import { getNftsFromCollectionApi } from 'state/nftMarket/helpers'
 import { ApiSingleTokenData } from 'state/nftMarket/types'
 import { pancakeBunniesAddress } from 'views/Nft/market/constants'
+import { requiresApproval } from 'utils/requiresApproval'
 import { FetchStatus } from 'config/constants/types'
 import SelectionCard from './SelectionCard'
 import NextStepButton from './NextStepButton'
@@ -29,7 +30,8 @@ const Mint: React.FC = () => {
   const { toastSuccess } = useToast()
 
   const { account } = useWeb3React()
-  const cakeContract = useCake()
+  const cakeContractReader = useCake(false)
+  const cakeContractApprover = useCake()
   const bunnyFactoryContract = useBunnyFactory()
   const { t } = useTranslation()
   const { balance: cakeBalance, fetchStatus } = useGetCakeBalance()
@@ -55,16 +57,10 @@ const Mint: React.FC = () => {
   const { isApproving, isApproved, isConfirmed, isConfirming, handleApprove, handleConfirm } =
     useApproveConfirmTransaction({
       onRequiresApproval: async () => {
-        // TODO: Move this to a helper, this check will be probably be used many times
-        try {
-          const response = await cakeContract.allowance(account, bunnyFactoryContract.address)
-          return response.gte(minimumCakeRequired)
-        } catch (error) {
-          return false
-        }
+        return requiresApproval(cakeContractReader, account, bunnyFactoryContract.address, minimumCakeRequired)
       },
       onApprove: () => {
-        return callWithGasPrice(cakeContract, 'approve', [bunnyFactoryContract.address, allowance.toString()])
+        return callWithGasPrice(cakeContractApprover, 'approve', [bunnyFactoryContract.address, allowance.toString()])
       },
       onConfirm: () => {
         return callWithGasPrice(bunnyFactoryContract, 'mintNFT', [selectedBunnyId])

--- a/src/views/ProfileCreation/Mint.tsx
+++ b/src/views/ProfileCreation/Mint.tsx
@@ -30,8 +30,7 @@ const Mint: React.FC = () => {
   const { toastSuccess } = useToast()
 
   const { account } = useWeb3React()
-  const cakeContractReader = useCake(false)
-  const cakeContractApprover = useCake()
+  const { reader: cakeContractReader, signer: cakeContractApprover } = useCake()
   const bunnyFactoryContract = useBunnyFactory()
   const { t } = useTranslation()
   const { balance: cakeBalance, fetchStatus } = useGetCakeBalance()


### PR DESCRIPTION
For better ux if users wallet rpc node is laggy. This also extracts commonly used requiresApproval function