### PR TITLE
fix: Fix color for Lottery Input

### DIFF
--- a/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/TicketInput.tsx
@@ -29,6 +29,7 @@ const InputsContainer = styled.div<{ focused: boolean; isDuplicate: boolean }>`
 `
 
 const DigitInput = styled.input`
+  color: ${({ theme }) => theme.colors.primaryDark};
   border: none;
   height: 32px;
   padding: 0 12px;


### PR DESCRIPTION
Before:
<img width="347" alt="Screen Shot 2022-03-15 at 22 21 05" src="https://user-images.githubusercontent.com/97418926/158498001-3d5642f8-6102-4a90-9066-f10702302c26.png">

After:
<img width="359" alt="Screen Shot 2022-03-15 at 22 19 08" src="https://user-images.githubusercontent.com/97418926/158497964-5675ee6b-1e88-4f94-92cc-907542d260ce.png">

