### PR TITLE
feat: add skeleton for lock cake table view

### DIFF
--- a/packages/uikit/src/components/Skeleton/Skeleton.tsx
+++ b/packages/uikit/src/components/Skeleton/Skeleton.tsx
@@ -44,6 +44,12 @@ const AnimationWrapper = styled(Motion.div)`
   }
 `;
 
+const SkeletonWrapper = styled.div<SkeletonProps>`
+  position: relative;
+  ${layout}
+  ${space}
+`;
+
 const Root = styled.div<SkeletonProps>`
   min-height: 20px;
   display: block;
@@ -87,44 +93,49 @@ export const SkeletonV2: React.FC<SkeletonV2Props> = ({
   animation = ANIMATION.PULSE,
   isDataReady = false,
   children,
+  wrapperProps,
+  skeletonTop = "0",
+  skeletonLeft = "0",
   ...props
 }) => {
   const animationRef = useRef<HTMLDivElement>(null);
   const skeletonRef = useRef<HTMLDivElement>(null);
   return (
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence>
-        {isDataReady && (
-          <AnimationWrapper
-            key="content"
-            ref={animationRef}
-            onAnimationStart={() => animationHandler(animationRef.current)}
-            {...animationMap}
-            variants={animationVariants}
-            transition={{ duration: 0.3 }}
-          >
-            {children}
-          </AnimationWrapper>
-        )}
-        {!isDataReady && (
-          <AnimationWrapper
-            key="skeleton"
-            style={{ position: "absolute", top: 0, left: 0 }}
-            ref={skeletonRef}
-            onAnimationStart={() => animationHandler(skeletonRef.current)}
-            {...animationMap}
-            variants={animationVariants}
-            transition={{ duration: 0.3 }}
-          >
-            {animation === ANIMATION.WAVES ? (
-              <Waves variant={variant} {...props} />
-            ) : (
-              <Pulse variant={variant} {...props} />
-            )}
-          </AnimationWrapper>
-        )}
-      </AnimatePresence>
-    </LazyMotion>
+    <SkeletonWrapper {...wrapperProps}>
+      <LazyMotion features={domAnimation}>
+        <AnimatePresence>
+          {isDataReady && (
+            <AnimationWrapper
+              key="content"
+              ref={animationRef}
+              onAnimationStart={() => animationHandler(animationRef.current)}
+              {...animationMap}
+              variants={animationVariants}
+              transition={{ duration: 0.3 }}
+            >
+              {children}
+            </AnimationWrapper>
+          )}
+          {!isDataReady && (
+            <AnimationWrapper
+              key="skeleton"
+              style={{ position: "absolute", top: skeletonTop, left: skeletonLeft }}
+              ref={skeletonRef}
+              onAnimationStart={() => animationHandler(skeletonRef.current)}
+              {...animationMap}
+              variants={animationVariants}
+              transition={{ duration: 0.3 }}
+            >
+              {animation === ANIMATION.WAVES ? (
+                <Waves variant={variant} {...props} />
+              ) : (
+                <Pulse variant={variant} {...props} />
+              )}
+            </AnimationWrapper>
+          )}
+        </AnimatePresence>
+      </LazyMotion>
+    </SkeletonWrapper>
   );
 };
 

--- a/packages/uikit/src/components/Skeleton/index.tsx
+++ b/packages/uikit/src/components/Skeleton/index.tsx
@@ -1,2 +1,2 @@
-export { default as Skeleton } from "./Skeleton";
+export { default as Skeleton, SkeletonV2 } from "./Skeleton";
 export type { SkeletonProps } from "./types";

--- a/packages/uikit/src/components/Skeleton/types.ts
+++ b/packages/uikit/src/components/Skeleton/types.ts
@@ -23,6 +23,6 @@ export interface SkeletonV2Props extends SpaceProps, LayoutProps {
   variant?: Variant;
   isDataReady?: boolean;
   wrapperProps?: SpaceProps & LayoutProps;
-  skeletonTop: string;
-  skeletonLeft: string;
+  skeletonTop?: string;
+  skeletonLeft?: string;
 }

--- a/packages/uikit/src/components/Skeleton/types.ts
+++ b/packages/uikit/src/components/Skeleton/types.ts
@@ -22,4 +22,7 @@ export interface SkeletonV2Props extends SpaceProps, LayoutProps {
   animation?: Animation;
   variant?: Variant;
   isDataReady?: boolean;
+  wrapperProps?: SpaceProps & LayoutProps;
+  skeletonTop: string;
+  skeletonLeft: string;
 }

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -10,6 +10,7 @@ import {
   useTooltip,
   Box,
   useMatchBreakpoints,
+  SkeletonV2,
 } from '@pancakeswap/uikit'
 import { useWeb3React } from '@web3-react/core'
 import BigNumber from 'bignumber.js'
@@ -256,7 +257,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
                 </Text>
               </ActionTitles>
               <ActionContent>
-                <Box>
+                <Box position="relative">
                   <Balance
                     lineHeight="1"
                     bold
@@ -264,7 +265,12 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
                     decimals={5}
                     value={vaultKey ? cakeAsNumberBalance : stakedTokenBalance}
                   />
-                  {Number.isFinite(vaultKey ? stakedAutoDollarValue : stakedTokenDollarBalance) && (
+                  <SkeletonV2
+                    isDataReady={Number.isFinite(vaultKey ? stakedAutoDollarValue : stakedTokenDollarBalance)}
+                    width={120}
+                    wrapperProps={{ height: '20px' }}
+                    skeletonTop="2px"
+                  >
                     <Balance
                       fontSize="12px"
                       display="inline"
@@ -274,7 +280,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
                       unit=" USD"
                       prefix="~"
                     />
-                  )}
+                  </SkeletonV2>
                 </Box>
               </ActionContent>
               {vaultPosition === VaultPosition.Locked && (


### PR DESCRIPTION
using SkeletonV2 to add a skeleton to avoid layout shift after data load
SkeletonV2 will handle the transition between Skeleton and content automatically



before:
<img width="494" alt="before" src="https://user-images.githubusercontent.com/99634186/165466904-24ce6dc0-463d-4825-b25b-6ee15454b5a6.png">

after:
[desktop]
<img width="502" alt="demo" src="https://user-images.githubusercontent.com/99634186/165461359-dd9427f6-93cd-49d6-b8fa-6c0fab69fdfb.png">
[Mobile]
![demo2](https://user-images.githubusercontent.com/99634186/165463257-e7d3ce18-b408-4a2e-b9d1-7d9491899edc.jpeg)