### PR TITLE
perf(prediction): Avoid redundant re-render

### DIFF
--- a/src/views/Predictions/Desktop.tsx
+++ b/src/views/Predictions/Desktop.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import Split from 'split-grid'
 import { ArrowDownIcon, Button, ChartIcon } from '@pancakeswap/uikit'
@@ -187,4 +187,4 @@ const Desktop: React.FC = () => {
   )
 }
 
-export default Desktop
+export default memo(Desktop)

--- a/src/views/Predictions/Mobile.tsx
+++ b/src/views/Predictions/Mobile.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { memo } from 'react'
 import styled from 'styled-components'
 import { Box, Flex } from '@pancakeswap/uikit'
 import { useGetPredictionsStatus, useIsChartPaneOpen, useIsHistoryPaneOpen } from 'state/predictions/hooks'
@@ -70,4 +70,4 @@ const Mobile: React.FC = () => {
   )
 }
 
-export default Mobile
+export default memo(Mobile)

--- a/src/views/Predictions/components/CollectWinningsPopup.tsx
+++ b/src/views/Predictions/components/CollectWinningsPopup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import styled, { css, keyframes } from 'styled-components'
 import { Button, CloseIcon, IconButton, TrophyGoldIcon } from '@pancakeswap/uikit'
@@ -187,4 +187,4 @@ const CollectWinningsPopup = () => {
   )
 }
 
-export default CollectWinningsPopup
+export default memo(CollectWinningsPopup)

--- a/src/views/Predictions/components/Container.tsx
+++ b/src/views/Predictions/components/Container.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import styled from 'styled-components'
 
 const Container = styled.div`
@@ -7,4 +8,4 @@ const Container = styled.div`
   position: relative;
 `
 
-export default Container
+export default memo(Container)

--- a/src/views/Predictions/context/SwiperProvider.tsx
+++ b/src/views/Predictions/context/SwiperProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, Dispatch, useState } from 'react'
+import { memo, createContext, Dispatch, useState } from 'react'
 import SwiperCore from 'swiper'
 
 interface Context {
@@ -22,4 +22,4 @@ const SwiperProvider = ({ children }) => {
   return <SwiperContext.Provider value={{ swiper, setSwiper, destroySwiper }}>{children}</SwiperContext.Provider>
 }
 
-export default SwiperProvider
+export default memo(SwiperProvider)


### PR DESCRIPTION
Using `React.memo` for components not receiving props to avoid redundant re-render in Prediction page.

```
<>
      <PageMeta />
      <SwiperProvider>
        <Container>
          {isDesktop ? <Desktop /> : <Mobile />}
          <CollectWinningsPopup />
        </Container>
      </SwiperProvider>
</>
```