### PR TITLE
fix: Swiper moves to next round card from currently focused after removing earliest card

### DIFF
--- a/src/views/Predictions/hooks/useOnNextRound.ts
+++ b/src/views/Predictions/hooks/useOnNextRound.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react'
+import { useLayoutEffect } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import usePreviousValue from 'hooks/usePreviousValue'
 import { useAppDispatch } from 'state'
@@ -16,7 +16,6 @@ const useOnNextRound = () => {
   const roundsEpochsString = JSON.stringify(Object.keys(rounds))
   const previousEpoch = usePreviousValue(currentEpoch)
   const previousRoundsEpochsString = usePreviousValue(roundsEpochsString)
-  const previousActiveRoundIndex = useRef(0)
 
   useLayoutEffect(() => {
     if (
@@ -30,10 +29,8 @@ const useOnNextRound = () => {
       // Slide to the current LIVE round which is always the one before the current round
       if (currentEpoch !== previousEpoch) {
         swiper.slideTo(currentEpochIndex - 1)
-        previousActiveRoundIndex.current = currentEpochIndex - 1
-      } else if (swiper.activeIndex === previousActiveRoundIndex.current) {
-        // The check above is not to slide after the removal of earliest round if user goes to another slide than active round meanwhile
-        swiper.slideTo(currentEpochIndex - 1, 0)
+      } else if (!swiper.isBeginning && !swiper.isEnd) {
+        swiper.slideTo(swiper.activeIndex - 1, 0)
       }
     }
   }, [previousEpoch, currentEpoch, previousRoundsEpochsString, roundsEpochsString, rounds, swiper, account, dispatch])


### PR DESCRIPTION
To reproduce: 

1. Go to prediction
2. Wait for the round transition happens to new live round
3. Switch to another round from live one
4. See after the next refresh cycle it will move to the round next to the switched one