### PR TITLE
fix(proposal): Fix time select on light theme

### DIFF
--- a/src/views/Voting/components/DatePicker/DatePickerPortal.tsx
+++ b/src/views/Voting/components/DatePicker/DatePickerPortal.tsx
@@ -114,6 +114,14 @@ const StyledDatePickerPortal = styled.div`
       background-color: ${({ theme }) => theme.colors.cardBorder};
     }
   }
+
+  .react-datepicker__time-container
+    .react-datepicker__time
+    .react-datepicker__time-box
+    ul.react-datepicker__time-list
+    li.react-datepicker__time-list-item--selected {
+    color: ${({ theme }) => theme.colors.text};
+  }
 `
 
 const DatePickerPortal = () => {


### PR DESCRIPTION
Before 
<img width="385" alt="Screen Shot 2022-03-05 at 14 12 41" src="https://user-images.githubusercontent.com/97418926/156872829-75fbb849-62c2-435e-abeb-392ae5a876f5.png">

After
<img width="386" alt="Screen Shot 2022-03-05 at 14 13 00" src="https://user-images.githubusercontent.com/97418926/156872833-23845bf5-0031-47ac-8704-60c2b64387fe.png">

