### PR TITLE
feat(farms): Add poolLength check

### DIFF
--- a/src/state/farms/fetchMasterChefData.ts
+++ b/src/state/farms/fetchMasterChefData.ts
@@ -4,18 +4,27 @@ import { multicallv2 } from 'utils/multicall'
 import { SerializedFarmConfig } from '../../config/constants/types'
 import { SerializedFarm } from '../types'
 import { getMasterChefAddress } from '../../utils/addressHelpers'
+import { getMasterchefContract } from '../../utils/contractHelpers'
 
-const fetchMasterChefFarmCalls = (farm: SerializedFarm) => {
+const masterChefAddress = getMasterChefAddress()
+const masterChefContract = getMasterchefContract()
+
+export const fetchMasterChefFarmPoolLength = async () => {
+  const poolLength = await masterChefContract.poolLength()
+  return poolLength
+}
+
+const masterChefFarmCalls = (farm: SerializedFarm) => {
   const { pid } = farm
   return pid || pid === 0
     ? [
         {
-          address: getMasterChefAddress(),
+          address: masterChefAddress,
           name: 'poolInfo',
           params: [pid],
         },
         {
-          address: getMasterChefAddress(),
+          address: masterChefAddress,
           name: 'totalAllocPoint',
         },
       ]
@@ -23,7 +32,7 @@ const fetchMasterChefFarmCalls = (farm: SerializedFarm) => {
 }
 
 export const fetchMasterChefData = async (farms: SerializedFarmConfig[]): Promise<any[]> => {
-  const masterChefCalls = farms.map((farm) => fetchMasterChefFarmCalls(farm))
+  const masterChefCalls = farms.map((farm) => masterChefFarmCalls(farm))
   const chunkSize = masterChefCalls.flat().length / farms.length
   const masterChefAggregatedCalls = masterChefCalls
     .filter((masterChefCall) => masterChefCall[0] !== null && masterChefCall[1] !== null)

--- a/src/state/farms/hooks.ts
+++ b/src/state/farms/hooks.ts
@@ -84,6 +84,10 @@ export const useFarms = (): DeserializedFarmsState => {
   }
 }
 
+export const useFarmsPoolLength = (): number => {
+  return useSelector((state: State) => state.farms.poolLength)
+}
+
 export const useFarmFromPid = (pid: number): DeserializedFarm => {
   const farm = useSelector((state: State) => state.farms.data.find((f) => f.pid === pid))
   return deserializeFarm(farm)

--- a/src/state/farms/hooks.ts
+++ b/src/state/farms/hooks.ts
@@ -43,17 +43,6 @@ const deserializeFarm = (farm: SerializedFarm): DeserializedFarm => {
   }
 }
 
-export const usePollFarmsPublicData = (includeArchive = false) => {
-  const dispatch = useAppDispatch()
-
-  useSlowRefreshEffect(() => {
-    const farmsToFetch = includeArchive ? farmsConfig : nonArchivedFarms
-    const pids = farmsToFetch.map((farmToFetch) => farmToFetch.pid)
-
-    dispatch(fetchFarmsPublicDataAsync(pids))
-  }, [includeArchive, dispatch])
-}
-
 export const usePollFarmsWithUserData = (includeArchive = false) => {
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
@@ -86,11 +75,12 @@ export const usePollCoreFarmData = () => {
 export const useFarms = (): DeserializedFarmsState => {
   const farms = useSelector((state: State) => state.farms)
   const deserializedFarmsData = farms.data.map(deserializeFarm)
-  const { loadArchivedFarmsData, userDataLoaded } = farms
+  const { loadArchivedFarmsData, userDataLoaded, poolLength } = farms
   return {
     loadArchivedFarmsData,
     userDataLoaded,
     data: deserializedFarmsData,
+    poolLength,
   }
 }
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -126,12 +126,14 @@ export interface SerializedFarmsState {
   loadArchivedFarmsData: boolean
   userDataLoaded: boolean
   loadingKeys: Record<string, boolean>
+  poolLength?: number
 }
 
 export interface DeserializedFarmsState {
   data: DeserializedFarm[]
   loadArchivedFarmsData: boolean
   userDataLoaded: boolean
+  poolLength?: number
 }
 
 export interface VaultFees {

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -117,7 +117,7 @@ export const getDisplayApr = (cakeRewardsApr?: number, lpRewardsApr?: number) =>
 const Farms: React.FC = ({ children }) => {
   const { pathname } = useRouter()
   const { t } = useTranslation()
-  const { data: farmsLP, userDataLoaded } = useFarms()
+  const { data: farmsLP, userDataLoaded, poolLength } = useFarms()
   const cakePrice = usePriceCakeBusd()
   const [query, setQuery] = useState('')
   const [viewMode, setViewMode] = useUserFarmsViewMode()
@@ -138,7 +138,10 @@ const Farms: React.FC = ({ children }) => {
 
   const [stakedOnly, setStakedOnly] = useUserFarmStakedOnly(isActive)
 
-  const activeFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier !== '0X' && !isArchivedPid(farm.pid))
+  const activeFarms = farmsLP.filter(
+    (farm) =>
+      farm.pid !== 0 && farm.multiplier !== '0X' && !isArchivedPid(farm.pid) && (!poolLength || poolLength > farm.pid),
+  )
   const inactiveFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X' && !isArchivedPid(farm.pid))
   const archivedFarms = farmsLP.filter((farm) => isArchivedPid(farm.pid))
 

--- a/src/views/Home/hooks/useFarmsWithBalance.tsx
+++ b/src/views/Home/hooks/useFarmsWithBalance.tsx
@@ -8,7 +8,7 @@ import { farmsConfig } from 'config/constants'
 import { SerializedFarmConfig } from 'config/constants/types'
 import { DEFAULT_TOKEN_DECIMAL } from 'config'
 import { useFastRefreshEffect } from 'hooks/useRefreshEffect'
-import { fetchMasterChefFarmPoolLength } from 'state/farms/fetchMasterChefData'
+import { useFarmsPoolLength } from 'state/farms/hooks'
 
 export interface FarmWithBalance extends SerializedFarmConfig {
   balance: BigNumber
@@ -18,11 +18,11 @@ const useFarmsWithBalance = () => {
   const [farmsWithStakedBalance, setFarmsWithStakedBalance] = useState<FarmWithBalance[]>([])
   const [earningsSum, setEarningsSum] = useState<number>(null)
   const { account } = useWeb3React()
+  const poolLength = useFarmsPoolLength()
 
   useFastRefreshEffect(() => {
     const fetchBalances = async () => {
-      const poolLength = await fetchMasterChefFarmPoolLength()
-      const farmsCanFetch = farmsConfig.filter((f) => poolLength.gt(f.pid))
+      const farmsCanFetch = farmsConfig.filter((f) => poolLength > f.pid)
       const calls = farmsCanFetch.map((farm) => ({
         address: getMasterChefAddress(),
         name: 'pendingCake',
@@ -44,10 +44,10 @@ const useFarmsWithBalance = () => {
       setEarningsSum(totalEarned)
     }
 
-    if (account) {
+    if (account && poolLength) {
       fetchBalances()
     }
-  }, [account])
+  }, [account, poolLength])
 
   return { farmsWithStakedBalance, earningsSum }
 }


### PR DESCRIPTION
It's weird get pool info using multicallv2 with `requireSuccess = false` will result out of gas issue when pid is not found 🤔 
Has to fetch poolLength and filter out the farm isn't there