### PR TITLE
chore: Use Deutsch as a language label

### DIFF
--- a/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
+++ b/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
@@ -2551,14 +2551,14 @@ exports[`renders correctly 1`] = `
                     Français
                   </a>
                   <a
-                    aria-label="Datch"
+                    aria-label="Deutsch"
                     class="c29 c61"
                     color="textSubtle"
                     href="https://t.me/PancakeSwap_DE"
                     rel="noreferrer noopener"
                     target="_blank"
                   >
-                    Datch
+                    Deutsch
                   </a>
                   <a
                     aria-label="Filipino"

--- a/packages/uikit/src/components/Footer/config.tsx
+++ b/packages/uikit/src/components/Footer/config.tsx
@@ -131,7 +131,7 @@ export const socials = [
         href: "https://t.me/pancakeswapfr",
       },
       {
-        label: "Datch",
+        label: "Deutsch",
         href: "https://t.me/PancakeSwap_DE",
       },
       {


### PR DESCRIPTION
"Datch" seems to be typo of "Dach".
"Dach" means the areas where people speak German (Deutschland+Austria+Confoederatio Helvetica).
As a language label, "Deutsch"(German) is more clear.
