### PR TITLE
fix: Manage nft cards still shows user nfts after logout

### DIFF
--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -6,7 +6,6 @@ import erc721Abi from 'config/abi/erc721.json'
 import range from 'lodash/range'
 import uniq from 'lodash/uniq'
 import { pancakeBunniesAddress } from 'views/Nft/market/constants'
-import { isAddress } from 'utils'
 import {
   ApiCollection,
   ApiCollections,

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -987,8 +987,6 @@ export const getCompleteAccountNftData = async (
   collections: ApiCollections,
   profileNftWithCollectionAddress?: TokenIdWithCollectionAddress,
 ): Promise<NftToken[]> => {
-  if (!isAddress(account)) return []
-
   const walletNftIdsWithCollectionAddress = await fetchWalletTokenIdsForCollections(account, collections)
   if (profileNftWithCollectionAddress?.tokenId) {
     walletNftIdsWithCollectionAddress.unshift(profileNftWithCollectionAddress)

--- a/src/state/nftMarket/helpers.ts
+++ b/src/state/nftMarket/helpers.ts
@@ -6,6 +6,7 @@ import erc721Abi from 'config/abi/erc721.json'
 import range from 'lodash/range'
 import uniq from 'lodash/uniq'
 import { pancakeBunniesAddress } from 'views/Nft/market/constants'
+import { isAddress } from 'utils'
 import {
   ApiCollection,
   ApiCollections,
@@ -986,6 +987,8 @@ export const getCompleteAccountNftData = async (
   collections: ApiCollections,
   profileNftWithCollectionAddress?: TokenIdWithCollectionAddress,
 ): Promise<NftToken[]> => {
+  if (!isAddress(account)) return []
+
   const walletNftIdsWithCollectionAddress = await fetchWalletTokenIdsForCollections(account, collections)
   if (profileNftWithCollectionAddress?.tokenId) {
     walletNftIdsWithCollectionAddress.unshift(profileNftWithCollectionAddress)

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
@@ -157,7 +157,7 @@ const ManagePancakeBunniesCard: React.FC<ManagePancakeBunniesCardProps> = ({ bun
   )
 
   const useHasNoBunnies =
-    !isLoading && bunniesInWallet.length === 0 && bunniesForSale.length === 0 && profilePicBunny.length === 0
+    account && !isLoading && bunniesInWallet.length === 0 && bunniesForSale.length === 0 && profilePicBunny.length === 0
   const totalBunnies = bunniesInWallet.length + bunniesForSale.length + profilePicBunny.length
   const totalBunniesText = account && !useHasNoBunnies ? ` (${totalBunnies})` : ''
 

--- a/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
+++ b/src/views/Nft/market/Collection/IndividualNFTPage/PancakeBunnyPage/ManagePancakeBunniesCard.tsx
@@ -157,7 +157,7 @@ const ManagePancakeBunniesCard: React.FC<ManagePancakeBunniesCardProps> = ({ bun
   )
 
   const useHasNoBunnies =
-    account && !isLoading && bunniesInWallet.length === 0 && bunniesForSale.length === 0 && profilePicBunny.length === 0
+    !isLoading && bunniesInWallet.length === 0 && bunniesForSale.length === 0 && profilePicBunny.length === 0
   const totalBunnies = bunniesInWallet.length + bunniesForSale.length + profilePicBunny.length
   const totalBunniesText = account && !useHasNoBunnies ? ` (${totalBunnies})` : ''
 
@@ -168,7 +168,7 @@ const ManagePancakeBunniesCard: React.FC<ManagePancakeBunniesCardProps> = ({ bun
           <ConnectWalletButton />
         </Flex>
       )}
-      {useHasNoBunnies && (
+      {account && useHasNoBunnies && (
         <Text px="16px" pb="16px" color="textSubtle">
           {t('You don’t have any of this item.')}
         </Text>

--- a/src/views/Nft/market/hooks/useNftsForAddress.tsx
+++ b/src/views/Nft/market/hooks/useNftsForAddress.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import isEmpty from 'lodash/isEmpty'
 import { useGetCollections } from 'state/nftMarket/hooks'
 import { NftLocation } from 'state/nftMarket/types'

--- a/src/views/Nft/market/hooks/useNftsForAddress.tsx
+++ b/src/views/Nft/market/hooks/useNftsForAddress.tsx
@@ -4,7 +4,6 @@ import { useGetCollections } from 'state/nftMarket/hooks'
 import { NftLocation } from 'state/nftMarket/types'
 import { Profile } from 'state/types'
 import { getCompleteAccountNftData } from 'state/nftMarket/helpers'
-import { isAddress } from 'utils'
 import useSWR from 'swr'
 import { FetchStatus } from 'config/constants/types'
 import { laggyMiddleware } from 'hooks/useSWRContract'
@@ -28,7 +27,7 @@ const useNftsForAddress = (account: string, profile: Profile, isProfileFetching:
   }, [profileNftTokenId, profileNftCollectionAddress, hasProfileNft])
 
   const { status, data, mutate } = useSWR(
-    !isProfileFetching && !isEmpty(collections) && isAddress(account) ? [account, 'userNfts'] : null,
+    !isProfileFetching && !isEmpty(collections) ? [account, 'userNfts'] : null,
     async () => getCompleteAccountNftData(account, collections, profileNftWithCollectionAddress),
     { use: [laggyMiddleware] },
   )

--- a/src/views/Nft/market/hooks/useNftsForAddress.tsx
+++ b/src/views/Nft/market/hooks/useNftsForAddress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useEffect, useRef } from 'react'
 import isEmpty from 'lodash/isEmpty'
 import { useGetCollections } from 'state/nftMarket/hooks'
 import { NftLocation } from 'state/nftMarket/types'
@@ -7,9 +7,17 @@ import { getCompleteAccountNftData } from 'state/nftMarket/helpers'
 import useSWR from 'swr'
 import { FetchStatus } from 'config/constants/types'
 import { laggyMiddleware } from 'hooks/useSWRContract'
+import usePrevious from 'hooks/usePreviousValue'
+import { isAddress } from 'utils'
 
 const useNftsForAddress = (account: string, profile: Profile, isProfileFetching: boolean) => {
   const { data: collections } = useGetCollections()
+  const resetLaggyRef = useRef(null)
+  const previousAccount = usePrevious(account)
+
+  if (resetLaggyRef.current && previousAccount !== account) {
+    resetLaggyRef.current()
+  }
 
   const hasProfileNft = profile?.tokenId
   const profileNftTokenId = profile?.tokenId?.toString()
@@ -26,11 +34,14 @@ const useNftsForAddress = (account: string, profile: Profile, isProfileFetching:
     return null
   }, [profileNftTokenId, profileNftCollectionAddress, hasProfileNft])
 
-  const { status, data, mutate } = useSWR(
-    !isProfileFetching && !isEmpty(collections) ? [account, 'userNfts'] : null,
+  // @ts-ignore
+  const { status, data, mutate, resetLaggy } = useSWR(
+    !isProfileFetching && !isEmpty(collections) && isAddress(account) ? [account, 'userNfts'] : null,
     async () => getCompleteAccountNftData(account, collections, profileNftWithCollectionAddress),
     { use: [laggyMiddleware] },
   )
+
+  resetLaggyRef.current = resetLaggy
 
   return { nfts: data ?? [], isLoading: status !== FetchStatus.Fetched, refresh: mutate }
 }


### PR DESCRIPTION
Root cause is laggy middleware shows the last data after key changes. We should keep this behaviour and resolve the account changes in the fetcher

To reproduce:

1. Go to pb nft token detail page that account has bunny
2. See nfts on manage yours
3. Logout
4. See it is still visible