### PR TITLE
fix(limit-orders): Avoid showing incorrect price format in confirm modal

### DIFF
--- a/src/views/LimitOrders/index.tsx
+++ b/src/views/LimitOrders/index.tsx
@@ -223,7 +223,7 @@ const LimitOrders = () => {
       formattedAmounts={formattedAmounts}
       currentMarketRate={currentMarketRate?.toSignificant(4)}
       currentMarketRateInverted={currentMarketRate?.invert().toSignificant(4)}
-      limitPrice={formattedAmounts.price}
+      limitPrice={price?.toSignificant(6)}
       limitPriceInverted={price?.invert().toSignificant(6)}
       percentageRateDifference={parseFloat(percentageRateDifference?.toSignificant(3)).toLocaleString(undefined, {
         minimumFractionDigits: 0,


### PR DESCRIPTION
Before

<img width="982" alt="Screen Shot 2022-03-12 at 14 11 07" src="https://user-images.githubusercontent.com/97418926/158029638-bed65916-8530-4c4d-92ff-3618642c8aeb.png">

After
<img width="736" alt="Screen Shot 2022-03-12 at 14 12 15" src="https://user-images.githubusercontent.com/97418926/158029664-8edb0763-dd87-4d97-982f-0437b8a7995b.png">

