### PR TITLE
fix: (prediction): Round card transition on prediction

### DIFF
--- a/src/state/predictions/hooks.ts
+++ b/src/state/predictions/hooks.ts
@@ -5,31 +5,17 @@ import { useAppDispatch } from 'state'
 import { State } from '../types'
 import { fetchAddressResult } from '.'
 import {
-  getBigNumberRounds,
   getRoundsByCloseOracleIdSelector,
-  makeGetRoundSelector,
   getSortedRoundsSelector,
   makeGetBetByEpochSelector,
   makeGetIsClaimableSelector,
-  getCurrentRoundSelector,
   getMinBetAmountSelector,
   getCurrentRoundLockTimestampSelector,
-  getEarliestEpochSelector,
   getSortedRoundsCurrentEpochSelector,
-  getRoundsCurrentEpochSelector,
 } from './selectors'
-
-export const useGetRounds = () => {
-  return useSelector(getBigNumberRounds)
-}
 
 export const useGetRoundsByCloseOracleId = () => {
   return useSelector(getRoundsByCloseOracleIdSelector)
-}
-
-export const useGetRound = (epoch: number) => {
-  const getRoundSelector = useMemo(() => makeGetRoundSelector(epoch), [epoch])
-  return useSelector(getRoundSelector)
 }
 
 export const useGetSortedRounds = () => {
@@ -40,10 +26,6 @@ export const useGetSortedRoundsCurrentEpoch = () => {
   return useSelector(getSortedRoundsCurrentEpochSelector)
 }
 
-export const useGetRoundsCurrentEpoch = () => {
-  return useSelector(getRoundsCurrentEpochSelector)
-}
-
 export const useGetBetByEpoch = (account: string, epoch: number) => {
   const getBetByEpochSelector = useMemo(() => makeGetBetByEpochSelector(account, epoch), [account, epoch])
   return useSelector(getBetByEpochSelector)
@@ -52,13 +34,6 @@ export const useGetBetByEpoch = (account: string, epoch: number) => {
 export const useGetIsClaimable = (epoch) => {
   const getIsClaimableSelector = useMemo(() => makeGetIsClaimableSelector(epoch), [epoch])
   return useSelector(getIsClaimableSelector)
-}
-
-/**
- * Used to get the range of rounds to poll for
- */
-export const useGetEarliestEpoch = () => {
-  return useSelector(getEarliestEpochSelector)
 }
 
 export const useIsHistoryPaneOpen = () => {
@@ -79,10 +54,6 @@ export const useGetCurrentEpoch = () => {
 
 export const useGetIntervalSeconds = () => {
   return useSelector((state: State) => state.predictions.intervalSeconds)
-}
-
-export const useGetCurrentRound = () => {
-  return useSelector(getCurrentRoundSelector)
 }
 
 export const useGetPredictionsStatus = () => {

--- a/src/state/predictions/hooks.ts
+++ b/src/state/predictions/hooks.ts
@@ -15,6 +15,8 @@ import {
   getMinBetAmountSelector,
   getCurrentRoundLockTimestampSelector,
   getEarliestEpochSelector,
+  getSortedRoundsCurrentEpochSelector,
+  getRoundsCurrentEpochSelector,
 } from './selectors'
 
 export const useGetRounds = () => {
@@ -32,6 +34,14 @@ export const useGetRound = (epoch: number) => {
 
 export const useGetSortedRounds = () => {
   return useSelector(getSortedRoundsSelector)
+}
+
+export const useGetSortedRoundsCurrentEpoch = () => {
+  return useSelector(getSortedRoundsCurrentEpochSelector)
+}
+
+export const useGetRoundsCurrentEpoch = () => {
+  return useSelector(getRoundsCurrentEpochSelector)
 }
 
 export const useGetBetByEpoch = (account: string, epoch: number) => {

--- a/src/state/predictions/selectors.ts
+++ b/src/state/predictions/selectors.ts
@@ -57,6 +57,26 @@ export const getSortedRoundsSelector = createSelector([getBigNumberRounds], (rou
   return orderBy(Object.values(rounds), ['epoch'], ['asc'])
 })
 
+export const getSortedRoundsCurrentEpochSelector = createSelector(
+  [selectCurrentEpoch, getSortedRoundsSelector],
+  (currentEpoch, sortedRounds) => {
+    return {
+      currentEpoch,
+      rounds: sortedRounds,
+    }
+  },
+)
+
+export const getRoundsCurrentEpochSelector = createSelector(
+  [selectCurrentEpoch, getBigNumberRounds],
+  (currentEpoch, rounds) => {
+    return {
+      currentEpoch,
+      rounds,
+    }
+  },
+)
+
 export const getCurrentRoundSelector = createSelector(
   [selectCurrentEpoch, getBigNumberRounds],
   (currentEpoch, rounds) => {

--- a/src/state/predictions/selectors.ts
+++ b/src/state/predictions/selectors.ts
@@ -1,20 +1,15 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import orderBy from 'lodash/orderBy'
-import minBy from 'lodash/minBy'
 import { createSelector } from '@reduxjs/toolkit'
 import { State, ReduxNodeRound, NodeRound, ReduxNodeLedger, NodeLedger } from '../types'
 import { parseBigNumberObj } from './helpers'
 
 const selectCurrentEpoch = (state: State) => state.predictions.currentEpoch
 const selectRounds = (state: State) => state.predictions.rounds
-const selectRound = (epoch) => (state: State) => state.predictions.rounds[epoch]
 const selectLedgers = (state: State) => state.predictions.ledgers
 const selectClaimableStatuses = (state: State) => state.predictions.claimableStatuses
 const selectMinBetAmount = (state: State) => state.predictions.minBetAmount
 const selectIntervalSeconds = (state: State) => state.predictions.intervalSeconds
-
-export const makeGetRoundSelector = (epoch: number) =>
-  createSelector([selectRound(epoch)], (round) => parseBigNumberObj<ReduxNodeRound, NodeRound>(round))
 
 export const makeGetBetByEpochSelector = (account: string, epoch: number) =>
   createSelector([selectLedgers], (bets) => {
@@ -67,29 +62,7 @@ export const getSortedRoundsCurrentEpochSelector = createSelector(
   },
 )
 
-export const getRoundsCurrentEpochSelector = createSelector(
-  [selectCurrentEpoch, getBigNumberRounds],
-  (currentEpoch, rounds) => {
-    return {
-      currentEpoch,
-      rounds,
-    }
-  },
-)
-
-export const getCurrentRoundSelector = createSelector(
-  [selectCurrentEpoch, getBigNumberRounds],
-  (currentEpoch, rounds) => {
-    return rounds[currentEpoch]
-  },
-)
-
 export const getMinBetAmountSelector = createSelector([selectMinBetAmount], BigNumber.from)
-
-export const getEarliestEpochSelector = createSelector([selectRounds], (rounds) => {
-  const earliestRound = minBy(Object.values(rounds), 'epoch')
-  return earliestRound?.epoch
-})
 
 export const getCurrentRoundLockTimestampSelector = createSelector(
   [selectCurrentEpoch, getBigNumberRounds, selectIntervalSeconds],

--- a/src/views/Predictions/Positions.tsx
+++ b/src/views/Predictions/Positions.tsx
@@ -31,8 +31,7 @@ const Positions: React.FC<{ view?: PageView }> = ({ view }) => {
   const { setSwiper, swiper } = useSwiper()
   const { currentEpoch, rounds } = useGetSortedRoundsCurrentEpoch()
   const previousEpoch = currentEpoch > 0 ? currentEpoch - 1 : currentEpoch
-  const previousRound = rounds.find((round) => round.epoch === previousEpoch)
-  const swiperIndex = rounds.indexOf(previousRound)
+  const swiperIndex = rounds.findIndex((round) => round.epoch === previousEpoch)
 
   useOnNextRound()
   useOnViewChange(swiperIndex, view)

--- a/src/views/Predictions/Positions.tsx
+++ b/src/views/Predictions/Positions.tsx
@@ -4,7 +4,7 @@ import SwiperCore, { Keyboard, Mousewheel, FreeMode } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import 'swiper/css/bundle'
 import { Box } from '@pancakeswap/uikit'
-import { useGetCurrentEpoch, useGetSortedRounds } from 'state/predictions/hooks'
+import { useGetSortedRoundsCurrentEpoch } from 'state/predictions/hooks'
 import delay from 'lodash/delay'
 import RoundCard from './components/RoundCard'
 import Menu from './components/Menu'
@@ -29,8 +29,7 @@ const StyledSwiper = styled.div`
 
 const Positions: React.FC<{ view?: PageView }> = ({ view }) => {
   const { setSwiper, swiper } = useSwiper()
-  const rounds = useGetSortedRounds()
-  const currentEpoch = useGetCurrentEpoch()
+  const { currentEpoch, rounds } = useGetSortedRoundsCurrentEpoch()
   const previousEpoch = currentEpoch > 0 ? currentEpoch - 1 : currentEpoch
   const previousRound = rounds.find((round) => round.epoch === previousEpoch)
   const swiperIndex = rounds.indexOf(previousRound)

--- a/src/views/Predictions/components/PrevNextNav.tsx
+++ b/src/views/Predictions/components/PrevNextNav.tsx
@@ -1,6 +1,6 @@
 import { ArrowBackIcon, ArrowForwardIcon, BunnyCardsIcon, Flex, IconButton } from '@pancakeswap/uikit'
 import styled from 'styled-components'
-import { useGetCurrentEpoch, useGetSortedRounds } from 'state/predictions/hooks'
+import { useGetSortedRoundsCurrentEpoch } from 'state/predictions/hooks'
 import useSwiper from '../hooks/useSwiper'
 
 const StyledPrevNextNav = styled(Flex)`
@@ -29,8 +29,7 @@ const Icon = styled.div`
 
 const PrevNextNav = () => {
   const { swiper } = useSwiper()
-  const currentEpoch = useGetCurrentEpoch()
-  const rounds = useGetSortedRounds()
+  const { currentEpoch, rounds } = useGetSortedRoundsCurrentEpoch()
 
   const handlePrevSlide = () => {
     swiper.slidePrev()

--- a/src/views/Predictions/hooks/useOnNextRound.ts
+++ b/src/views/Predictions/hooks/useOnNextRound.ts
@@ -1,9 +1,9 @@
-import { useEffect } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import usePreviousValue from 'hooks/usePreviousValue'
 import { useAppDispatch } from 'state'
 import orderBy from 'lodash/orderBy'
-import { useGetCurrentEpoch, useGetRounds } from 'state/predictions/hooks'
+import { useGetRoundsCurrentEpoch } from 'state/predictions/hooks'
 import useSwiper from './useSwiper'
 
 /**
@@ -13,8 +13,7 @@ const useOnNextRound = () => {
   const { account } = useWeb3React()
   const dispatch = useAppDispatch()
   const { swiper } = useSwiper()
-  const currentEpoch = useGetCurrentEpoch()
-  const rounds = useGetRounds()
+  const { currentEpoch, rounds } = useGetRoundsCurrentEpoch()
   const roundsEpochsString = JSON.stringify(
     Object.keys(rounds)
       .map((roundKey) => parseInt(roundKey))
@@ -22,12 +21,13 @@ const useOnNextRound = () => {
   )
   const previousEpoch = usePreviousValue(currentEpoch)
   const previousRoundsEpochsString = usePreviousValue(roundsEpochsString)
+  const previousActiveRoundIndex = useRef(0)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (
       swiper &&
-      currentEpoch !== undefined &&
-      previousEpoch !== undefined &&
+      currentEpoch &&
+      previousEpoch &&
       (currentEpoch !== previousEpoch || roundsEpochsString !== previousRoundsEpochsString)
     ) {
       const currentEpochIndex = orderBy(Object.values(rounds), ['epoch'], ['asc']).findIndex(
@@ -35,8 +35,13 @@ const useOnNextRound = () => {
       )
 
       // Slide to the current LIVE round which is always the one before the current round
-      swiper.slideTo(currentEpochIndex - 1)
-      swiper.update()
+      if (currentEpoch !== previousEpoch) {
+        swiper.slideTo(currentEpochIndex - 1)
+        previousActiveRoundIndex.current = currentEpochIndex - 1
+      } else if (swiper.activeIndex === previousActiveRoundIndex.current) {
+        // The check above is not to slide after the removal of earliest round if user goes to another slide than active round meanwhile
+        swiper.slideTo(currentEpochIndex - 1, 0)
+      }
     }
   }, [previousEpoch, currentEpoch, previousRoundsEpochsString, roundsEpochsString, rounds, swiper, account, dispatch])
 }

--- a/src/views/Predictions/hooks/useOnNextRound.ts
+++ b/src/views/Predictions/hooks/useOnNextRound.ts
@@ -2,8 +2,7 @@ import { useLayoutEffect, useRef } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import usePreviousValue from 'hooks/usePreviousValue'
 import { useAppDispatch } from 'state'
-import orderBy from 'lodash/orderBy'
-import { useGetRoundsCurrentEpoch } from 'state/predictions/hooks'
+import { useGetSortedRoundsCurrentEpoch } from 'state/predictions/hooks'
 import useSwiper from './useSwiper'
 
 /**
@@ -13,12 +12,8 @@ const useOnNextRound = () => {
   const { account } = useWeb3React()
   const dispatch = useAppDispatch()
   const { swiper } = useSwiper()
-  const { currentEpoch, rounds } = useGetRoundsCurrentEpoch()
-  const roundsEpochsString = JSON.stringify(
-    Object.keys(rounds)
-      .map((roundKey) => parseInt(roundKey))
-      .sort((a, b) => a - b),
-  )
+  const { currentEpoch, rounds } = useGetSortedRoundsCurrentEpoch()
+  const roundsEpochsString = JSON.stringify(Object.keys(rounds))
   const previousEpoch = usePreviousValue(currentEpoch)
   const previousRoundsEpochsString = usePreviousValue(roundsEpochsString)
   const previousActiveRoundIndex = useRef(0)
@@ -30,9 +25,7 @@ const useOnNextRound = () => {
       previousEpoch &&
       (currentEpoch !== previousEpoch || roundsEpochsString !== previousRoundsEpochsString)
     ) {
-      const currentEpochIndex = orderBy(Object.values(rounds), ['epoch'], ['asc']).findIndex(
-        (round) => round.epoch === currentEpoch,
-      )
+      const currentEpochIndex = rounds.findIndex((round) => round.epoch === currentEpoch)
 
       // Slide to the current LIVE round which is always the one before the current round
       if (currentEpoch !== previousEpoch) {

--- a/src/views/Predictions/hooks/usePollPredictions.ts
+++ b/src/views/Predictions/hooks/usePollPredictions.ts
@@ -1,9 +1,8 @@
 import { useWeb3React } from '@web3-react/core'
 import { useAppDispatch } from 'state'
-import { useGetCurrentEpoch, useGetEarliestEpoch, useGetPredictionsStatus } from 'state/predictions/hooks'
-import { fetchClaimableStatuses, fetchLedgerData, fetchMarketData, fetchRounds } from 'state/predictions'
+import { useGetPredictionsStatus } from 'state/predictions/hooks'
+import { fetchPredictionData } from 'state/predictions'
 import { PredictionStatus } from 'state/types'
-import range from 'lodash/range'
 import useSWR from 'swr'
 import { batch } from 'react-redux'
 
@@ -12,25 +11,13 @@ const POLL_TIME_IN_SECONDS = 10
 const usePollPredictions = () => {
   const dispatch = useAppDispatch()
   const { account } = useWeb3React()
-  const currentEpoch = useGetCurrentEpoch()
-  const earliestEpoch = useGetEarliestEpoch()
   const status = useGetPredictionsStatus()
 
   useSWR(
-    status !== PredictionStatus.INITIAL && currentEpoch && earliestEpoch
-      ? ['predictions', currentEpoch, earliestEpoch, account]
-      : null,
+    status !== PredictionStatus.INITIAL ? ['predictions', account] : null,
     () => {
-      const liveCurrentAndRecent = [currentEpoch, currentEpoch - 1, currentEpoch - 2]
-
       batch(() => {
-        dispatch(fetchRounds(liveCurrentAndRecent))
-        dispatch(fetchMarketData())
-        if (account) {
-          const epochRange = range(earliestEpoch, currentEpoch + 1)
-          dispatch(fetchLedgerData({ account, epochs: epochRange }))
-          dispatch(fetchClaimableStatuses({ account, epochs: epochRange }))
-        }
+        dispatch(fetchPredictionData(account))
       })
     },
     {

--- a/src/views/Predictions/hooks/usePollPredictions.ts
+++ b/src/views/Predictions/hooks/usePollPredictions.ts
@@ -4,7 +4,6 @@ import { useGetPredictionsStatus } from 'state/predictions/hooks'
 import { fetchPredictionData } from 'state/predictions'
 import { PredictionStatus } from 'state/types'
 import useSWR from 'swr'
-import { batch } from 'react-redux'
 
 const POLL_TIME_IN_SECONDS = 10
 
@@ -15,11 +14,7 @@ const usePollPredictions = () => {
 
   useSWR(
     status !== PredictionStatus.INITIAL ? ['predictions', account] : null,
-    () => {
-      batch(() => {
-        dispatch(fetchPredictionData(account))
-      })
-    },
+    () => dispatch(fetchPredictionData(account)),
     {
       refreshInterval: POLL_TIME_IN_SECONDS * 1000,
       refreshWhenHidden: true,


### PR DESCRIPTION
Before: 

https://user-images.githubusercontent.com/2213635/159758997-d4f1e562-bb8e-4896-b93c-9336f5f5c9f8.mov

After:

https://user-images.githubusercontent.com/2213635/159759096-333cdef6-7575-47a3-b900-8d97eb6f9066.mov


This fix will also reduce the calls, the size of swr cache of prediction and rerenders
