### PR TITLE
fix: Modal close on overlay click cannot be disabled

### DIFF
--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -16,9 +16,8 @@ interface ModalsContext {
   nodeId: string;
   modalNode: React.ReactNode;
   setModalNode: React.Dispatch<React.SetStateAction<React.ReactNode>>;
-  onPresent: (node: React.ReactNode, newNodeId: string) => void;
+  onPresent: (node: React.ReactNode, newNodeId: string, closeOverlayClick: boolean) => void;
   onDismiss: Handler;
-  setCloseOnOverlayClick: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const ModalWrapper = styled(m.div)`
@@ -49,7 +48,6 @@ export const Context = createContext<ModalsContext>({
   setModalNode: () => null,
   onPresent: () => null,
   onDismiss: () => null,
-  setCloseOnOverlayClick: () => true,
 });
 
 const ModalProvider: React.FC = ({ children }) => {
@@ -59,10 +57,11 @@ const ModalProvider: React.FC = ({ children }) => {
   const [closeOnOverlayClick, setCloseOnOverlayClick] = useState(true);
   const animationRef = useRef<HTMLDivElement>(null);
 
-  const handlePresent = (node: React.ReactNode, newNodeId: string) => {
+  const handlePresent = (node: React.ReactNode, newNodeId: string, closeOverlayClick: boolean) => {
     setModalNode(node);
     setIsOpen(true);
     setNodeId(newNodeId);
+    setCloseOnOverlayClick(closeOverlayClick);
   };
 
   const handleDismiss = () => {
@@ -86,7 +85,6 @@ const ModalProvider: React.FC = ({ children }) => {
         setModalNode,
         onPresent: handlePresent,
         onDismiss: handleDismiss,
-        setCloseOnOverlayClick,
       }}
     >
       <LazyMotion features={domAnimation}>

--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -68,6 +68,7 @@ const ModalProvider: React.FC = ({ children }) => {
     setModalNode(undefined);
     setIsOpen(false);
     setNodeId("");
+    setCloseOnOverlayClick(true);
   };
 
   const handleOverlayDismiss = () => {

--- a/packages/uikit/src/widgets/Modal/useModal.ts
+++ b/packages/uikit/src/widgets/Modal/useModal.ts
@@ -9,14 +9,14 @@ const useModal = (
   updateOnPropsChange = false,
   modalId = "defaultNodeId"
 ): [Handler, Handler] => {
-  const { isOpen, nodeId, modalNode, setModalNode, onPresent, onDismiss, setCloseOnOverlayClick } = useContext(Context);
+  const { isOpen, nodeId, modalNode, setModalNode, onPresent, onDismiss } = useContext(Context);
   const onPresentCallback = useCallback(() => {
-    onPresent(modal, modalId);
-  }, [modal, modalId, onPresent]);
+    onPresent(modal, modalId, closeOnOverlayClick);
+  }, [modal, modalId, onPresent, closeOnOverlayClick]);
 
   // Updates the "modal" component if props are changed
   // Use carefully since it might result in unnecessary rerenders
-  // Typically if modal is staic there is no need for updates, use when you expect props to change
+  // Typically if modal is static there is no need for updates, use when you expect props to change
   useEffect(() => {
     // NodeId is needed in case there are 2 useModal hooks on the same page and one has updateOnPropsChange
     if (updateOnPropsChange && isOpen && nodeId === modalId) {
@@ -33,10 +33,6 @@ const useModal = (
       }
     }
   }, [updateOnPropsChange, nodeId, modalId, isOpen, modal, modalNode, setModalNode]);
-
-  useEffect(() => {
-    setCloseOnOverlayClick(closeOnOverlayClick);
-  }, [closeOnOverlayClick, setCloseOnOverlayClick]);
 
   return [onPresentCallback, onDismiss];
 };

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -26,31 +26,9 @@ interface SwapWarningModalProps {
   onDismiss?: () => void
 }
 
-// Modal is fired by a useEffect and doesn't respond to closeOnOverlayClick prop being set to false
-const usePreventModalOverlayClick = () => {
-  useEffect(() => {
-    const preventClickHandler = (e) => {
-      e.stopPropagation()
-      e.preventDefault()
-      return false
-    }
-
-    document.querySelectorAll('[role="presentation"]').forEach((el) => {
-      el.addEventListener('click', preventClickHandler, true)
-    })
-
-    return () => {
-      document.querySelectorAll('[role="presentation"]').forEach((el) => {
-        el.removeEventListener('click', preventClickHandler, true)
-      })
-    }
-  }, [])
-}
-
 const SwapWarningModal: React.FC<SwapWarningModalProps> = ({ swapCurrency, onDismiss }) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
-  usePreventModalOverlayClick()
 
   const TOKEN_WARNINGS = {
     [SwapWarningTokensConfig.safemoon.address]: {

--- a/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import styled from 'styled-components'
 import { ModalBody, ModalContainer, Message, ModalHeader, Box, Heading } from '@pancakeswap/uikit'
 import useTheme from 'hooks/useTheme'

--- a/src/views/Swap/index.tsx
+++ b/src/views/Swap/index.tsx
@@ -284,7 +284,7 @@ export default function Swap() {
 
   // swap warning state
   const [swapWarningCurrency, setSwapWarningCurrency] = useState(null)
-  const [onPresentSwapWarningModal] = useModal(<SwapWarningModal swapCurrency={swapWarningCurrency} />)
+  const [onPresentSwapWarningModal] = useModal(<SwapWarningModal swapCurrency={swapWarningCurrency} />, false)
 
   useEffect(() => {
     if (swapWarningCurrency) {


### PR DESCRIPTION
To reproduce: 

1. Go to prediction after cleaning the cache
2. See risk disclaimer
3. Click the overlay
4. See modal is closed though it shouldn't be