### PR TITLE
fix: Lottery selectors not trigger rerender after user tickets fetch

### DIFF
--- a/src/state/lottery/index.ts
+++ b/src/state/lottery/index.ts
@@ -119,8 +119,10 @@ export const LotterySlice = createSlice({
     builder.addCase(
       fetchUserTicketsAndLotteries.fulfilled,
       (state, action: PayloadAction<{ userTickets: LotteryTicket[]; userLotteries: LotteryUserGraphEntity }>) => {
-        state.currentRound.userTickets.isLoading = false
-        state.currentRound.userTickets.tickets = action.payload.userTickets
+        state.currentRound = {
+          ...state.currentRound,
+          userTickets: { isLoading: false, tickets: action.payload.userTickets },
+        }
         state.userLotteryData = action.payload.userLotteries
       },
     )
@@ -132,7 +134,7 @@ export const LotterySlice = createSlice({
     })
     builder.addCase(fetchAdditionalUserLotteries.fulfilled, (state, action: PayloadAction<LotteryUserGraphEntity>) => {
       const mergedRounds = [...state.userLotteryData.rounds, ...action.payload.rounds]
-      state.userLotteryData.rounds = mergedRounds
+      state.userLotteryData = { ...state.userLotteryData, rounds: mergedRounds }
     })
     builder.addCase(
       setLotteryIsTransitioning.fulfilled,


### PR DESCRIPTION
To reproduce: 

1. Go to lottery
2. Buy ticket
3. See Your tickets section on main page not updated that you have to refresh the page to see it or wait for the next cycle of fetchcurrentround