### PR TITLE
fix: (nft): Collection listing page scroll to top button renders on each scroll event

### DIFF
--- a/src/components/ScrollToTopButton/index.tsx
+++ b/src/components/ScrollToTopButton/index.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import styled from 'styled-components'
 import { Button, ChevronUpIcon } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import throttle from 'lodash/throttle'
 
 const FixedContainer = styled.div`
   position: fixed;
@@ -13,26 +14,28 @@ const ScrollToTopButton = () => {
   const [visible, setVisible] = useState(false)
   const { t } = useTranslation()
 
-  const toggleVisible = () => {
-    const scrolled = document.documentElement.scrollTop
-    if (scrolled > 700) {
-      setVisible(true)
-    } else if (scrolled <= 700) {
-      setVisible(false)
-    }
-  }
-
-  const scrollToTop = () => {
+  const scrollToTop = useCallback(() => {
     window.scrollTo({
       top: 400,
       behavior: 'auto',
     })
-  }
+  }, [])
 
   useEffect(() => {
-    window.addEventListener('scroll', toggleVisible)
+    const toggleVisible = () => {
+      const scrolled = document.documentElement.scrollTop
+      if (scrolled > 700) {
+        setVisible(true)
+      } else if (scrolled <= 700) {
+        setVisible(false)
+      }
+    }
 
-    return () => window.removeEventListener('scroll', toggleVisible)
+    const throttledToggleVisible = throttle(toggleVisible, 200)
+
+    window.addEventListener('scroll', throttledToggleVisible)
+
+    return () => window.removeEventListener('scroll', throttledToggleVisible)
   }, [])
 
   return (


### PR DESCRIPTION
It renders on each scroll event which puts load on while user visiting the page