### PR TITLE
refactor: (lottery-banner): Use swr for to fetch current lottery without fetching graph data

### DIFF
--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -101,11 +101,7 @@ export const fetchMultipleLotteries = async (lotteryIds: string[]): Promise<Lott
 }
 
 export const fetchCurrentLotteryId = async (): Promise<EthersBigNumber> => {
-  try {
-    return lotteryContract.currentLotteryId()
-  } catch (error) {
-    return null
-  }
+  return lotteryContract.currentLotteryId()
 }
 
 export const fetchCurrentLotteryIdAndMaxBuy = async () => {

--- a/src/state/lottery/helpers.ts
+++ b/src/state/lottery/helpers.ts
@@ -100,6 +100,14 @@ export const fetchMultipleLotteries = async (lotteryIds: string[]): Promise<Lott
   }
 }
 
+export const fetchCurrentLotteryId = async (): Promise<EthersBigNumber> => {
+  try {
+    return lotteryContract.currentLotteryId()
+  } catch (error) {
+    return null
+  }
+}
+
 export const fetchCurrentLotteryIdAndMaxBuy = async () => {
   try {
     const calls = ['currentLotteryId', 'maxNumberTicketsPerBuyOrClaim'].map((method) => ({

--- a/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
+++ b/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
@@ -1,11 +1,19 @@
-import { useFetchLottery, useLottery } from 'state/lottery/hooks'
+import useSWR from 'swr'
+import { fetchCurrentLotteryId, fetchLottery } from 'state/lottery/helpers'
+import { FetchStatus } from 'config/constants/types'
+import { FAST_INTERVAL } from 'config/constants'
 
 const useIsRenderLotteryBanner = () => {
-  useFetchLottery(true)
-  const {
-    currentRound: { isLoading },
-  } = useLottery()
-  return !isLoading
+  const { status } = useSWR(
+    ['currentLottery'],
+    async () => {
+      const currentLotteryId = await fetchCurrentLotteryId()
+      return fetchLottery(currentLotteryId?.toString())
+    },
+    { refreshInterval: FAST_INTERVAL },
+  )
+
+  return status === FetchStatus.Fetched
 }
 
 export default useIsRenderLotteryBanner

--- a/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
+++ b/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
@@ -1,19 +1,22 @@
 import useSWR from 'swr'
 import { fetchCurrentLotteryId, fetchLottery } from 'state/lottery/helpers'
 import { FetchStatus } from 'config/constants/types'
-import { FAST_INTERVAL } from 'config/constants'
+import { FAST_INTERVAL, SLOW_INTERVAL } from 'config/constants'
 
 const useIsRenderLotteryBanner = () => {
-  const { status } = useSWR(
-    ['currentLottery'],
-    async () => {
-      const currentLotteryId = await fetchCurrentLotteryId()
-      return fetchLottery(currentLotteryId?.toString())
-    },
+  const { data: currentLotteryId, status: currentLotteryIdStatus } = useSWR(
+    ['currentLotteryId'],
+    fetchCurrentLotteryId,
+    { refreshInterval: SLOW_INTERVAL },
+  )
+
+  const { status: currentLotteryStatus } = useSWR(
+    currentLotteryId ? ['currentLottery'] : null,
+    async () => fetchLottery(currentLotteryId.toString()),
     { refreshInterval: FAST_INTERVAL },
   )
 
-  return status === FetchStatus.Fetched
+  return currentLotteryIdStatus === FetchStatus.Fetched && currentLotteryStatus === FetchStatus.Fetched
 }
 
 export default useIsRenderLotteryBanner

--- a/src/views/Home/components/Banners/hooks/useNextEventCountdown.ts
+++ b/src/views/Home/components/Banners/hooks/useNextEventCountdown.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState, useRef } from 'react'
+
+const useNextEventCountdown = (nextEventTime: number): number => {
+  const [secondsRemaining, setSecondsRemaining] = useState(null)
+  const timer = useRef(null)
+
+  useEffect(() => {
+    const currentSeconds = Math.floor(Date.now() / 1000)
+    const secondsRemainingCalc = Math.max(nextEventTime - currentSeconds, 0)
+    setSecondsRemaining(secondsRemainingCalc)
+
+    timer.current = setInterval(() => {
+      setSecondsRemaining((prevSecondsRemaining) => Math.max(prevSecondsRemaining - 1, 0))
+    }, 1000)
+
+    return () => clearInterval(timer.current)
+  }, [nextEventTime])
+
+  return secondsRemaining
+}
+
+export default useNextEventCountdown

--- a/src/views/Lottery/hooks/useGetNextLotteryEvent.ts
+++ b/src/views/Lottery/hooks/useGetNextLotteryEvent.ts
@@ -1,6 +1,6 @@
 import { LotteryStatus } from 'config/constants/types'
 import { useTranslation } from 'contexts/Localization'
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 
 interface LotteryEvent {
   nextEventTime: number
@@ -8,41 +8,39 @@ interface LotteryEvent {
   preCountdownText?: string
 }
 
+const vrfRequestTime = 180 // 3 mins
+const secondsBetweenRounds = 300 // 5 mins
+const transactionResolvingBuffer = 30 // Delay countdown by 30s to ensure contract transactions have been calculated and broadcast
+
 const useGetNextLotteryEvent = (endTime: number, status: LotteryStatus): LotteryEvent => {
   const { t } = useTranslation()
-  const vrfRequestTime = 180 // 3 mins
-  const secondsBetweenRounds = 300 // 5 mins
-  const transactionResolvingBuffer = 30 // Delay countdown by 30s to ensure contract transactions have been calculated and broadcast
-  const [nextEvent, setNextEvent] = useState({ nextEventTime: null, preCountdownText: null, postCountdownText: null })
-
-  useEffect(() => {
+  return useMemo(() => {
     // Current lottery is active
     if (status === LotteryStatus.OPEN) {
-      setNextEvent({
+      return {
         nextEventTime: endTime + transactionResolvingBuffer,
         preCountdownText: null,
         postCountdownText: t('until the draw'),
-      })
+      }
     }
     // Current lottery has finished but not yet claimable
     if (status === LotteryStatus.CLOSE) {
-      setNextEvent({
+      return {
         nextEventTime: endTime + transactionResolvingBuffer + vrfRequestTime,
         preCountdownText: t('Winners announced in'),
         postCountdownText: null,
-      })
+      }
     }
     // Current lottery claimable. Next lottery has not yet started
     if (status === LotteryStatus.CLAIMABLE) {
-      setNextEvent({
+      return {
         nextEventTime: endTime + transactionResolvingBuffer + secondsBetweenRounds,
         preCountdownText: t('Tickets on sale in'),
         postCountdownText: null,
-      })
+      }
     }
-  }, [status, endTime, t])
-
-  return nextEvent
+    return { nextEventTime: null, preCountdownText: null, postCountdownText: null }
+  }, [endTime, status, t])
 }
 
 export default useGetNextLotteryEvent


### PR DESCRIPTION
Currently there is a graph data and additional onchain lottery requests being made which we don't need it when we show lottery banner