### PR TITLE
refactor: Use more visible colors for chainlink chart round dots

### DIFF
--- a/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/src/views/Predictions/components/ChainlinkChart.tsx
@@ -202,7 +202,7 @@ const Chart = ({
   const {
     currentLanguage: { locale },
   } = useTranslation()
-  const { theme } = useTheme()
+  const { isDark, theme } = useTheme()
   const mutate = useChartHoverMutate()
 
   return (
@@ -270,7 +270,15 @@ const Chart = ({
           }}
           dot={(props) => {
             if (rounds[props.payload.roundId]) {
-              return <Dot {...props} r={4} fill={chartColor.stroke} fillOpacity={1} strokeWidth={0} />
+              return (
+                <Dot
+                  {...props}
+                  r={4}
+                  fill={isDark ? theme.colors.gold : theme.colors.secondary}
+                  fillOpacity={1}
+                  strokeWidth={0}
+                />
+              )
             }
             return null
           }}


### PR DESCRIPTION
To review:

1. Go to prediction
2. Go to chainlink chart
3. See colors of round dots on the chart on both themes