### PR TITLE
fix: (nft): Token detail and user profile pages not show updated market data

### DIFF
--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -447,7 +447,8 @@ export const getAccountNftsOnChainMarketData = async (
     const askCallsResultsRaw = await multicallv2(nftMarketAbi, askCalls, { requireSuccess: false })
     const askCallsResults = askCallsResultsRaw
       .map((askCallsResultRaw, askCallIndex) => {
-        if (!askCallsResultRaw.tokenIds || !askCallsResultRaw.askInfo) return null
+        if (!askCallsResultRaw?.tokenIds || !askCallsResultRaw?.askInfo || !collectionList[askCallIndex]?.address)
+          return null
         return askCallsResultRaw.tokenIds
           .map((tokenId, tokenIdIndex) => {
             if (!tokenId || !askCallsResultRaw.askInfo[tokenIdIndex] || !askCallsResultRaw.askInfo[tokenIdIndex].price)

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -1104,7 +1104,7 @@ const fetchWalletMarketData = async (
 
         return { ...nftMarketData, ...onChainMarketData }
       })
-      .filter((value) => value && Object.keys(value).length)
+      .filter(Boolean)
   })
 
   const walletMarketDataResponses = await Promise.all(walletMarketDataRequests)
@@ -1121,7 +1121,7 @@ const fetchMarketDataForSaleNfts = async (collections: ApiCollections, account: 
       const tokenIds = onChainTokenMarketDatas.map((marketData) => marketData.tokenId)
       const marketDataForSaleNfts = await getNftsMarketData({
         tokenId_in: tokenIds,
-        collection: collectionAddress.toLowerCase(),
+        collection: collectionAddress,
       })
       return onChainTokenMarketDatas.map((onChainTokenMarketData) => {
         const marketDataForSaleNft = marketDataForSaleNfts.find(

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -1083,14 +1083,13 @@ const fetchWalletMarketData = async (
 ): Promise<TokenMarketData[]> => {
   const walletMarketDataRequests = walletNftsByCollection.map(async (walletNftByCollection) => {
     const tokenIdIn = walletNftByCollection.idWithCollectionAddress.map((walletNft) => walletNft.tokenId)
-    const nftsOnChainMarketData = await getNftsOnChainMarketData(
-      walletNftByCollection.collectionAddress.toLowerCase(),
-      tokenIdIn,
-    )
-    const nftsMarketData = await getNftsMarketData({
-      tokenId_in: tokenIdIn,
-      collection: walletNftByCollection.collectionAddress.toLowerCase(),
-    })
+    const [nftsOnChainMarketData, nftsMarketData] = await Promise.all([
+      getNftsOnChainMarketData(walletNftByCollection.collectionAddress.toLowerCase(), tokenIdIn),
+      getNftsMarketData({
+        tokenId_in: tokenIdIn,
+        collection: walletNftByCollection.collectionAddress.toLowerCase(),
+      }),
+    ])
 
     return tokenIdIn
       .map((tokenId) => {

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -65,14 +65,14 @@ export enum NftLocation {
 // Market data regarding specific token ID, acquired via subgraph
 export interface TokenMarketData {
   tokenId: string
-  metadataUrl: string
+  metadataUrl?: string
   currentAskPrice: string
   currentSeller: string
-  latestTradedPriceInBNB: string
-  tradeVolumeBNB: string
-  totalTrades: string
+  latestTradedPriceInBNB?: string
+  tradeVolumeBNB?: string
+  totalTrades?: string
   isTradable: boolean
-  otherId: string
+  otherId?: string
   collection?: {
     id: string
   }

--- a/src/state/nftMarket/types.ts
+++ b/src/state/nftMarket/types.ts
@@ -65,17 +65,17 @@ export enum NftLocation {
 // Market data regarding specific token ID, acquired via subgraph
 export interface TokenMarketData {
   tokenId: string
-  metadataUrl?: string
+  collection: {
+    id: string
+  }
   currentAskPrice: string
   currentSeller: string
+  isTradable: boolean
+  metadataUrl?: string
   latestTradedPriceInBNB?: string
   tradeVolumeBNB?: string
   totalTrades?: string
-  isTradable: boolean
   otherId?: string
-  collection?: {
-    id: string
-  }
   updatedAt?: string
   transactionHistory?: Transaction[]
 }

--- a/src/views/Nft/market/hooks/useCompleteNft.tsx
+++ b/src/views/Nft/market/hooks/useCompleteNft.tsx
@@ -86,9 +86,7 @@ export const useCompleteNft = (collectionAddress: string, tokenId: string) => {
   }, [mutate, refetchNftMarketData, refetchNftOwn])
 
   return {
-    combinedNft: nft
-      ? { ...nft, ...(marketData && { marketData }), location: nftOwn?.location ?? NftLocation.WALLET }
-      : undefined,
+    combinedNft: nft ? { ...nft, marketData, location: nftOwn?.location ?? NftLocation.WALLET } : undefined,
     isOwn: nftOwn?.isOwn || false,
     isProfilePic: nftOwn?.nftIsProfilePic || false,
     isLoading: status !== FetchStatus.Fetched,

--- a/src/views/Nft/market/hooks/useCompleteNft.tsx
+++ b/src/views/Nft/market/hooks/useCompleteNft.tsx
@@ -72,12 +72,8 @@ export const useCompleteNft = (collectionAddress: string, tokenId: string) => {
       const onChainMarketData = onChainMarketDatas[0]
       const marketDatas = await getNftsMarketData({ collection: collectionAddress.toLowerCase(), tokenId }, 1)
 
-      return {
-        ...marketDatas[0],
-        ...(onChainMarketData?.currentSeller && { currentSeller: onChainMarketData.currentSeller }),
-        ...(onChainMarketData?.isTradable && { isTradable: onChainMarketData.isTradable }),
-        ...(onChainMarketData?.currentAskPrice && { currentAskPrice: onChainMarketData.currentAskPrice }),
-      }
+      if (!marketDatas[0] || !onChainMarketData) return null
+      return { ...marketDatas[0], ...onChainMarketData }
     },
   )
 
@@ -90,7 +86,9 @@ export const useCompleteNft = (collectionAddress: string, tokenId: string) => {
   }, [mutate, refetchNftMarketData, refetchNftOwn])
 
   return {
-    combinedNft: nft ? { ...nft, marketData, location: nftOwn?.location ?? NftLocation.WALLET } : undefined,
+    combinedNft: nft
+      ? { ...nft, ...(marketData && { marketData }), location: nftOwn?.location ?? NftLocation.WALLET }
+      : undefined,
     isOwn: nftOwn?.isOwn || false,
     isProfilePic: nftOwn?.nftIsProfilePic || false,
     isLoading: status !== FetchStatus.Fetched,

--- a/src/views/Nft/market/hooks/useCompleteNft.tsx
+++ b/src/views/Nft/market/hooks/useCompleteNft.tsx
@@ -68,11 +68,16 @@ export const useCompleteNft = (collectionAddress: string, tokenId: string) => {
   const { data: marketData, mutate: refetchNftMarketData } = useSWR(
     collectionAddress && tokenId ? ['nft', 'marketData', collectionAddress, tokenId] : null,
     async () => {
-      const onChainMarketDatas = await getNftsOnChainMarketData(collectionAddress.toLowerCase(), [tokenId])
+      const [onChainMarketDatas, marketDatas] = await Promise.all([
+        getNftsOnChainMarketData(collectionAddress.toLowerCase(), [tokenId]),
+        getNftsMarketData({ collection: collectionAddress.toLowerCase(), tokenId }, 1),
+      ])
       const onChainMarketData = onChainMarketDatas[0]
-      const marketDatas = await getNftsMarketData({ collection: collectionAddress.toLowerCase(), tokenId }, 1)
 
-      if (!marketDatas[0] || !onChainMarketData) return null
+      if (!marketDatas[0] && !onChainMarketData) return null
+
+      if (!onChainMarketData) return marketDatas[0]
+
       return { ...marketDatas[0], ...onChainMarketData }
     },
   )

--- a/src/views/Nft/market/hooks/useNftOwner.tsx
+++ b/src/views/Nft/market/hooks/useNftOwner.tsx
@@ -3,8 +3,7 @@ import { useEffect, useState } from 'react'
 import { useErc721CollectionContract } from 'hooks/useContract'
 import { NftToken } from 'state/nftMarket/types'
 import { getPancakeProfileAddress } from 'utils/addressHelpers'
-
-const NOT_ON_SALE_SELLER = '0x0000000000000000000000000000000000000000'
+import { NOT_ON_SALE_SELLER } from 'config/constants'
 
 const useNftOwner = (nft: NftToken, isOwnNft = false) => {
   const { account } = useWeb3React()


### PR DESCRIPTION
Because of the delays on graph api, users will not able to see actual market data on token detail and user profile page for long times.

To reproduce on token detail page:

1. Go to any collection 
2. Buy one item 
3. After successful transaction it still shows the old price and it will be still on sale

To reproduce issues on profile page:

1. Change sell price of nft that is on market
2. See market data is not updated if graph data is delayed

------------------------

1. Remove nft from the market
2. See it shows the same nft twice on the list until graph api is updated

------------------------

1. List nft to the market
2. User has to wait until graph api is updated (and until that time that nft is not shown in the user nft list)