### PR TITLE
fix: (liquidity): No Lp found message when lp's are loading

### DIFF
--- a/src/views/Pool/index.tsx
+++ b/src/views/Pool/index.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { Pair } from '@pancakeswap/sdk'
 import { Text, Flex, CardBody, CardFooter, Button, AddIcon } from '@pancakeswap/uikit'
 import Link from 'next/link'
 import { useTranslation } from 'contexts/Localization'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import FullPositionCard from '../../components/PositionCard'
 import { useTokenBalancesWithLoadingIndicator } from '../../state/wallet/hooks'
-import { usePairs } from '../../hooks/usePairs'
+import { usePairs, PairState } from '../../hooks/usePairs'
 import { toV2LiquidityToken, useTrackedTokenPairs } from '../../state/user/hooks'
 import Dots from '../../components/Loader/Dots'
 import { AppHeader, AppBody } from '../../components/App'
@@ -47,9 +46,12 @@ export default function Pool() {
 
   const v2Pairs = usePairs(liquidityTokensWithBalances.map(({ tokens }) => tokens))
   const v2IsLoading =
-    fetchingV2PairBalances || v2Pairs?.length < liquidityTokensWithBalances.length || v2Pairs?.some((V2Pair) => !V2Pair)
-
-  const allV2PairsWithLiquidity = v2Pairs.map(([, pair]) => pair).filter((v2Pair): v2Pair is Pair => Boolean(v2Pair))
+    fetchingV2PairBalances ||
+    v2Pairs?.length < liquidityTokensWithBalances.length ||
+    (v2Pairs ? v2Pairs.length > 0 && v2Pairs.every(([pairState]) => pairState === PairState.LOADING) : false)
+  const allV2PairsWithLiquidity = v2Pairs
+    ?.filter(([pairState, pair]) => pairState === PairState.EXISTS && Boolean(pair))
+    .map(([, pair]) => pair)
 
   const renderBody = () => {
     if (!account) {

--- a/src/views/Pool/index.tsx
+++ b/src/views/Pool/index.tsx
@@ -48,7 +48,7 @@ export default function Pool() {
   const v2IsLoading =
     fetchingV2PairBalances ||
     v2Pairs?.length < liquidityTokensWithBalances.length ||
-    (v2Pairs ? v2Pairs.length > 0 && v2Pairs.every(([pairState]) => pairState === PairState.LOADING) : false)
+    (v2Pairs?.length && v2Pairs.every(([pairState]) => pairState === PairState.LOADING))
   const allV2PairsWithLiquidity = v2Pairs
     ?.filter(([pairState, pair]) => pairState === PairState.EXISTS && Boolean(pair))
     .map(([, pair]) => pair)


### PR DESCRIPTION
To reproduce:

1. Go to liquidity with an account that has lp
2. See it shows no lp's found message for a short time when lp's loading