### PR TITLE
fix: Migration page new cake pool add cake button gets stuck and use userdataloaded per pool

### DIFF
--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -142,6 +142,7 @@ export interface DeserializedPool extends DeserializedPoolConfig, CorePoolProps 
     required: boolean
     thresholdPoints: BigNumber
   }
+  userDataLoaded?: boolean
   userData?: {
     allowance: BigNumber
     stakingTokenBalance: BigNumber

--- a/src/views/Migration/components/MigrationStep2/NewPool/PoolRow.tsx
+++ b/src/views/Migration/components/MigrationStep2/NewPool/PoolRow.tsx
@@ -63,7 +63,6 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account }) => {
         <ActionPanel
           account={account}
           pool={pool}
-          userDataLoaded
           expanded={expanded}
           breakpoints={{ isXs, isSm, isMd, isLg, isXl, isXxl }}
         />

--- a/src/views/Migration/components/MigrationStep2/NewPool/index.tsx
+++ b/src/views/Migration/components/MigrationStep2/NewPool/index.tsx
@@ -8,6 +8,7 @@ import {
   fetchCakeVaultFees,
   fetchCakeVaultPublicData,
   fetchCakeVaultUserData,
+  fetchCakePoolPublicDataAsync,
 } from 'state/pools'
 import PoolsTable from './PoolTable'
 
@@ -27,6 +28,7 @@ const NewPool: React.FC = () => {
 
   useFastRefreshEffect(() => {
     dispatch(fetchCakeVaultPublicData())
+    dispatch(fetchCakePoolPublicDataAsync())
     if (account) {
       dispatch(fetchCakeVaultUserData({ account }))
       dispatch(fetchCakePoolUserDataAsync(account))

--- a/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
@@ -1,7 +1,6 @@
 import { Flex, Skeleton, useModal } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { DeserializedPool } from 'state/types'
-import { usePoolsWithVault } from 'state/pools/hooks'
 import NotEnoughTokensModal from '../../PoolCard/Modals/NotEnoughTokensModal'
 import { VaultStakeButtonGroup } from '../../Vault/VaultStakeButtonGroup'
 import VaultStakeModal from '../VaultStakeModal'
@@ -21,8 +20,7 @@ const VaultStakeActions: React.FC<VaultStakeActionsProps> = ({
   accountHasSharesStaked,
   performanceFee,
 }) => {
-  const { stakingToken } = pool
-  const { userDataLoaded } = usePoolsWithVault()
+  const { stakingToken, userDataLoaded } = pool
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
   const [onPresentStake] = useModal(
     <VaultStakeModal stakingMax={stakingTokenBalance} pool={pool} performanceFee={performanceFee} />,

--- a/src/views/Pools/components/LockedPool/Buttons/AddCakeButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/AddCakeButton.tsx
@@ -3,7 +3,7 @@ import { Button, useModal, Skeleton } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { differenceInSeconds } from 'date-fns'
 import { convertTimeToSeconds } from 'utils/timeHelper'
-import { usePoolsWithVault } from 'state/pools/hooks'
+import { usePool } from 'state/pools/hooks'
 import AddAmountModal from '../Modals/AddAmountModal'
 import { AddButtonProps } from '../types'
 import NotEnoughTokensModal from '../../PoolCard/Modals/NotEnoughTokensModal'
@@ -16,7 +16,9 @@ const AddCakeButton: React.FC<AddButtonProps> = ({
   lockStartTime,
   stakingTokenBalance,
 }) => {
-  const { userDataLoaded } = usePoolsWithVault()
+  const {
+    pool: { userDataLoaded },
+  } = usePool(0)
 
   const { t } = useTranslation()
   const remainingDuration = useMemo(

--- a/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -85,7 +85,6 @@ type MediaBreakpoints = {
 interface ActionPanelProps {
   account: string
   pool: DeserializedPool
-  userDataLoaded: boolean
   expanded: boolean
   breakpoints: MediaBreakpoints
 }
@@ -119,7 +118,7 @@ const YieldBoostDurationRow = ({ lockEndTime, lockStartTime }) => {
   )
 }
 
-const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded, expanded }) => {
+const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, expanded }) => {
   const { userData, vaultKey } = pool
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
@@ -186,12 +185,8 @@ const ActionPanel: React.FC<ActionPanelProps> = ({ account, pool, userDataLoaded
             />
           )}
           <ActionContainer isAutoVault={!!pool.vaultKey} hasBalance={poolStakingTokenBalance.gt(0)}>
-            {pool.vaultKey ? (
-              <AutoHarvest {...pool} userDataLoaded={userDataLoaded} />
-            ) : (
-              <Harvest {...pool} userDataLoaded={userDataLoaded} />
-            )}
-            <Stake pool={pool} userDataLoaded={userDataLoaded} />
+            {pool.vaultKey ? <AutoHarvest {...pool} /> : <Harvest {...pool} />}
+            <Stake pool={pool} />
           </ActionContainer>
         </Box>
       </ActionContainer>

--- a/src/views/Pools/components/PoolsTable/ActionPanel/AutoHarvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/AutoHarvest.tsx
@@ -12,11 +12,7 @@ import { ActionContainer, ActionTitles, ActionContent, RowActionContainer } from
 import UnstakingFeeCountdownRow from '../../CakeVaultCard/UnstakingFeeCountdownRow'
 import useUserDataInVaultPresenter from '../../LockedPool/hooks/useUserDataInVaultPresenter'
 
-interface AutoHarvestActionProps extends DeserializedPool {
-  userDataLoaded: boolean
-}
-
-const AutoHarvestAction: React.FunctionComponent<AutoHarvestActionProps> = ({
+const AutoHarvestAction: React.FunctionComponent<DeserializedPool> = ({
   userDataLoaded,
   earningTokenPrice,
   vaultKey,

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Harvest.tsx
@@ -11,11 +11,7 @@ import { DeserializedPool } from 'state/types'
 import { ActionContainer, ActionTitles, ActionContent } from './styles'
 import CollectModal from '../../PoolCard/Modals/CollectModal'
 
-interface HarvestActionProps extends DeserializedPool {
-  userDataLoaded: boolean
-}
-
-const HarvestAction: React.FunctionComponent<HarvestActionProps> = ({
+const HarvestAction: React.FunctionComponent<DeserializedPool> = ({
   sousId,
   poolCategory,
   earningToken,

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -50,10 +50,9 @@ const IconButtonWrapper = styled.div`
 
 interface StackedActionProps {
   pool: DeserializedPool
-  userDataLoaded: boolean
 }
 
-const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoaded }) => {
+const Staked: React.FunctionComponent<StackedActionProps> = ({ pool }) => {
   const {
     sousId,
     stakingToken,
@@ -65,6 +64,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool, userDataLoa
     stakingTokenPrice,
     vaultKey,
     profileRequirement,
+    userDataLoaded,
   } = pool
   const { t } = useTranslation()
   const { account } = useWeb3React()

--- a/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -13,7 +13,6 @@ import CollectModal from '../../PoolCard/Modals/CollectModal'
 interface EarningsCellProps {
   pool: DeserializedPool
   account: string
-  userDataLoaded: boolean
 }
 
 const StyledCell = styled(BaseCell)`
@@ -23,7 +22,7 @@ const StyledCell = styled(BaseCell)`
   }
 `
 
-const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoaded }) => {
+const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account }) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
   const { sousId, earningToken, poolCategory, userData, earningTokenPrice } = pool
@@ -62,7 +61,7 @@ const EarningsCell: React.FC<EarningsCellProps> = ({ pool, account, userDataLoad
         <Text fontSize="12px" color="textSubtle" textAlign="left">
           {labelText}
         </Text>
-        {!userDataLoaded && account ? (
+        {!pool.userDataLoaded && account ? (
           <Skeleton width="80px" height="16px" />
         ) : (
           <>

--- a/src/views/Pools/components/PoolsTable/Cells/StakedCell.tsx
+++ b/src/views/Pools/components/PoolsTable/Cells/StakedCell.tsx
@@ -13,12 +13,11 @@ import BaseCell, { CellContent } from './BaseCell'
 interface StakedCellProps {
   pool: DeserializedPool
   account: string
-  userDataLoaded: boolean
 }
 
 const StyledCell = styled(BaseCell)``
 
-const StakedCell: React.FC<StakedCellProps> = ({ pool, account, userDataLoaded }) => {
+const StakedCell: React.FC<StakedCellProps> = ({ pool, account }) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
 
@@ -48,7 +47,7 @@ const StakedCell: React.FC<StakedCellProps> = ({ pool, account, userDataLoaded }
 
   const hasStaked = account && (stakedBalance.gt(0) || isVaultWithShares)
 
-  const userDataLoading = pool.vaultKey ? vaultUserDataLoading : !userDataLoaded
+  const userDataLoading = pool.vaultKey ? vaultUserDataLoading : !pool.userDataLoaded
 
   return (
     <StyledCell role="cell" flex={pool.vaultKey && !hasStaked ? '1 0 120px' : '2 0 100px'}>

--- a/src/views/Pools/components/PoolsTable/PoolRow.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolRow.tsx
@@ -17,7 +17,6 @@ import StakedCell from './Cells/StakedCell'
 interface PoolRowProps {
   pool: DeserializedPool
   account: string
-  userDataLoaded: boolean
 }
 
 const StyledRow = styled.div`
@@ -26,7 +25,7 @@ const StyledRow = styled.div`
   cursor: pointer;
 `
 
-const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
+const PoolRow: React.FC<PoolRowProps> = ({ pool, account }) => {
   const { isXs, isSm, isMd, isLg, isXl, isXxl, isTablet, isDesktop } = useMatchBreakpoints()
   const isLargerScreen = isLg || isXl || isXxl
   const isXLargerScreen = isXl || isXxl
@@ -46,10 +45,10 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
         {pool.vaultKey ? (
           isXLargerScreen && pool.vaultKey === VaultKey.CakeVault && <AutoEarningsCell pool={pool} account={account} />
         ) : (
-          <EarningsCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
+          <EarningsCell pool={pool} account={account} />
         )}
         {isXLargerScreen && pool.vaultKey === VaultKey.CakeVault && isCakePool ? (
-          <StakedCell pool={pool} account={account} userDataLoaded={userDataLoaded} />
+          <StakedCell pool={pool} account={account} />
         ) : null}
         {isLargerScreen && !isCakePool && <TotalStakedCell pool={pool} />}
         {pool.vaultKey ? <AutoAprCell pool={pool} /> : <AprCell pool={pool} />}
@@ -61,7 +60,6 @@ const PoolRow: React.FC<PoolRowProps> = ({ pool, account, userDataLoaded }) => {
         <ActionPanel
           account={account}
           pool={pool}
-          userDataLoaded={userDataLoaded}
           expanded={expanded}
           breakpoints={{ isXs, isSm, isMd, isLg, isXl, isXxl }}
         />

--- a/src/views/Pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolsTable.tsx
@@ -7,7 +7,6 @@ import PoolRow from './PoolRow'
 
 interface PoolsTableProps {
   pools: DeserializedPool[]
-  userDataLoaded: boolean
   account: string
 }
 
@@ -35,7 +34,7 @@ const ScrollButtonContainer = styled.div`
   padding-bottom: 5px;
 `
 
-const PoolsTable: React.FC<PoolsTableProps> = ({ pools, userDataLoaded, account }) => {
+const PoolsTable: React.FC<PoolsTableProps> = ({ pools, account }) => {
   const { t } = useTranslation()
   const tableWrapperEl = useRef<HTMLDivElement>(null)
   const scrollToTop = (): void => {
@@ -47,7 +46,7 @@ const PoolsTable: React.FC<PoolsTableProps> = ({ pools, userDataLoaded, account 
     <StyledTableBorder>
       <StyledTable id="pools-table" role="table" ref={tableWrapperEl}>
         {pools.map((pool) => (
-          <PoolRow key={pool.vaultKey ?? pool.sousId} pool={pool} account={account} userDataLoaded={userDataLoaded} />
+          <PoolRow key={pool.vaultKey ?? pool.sousId} pool={pool} account={account} />
         ))}
         <ScrollButtonContainer>
           <Button variant="text" onClick={scrollToTop}>

--- a/src/views/Pools/index.tsx
+++ b/src/views/Pools/index.tsx
@@ -251,7 +251,7 @@ const Pools: React.FC = () => {
     </CardLayout>
   )
 
-  const tableLayout = <PoolsTable pools={chosenPools} account={account} userDataLoaded={userDataLoaded} />
+  const tableLayout = <PoolsTable pools={chosenPools} account={account} />
 
   return (
     <>


### PR DESCRIPTION
Introducing userdataloaded flag per pool, which is beneficial if only one pool needed in page

To reproduce: 

1. Go to pools
2. Go to finished pools 
3. Click migration page
4. Since it opens page in new tab there is no state in redux
5. Go to second step
6. See add cake button is not loaded (if user already has cakes in locked pool)