### PR TITLE
feat: Ambire Wallet transaction batching skipping gas estimation

### DIFF
--- a/src/hooks/useIsAmbireWC.ts
+++ b/src/hooks/useIsAmbireWC.ts
@@ -1,0 +1,9 @@
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
+import useActiveWeb3React from './useActiveWeb3React'
+
+export default function useIsAmbireWC(): boolean {
+  const res = useActiveWeb3React()
+  const wcConnector = res?.connector as WalletConnectConnector
+
+  return wcConnector?.walletConnectProvider?.wc?._peerMeta?.name === 'Ambire Wallet'
+}

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -64,6 +64,7 @@ import SwapWarningModal from './components/SwapWarningModal'
 import PriceChartContainer from './components/Chart/PriceChartContainer'
 import { StyledInputCurrencyWrapper, StyledSwapContainer } from './styles'
 import CurrencyInputHeader from './components/CurrencyInputHeader'
+import useIsAmbireWC from '../../hooks/useIsAmbireWC'
 
 const Label = styled(Text)`
   font-size: 12px;
@@ -233,6 +234,8 @@ export default function Swap() {
 
   const [singleHopOnly] = useUserSingleHopOnly()
 
+  const isAmbireWC = useIsAmbireWC()
+
   const handleSwap = useCallback(() => {
     if (priceImpactWithoutFee && !confirmPriceImpactWithoutFee(priceImpactWithoutFee, t)) {
       return
@@ -264,6 +267,7 @@ export default function Swap() {
   // show approve flow when: no error on inputs, not approved or pending, or approved in current session
   // never show if price impact is above threshold in non expert mode
   const showApproveFlow =
+    !isAmbireWC &&
     !swapInputError &&
     (approval === ApprovalState.NOT_APPROVED ||
       approval === ApprovalState.PENDING ||


### PR DESCRIPTION
This PR implements batching for ERC20 approvals with Ambire, which is a smart wallet that allows for transaction batching, smart recovery, gas abstractions and others. Rather than having to sign & send the ERC20 approval transaction separately, with this PR, it will be batched together with the specific action when the wallet used is Ambire.

The UX impact is immense, as the approval step is essentially permanently eliminated, without compromising security (the same calls are being done, just in one tx).

While this PR implements some logic custom to Ambire, this logic can be easily modified into an implementation of the batching EIP that’s currently being worked on by Gnosis Safe and Ambire, turning the code into a general implementation of txn batching.

This implementation uses altered SwapCall structure to skip the swap gas estimation, therefore no error is thrown. It can also be future proof, for smart wallets that calculate the gas independently from the dapp.