### PR TITLE
fix: Not show collect win after polling predictions

### DIFF
--- a/src/state/predictions/index.ts
+++ b/src/state/predictions/index.ts
@@ -478,8 +478,8 @@ export const predictionsSlice = createSlice({
       state.currentEpoch = currentEpoch
       state.intervalSeconds = intervalSeconds
       state.minBetAmount = minBetAmount
-      state.claimableStatuses = claimableStatuses
-      state.ledgers = ledgers
+      state.claimableStatuses = merge({}, state.claimableStatuses, claimableStatuses)
+      state.ledgers = merge({}, state.ledgers, ledgers)
       state.rounds = newRounds
     })
 


### PR DESCRIPTION
`Collect Win` button is not showned when history after polling. 

Reproduce:
1. Win a bet
2. Open history tab
3. `Collect Win` is disappeared 