### PR TITLE
fix: Remove 0 teams point in leaderboard page

### DIFF
--- a/src/views/Teams/components/TeamListCard.tsx
+++ b/src/views/Teams/components/TeamListCard.tsx
@@ -113,9 +113,9 @@ const TeamCard: React.FC<TeamCardProps> = ({ rank, team }) => {
             <Flex>
               <Flex>
                 {/* alignSelf for Safari fix */}
-                <PrizeIcon width="24px" mr="8px" style={{ alignSelf: 'center' }} />
-                <Text fontSize="24px" bold>
-                  {team.points.toLocaleString()}
+                <PrizeIcon width="24px" mr="8px" style={{ alignSelf: 'center' }} color="textDisabled" />
+                <Text fontSize="24px" bold color="textDisabled">
+                  {t('Coming Soon')}
                 </Text>
               </Flex>
               <Flex ml="24px">


### PR DESCRIPTION
To review:

1. Go to leaderboard page
2. See team points are 0 instead of coming soon 