### PR TITLE
fix: (prediction): Mitigate discrepancy between last price of live round card and expired round card

### DIFF
--- a/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/src/views/Predictions/components/ChainlinkChart.tsx
@@ -120,7 +120,7 @@ const ChainlinkChartWrapper = styled(Flex)<{ isMobile?: boolean }>`
 
 const HoverData = ({ rounds }: { rounds: { [key: string]: NodeRound } }) => {
   const hoverData = useChartHover()
-  const answerAsBigNumber = usePollOraclePrice()
+  const { price: answerAsBigNumber } = usePollOraclePrice()
   const {
     t,
     currentLanguage: { locale },

--- a/src/views/Predictions/components/Label.tsx
+++ b/src/views/Predictions/components/Label.tsx
@@ -90,7 +90,7 @@ const Label = styled(Flex)<{ dir: 'left' | 'right' }>`
 `
 
 export const PricePairLabel: React.FC = () => {
-  const price = usePollOraclePrice()
+  const { price } = usePollOraclePrice()
   const priceAsNumber = parseFloat(formatBigNumberToFixed(price, 3, 8))
   const countUpState = useCountUp({
     start: 0,

--- a/src/views/Predictions/components/RoundCard/LiveRoundPrice.tsx
+++ b/src/views/Predictions/components/RoundCard/LiveRoundPrice.tsx
@@ -9,7 +9,7 @@ interface LiveRoundPriceProps {
 }
 
 const LiveRoundPrice: React.FC<LiveRoundPriceProps> = ({ isBull }) => {
-  const price = usePollOraclePrice()
+  const { price } = usePollOraclePrice()
 
   const priceAsNumber = parseFloat(formatBigNumberToFixed(price, 3, 8))
   const priceColor = isBull ? 'success' : 'failure'

--- a/src/views/Predictions/hooks/usePollOraclePrice.ts
+++ b/src/views/Predictions/hooks/usePollOraclePrice.ts
@@ -5,7 +5,7 @@ import { Zero } from '@ethersproject/constants'
 const usePollOraclePrice = (seconds = 10) => {
   const chainlinkOracleContract = useChainlinkOracleContract(false)
   // Can refactor to subscription later
-  const { data: price } = useSWRContract([chainlinkOracleContract, 'latestAnswer'], {
+  const { data: price, mutate } = useSWRContract([chainlinkOracleContract, 'latestAnswer'], {
     refreshInterval: seconds * 1000,
     refreshWhenHidden: true,
     refreshWhenOffline: true,
@@ -13,7 +13,7 @@ const usePollOraclePrice = (seconds = 10) => {
     fallbackData: Zero,
   })
 
-  return price
+  return { price, refresh: mutate }
 }
 
 export default usePollOraclePrice


### PR DESCRIPTION
Although rounds in here are just visual representation and it is not affecting predictions, this issue is complaint by users that seeing different price after round closes. To mitigate the price discrepancy, it will send price fetching right before round closes. 