### PR TITLE
fix: Contract hooks cause unnecessary rerenders and requests even signer not used

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -292,7 +292,7 @@ function useContract<T extends Contract = Contract>(
   )
 
   const canReturnContract = useMemo(
-    () => !(!address || !ABI || withSignerIfPossible ? !library : false),
+    () => (address && ABI && withSignerIfPossible ? library : true),
     [address, ABI, library, withSignerIfPossible],
   )
 

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -50,6 +50,8 @@ import { getContract, getProviderOrSigner } from '../utils'
 
 import { IPancakePair } from '../config/abi/types/IPancakePair'
 
+const EMPTY_ARRAY = Object.freeze([])
+
 /**
  * Helper hooks to get specific contracts (by ABI)
  */
@@ -68,7 +70,8 @@ export const useERC20 = (address: string, withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getBep20Contract(address, withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [account, address, library, withSignerIfPossible],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [address, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -76,10 +79,11 @@ export const useERC20 = (address: string, withSignerIfPossible = true) => {
  * @see https://docs.openzeppelin.com/contracts/3.x/api/token/erc721
  */
 export const useERC721 = (address: string, withSignerIfPossible = true) => {
-  const { library, account } = useActiveWeb3React()
+  const { account, library } = useActiveWeb3React()
   return useMemo(
     () => getErc721Contract(address, withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [address, library, withSignerIfPossible, account],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [address, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -108,7 +112,8 @@ export const useProfileContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getProfileContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [withSignerIfPossible, account, library],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -121,7 +126,8 @@ export const useMasterchef = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getMasterchefContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [library, withSignerIfPossible, account],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -159,7 +165,8 @@ export const useTradingCompetitionContractV2 = (withSignerIfPossible = true) => 
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getTradingCompetitionContractV2(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [library, withSignerIfPossible, account],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -167,7 +174,8 @@ export const useTradingCompetitionContractMobox = (withSignerIfPossible = true) 
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getTradingCompetitionContractMobox(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [library, withSignerIfPossible, account],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -185,7 +193,8 @@ export const useCakeVaultContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getCakeVaultV2Contract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [withSignerIfPossible, library, account],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -198,7 +207,8 @@ export const useChainlinkOracleContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
   return useMemo(
     () => getChainlinkOracleContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [account, library, withSignerIfPossible],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -246,7 +256,8 @@ export const useFarmAuctionContract = (withSignerIfPossible = true) => {
   const { account, library } = useActiveWeb3React()
   return useMemo(
     () => getFarmAuctionContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    [library, account, withSignerIfPossible],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
   )
 }
 
@@ -286,7 +297,8 @@ function useContract<T extends Contract = Contract>(
       console.error('Failed to get contract', error)
       return null
     }
-  }, [address, ABI, library, withSignerIfPossible, account]) as T
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, ABI, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)]) as T
 }
 
 export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean) {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -290,16 +290,21 @@ function useContract<T extends Contract = Contract>(
     () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
     [withSignerIfPossible, library, account],
   )
+
+  const canReturnContract = useMemo(
+    () => !(!address || !ABI || withSignerIfPossible ? !library : false),
+    [address, ABI, library, withSignerIfPossible],
+  )
+
   return useMemo(() => {
-    if (!address || !ABI || !library) return null
+    if (!canReturnContract) return null
     try {
       return getContract(address, ABI, signer)
     } catch (error) {
       console.error('Failed to get contract', error)
       return null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, ABI, signer]) as T
+  }, [address, ABI, signer, canReturnContract]) as T
 }
 
 export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean) {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -50,8 +50,6 @@ import { getContract, getProviderOrSigner } from '../utils'
 
 import { IPancakePair } from '../config/abi/types/IPancakePair'
 
-const EMPTY_ARRAY = Object.freeze([])
-
 /**
  * Helper hooks to get specific contracts (by ABI)
  */

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -68,11 +68,11 @@ export const useIfoV2Contract = (address: string) => {
 
 export const useERC20 = (address: string, withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getBep20Contract(address, withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [address, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getBep20Contract(address, signer), [address, signer])
 }
 
 /**
@@ -80,11 +80,11 @@ export const useERC20 = (address: string, withSignerIfPossible = true) => {
  */
 export const useERC721 = (address: string, withSignerIfPossible = true) => {
   const { account, library } = useActiveWeb3React()
-  return useMemo(
-    () => getErc721Contract(address, withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [address, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getErc721Contract(address, signer), [address, signer])
 }
 
 export const useCake = (): { reader: Cake; signer: Cake } => {
@@ -110,11 +110,11 @@ export const usePancakeBunnies = () => {
 
 export const useProfileContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getProfileContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getProfileContract(signer), [signer])
 }
 
 export const useLotteryV2Contract = () => {
@@ -124,11 +124,11 @@ export const useLotteryV2Contract = () => {
 
 export const useMasterchef = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getMasterchefContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getMasterchefContract(signer), [signer])
 }
 
 export const useMasterchefV1 = () => {
@@ -163,20 +163,20 @@ export const useTradingCompetitionContract = () => {
 
 export const useTradingCompetitionContractV2 = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getTradingCompetitionContractV2(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getTradingCompetitionContractV2(signer), [signer])
 }
 
 export const useTradingCompetitionContractMobox = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getTradingCompetitionContractMobox(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getTradingCompetitionContractMobox(signer), [signer])
 }
 
 export const useEasterNftContract = () => {
@@ -191,11 +191,11 @@ export const useVaultPoolContract = (): CakeVaultV2 => {
 
 export const useCakeVaultContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getCakeVaultV2Contract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getCakeVaultV2Contract(signer), [signer])
 }
 
 export const usePredictionsContract = () => {
@@ -205,11 +205,11 @@ export const usePredictionsContract = () => {
 
 export const useChainlinkOracleContract = (withSignerIfPossible = true) => {
   const { library, account } = useActiveWeb3React()
-  return useMemo(
-    () => getChainlinkOracleContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getChainlinkOracleContract(signer), [signer])
 }
 
 export const useSpecialBunnyCakeVaultContract = () => {
@@ -254,11 +254,11 @@ export const usePancakeSquadContract = () => {
 
 export const useFarmAuctionContract = (withSignerIfPossible = true) => {
   const { account, library } = useActiveWeb3React()
-  return useMemo(
-    () => getFarmAuctionContract(withSignerIfPossible ? getProviderOrSigner(library, account) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)],
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
   )
+  return useMemo(() => getFarmAuctionContract(signer), [signer])
 }
 
 export const useNftMarketContract = () => {
@@ -288,17 +288,20 @@ function useContract<T extends Contract = Contract>(
   withSignerIfPossible = true,
 ): T | null {
   const { library, account } = useActiveWeb3React()
-
+  const signer = useMemo(
+    () => (withSignerIfPossible ? getProviderOrSigner(library, account) : null),
+    [withSignerIfPossible, library, account],
+  )
   return useMemo(() => {
     if (!address || !ABI || !library) return null
     try {
-      return getContract(address, ABI, withSignerIfPossible ? getProviderOrSigner(library, account) : null)
+      return getContract(address, ABI, signer)
     } catch (error) {
       console.error('Failed to get contract', error)
       return null
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, ABI, withSignerIfPossible, ...(withSignerIfPossible ? [account, library] : EMPTY_ARRAY)]) as T
+  }, [address, ABI, signer]) as T
 }
 
 export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean) {


### PR DESCRIPTION
https://github.com/pancakeswap/pancake-frontend/blob/2d1c22c99035d319cf118019d0968776e7295b0c/src/components/GlobalCheckClaimStatus/index.tsx#L73

When loading the page for the first time, it renders twice since reference from contract hook changes (because of wallet login) even the signer is not used. In here it makes requests twice unnecessarily.