### PR TITLE
fix: (prediction): Round card arrow svgs disappears on ios browsers after making app on foreground again

### DIFF
--- a/packages/uikit/src/components/Svg/Svg.tsx
+++ b/packages/uikit/src/components/Svg/Svg.tsx
@@ -20,8 +20,13 @@ const Svg = styled.svg<SvgProps>`
   align-self: center; // Safari fix
   fill: ${({ theme, color }) => getThemeValue(`colors.${color}`, color)(theme)};
   flex-shrink: 0;
-  ${({ spin }) => spin && spinStyle}
-  ${space}
+  ${({ spin }) => spin && spinStyle};
+  ${space};
+
+  // Safari fix
+  @supports (-webkit-text-size-adjust: none) and (not (-ms-accelerator: true)) and (not (-moz-appearance: none)) {
+    filter: none !important;
+  }
 `;
 
 Svg.defaultProps = {


### PR DESCRIPTION
https://ethanclevenger.com/Filter-Bug-Turns-SVGs-Invisible-on-iOS-Browsers/

To reproduce:

1. Go to prediction on ios safari
2. See red,green or gray arrows on round cards
3. Send browser to background and back to foreground again
4. See sometimes arrows are getting invisible