### PR TITLE
chore: Shared component AnimatedBlanace

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -1,6 +1,7 @@
+import { Text, TextProps } from '@pancakeswap/uikit'
 import React, { useEffect, useRef } from 'react'
 import CountUp from 'react-countup'
-import { Text, TextProps } from '@pancakeswap/uikit'
+import styled, { keyframes } from 'styled-components'
 
 interface BalanceProps extends TextProps {
   value: number
@@ -43,3 +44,17 @@ const Balance: React.FC<BalanceProps> = ({
 }
 
 export default Balance
+
+const appear = keyframes`
+  from {
+    opacity:0;
+  }
+
+  to {
+    opacity:1;
+  }
+`
+
+export const AnimateBalance = styled(Balance)`
+  animation: ${appear} 0.65s ease-in-out forwards;
+`

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -55,6 +55,6 @@ const appear = keyframes`
   }
 `
 
-export const AnimateBalance = styled(Balance)`
+export const AnimatedBalance = styled(Balance)`
   animation: ${appear} 0.65s ease-in-out forwards;
 `

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -1,24 +1,24 @@
-import { useMemo } from 'react'
-import BigNumber from 'bignumber.js'
-import styled from 'styled-components'
 import {
+  Box,
+  Button,
   Card,
   CardBody,
-  Text,
   Flex,
-  HelpIcon,
-  Button,
   Heading,
+  HelpIcon,
   Skeleton,
+  Text,
   useModal,
-  Box,
   useTooltip,
 } from '@pancakeswap/uikit'
+import BigNumber from 'bignumber.js'
+import { AnimateBalance as Balance } from 'components/Balance'
 import { useTranslation } from 'contexts/Localization'
-import { getBalanceNumber } from 'utils/formatBalance'
+import { useMemo } from 'react'
 import { usePriceCakeBusd } from 'state/farms/hooks'
 import { useCakeVault } from 'state/pools/hooks'
-import Balance from 'components/Balance'
+import styled from 'styled-components'
+import { getBalanceNumber } from 'utils/formatBalance'
 import BountyModal from './BountyModal'
 
 const StyledCard = styled(Card)`

--- a/src/views/Pools/components/BountyCard.tsx
+++ b/src/views/Pools/components/BountyCard.tsx
@@ -12,7 +12,7 @@ import {
   useTooltip,
 } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
-import { AnimateBalance as Balance } from 'components/Balance'
+import { AnimatedBalance as Balance } from 'components/Balance'
 import { useTranslation } from 'contexts/Localization'
 import { useMemo } from 'react'
 import { usePriceCakeBusd } from 'state/farms/hooks'


### PR DESCRIPTION
the result 
![after](https://user-images.githubusercontent.com/99634186/154208902-6c84246d-703b-4ded-b85c-f407eed68d53.gif)

I also tried Framer-motion [AnimatePresence](https://www.framer.com/docs/animate-presence/) component to make a transition between the Balance component and Skeleton component, but as the screenshot,
<img width="1199" alt="截圖 2022-02-16 下午12 52 44" src="https://user-images.githubusercontent.com/99634186/154209351-b15daf27-eb3b-4fe6-b123-e68e38d9dcda.png">
this is a more complex way to apply this to the codebase.
So, I decide to wrap the Blanace  componet to AnimatedBlanace.
