### PR TITLE
fix: Swap modal doesn't show insufficient input token info after price change

### DIFF
--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1910,5 +1910,6 @@
   "Remove %amountA% %symbolA% and %amountB% %symbolB%": "Remove %amountA% %symbolA% and %amountB% %symbolB%",
   "Zap %amountA% %symbolA% and %amountB% %symbolB%": "Zap %amountA% %symbolA% and %amountB% %symbolB%",
   "Zap in %amount% BNB for %symbol%": "Zap in %amount% BNB for %symbol%",
-  "Zap in %amount% %symbol% for %lpSymbol%": "Zap in %amount% %symbol% for %lpSymbol%"
+  "Zap in %amount% %symbol% for %lpSymbol%": "Zap in %amount% %symbol% for %lpSymbol%",
+  "Insufficent input token balance. Your transaction may fail.": "Insufficent input token balance. Your transaction may fail."
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1911,5 +1911,5 @@
   "Zap %amountA% %symbolA% and %amountB% %symbolB%": "Zap %amountA% %symbolA% and %amountB% %symbolB%",
   "Zap in %amount% BNB for %symbol%": "Zap in %amount% BNB for %symbol%",
   "Zap in %amount% %symbol% for %lpSymbol%": "Zap in %amount% %symbol% for %lpSymbol%",
-  "Insufficent input token balance. Your transaction may fail.": "Insufficent input token balance. Your transaction may fail."
+  "Insufficient input token balance. Your transaction may fail.": "Insufficient input token balance. Your transaction may fail."
 }

--- a/src/views/Swap/components/ConfirmSwapModal.tsx
+++ b/src/views/Swap/components/ConfirmSwapModal.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useMemo } from 'react'
-import { Currency, Trade, TradeType } from '@pancakeswap/sdk'
+import { Trade, CurrencyAmount, Currency, TradeType } from "@pancakeswap/sdk"
 import { InjectedModalProps } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { Field } from 'state/swap/actions'
 import TransactionConfirmationModal, {
   ConfirmationModalContent,
   TransactionErrorContent,
 } from 'components/TransactionConfirmationModal'
 import SwapModalFooter from './SwapModalFooter'
 import SwapModalHeader from './SwapModalHeader'
