### PR TITLE
fix: (nft): Collection listings not updated in user session

### DIFF
--- a/src/views/Nft/market/hooks/useCollectionNfts.tsx
+++ b/src/views/Nft/market/hooks/useCollectionNfts.tsx
@@ -260,7 +260,7 @@ export const useCollectionNfts = (collectionAddress: string) => {
       }
       return newNfts
     },
-    { revalidateFirstPage: false },
+    { revalidateAll: true },
   )
 
   const uniqueNftList: NftToken[] = useMemo(() => (nfts ? uniqBy(nfts.flat(), 'tokenId') : []), [nfts])


### PR DESCRIPTION
Currently user has to refresh the page in order to update nft collection listings

To reproduce:

1. Go to one collection listings
2. Then go to another collection item listing
3. Then go back to the first collection listings
4. See it shows the old data since it is not revalidated
