### PR TITLE
fix: (nft): Wrong result amount in collection listing

### DIFF
--- a/src/views/Nft/market/hooks/useCollectionNfts.tsx
+++ b/src/views/Nft/market/hooks/useCollectionNfts.tsx
@@ -200,7 +200,7 @@ export const useCollectionNfts = (collectionAddress: string) => {
   // We don't know the amount in advance if nft filters exist
   const resultSize =
     !Object.keys(nftFilters).length && collection
-      ? showOnlyNftsOnSale || field !== 'tokenId'
+      ? showOnlyNftsOnSale
         ? collection.numberTokensListed
         : collection.totalSupply
       : null


### PR DESCRIPTION
To reproduce:

1. Go to one of the collection items page
2. Order by lowest price
3. Select filter by all
4. See result size shows filtered number instead of all items