### PR TITLE
fix: SWR fallback undefined override

### DIFF
--- a/src/pages/nfts/collections/[collectionAddress].tsx
+++ b/src/pages/nfts/collections/[collectionAddress].tsx
@@ -4,7 +4,7 @@ import { SWRConfig, unstable_serialize } from 'swr'
 import { getCollection } from 'state/nftMarket/helpers'
 import CollectionPageRouter from 'views/Nft/market/Collection/CollectionPageRouter'
 
-const CollectionPage = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
+const CollectionPage = ({ fallback = {} }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <SWRConfig
       value={{

--- a/src/pages/nfts/collections/[collectionAddress]/[tokenId].tsx
+++ b/src/pages/nfts/collections/[collectionAddress]/[tokenId].tsx
@@ -5,7 +5,7 @@ import { NftToken } from 'state/nftMarket/types'
 // eslint-disable-next-line camelcase
 import { SWRConfig, unstable_serialize } from 'swr'
 
-const IndividualNFTPage = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
+const IndividualNFTPage = ({ fallback = {} }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <SWRConfig
       value={{

--- a/src/pages/teams/[id].tsx
+++ b/src/pages/teams/[id].tsx
@@ -6,7 +6,7 @@ import teams from 'config/constants/teams'
 import { getTeam } from 'state/teams/helpers'
 import { teamsById } from 'utils/teamsById'
 
-const TeamPage = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
+const TeamPage = ({ fallback = {} }: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <SWRConfig
       value={{


### PR DESCRIPTION
fallback undefined will override the default fallback `{}`
most likely happens when you access to the url directly, client side navigation works fine.