### PR TITLE
fix: (prediction) Wrong buffer phase let users to bet until the very end of the open round

### DIFF
--- a/src/state/predictions/config.ts
+++ b/src/state/predictions/config.ts
@@ -1,7 +1,9 @@
+import { BSC_BLOCK_TIME } from 'config'
+
 export const REWARD_RATE = 0.97
 
 // Estimated number of seconds it takes to submit a transaction (3 blocks) in seconds
-export const ROUND_BUFFER = 9
+export const ROUND_BUFFER = BSC_BLOCK_TIME * 3
 
 export const PAST_ROUND_COUNT = 5
 export const FUTURE_ROUND_COUNT = 2

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -56,7 +56,7 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
   const { account } = useWeb3React()
   const dispatch = useAppDispatch()
   const { isSettingPosition, position } = state
-  const isBufferPhase = Date.now() > (round.lockTimestamp + ROUND_BUFFER) * 1000
+  const isBufferPhase = round.lockTimestamp * 1000 - Date.now() <= ROUND_BUFFER * 1000
   const positionDisplay = position === BetPosition.BULL ? t('Up').toUpperCase() : t('Down').toUpperCase()
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount)} BNB`}</div>,


### PR DESCRIPTION
Currently buffer phase is not working correctly which let users to bet until the very end of open round which results transaction failures on onchain side when submitting a transaction exceeds lock timestamp

@Chef-Cheems can you confirm ?