### PR TITLE
fix: Remove limit order local storage data after disconnect

### DIFF
--- a/src/utils/clearUserStates.ts
+++ b/src/utils/clearUserStates.ts
@@ -4,6 +4,8 @@ import { resetUserState } from 'state/global/actions'
 import { clearAllTransactions } from 'state/transactions/actions'
 import { connectorLocalStorageKey } from '@pancakeswap/uikit'
 import { connectorsByName } from './web3React'
+import { LS_ORDERS } from './localStorageOrders'
+import getLocalStorageItemKeys from './getLocalStorageItemKeys'
 
 export const clearUserStates = (dispatch: Dispatch<any>, chainId: number) => {
   dispatch(resetUserState())
@@ -14,6 +16,8 @@ export const clearUserStates = (dispatch: Dispatch<any>, chainId: number) => {
     connectorsByName.walletconnect.walletConnectProvider = null
   }
   window.localStorage.removeItem(connectorLocalStorageKey)
+  const lsOrderKeys = getLocalStorageItemKeys(LS_ORDERS)
+  lsOrderKeys.forEach((lsOrderKey) => window.localStorage.removeItem(lsOrderKey))
   if (chainId) {
     dispatch(clearAllTransactions({ chainId }))
   }

--- a/src/utils/getLocalStorageItemKeys.ts
+++ b/src/utils/getLocalStorageItemKeys.ts
@@ -1,0 +1,11 @@
+const getLocalStorageItemKeys = (prefix: string) => {
+  const result = []
+  for (let i = 0; i < localStorage.length; i++) {
+    if (localStorage.key(i).startsWith(prefix)) {
+      result.push(localStorage.key(i))
+    }
+  }
+  return result
+}
+
+export default getLocalStorageItemKeys

--- a/src/utils/localStorageOrders.ts
+++ b/src/utils/localStorageOrders.ts
@@ -1,7 +1,7 @@
 import { Order } from '@gelatonetwork/limit-orders-lib'
 import { get, set, clear } from 'local-storage'
 
-const LS_ORDERS = 'gorders_'
+export const LS_ORDERS = 'gorders_'
 
 export function clearOrdersLocalStorage() {
   return clear()


### PR DESCRIPTION
To reproduce:

1. Connect account that has limit orders
2. Go limit order page
3. Go to order history
4. Disconnect account 
5. See data still available in web storage 