### PR TITLE
fix: (trading-competition): Crash when changing accounts, avoid flashing and set inital state statically

### DIFF
--- a/src/views/TradingCompetition/EasterCompetition.tsx
+++ b/src/views/TradingCompetition/EasterCompetition.tsx
@@ -51,12 +51,14 @@ const EasterCompetition = () => {
   const profileApiUrl = process.env.NEXT_PUBLIC_API_PROFILE
   const { account } = useWeb3React()
   const { isMobile } = useMatchBreakpointsContext()
-  const { profile, isLoading } = useProfile()
+  const { profile, isLoading: isProfileLoading } = useProfile()
   const { isDark } = useTheme()
   const tradingCompetitionContract = useTradingCompetitionContractEaster(false)
   const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.OVER)
   const { registrationSuccessful, claimSuccessful, onRegisterSuccess, onClaimSuccess } = useRegistrationClaimStatus()
   const [userTradingInformation, setUserTradingInformation] = useState({
+    isLoading: true,
+    account: undefined,
     hasRegistered: false,
     hasUserClaimed: false,
     userRewardGroup: '0',
@@ -100,6 +102,8 @@ const EasterCompetition = () => {
     const fetchUserContract = async () => {
       const user = await tradingCompetitionContract.claimInformation(account)
       const userObject = {
+        isLoading: false,
+        account,
         hasRegistered: user[0],
         hasUserClaimed: user[1],
         userRewardGroup: user[2].toString(),
@@ -115,6 +119,8 @@ const EasterCompetition = () => {
       fetchCompetitionInfoContract()
     } else {
       setUserTradingInformation({
+        isLoading: false,
+        account,
         hasRegistered: false,
         hasUserClaimed: false,
         userRewardGroup: '0',
@@ -132,14 +138,19 @@ const EasterCompetition = () => {
       setUserLeaderboardInformation(data.leaderboard)
     }
     // If user has not registered, user trading information will not be displayed and should not be fetched
-    if (account && userTradingInformation.hasRegistered) {
+    if (userTradingInformation.account && userTradingInformation.hasRegistered) {
       fetchUserTradingStats()
     }
   }, [account, userTradingInformation, profileApiUrl])
 
+  const isLoading = isProfileLoading || userTradingInformation.isLoading
+
   // Don't hide when loading. Hide if the account is connected && the user hasn't registered && the competition is live or finished
   const shouldHideCta =
-    !isLoading && account && !userTradingInformation.hasRegistered && (isCompetitionLive || hasCompetitionEnded)
+    !isLoading &&
+    userTradingInformation.account &&
+    !userTradingInformation.hasRegistered &&
+    (isCompetitionLive || hasCompetitionEnded)
 
   return (
     <CompetitionPage>

--- a/src/views/TradingCompetition/FanTokenCompetition.tsx
+++ b/src/views/TradingCompetition/FanTokenCompetition.tsx
@@ -35,12 +35,14 @@ const FanTokenCompetition = () => {
   const profileApiUrl = process.env.NEXT_PUBLIC_API_PROFILE
   const { account } = useWeb3React()
   const { isMobile } = useMatchBreakpointsContext()
-  const { profile, isLoading } = useProfile()
+  const { profile, isLoading: isProfileLoading } = useProfile()
   const { isDark } = useTheme()
   const tradingCompetitionContract = useTradingCompetitionContractFanToken(false)
   const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.OVER)
   const { registrationSuccessful, claimSuccessful, onRegisterSuccess, onClaimSuccess } = useRegistrationClaimStatus()
   const [userTradingInformation, setUserTradingInformation] = useState({
+    isLoading: true,
+    account: undefined,
     hasRegistered: false,
     hasUserClaimed: false,
     userRewardGroup: '0',
@@ -101,6 +103,8 @@ const FanTokenCompetition = () => {
       try {
         const user = await tradingCompetitionContract.claimInformation(account)
         const userObject = {
+          isLoading: false,
+          account,
           hasRegistered: user[0],
           hasUserClaimed: user[1],
           userRewardGroup: user[2].toString(),
@@ -122,6 +126,8 @@ const FanTokenCompetition = () => {
       fetchUserContract()
     } else {
       setUserTradingInformation({
+        isLoading: false,
+        account,
         hasRegistered: false,
         hasUserClaimed: false,
         userRewardGroup: '0',
@@ -142,14 +148,19 @@ const FanTokenCompetition = () => {
       setUserLeaderboardInformation(data.leaderboard_fantoken)
     }
     // If user has not registered, user trading information will not be displayed and should not be fetched
-    if (account && userTradingInformation.hasRegistered) {
+    if (userTradingInformation.account && userTradingInformation.hasRegistered) {
       fetchUserTradingStats()
     }
   }, [account, userTradingInformation, profileApiUrl])
 
+  const isLoading = isProfileLoading || userTradingInformation.isLoading
+
   // Don't hide when loading. Hide if the account is connected && the user hasn't registered && the competition is live or finished
   const shouldHideCta =
-    !isLoading && account && !userTradingInformation.hasRegistered && (isCompetitionLive || hasCompetitionEnded)
+    !isLoading &&
+    userTradingInformation.account &&
+    !userTradingInformation.hasRegistered &&
+    (isCompetitionLive || hasCompetitionEnded)
 
   return (
     <>

--- a/src/views/TradingCompetition/MoDCompetition.tsx
+++ b/src/views/TradingCompetition/MoDCompetition.tsx
@@ -31,7 +31,7 @@ import RibbonWithImage from './components/RibbonWithImage'
 import HowToJoin from './components/HowToJoin'
 import BattleCta from './components/BattleCta'
 import Rules from './components/Rules'
-import { UserTradingInformation } from './types'
+import { UserTradingInformation, initialUserTradingInformation, initialUserLeaderboardInformation } from './types'
 import { CompetitionPage, BannerFlex, BottomBunnyWrapper } from './styles'
 import RanksIcon from './svgs/RanksIcon'
 import ModBattleBanner, { CoinDecoration } from './mod/components/BattleBanner/ModBattleBanner'
@@ -47,30 +47,15 @@ const MoDCompetition = () => {
   const profileApiUrl = process.env.NEXT_PUBLIC_API_PROFILE
   const { account } = useWeb3React()
   const { t } = useTranslation()
-  const { profile, isLoading } = useProfile()
-  const { isMobile } = useMatchBreakpointsContext()
+  const { profile, isLoading: isProfileLoading } = useProfile()
+  const { isMobile } = useMatchBreakpoints()
   const { isDark, theme } = useTheme()
   const tradingCompetitionContract = useTradingCompetitionContractMoD(false)
   const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.CLAIM)
   const { registrationSuccessful, claimSuccessful, onRegisterSuccess, onClaimSuccess } = useRegistrationClaimStatus()
-  const [userTradingInformation, setUserTradingInformation] = useState<UserTradingInformation>({
-    hasRegistered: false,
-    isUserActive: false,
-    hasUserClaimed: false,
-    userRewardGroup: '0',
-    userCakeRewards: '0',
-    userDarRewards: '0',
-    userPointReward: '0',
-    canClaimNFT: false,
-  })
-  const [userLeaderboardInformation, setUserLeaderboardInformation] = useState({
-    global: 0,
-    team: 0,
-    volume: 0,
-    next_rank: 0,
-    darVolumeRank: '???',
-    darVolume: '???',
-  })
+  const [userTradingInformation, setUserTradingInformation] =
+    useState<UserTradingInformation>(initialUserTradingInformation)
+  const [userLeaderboardInformation, setUserLeaderboardInformation] = useState(initialUserLeaderboardInformation)
 
   const {
     globalLeaderboardInformation,
@@ -119,6 +104,7 @@ const MoDCompetition = () => {
           { requireSuccess: false },
         )
         const userObject: UserTradingInformation = {
+          isLoading: false,
           hasRegistered: user[0],
           isUserActive: user[1],
           hasUserClaimed: userClaimed,
@@ -131,6 +117,7 @@ const MoDCompetition = () => {
         setUserTradingInformation(userObject)
       } catch (error) {
         console.error(error)
+        setUserTradingInformation({ ...initialUserTradingInformation, account, isLoading: false })
       }
     }
 
@@ -138,16 +125,7 @@ const MoDCompetition = () => {
     if (account) {
       fetchUserContract()
     } else {
-      setUserTradingInformation({
-        hasRegistered: false,
-        isUserActive: false,
-        hasUserClaimed: false,
-        userRewardGroup: '0',
-        userCakeRewards: '0',
-        userDarRewards: '0',
-        userPointReward: '0',
-        canClaimNFT: false,
-      })
+      setUserTradingInformation({ ...initialUserTradingInformation, isLoading: false })
     }
   }, [account, registrationSuccessful, claimSuccessful, tradingCompetitionContract])
 
@@ -160,9 +138,12 @@ const MoDCompetition = () => {
     // If user has not registered, user trading information will not be displayed and should not be fetched
     if (account && userTradingInformation.hasRegistered) {
       fetchUserTradingStats()
+    } else {
+      setUserLeaderboardInformation({ ...initialUserLeaderboardInformation })
     }
   }, [account, userTradingInformation, profileApiUrl])
 
+  const isLoading = isProfileLoading || userTradingInformation.isLoading
   // Don't hide when loading. Hide if the account is connected && the user hasn't registered && the competition is live or finished
   const shouldHideCta =
     !isLoading && account && !userTradingInformation.hasRegistered && (isCompetitionLive || hasCompetitionEnded)

--- a/src/views/TradingCompetition/MoDCompetition.tsx
+++ b/src/views/TradingCompetition/MoDCompetition.tsx
@@ -105,6 +105,7 @@ const MoDCompetition = () => {
         )
         const userObject: UserTradingInformation = {
           isLoading: false,
+          account,
           hasRegistered: user[0],
           isUserActive: user[1],
           hasUserClaimed: userClaimed,
@@ -136,7 +137,7 @@ const MoDCompetition = () => {
       setUserLeaderboardInformation(data.leaderboard_dar)
     }
     // If user has not registered, user trading information will not be displayed and should not be fetched
-    if (account && userTradingInformation.hasRegistered) {
+    if (userTradingInformation.account && userTradingInformation.hasRegistered) {
       fetchUserTradingStats()
     } else {
       setUserLeaderboardInformation({ ...initialUserLeaderboardInformation })
@@ -146,7 +147,10 @@ const MoDCompetition = () => {
   const isLoading = isProfileLoading || userTradingInformation.isLoading
   // Don't hide when loading. Hide if the account is connected && the user hasn't registered && the competition is live or finished
   const shouldHideCta =
-    !isLoading && account && !userTradingInformation.hasRegistered && (isCompetitionLive || hasCompetitionEnded)
+    !isLoading &&
+    userTradingInformation.account &&
+    !userTradingInformation.hasRegistered &&
+    (isCompetitionLive || hasCompetitionEnded)
 
   return (
     <>

--- a/src/views/TradingCompetition/MoDCompetition.tsx
+++ b/src/views/TradingCompetition/MoDCompetition.tsx
@@ -48,7 +48,7 @@ const MoDCompetition = () => {
   const { account } = useWeb3React()
   const { t } = useTranslation()
   const { profile, isLoading: isProfileLoading } = useProfile()
-  const { isMobile } = useMatchBreakpoints()
+  const { isMobile } = useMatchBreakpointsContext()
   const { isDark, theme } = useTheme()
   const tradingCompetitionContract = useTradingCompetitionContractMoD(false)
   const [currentPhase, setCurrentPhase] = useState(CompetitionPhases.CLAIM)

--- a/src/views/TradingCompetition/MoboxCompetition.tsx
+++ b/src/views/TradingCompetition/MoboxCompetition.tsx
@@ -26,7 +26,7 @@ import RibbonWithImage from './components/RibbonWithImage'
 import HowToJoin from './components/HowToJoin'
 import BattleCta from './components/BattleCta'
 import Rules from './components/Rules'
-import { UserTradingInformation } from './types'
+import { UserTradingInformation, initialUserTradingInformation } from "./types"
 import { CompetitionPage, BannerFlex } from './styles'
 import RanksIcon from './svgs/RanksIcon'
 import MoboxYourScore from './mobox/components/YourScore/MoboxYourScore'
@@ -64,7 +64,7 @@ const MoboxCompetition = () => {
   })
   const { registrationSuccessful, claimSuccessful, onRegisterSuccess, onClaimSuccess } = useRegistrationClaimStatus()
   const [userTradingInformation, setUserTradingInformation] =
-    useState<UserTradingInformationProps>(initialUserTradingInformation)
+    useState<UserTradingInformation>(initialUserTradingInformation)
   const [userLeaderboardInformation, setUserLeaderboardInformation] = useState({
     global: 0,
     team: 0,
@@ -106,7 +106,6 @@ const MoboxCompetition = () => {
       canClaimNFT)
   const finishedAndPrizesClaimed = hasCompetitionEnded && account && hasUserClaimed
   const finishedAndNothingToClaim = hasCompetitionEnded && account && !userCanClaimPrizes
-
   useEffect(() => {
     const fetchCompetitionInfoContract = async () => {
       const competitionStatus = await tradingCompetitionContract.currentStatus()
@@ -152,15 +151,17 @@ const MoboxCompetition = () => {
 
   useEffect(() => {
     const fetchUserTradingStats = async () => {
-      const res = await fetch(`${profileApiUrl}/api/users/${account}`)
+      const res = await fetch(`${profileApiUrl}/api/users/${userTradingInformation.account}`)
       const data = await res.json()
       setUserLeaderboardInformation(data.leaderboard_mobox)
     }
     // If user has not registered, user trading information will not be displayed and should not be fetched
-    if (account && userTradingInformation.hasRegistered) {
+    if (userTradingInformation.account && userTradingInformation.hasRegistered) {
       fetchUserTradingStats()
+    } else {
+      setUserLeaderboardInformation({ ...initialUserLeaderboardInformation })
     }
-  }, [account, userTradingInformation, profileApiUrl])
+  }, [userTradingInformation, profileApiUrl])
 
   const isLoading = isProfileLoading || userTradingInformation.isLoading
 

--- a/src/views/TradingCompetition/MoboxCompetition.tsx
+++ b/src/views/TradingCompetition/MoboxCompetition.tsx
@@ -26,7 +26,7 @@ import RibbonWithImage from './components/RibbonWithImage'
 import HowToJoin from './components/HowToJoin'
 import BattleCta from './components/BattleCta'
 import Rules from './components/Rules'
-import { UserTradingInformation, initialUserTradingInformation } from "./types"
+import { UserTradingInformation, initialUserTradingInformation, initialUserLeaderboardInformation } from './types'
 import { CompetitionPage, BannerFlex } from './styles'
 import RanksIcon from './svgs/RanksIcon'
 import MoboxYourScore from './mobox/components/YourScore/MoboxYourScore'
@@ -65,14 +65,7 @@ const MoboxCompetition = () => {
   const { registrationSuccessful, claimSuccessful, onRegisterSuccess, onClaimSuccess } = useRegistrationClaimStatus()
   const [userTradingInformation, setUserTradingInformation] =
     useState<UserTradingInformation>(initialUserTradingInformation)
-  const [userLeaderboardInformation, setUserLeaderboardInformation] = useState({
-    global: 0,
-    team: 0,
-    volume: 0,
-    next_rank: 0,
-    moboxVolumeRank: '???',
-    moboxVolume: '???',
-  })
+  const [userLeaderboardInformation, setUserLeaderboardInformation] = useState(initialUserLeaderboardInformation)
 
   const {
     globalLeaderboardInformation,

--- a/src/views/TradingCompetition/components/BattleCta/index.tsx
+++ b/src/views/TradingCompetition/components/BattleCta/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@pancakeswap/uikit'
 import { useWallet } from 'hooks/useWallet'
 import { useTranslation } from '@pancakeswap/localization'
-import { FINISHED, OVER } from 'config/constants/trading-competition/phases'
+import { FINISHED, OVER, REGISTRATION } from 'config/constants/trading-competition/phases'
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
 import RegisterModal from '../RegisterModal'
@@ -116,15 +116,14 @@ const BattleCta: React.FC<React.PropsWithChildren<CompetitionProps>> = ({
     if (!account) {
       return t('Connect Wallet')
     }
-    // User not registered
-    if (!hasRegistered) {
+    // User not registered and competition in register
+    if (currentPhase.state === REGISTRATION && !hasRegistered) {
       return t('I want to Battle!')
     }
-    // User registered and competition live
+    // Competition live
     if (isCompetitionLive) {
       return t('Trade Now')
     }
-
     // User registered and competition finished
     if (hasCompetitionEnded) {
       // Claim period has ended

--- a/src/views/TradingCompetition/easter/components/YourScore/EasterYourScore.tsx
+++ b/src/views/TradingCompetition/easter/components/YourScore/EasterYourScore.tsx
@@ -30,7 +30,7 @@ const EasterYourScore: React.FC<React.PropsWithChildren<YourScoreProps>> = ({
   onClaimSuccess,
 }) => {
   const { t } = useTranslation()
-  const showRibbon = !account || hasRegistered
+  const showRibbon = !account || isLoading || hasRegistered
 
   return (
     <Wrapper>

--- a/src/views/TradingCompetition/types.ts
+++ b/src/views/TradingCompetition/types.ts
@@ -95,6 +95,8 @@ export const initialUserLeaderboardInformation = {
   next_rank: 0,
   moboxVolumeRank: '???',
   moboxVolume: '???',
+  darVolumeRank: '???',
+  darVolume: '???',
 }
 
 export const initialUserTradingInformation = {
@@ -105,6 +107,7 @@ export const initialUserTradingInformation = {
   userRewardGroup: '0',
   userCakeRewards: '0',
   userMoboxRewards: '0',
+  userDarRewards: '0',
   userPointReward: '0',
   canClaimMysteryBox: false,
   canClaimNFT: false,

--- a/src/views/TradingCompetition/types.ts
+++ b/src/views/TradingCompetition/types.ts
@@ -87,7 +87,23 @@ export interface UserRewardsProps {
     pointsToClaim?: string
   }
 }
+
+export const initialUserTradingInformation = {
+  isLoading: true,
+  hasRegistered: false,
+  isUserActive: false,
+  hasUserClaimed: false,
+  userRewardGroup: '0',
+  userCakeRewards: '0',
+  userMoboxRewards: '0',
+  userPointReward: '0',
+  canClaimMysteryBox: false,
+  canClaimNFT: false,
+}
+
 export interface UserTradingInformation {
+  isLoading: boolean
+  account?: string
   hasRegistered?: boolean
   isUserActive?: boolean
   hasUserClaimed?: boolean

--- a/src/views/TradingCompetition/types.ts
+++ b/src/views/TradingCompetition/types.ts
@@ -88,6 +88,15 @@ export interface UserRewardsProps {
   }
 }
 
+export const initialUserLeaderboardInformation = {
+  global: 0,
+  team: 0,
+  volume: 0,
+  next_rank: 0,
+  moboxVolumeRank: '???',
+  moboxVolume: '???',
+}
+
 export const initialUserTradingInformation = {
   isLoading: true,
   hasRegistered: false,


### PR DESCRIPTION
Currently it blinks and shows the registration components depending on the users internet connection speed until it fetches the actual trading state.

To reproduce crash: 

1. Go to competition with registered account
2. Change to unregistered account
3. See it crashed