### PR TITLE
refactor: Use new empty array instead of constant

### DIFF
--- a/src/views/Nft/market/hooks/useCollectionNfts.tsx
+++ b/src/views/Nft/market/hooks/useCollectionNfts.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef, useMemo } from 'react'
-import { EMPTY_ARRAY } from 'utils/constantObjects'
 import {
   ApiResponseCollectionTokens,
   ApiSingleTokenData,

--- a/src/views/Nft/market/hooks/useCollectionNfts.tsx
+++ b/src/views/Nft/market/hooks/useCollectionNfts.tsx
@@ -228,7 +228,7 @@ export const useCollectionNfts = (collectionAddress: string) => {
     status,
     size,
     setSize,
-  } = useSWRInfinite(
+  } = useSWRInfinite<NftToken[]>(
     (pageIndex, previousPageData) => {
       if (pageIndex !== 0 && previousPageData && !previousPageData.length) return null
       return [collectionAddress, itemListingSettingsJson, pageIndex, 'collectionNfts']
@@ -265,7 +265,7 @@ export const useCollectionNfts = (collectionAddress: string) => {
     { revalidateFirstPage: false },
   )
 
-  const uniqueNftList: NftToken[] = useMemo(() => (nfts ? uniqBy(nfts.flat(), 'tokenId') : EMPTY_ARRAY), [nfts])
+  const uniqueNftList = useMemo(() => (nfts ? uniqBy(nfts.flat(), 'tokenId') : []), [nfts])
   fetchedNfts.current = uniqueNftList
 
   return {


### PR DESCRIPTION
Using constant as mutable can be dangerous and after this pr https://github.com/pancakeswap/pancake-frontend/pull/3390, that usage will not be allowed 