### PR TITLE
fix: UseIsWindowVisible hook initial state value calculated on each render

### DIFF
--- a/src/hooks/useIsWindowVisible.ts
+++ b/src/hooks/useIsWindowVisible.ts
@@ -12,7 +12,7 @@ function isWindowVisible() {
  * Returns whether the window is currently visible to the user.
  */
 export default function useIsWindowVisible() {
-  const [isVisible, setIsVisible] = useState(isWindowVisible())
+  const [isVisible, setIsVisible] = useState(() => isWindowVisible())
 
   useEffect(() => {
     if (!('visibilityState' in document)) return undefined


### PR DESCRIPTION
This hook is used in useCountdown hook which runs in every second (on prediction for example) as a result of this window visible default value calculated every second unnecessarily.