### PR TITLE
refactor: Use orderBy instead of sort

### DIFF
--- a/src/components/Menu/utils.ts
+++ b/src/components/Menu/utils.ts
@@ -1,3 +1,4 @@
+import orderBy from 'lodash/orderBy'
 import { ConfigMenuItemsType } from './config/config'
 
 export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
@@ -17,9 +18,7 @@ export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string;
   }
 
   // Pathname includes multiple sub menu item hrefs - find the most specific match
-  const mostSpecificMatch = activeSubMenuItems.sort(
-    (subMenuItem1, subMenuItem2) => subMenuItem2.href.length - subMenuItem1.href.length,
-  )[0]
+  const mostSpecificMatch = orderBy(activeSubMenuItems, (subMenuItem) => subMenuItem.href.length, 'desc')[0]
 
   return mostSpecificMatch
 }

--- a/src/state/info/queries/tokens/priceData.ts
+++ b/src/state/info/queries/tokens/priceData.ts
@@ -4,6 +4,7 @@ import { getBlocksFromTimestamps } from 'views/Info/hooks/useBlocksFromTimestamp
 import { multiQuery } from 'views/Info/utils/infoQueryHelpers'
 import { PriceChartEntry } from 'state/info/types'
 import { INFO_CLIENT } from 'config/constants/endpoints'
+import orderBy from 'lodash/orderBy'
 
 const getPriceSubqueries = (tokenAddress: string, blocks: any) =>
   blocks.map(
@@ -101,18 +102,18 @@ const fetchTokenPriceData = async (
     })
 
     // graphql-request does not guarantee same ordering of batched requests subqueries, hence sorting by timestamp from oldest to newest
-    tokenPrices.sort((a, b) => parseInt(a.timestamp, 10) - parseInt(b.timestamp, 10))
+    const sortedTokenPrices = orderBy(tokenPrices, (tokenPrice) => parseInt(tokenPrice.timestamp, 10))
 
     const formattedHistory = []
 
     // for each timestamp, construct the open and close price
-    for (let i = 0; i < tokenPrices.length - 1; i++) {
+    for (let i = 0; i < sortedTokenPrices.length - 1; i++) {
       formattedHistory.push({
-        time: parseFloat(tokenPrices[i].timestamp),
-        open: tokenPrices[i].priceUSD,
-        close: tokenPrices[i + 1].priceUSD,
-        high: tokenPrices[i + 1].priceUSD,
-        low: tokenPrices[i].priceUSD,
+        time: parseFloat(sortedTokenPrices[i].timestamp),
+        open: sortedTokenPrices[i].priceUSD,
+        close: sortedTokenPrices[i + 1].priceUSD,
+        high: sortedTokenPrices[i + 1].priceUSD,
+        low: sortedTokenPrices[i].priceUSD,
       })
     }
 

--- a/src/state/swap/fetch/fetchDerivedPriceData.ts
+++ b/src/state/swap/fetch/fetchDerivedPriceData.ts
@@ -1,3 +1,4 @@
+import orderBy from 'lodash/orderBy'
 import { INFO_CLIENT } from 'config/constants/endpoints'
 import { ONE_DAY_UNIX, ONE_HOUR_SECONDS } from 'config/constants/info'
 import { getUnixTime, startOfHour, sub } from 'date-fns'
@@ -39,9 +40,7 @@ const getTokenDerivedBnbPrices = async (tokenAddress: string, blocks: Block[]) =
     }
   })
 