+import { maxAmountSpend } from '../../../utils/maxAmountSpend'
+import { computeSlippageAdjustedAmounts } from "../../../utils/exchange"
 
 /**
  * Returns true if the trade requires a confirmation of details before we can submit it
@@ -29,6 +32,7 @@ function tradeMeaningfullyDiffers(
 interface ConfirmSwapModalProps {
   trade?: Trade<Currency, Currency, TradeType>
   originalTrade?: Trade<Currency, Currency, TradeType>
+  currencyBalances: { [field in Field]?: CurrencyAmount<Currency> }
   attemptingTxn: boolean
   txHash?: string
   recipient: string | null
@@ -42,6 +46,7 @@ interface ConfirmSwapModalProps {
 const ConfirmSwapModal: React.FC<React.PropsWithChildren<InjectedModalProps & ConfirmSwapModalProps>> = ({
   trade,
   originalTrade,
+  currencyBalances,
   onAcceptChanges,
   allowedSlippage,
   onConfirm,
@@ -52,36 +57,59 @@ const ConfirmSwapModal: React.FC<React.PropsWithChildren<InjectedModalProps & Co
   attemptingTxn,
   txHash,
 }) => {
+  const { t } = useTranslation()
+
   const showAcceptChanges = useMemo(
     () => Boolean(trade && originalTrade && tradeMeaningfullyDiffers(trade, originalTrade)),
     [originalTrade, trade],
   )
 
-  const { t } = useTranslation()
+  const slippageAdjustedAmounts = useMemo(
+    () => computeSlippageAdjustedAmounts(trade, allowedSlippage),
+    [trade, allowedSlippage],
+  )
+
+  const isEnoughInputBalance = useMemo(() => {
+    if (trade?.tradeType !== TradeType.EXACT_OUTPUT) return null
+
+    const isInputBalanceExist = !!(currencyBalances && currencyBalances[Field.INPUT])
+    const isInputBalanceBNB = isInputBalanceExist && currencyBalances[Field.INPUT].currency.isNative
+    const inputCurrencyAmount = isInputBalanceExist
+      ? isInputBalanceBNB
+        ? maxAmountSpend(currencyBalances[Field.INPUT])
+        : currencyBalances[Field.INPUT]
+      : null
+    return inputCurrencyAmount && slippageAdjustedAmounts && slippageAdjustedAmounts[Field.INPUT]
+      ? inputCurrencyAmount.greaterThan(slippageAdjustedAmounts[Field.INPUT]) ||
+          inputCurrencyAmount.equalTo(slippageAdjustedAmounts[Field.INPUT])
+      : false
+  }, [currencyBalances, trade, slippageAdjustedAmounts])
 
   const modalHeader = useCallback(() => {
     return trade ? (
       <SwapModalHeader
         trade={trade}
-        allowedSlippage={allowedSlippage}
+        slippageAdjustedAmounts={slippageAdjustedAmounts}
+        isEnoughInputBalance={isEnoughInputBalance}
         recipient={recipient}
         showAcceptChanges={showAcceptChanges}
         onAcceptChanges={onAcceptChanges}
       />
     ) : null
-  }, [allowedSlippage, onAcceptChanges, recipient, showAcceptChanges, trade])
+  }, [slippageAdjustedAmounts, isEnoughInputBalance, onAcceptChanges, recipient, showAcceptChanges, trade])
 
   const modalBottom = useCallback(() => {
     return trade ? (
       <SwapModalFooter
         onConfirm={onConfirm}
         trade={trade}
+        slippageAdjustedAmounts={slippageAdjustedAmounts}
+        isEnoughInputBalance={isEnoughInputBalance}
         disabledConfirm={showAcceptChanges}
         swapErrorMessage={swapErrorMessage}
-        allowedSlippage={allowedSlippage}
       />
     ) : null
-  }, [allowedSlippage, onConfirm, showAcceptChanges, swapErrorMessage, trade])
+  }, [slippageAdjustedAmounts, isEnoughInputBalance, onConfirm, showAcceptChanges, swapErrorMessage, trade])
 
   // text to show while loading
   const pendingText = t('Swapping %amountA% %symbolA% for %amountB% %symbolB%', {

--- a/src/views/Swap/components/ConfirmSwapModal.tsx
+++ b/src/views/Swap/components/ConfirmSwapModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react'
-import { Trade, CurrencyAmount, Currency, TradeType } from "@pancakeswap/sdk"
+import { Trade, CurrencyAmount, Currency, TradeType } from '@pancakeswap/sdk'
 import { InjectedModalProps } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { Field } from 'state/swap/actions'
@@ -10,7 +10,7 @@ import TransactionConfirmationModal, {
 import SwapModalFooter from './SwapModalFooter'
 import SwapModalHeader from './SwapModalHeader'
 import { maxAmountSpend } from '../../../utils/maxAmountSpend'
-import { computeSlippageAdjustedAmounts } from "../../../utils/exchange"
+import { computeSlippageAdjustedAmounts } from '../../../utils/exchange'
 
 /**
  * Returns true if the trade requires a confirmation of details before we can submit it

--- a/src/views/Swap/components/SwapModalFooter.tsx
+++ b/src/views/Swap/components/SwapModalFooter.tsx
@@ -4,11 +4,7 @@ import { Trade, TradeType, CurrencyAmount, Currency } from '@pancakeswap/sdk'
 import { Button, Text, AutoRenewIcon } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { Field } from 'state/swap/actions'
-import {
-  computeTradePriceBreakdown,
-  formatExecutionPrice,
-  warningSeverity,
-} from 'utils/exchange'
+import { computeTradePriceBreakdown, formatExecutionPrice, warningSeverity } from 'utils/exchange'
 import { AutoColumn } from 'components/Layout/Column'
 import QuestionHelper from 'components/QuestionHelper'
 import { AutoRow, RowBetween, RowFixed } from 'components/Layout/Row'

--- a/src/views/Swap/components/SwapModalHeader.tsx
+++ b/src/views/Swap/components/SwapModalHeader.tsx
@@ -119,7 +119,7 @@ export default function SwapModalHeader({
       <AutoColumn justify="flex-start" gap="sm" style={{ padding: '24px 0 0 0px' }}>
         {trade.tradeType === TradeType.EXACT_OUTPUT && !isEnoughInputBalance && (
           <Text small color="failure" textAlign="left" style={{ width: '100%' }}>
-            {t('Insufficent input token balance. Your transaction may fail.')}
+            {t('Insufficient input token balance. Your transaction may fail.')}
           </Text>
         )}
         <Text small color="textSubtle" textAlign="left" style={{ width: '100%' }}>

--- a/src/views/Swap/components/SwapModalHeader.tsx
+++ b/src/views/Swap/components/SwapModalHeader.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react'
-import { Trade, TradeType, Currency } from '@pancakeswap/sdk'
+import { Trade, TradeType, CurrencyAmount, Currency } from '@pancakeswap/sdk'
 import { Button, Text, ErrorIcon, ArrowDownIcon } from '@pancakeswap/uikit'
 import { Field } from 'state/swap/actions'
 import { useTranslation } from '@pancakeswap/localization'
-import { computeTradePriceBreakdown, warningSeverity, computeSlippageAdjustedAmounts } from 'utils/exchange'
+import { computeTradePriceBreakdown, warningSeverity } from 'utils/exchange'
 import { AutoColumn } from 'components/Layout/Column'
 import { CurrencyLogo } from 'components/Logo'
 import { RowBetween, RowFixed } from 'components/Layout/Row'
@@ -12,24 +12,30 @@ import { TruncatedText, SwapShowAcceptChanges } from './styleds'
 
 export default function SwapModalHeader({
   trade,
-  allowedSlippage,
+  slippageAdjustedAmounts,
+  isEnoughInputBalance,
   recipient,
   showAcceptChanges,
   onAcceptChanges,
 }: {
   trade: Trade<Currency, Currency, TradeType>
-  allowedSlippage: number
+  slippageAdjustedAmounts: { [field in Field]?: CurrencyAmount<Currency> }
+  isEnoughInputBalance: boolean
   recipient: string | null
   showAcceptChanges: boolean
   onAcceptChanges: () => void
 }) {
   const { t } = useTranslation()
-  const slippageAdjustedAmounts = useMemo(
-    () => computeSlippageAdjustedAmounts(trade, allowedSlippage),
-    [trade, allowedSlippage],
-  )
+
   const { priceImpactWithoutFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const priceImpactSeverity = warningSeverity(priceImpactWithoutFee)
+
+  const inputTextColor =
+    showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT && isEnoughInputBalance
+      ? 'primary'
+      : trade.tradeType === TradeType.EXACT_OUTPUT && !isEnoughInputBalance
+      ? 'failure'
+      : 'text'
 
   const amount =
     trade.tradeType === TradeType.EXACT_INPUT
@@ -63,11 +69,8 @@ export default function SwapModalHeader({
     <AutoColumn gap="md">
       <RowBetween align="flex-end">
         <RowFixed gap="4px">
-          <CurrencyLogo currency={trade.inputAmount.currency} size="24px" />
-          <TruncatedText
-            fontSize="24px"
-            color={showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT ? 'primary' : 'text'}
-          >
+          <CurrencyLogo currency={trade.inputAmount.currency} size="24px" style={{ marginRight: '12px' }} />
+          <TruncatedText fontSize="24px" color={inputTextColor}>
             {trade.inputAmount.toSignificant(6)}
           </TruncatedText>
         </RowFixed>
@@ -114,6 +117,11 @@ export default function SwapModalHeader({
         </SwapShowAcceptChanges>
       ) : null}
       <AutoColumn justify="flex-start" gap="sm" style={{ padding: '24px 0 0 0px' }}>
+        {trade.tradeType === TradeType.EXACT_OUTPUT && !isEnoughInputBalance && (
+          <Text small color="failure" textAlign="left" style={{ width: '100%' }}>
+            {t('Insufficent input token balance. Your transaction may fail.')}
+          </Text>
+        )}
         <Text small color="textSubtle" textAlign="left" style={{ width: '100%' }}>
           {estimatedText}
           <b>

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -354,6 +354,7 @@ export default function Swap() {
     <ConfirmSwapModal
       trade={trade}
       originalTrade={tradeToConfirm}
+      currencyBalances={currencyBalances}
       onAcceptChanges={handleAcceptChanges}
       attemptingTxn={attemptingTxn}
       txHash={txHash}


### PR DESCRIPTION
To reproduce:

1. Go to swap
2. Try swap with exact output 
3. On swap modal if your input balance is lower than the amount of trade input after the price change, there is no indicator that your swap may fail.

Issue can happen slippage adjusted amount can exceed the token balance if slippage is set to very high. 

So in both cases we should warn the user but let user to decide whether to continue to swap or not