### PR TITLE
fix: (limit-order): Missing subgraph health indicator when no order

### DIFF
--- a/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
+++ b/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
@@ -3,6 +3,9 @@ import { Text, Flex, Box, Grid, ArrowBackIcon, ArrowForwardIcon } from '@pancake
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 import { SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
+import NoOrdersMessage from './NoOrdersMessage'
+import { ORDER_CATEGORY } from '../../types'
+import LoadingTable from './LoadingTable'
 
 const Arrow = styled.div`
   color: ${({ theme }) => theme.colors.primary};
@@ -20,14 +23,14 @@ interface TableNavigationProps {
   data: any[]
   itemsPerPage?: number
   children: (exposedProps: ExposedProps) => ReactElement
-  resetFlag: boolean | number | string
+  orderCategory: ORDER_CATEGORY
 }
 
 const ORDERS_PER_PAGE = 5
 
 const TableNavigation: React.FC<TableNavigationProps> = ({
   data,
-  resetFlag,
+  orderCategory,
   itemsPerPage = ORDERS_PER_PAGE,
   children,
 }) => {
@@ -60,13 +63,15 @@ const TableNavigation: React.FC<TableNavigationProps> = ({
 
   useEffect(() => {
     setPage(1)
-  }, [resetFlag])
+  }, [orderCategory])
 
   return (
     <>
       {children({
         paginatedData,
       })}
+      {!data && <LoadingTable />}
+      {data && !total && <NoOrdersMessage orderCategory={orderCategory} />}
       <Grid gridGap="16px" gridTemplateColumns={['1fr', null, null, null, '1fr 2fr 1fr']} mt="16px" mb="16px" px="16px">
         <Box />
         <Flex width="100%" justifyContent="center" alignItems="center">

--- a/src/views/LimitOrders/components/LimitOrderTable/index.tsx
+++ b/src/views/LimitOrders/components/LimitOrderTable/index.tsx
@@ -6,8 +6,6 @@ import OrderTab from './OrderTab'
 import { ORDER_CATEGORY } from '../../types'
 
 import CompactLimitOrderTable from './CompactLimitOrderTable'
-import NoOrdersMessage from './NoOrdersMessage'
-import LoadingTable from './LoadingTable'
 import SpaciousLimitOrderTable from './SpaciousLimitOrderTable'
 import Navigation from './TableNavigation'
 
@@ -15,14 +13,8 @@ const OrderTable: React.FC<{ isCompact: boolean; orderCategory: ORDER_CATEGORY }
   ({ orderCategory, isCompact }) => {
     const orders = useGelatoLimitOrdersHistory(orderCategory)
 
-    if (!orders) return <LoadingTable />
-
-    if (!orders?.length) {
-      return <NoOrdersMessage orderCategory={orderCategory} />
-    }
-
     return (
-      <Navigation data={orders} resetFlag={orderCategory}>
+      <Navigation data={orders} orderCategory={orderCategory}>
         {({ paginatedData }) =>
           isCompact ? (
             <CompactLimitOrderTable orders={paginatedData} />


### PR DESCRIPTION
Before: 
<img width="831" alt="Screenshot 2022-03-25 at 12 32 01" src="https://user-images.githubusercontent.com/2213635/160113334-fd75fed3-ec86-42a9-92db-dc3c119a72a4.png">

After: 
<img width="815" alt="Screenshot 2022-03-25 at 12 26 50" src="https://user-images.githubusercontent.com/2213635/160113351-a4d4822b-4530-45ce-8bca-d9592a641131.png">

