### PR TITLE
fix: (limit-orders): Order still visible after executed in open orders tab

### DIFF
--- a/src/utils/localStorageOrders.ts
+++ b/src/utils/localStorageOrders.ts
@@ -20,34 +20,48 @@ export function getLSOrders(chainId: number, account: string, pending = false) {
 }
 
 export function saveOrder(chainId: number, account: string, order: Order, pending = false) {
+  saveOrders(chainId, account, [order], pending)
+}
+
+export function saveOrders(chainId: number, account: string, orders: Order[], pending = false) {
+  if (!orders || !orders.length) return
+
   const key = pending ? lsKey(`${LS_ORDERS}pending_`, account, chainId) : lsKey(LS_ORDERS, account, chainId)
 
   if (!pending) {
-    removeOrder(chainId, account, order, true)
+    removeOrders(chainId, account, orders, true)
   }
 
-  const orders = removeOrder(chainId, account, order, pending)
+  const result = removeOrders(chainId, account, orders, pending)
 
-  if (!orders.length) {
-    set(key, [order])
-  } else {
-    orders.push(order)
+  if (!result.length) {
     set(key, orders)
+  } else {
+    result.push(...orders)
+    set(key, result)
   }
 }
 
-export function removeOrder(chainId: number, account: string, order: Order, pending = false) {
+export function removeOrders(chainId: number, account: string, orders: Order[], pending = false) {
   const key = pending ? lsKey(`${LS_ORDERS}pending_`, account, chainId) : lsKey(LS_ORDERS, account, chainId)
 
   const prev = get<Order[]>(key)
 
   if (!prev) return []
 
-  const orders = prev.filter((orderInLS) => orderInLS.id.toLowerCase() !== order.id.toLowerCase())
+  if (!orders || !orders.length) return prev
 
-  set(key, orders)
+  const result = prev.filter(
+    (orderInLS) => !orders.some((order) => orderInLS.id.toLowerCase() === order.id.toLowerCase()),
+  )
 
-  return orders
+  set(key, result)
+
+  return result
+}
+
+export function removeOrder(chainId: number, account: string, order: Order, pending = false) {
+  return removeOrders(chainId, account, [order], pending)
 }
 
 export function confirmOrderCancellation(chainId: number, account: string, cancellationHash: string, success = true) {

--- a/src/utils/localStorageOrders.ts
+++ b/src/utils/localStorageOrders.ts
@@ -3,6 +3,10 @@ import { get, set, clear } from 'local-storage'
 
 const LS_ORDERS = 'gorders_'
 
+export const hashOrder = (order: Order) => order.id
+
+export const hashOrderSet = (orders: Order[]) => new Set(orders.map(hashOrder))
+
 export function clearOrdersLocalStorage() {
   return clear()
 }
@@ -51,9 +55,8 @@ export function removeOrders(chainId: number, account: string, orders: Order[], 
 
   if (!orders || !orders.length) return prev
 
-  const result = prev.filter(
-    (orderInLS) => !orders.some((order) => orderInLS.id.toLowerCase() === order.id.toLowerCase()),
-  )
+  const orderHashSet = hashOrderSet(orders)
+  const result = prev.filter((orderInLS: Order) => !orderHashSet.has(hashOrder(orderInLS)))
 
   set(key, result)
 

--- a/src/views/LimitOrders/components/LimitOrderTable/index.tsx
+++ b/src/views/LimitOrders/components/LimitOrderTable/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, memo } from 'react'
 import { Flex, Card } from '@pancakeswap/uikit'
-import useGelatoLimitOrdersHistory from '../../hooks/useGelatoLitmitOrdersHistory'
+import useGelatoLimitOrdersHistory from '../../hooks/useGelatoLimitOrdersHistory'
 
 import OrderTab from './OrderTab'
 import { ORDER_CATEGORY } from '../../types'

--- a/src/views/LimitOrders/hooks/useFormattedOrderData.ts
+++ b/src/views/LimitOrders/hooks/useFormattedOrderData.ts
@@ -7,6 +7,7 @@ import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { getBscScanLink } from 'utils'
 import { useIsTransactionPending } from 'state/transactions/hooks'
 import getPriceForOneToken from '../utils/getPriceForOneToken'
+import { LimitOrderType } from '../types'
 
 export interface FormattedOrderData {
   inputToken: Currency | Token
@@ -86,9 +87,9 @@ const useFormattedOrderData = (order: Order): FormattedOrderData => {
     outputAmount: formatForDisplay(outputAmount),
     executionPrice: formatForDisplay(executionPrice),
     invertedExecutionPrice: formatForDisplay(executionPrice?.invert()),
-    isOpen: order.status === 'open',
-    isCancelled: order.status === 'cancelled',
-    isExecuted: order.status === 'executed',
+    isOpen: order.status === LimitOrderType.OPEN,
+    isCancelled: order.status === LimitOrderType.CANCELLED,
+    isExecuted: order.status === LimitOrderType.EXECUTED,
     isSubmissionPending,
     isCancellationPending,
     bscScanUrls: {

--- a/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -4,7 +4,7 @@ import useSWR from 'swr'
 import { SLOW_INTERVAL } from 'config/constants'
 import { useMemo } from 'react'
 
-import { getLSOrders, saveOrder, removeOrder } from 'utils/localStorageOrders'
+import { getLSOrders, saveOrder, removeOrder, saveOrders } from 'utils/localStorageOrders'
 import useGelatoLimitOrdersLib from 'hooks/limitOrders/useGelatoLimitOrdersLib'
 
 import { ORDER_CATEGORY } from '../types'
@@ -13,15 +13,13 @@ function newOrdersFirst(a: Order, b: Order) {
   return Number(b.updatedAt) - Number(a.updatedAt)
 }
 
-function syncOrderToLocalStorage({ chainId, account, orders }) {
+function syncOrderToLocalStorage({ chainId, account, orders }: { chainId: number; account: string; orders: Order[] }) {
   const ordersLS = getLSOrders(chainId, account)
 
-  orders.forEach((order: Order) => {
-    const hasLSOrder = ordersLS.some((confOrder) => confOrder.id.toLowerCase() === order.id.toLowerCase())
-    if (!hasLSOrder) {
-      saveOrder(chainId, account, order)
-    }
-  })
+  const newOrders = orders.filter(
+    (order: Order) => !ordersLS.some((confOrder) => confOrder.id.toLowerCase() === order.id.toLowerCase()),
+  )
+  saveOrders(chainId, account, newOrders)
 
   ordersLS.forEach((confOrder: Order) => {
     const updatedOrder = orders.find((order) => confOrder.id.toLowerCase() === order.id.toLowerCase())

--- a/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -70,18 +70,18 @@ const useOpenOrders = (turnOn: boolean): Order[] => {
         console.error('Error fetching open orders from subgraph', e)
       }
 
-      const openOrdersLS = getLSOrders(chainId, account).filter((order) => order.status === 'open')
+      const openOrdersLS = getLSOrders(chainId, account).filter((order) => order.status === LimitOrderType.OPEN)
 
       const pendingOrdersLS = getLSOrders(chainId, account, true)
 
       return [
         ...openOrdersLS.filter((order: Order) => {
           const orderCancelled = pendingOrdersLS
-            .filter((pendingOrder) => pendingOrder.status === 'cancelled')
+            .filter((pendingOrder) => pendingOrder.status === LimitOrderType.CANCELLED)
             .find((pendingOrder) => pendingOrder.id.toLowerCase() === order.id.toLowerCase())
           return !orderCancelled
         }),
-        ...pendingOrdersLS.filter((order) => order.status === 'open'),
+        ...pendingOrdersLS.filter((order) => order.status === LimitOrderType.OPEN),
       ].sort(newOrdersFirst)
     },
     {
@@ -119,9 +119,11 @@ const useHistoryOrders = (turnOn: boolean): Order[] => {
         console.error('Error fetching history orders from subgraph', e)
       }
 
-      const executedOrdersLS = getLSOrders(chainId, account).filter((order) => order.status === 'executed')
+      const executedOrdersLS = getLSOrders(chainId, account).filter((order) => order.status === LimitOrderType.EXECUTED)
 
-      const cancelledOrdersLS = getLSOrders(chainId, account).filter((order) => order.status === 'cancelled')
+      const cancelledOrdersLS = getLSOrders(chainId, account).filter(
+        (order) => order.status === LimitOrderType.CANCELLED,
+      )
 
       const pendingCancelledOrdersLS = getLSOrders(chainId, account, true).filter(
         (order) => order.status === 'cancelled',

--- a/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -4,7 +4,7 @@ import useSWR from 'swr'
 import { SLOW_INTERVAL } from 'config/constants'
 import { useMemo } from 'react'
 
-import { getLSOrders, saveOrder, removeOrder, saveOrders } from 'utils/localStorageOrders'
+import { getLSOrders, saveOrder, removeOrder, saveOrders, hashOrderSet, hashOrder } from 'utils/localStorageOrders'
 import useGelatoLimitOrdersLib from 'hooks/limitOrders/useGelatoLimitOrdersLib'
 
 import { ORDER_CATEGORY } from '../types'
@@ -16,9 +16,8 @@ function newOrdersFirst(a: Order, b: Order) {
 function syncOrderToLocalStorage({ chainId, account, orders }: { chainId: number; account: string; orders: Order[] }) {
   const ordersLS = getLSOrders(chainId, account)
 
-  const newOrders = orders.filter(
-    (order: Order) => !ordersLS.some((confOrder) => confOrder.id.toLowerCase() === order.id.toLowerCase()),
-  )
+  const ordersLSHashSet = hashOrderSet(ordersLS)
+  const newOrders = orders.filter((order: Order) => !ordersLSHashSet.has(hashOrder(order)))
   saveOrders(chainId, account, newOrders)
 
   ordersLS.forEach((confOrder: Order) => {

--- a/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -7,13 +7,7 @@ import { useMemo } from 'react'
 import { getLSOrders, saveOrder, removeOrder, saveOrders, hashOrderSet, hashOrder } from 'utils/localStorageOrders'
 import useGelatoLimitOrdersLib from 'hooks/limitOrders/useGelatoLimitOrdersLib'
 
-import { ORDER_CATEGORY } from '../types'
-
-enum LimitOrderType {
-  OPEN = 'open',
-  CANCELLED = 'cancelled',
-  EXECUTED = 'executed',
-}
+import { ORDER_CATEGORY, LimitOrderType } from '../types'
 
 function newOrdersFirst(a: Order, b: Order) {
   return Number(b.updatedAt) - Number(a.updatedAt)

--- a/src/views/LimitOrders/types.ts
+++ b/src/views/LimitOrders/types.ts
@@ -5,6 +5,12 @@ export enum ORDER_CATEGORY {
   History = 1,
 }
 
+export enum LimitOrderType {
+  OPEN = 'open',
+  CANCELLED = 'cancelled',
+  EXECUTED = 'executed',
+}
+
 export interface LimitOrderTableProps {
   orders: Order[]
   orderCategory: ORDER_CATEGORY


### PR DESCRIPTION
Currently when open orders from gelato returns empty array, orders in local storage don't get updated