### PR TITLE
fix: Update cursor color in editor

### DIFF
--- a/src/components/EasyMde/index.tsx
+++ b/src/components/EasyMde/index.tsx
@@ -24,6 +24,10 @@ const Wrapper = styled.div`
     color: ${({ theme }) => theme.colors.text};
   }
 
+  .CodeMirror-cursor {
+    border-left: ${({ theme }) => `1px solid ${theme.colors.text}`};
+  }
+
   .editor-toolbar {
     background: ${({ theme }) => theme.card.background};
     border-color: ${({ theme }) => theme.colors.cardBorder};


### PR DESCRIPTION
Before:
<img width="484" alt="Screen Shot 2022-03-07 at 20 49 04" src="https://user-images.githubusercontent.com/97418926/157046531-a1ec5bdd-c1e4-4d8f-aa25-89938cd909b1.png">


After:
<img width="642" alt="Screen Shot 2022-03-07 at 20 48 33" src="https://user-images.githubusercontent.com/97418926/157046476-c5a540b7-484d-44b9-a07b-b3f9d42ca55d.png">