-  tokenPrices.sort((a, b) => parseInt(a.timestamp, 10) - parseInt(b.timestamp, 10))
-
-  return tokenPrices
+  return orderBy(tokenPrices, (tokenPrice) => parseInt(tokenPrice.timestamp, 10))
 }
 
 const getInterval = (timeWindow: PairDataTimeWindowEnum) => {

--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -5,6 +5,7 @@ import ERC20_INTERFACE from 'config/abi/erc20'
 import { useAllTokens } from 'hooks/Tokens'
 import { useMulticallContract } from 'hooks/useContract'
 import { isAddress } from 'utils'
+import orderBy from 'lodash/orderBy'
 import { useSingleContractMultipleData, useMultipleContractSingleData } from '../multicall/hooks'
 
 /**
@@ -17,12 +18,7 @@ export function useBNBBalances(uncheckedAddresses?: (string | undefined)[]): {
 
   const addresses: string[] = useMemo(
     () =>
-      uncheckedAddresses
-        ? uncheckedAddresses
-            .map(isAddress)
-            .filter((a): a is string => a !== false)
-            .sort()
-        : [],
+      uncheckedAddresses ? orderBy(uncheckedAddresses.map(isAddress).filter((a): a is string => a !== false)) : [],
     [uncheckedAddresses],
   )
 

--- a/src/utils/localStorageOrders.ts
+++ b/src/utils/localStorageOrders.ts
@@ -1,5 +1,6 @@
 import { Order } from '@gelatonetwork/limit-orders-lib'
 import { get, set, clear } from 'local-storage'
+import orderBy from 'lodash/orderBy'
 
 export const LS_ORDERS = 'gorders_'
 
@@ -130,9 +131,6 @@ export function confirmOrderSubmission(chainId: number, account: string, submiss
 
 export const getUniqueOrders = (allOrders: Order[]): Order[] => [
   ...new Map(
-    allOrders
-      // sort by `updatedAt` asc so that the most recent one will be used
-      .sort((a, b) => parseFloat(a.updatedAt) - parseFloat(b.updatedAt))
-      .map((order) => [order.id, order]),
+    orderBy(allOrders, (order) => parseFloat(order.updatedAt), 'desc').map((order) => [order.id, order]),
   ).values(),
 ]

--- a/src/views/FarmAuction/helpers.tsx
+++ b/src/views/FarmAuction/helpers.tsx
@@ -6,6 +6,7 @@ import { AuctionsResponse, FarmAuctionContractStatus, BidsPerAuction } from 'uti
 import { Auction, AuctionStatus, Bidder, BidderAuction } from 'config/constants/types'
 import { ethersToBigNumber } from 'utils/bigNumber'
 import { FarmAuction } from 'config/abi/types'
+import orderBy from 'lodash/orderBy'
 
 export const FORM_ADDRESS =
   'https://docs.google.com/forms/d/e/1FAIpQLSfQNsAfh98SAfcqJKR3is2hdvMRdnvfd2F3Hql96vXHgIi3Bw/viewform'
@@ -14,25 +15,15 @@ export const FORM_ADDRESS =
 // Also amends bidder information with getBidderInfo
 // auction is required if data will be used for table display, hence in reclaim and congratulations card its omitted
 export const sortAuctionBidders = (bidders: BidsPerAuction[], auction?: Auction): Bidder[] => {
-  const sortedBidders = [...bidders]
-    .sort((a, b) => {
-      if (a.amount.lt(b.amount)) {
-        return 1
-      }
-      if (a.amount.gt(b.amount)) {
-        return -1
-      }
-      return 0
-    })
-    .map((bidder, index) => {
-      const bidderInfo = getBidderInfo(bidder.account)
-      return {
-        ...bidderInfo,
-        position: index + 1,
-        account: bidder.account,
-        amount: bidder.amount,
-      }
-    })
+  const sortedBidders = orderBy(bidders, (bidder) => bidder.amount, 'desc').map((bidder, index) => {
+    const bidderInfo = getBidderInfo(bidder.account)
+    return {
+      ...bidderInfo,
+      position: index + 1,
+      account: bidder.account,
+      amount: bidder.amount,
+    }
+  })
 
   // Positions need to be adjusted in case 2 bidders has the same bid amount
   // adjustedPosition will always increase by 1 in the following block for the first bidder

--- a/src/views/FarmAuction/helpers.tsx
+++ b/src/views/FarmAuction/helpers.tsx
@@ -15,7 +15,7 @@ export const FORM_ADDRESS =
 // Also amends bidder information with getBidderInfo
 // auction is required if data will be used for table display, hence in reclaim and congratulations card its omitted
 export const sortAuctionBidders = (bidders: BidsPerAuction[], auction?: Auction): Bidder[] => {
-  const sortedBidders = orderBy(bidders, (bidder) => bidder.amount, 'desc').map((bidder, index) => {
+  const sortedBidders = orderBy(bidders, (bidder) => bidder.amount.toNumber(), 'desc').map((bidder, index) => {
     const bidderInfo = getBidderInfo(bidder.account)
     return {
       ...bidderInfo,

--- a/src/views/Info/components/InfoSearch/index.tsx
+++ b/src/views/Info/components/InfoSearch/index.tsx
@@ -12,6 +12,7 @@ import useDebounce from 'hooks/useDebounce'
 import { MINIMUM_SEARCH_CHARACTERS } from 'config/constants/info'
 import { PoolData } from 'state/info/types'
 import { useRouter } from 'next/router'
+import orderBy from 'lodash/orderBy'
 
 const Container = styled.div`
   position: relative;
@@ -210,14 +211,14 @@ const Search = () => {
     if (showWatchlist) {
       return watchListTokenData.filter((token) => tokenIncludesSearchTerm(token, value))
     }
-    return tokens.sort((t0, t1) => (t0.volumeUSD > t1.volumeUSD ? -1 : 1))
+    return orderBy(tokens, (token) => token.volumeUSD, 'desc')
   }, [showWatchlist, tokens, watchListTokenData, value])
 
   const poolForList = useMemo(() => {
     if (showWatchlist) {
       return watchListPoolData.filter((pool) => poolIncludesSearchTerm(pool, value))
     }
-    return pools.sort((p0, p1) => (p0.volumeUSD > p1.volumeUSD ? -1 : 1))
+    return orderBy(pools, (pool) => pool.volumeUSD, 'desc')
   }, [pools, showWatchlist, watchListPoolData, value])
 
   const contentUnderTokenList = () => {

--- a/src/views/Info/components/InfoTables/TokensTable.tsx
+++ b/src/views/Info/components/InfoTables/TokensTable.tsx
@@ -7,6 +7,7 @@ import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import Percent from 'views/Info/components/Percent'
 import { useTranslation } from 'contexts/Localization'
+import orderBy from 'lodash/orderBy'
 import { ClickableColumnHeader, TableWrapper, PageButtons, Arrow, Break } from './shared'
 
 /**
@@ -149,16 +150,11 @@ const TokenTable: React.FC<{
 
   const sortedTokens = useMemo(() => {
     return tokenDatas
-      ? tokenDatas
-          .sort((a, b) => {
-            if (a && b) {
-              return a[sortField as keyof TokenData] > b[sortField as keyof TokenData]
-                ? (sortDirection ? -1 : 1) * 1
-                : (sortDirection ? -1 : 1) * -1
-            }
-            return -1
-          })
-          .slice(maxItems * (page - 1), page * maxItems)
+      ? orderBy(
+          tokenDatas,
+          (tokenData) => tokenData[sortField as keyof TokenData],
+          sortDirection ? 'desc' : 'asc',
+        ).slice(maxItems * (page - 1), page * maxItems)
       : []
   }, [tokenDatas, maxItems, page, sortDirection, sortField])
 

--- a/src/views/Info/hooks/useBlocksFromTimestamps.ts
+++ b/src/views/Info/hooks/useBlocksFromTimestamps.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { multiQuery } from 'views/Info/utils/infoQueryHelpers'
 import { BLOCKS_CLIENT } from 'config/constants/endpoints'
 import { Block } from 'state/info/types'
+import orderBy from 'lodash/orderBy'
 
 const getBlockSubqueries = (timestamps: number[]) =>
   timestamps.map((timestamp) => {
@@ -39,9 +40,6 @@ export const getBlocksFromTimestamps = async (
     skipCount,
   )
 
-  const sortingFunction =
-    sortDirection === 'desc' ? (a: Block, b: Block) => b.number - a.number : (a: Block, b: Block) => a.number - b.number
-
   const blocks: Block[] = []
   if (fetchedData) {
     // eslint-disable-next-line no-restricted-syntax
@@ -54,7 +52,7 @@ export const getBlocksFromTimestamps = async (
       }
     }
     // graphql-request does not guarantee same ordering of batched requests subqueries, hence manual sorting
-    blocks.sort(sortingFunction)
+    return orderBy(blocks, (block) => block.number, sortDirection)
   }
   return blocks
 }

--- a/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -7,6 +7,7 @@ import { useMemo } from 'react'
 import { getLSOrders, saveOrder, saveOrders, hashOrderSet, hashOrder } from 'utils/localStorageOrders'
 import useGelatoLimitOrdersLib from 'hooks/limitOrders/useGelatoLimitOrdersLib'
 
+import orderBy from 'lodash/orderBy'
 import { ORDER_CATEGORY, LimitOrderStatus } from '../types'
 
 function newOrdersFirst(a: Order, b: Order) {
@@ -160,8 +161,7 @@ export default function useGelatoLimitOrdersHistory(orderCategory: ORDER_CATEGOR
   )
 
   return useMemo(
-    () =>
-      Array.isArray(orders) ? orders.sort((a, b) => parseInt(b.createdAt, 10) - parseInt(a.createdAt, 10)) : orders,
+    () => (Array.isArray(orders) ? orderBy(orders, (order) => parseInt(order.createdAt), 'desc') : orders),
     [orders],
   )
 }

--- a/src/views/Lottery/components/ViewTicketsModal/PreviousRoundTicketsInner.tsx
+++ b/src/views/Lottery/components/ViewTicketsModal/PreviousRoundTicketsInner.tsx
@@ -22,6 +22,7 @@ import { LotteryRound } from 'state/types'
 import { useGetUserLotteryGraphRoundById } from 'state/lottery/hooks'
 import { useTranslation } from 'contexts/Localization'
 import useTheme from 'hooks/useTheme'
+import orderBy from 'lodash/orderBy'
 import WinningNumbers from '../WinningNumbers'
 import { processLotteryResponse } from '../../helpers'
 import TicketNumber from '../TicketNumber'
@@ -101,11 +102,7 @@ const PreviousRoundTicketsInner: React.FC<{ roundId: string }> = ({ roundId }) =
     }
 
     const sortTicketsByWinningBracket = (tickets) => {
-      return tickets.sort((ticketA, ticketB) => {
-        const rewardBracket1 = ticketA.rewardBracket === undefined ? 0 : ticketA.rewardBracket + 1
-        const rewardBracket2 = ticketB.rewardBracket === undefined ? 0 : ticketB.rewardBracket + 1
-        return rewardBracket2 - rewardBracket1
-      })
+      return orderBy(tickets, (ticket) => (ticket.rewardBracket === undefined ? 0 : ticket.rewardBracket + 1), 'desc')
     }
 
     const fetchData = async () => {

--- a/src/views/Nft/market/ActivityHistory/utils/sortActivity.tsx
+++ b/src/views/Nft/market/ActivityHistory/utils/sortActivity.tsx
@@ -1,4 +1,3 @@
-import { BigNumber } from '@ethersproject/bignumber'
 import { Activity, AskOrder, AskOrderType, MarketEvent, Transaction } from 'state/nftMarket/types'
 import orderBy from 'lodash/orderBy'
 
@@ -51,7 +50,7 @@ export const sortActivity = ({
 
   const allActivity = [...transformAskOrders(askOrders), ...transformTransactions(transactions)]
   if (allActivity.length > 0) {
-    const sortedByMostRecent = orderBy(allActivity, (activity) => BigNumber.from(activity.timestamp), 'desc')
+    const sortedByMostRecent = orderBy(allActivity, (activity) => parseInt(activity.timestamp, 10), 'desc')
 
     return sortedByMostRecent
   }

--- a/src/views/Nft/market/ActivityHistory/utils/sortActivity.tsx
+++ b/src/views/Nft/market/ActivityHistory/utils/sortActivity.tsx
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Activity, AskOrder, AskOrderType, MarketEvent, Transaction } from 'state/nftMarket/types'
+import orderBy from 'lodash/orderBy'
 
 export const sortActivity = ({
   askOrders = [],
@@ -50,11 +51,7 @@ export const sortActivity = ({
 
   const allActivity = [...transformAskOrders(askOrders), ...transformTransactions(transactions)]
   if (allActivity.length > 0) {
-    const sortedByMostRecent = allActivity.sort((activityItem1, activityItem2) => {
-      const timestamp1 = BigNumber.from(activityItem1.timestamp)
-      const timestamp2 = BigNumber.from(activityItem2.timestamp)
-      return timestamp2.sub(timestamp1).toNumber()
-    })
+    const sortedByMostRecent = orderBy(allActivity, (activity) => BigNumber.from(activity.timestamp), 'desc')
 
     return sortedByMostRecent
   }

--- a/src/views/Nft/market/Collection/Traits/PancakeBunniesTraits.tsx
+++ b/src/views/Nft/market/Collection/Traits/PancakeBunniesTraits.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import { formatNumber } from 'utils/formatBalance'
 import { useTranslation } from 'contexts/Localization'
 import CollapsibleCard from 'components/CollapsibleCard'
+import orderBy from 'lodash/orderBy'
 import { useGetCollection } from 'state/nftMarket/hooks'
 import { useGetLowestPriceFromBunnyId } from '../../hooks/useGetLowestPrice'
 import { BNBAmountLabel } from '../../components/CollectibleCard/styles'
@@ -49,11 +50,11 @@ const PancakeBunniesTraits: React.FC<PancakeBunniesTraitsProps> = ({ collectionA
     const distributionKeys: string[] = Object.keys(distributionData)
     const distributionValues: any[] = Object.values(distributionData)
 
-    return distributionValues
-      .map((token, index) => ({ ...token, tokenId: distributionKeys[index] }))
-      .sort((tokenA, tokenB) => {
-        return raritySort === 'asc' ? tokenA.tokenCount - tokenB.tokenCount : tokenB.tokenCount - tokenA.tokenCount
-      })
+    return orderBy(
+      distributionValues.map((token, index) => ({ ...token, tokenId: distributionKeys[index] })),
+      (token) => token.tokenCount,
+      raritySort,
+    )
   }, [raritySort, distributionData])
 
   const toggleRaritySort = () => {

--- a/src/views/Nft/market/Collections/index.tsx
+++ b/src/views/Nft/market/Collections/index.tsx
@@ -15,6 +15,7 @@ import {
   Card,
 } from '@pancakeswap/uikit'
 import useSWRImmutable from 'swr/immutable'
+import orderBy from 'lodash/orderBy'
 import { getLeastMostPriceInCollection } from 'state/nftMarket/helpers'
 import { NextLinkFromReactRouter } from 'components/NextLink'
 import { ViewMode } from 'state/user/actions'
@@ -122,22 +123,19 @@ const Collectible = () => {
   }, [collections])
 
   const sortedCollections = useMemo(() => {
-    return collections.sort((a, b) => {
-      if (a && b) {
+    return orderBy(
+      collections,
+      (collection) => {
         if (sortField === SORT_FIELD.createdAt) {
-          if (a.createdAt && b.createdAt) {
-            return Date.parse(a.createdAt) > Date.parse(b.createdAt)
-              ? (sortDirection ? -1 : 1) * 1
-              : (sortDirection ? -1 : 1) * -1
+          if (collection.createdAt) {
+            return Date.parse(collection.createdAt)
           }
-          return -1
+          return null
         }
-        return parseFloat(a[sortField]) > parseFloat(b[sortField])
-          ? (sortDirection ? -1 : 1) * 1
-          : (sortDirection ? -1 : 1) * -1
-      }
-      return -1
-    })
+        return parseFloat(collection[sortField])
+      },
+      sortDirection ? 'desc' : 'asc',
+    )
   }, [collections, sortField, sortDirection])
 
   return (

--- a/src/views/Nft/market/Profile/utils/sortUserActivity.tsx
+++ b/src/views/Nft/market/Profile/utils/sortUserActivity.tsx
@@ -1,5 +1,5 @@
-import { BigNumber } from '@ethersproject/bignumber'
 import { Activity, AskOrder, AskOrderType, MarketEvent, Transaction } from 'state/nftMarket/types'
+import orderBy from 'lodash/orderBy'
 
 export const sortUserActivity = (
   account: string,
@@ -52,11 +52,7 @@ export const sortUserActivity = (
     ...transformTransactions(sellTradeHistory),
   ]
   if (allActivity.length > 0) {
-    const sortedByMostRecent = allActivity.sort((activityItem1, activityItem2) => {
-      const timestamp1 = BigNumber.from(activityItem1.timestamp)
-      const timestamp2 = BigNumber.from(activityItem2.timestamp)
-      return timestamp2.sub(timestamp1).toNumber()
-    })
+    const sortedByMostRecent = orderBy(allActivity, (activity) => parseInt(activity.timestamp, 10), 'desc')
 
     return sortedByMostRecent
   }

--- a/src/views/TradingCompetition/components/TeamRanks/index.tsx
+++ b/src/views/TradingCompetition/components/TeamRanks/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 import { Flex, Box } from '@pancakeswap/uikit'
 import Image from 'next/image'
+import orderBy from 'lodash/orderBy'
 import { TeamRanksProps } from '../../types'
 import CakerBunny from '../../pngs/cakers.png'
 import TopTradersCard from './TopTradersCard'
@@ -60,7 +61,7 @@ const TeamRanks: React.FC<TeamRanksProps> = ({
   const isGlobalLeaderboardDataComplete = Boolean(isTeamLeaderboardDataComplete && globalLeaderboardInformation)
 
   const getTeamsSortedByVolume = (arrayOfTeams) => {
-    return arrayOfTeams.sort((teamA, teamB) => teamB.leaderboardData.volume - teamA.leaderboardData.volume)
+    return orderBy(arrayOfTeams, (team) => team.leaderboardData.volume, 'desc')
   }
 
   return (


### PR DESCRIPTION
Orderby should be used where sort is applied on direct array references to not sort the array that is passed