### PR TITLE
perf: Don't make price requests when view mode is card and not sorted by price

### DIFF
--- a/src/views/Nft/market/Collections/index.tsx
+++ b/src/views/Nft/market/Collections/index.tsx
@@ -13,6 +13,7 @@ import {
   Table,
   Th,
   Card,
+  Skeleton,
 } from '@pancakeswap/uikit'
 import useSWRImmutable from 'swr/immutable'
 import orderBy from 'lodash/orderBy'
@@ -21,6 +22,7 @@ import { NextLinkFromReactRouter } from 'components/NextLink'
 import { ViewMode } from 'state/user/actions'
 import { Collection } from 'state/nftMarket/types'
 import styled from 'styled-components'
+import { laggyMiddleware } from 'hooks/useSWRContract'
 import { FetchStatus } from 'config/constants/types'
 import { useGetShuffledCollections } from 'state/nftMarket/hooks'
 import Select, { OptionProps } from 'components/Select/Select'
@@ -72,22 +74,30 @@ const Collectible = () => {
   const [sortDirection, setSortDirection] = useState<boolean>(false)
 
   const { data: collections = [], status } = useSWRImmutable<
-    (Collection & { lowestPrice: number; highestPrice: number })[]
-  >(shuffledCollections && shuffledCollections.length ? ['collectionsWithPrice'] : null, async () => {
-    return Promise.all(
-      shuffledCollections.map(async (collection) => {
-        const [lowestPrice, highestPrice] = await Promise.all([
-          getLeastMostPriceInCollection(collection.address, 'asc'),
-          getLeastMostPriceInCollection(collection.address, 'desc'),
-        ])
-        return {
-          ...collection,
-          lowestPrice,
-          highestPrice,
-        }
-      }),
-    )
-  })
+    (Collection & Partial<{ lowestPrice: number; highestPrice: number }>)[]
+  >(
+    shuffledCollections && shuffledCollections.length ? ['collectionsWithPrice', viewMode, sortField] : null,
+    async () => {
+      if (viewMode === ViewMode.CARD && sortField !== SORT_FIELD.lowestPrice && sortField !== SORT_FIELD.highestPrice)
+        return shuffledCollections
+      return Promise.all(
+        shuffledCollections.map(async (collection) => {
+          const [lowestPrice, highestPrice] = await Promise.all([
+            getLeastMostPriceInCollection(collection.address, 'asc'),
+            getLeastMostPriceInCollection(collection.address, 'desc'),
+          ])
+          return {
+            ...collection,
+            lowestPrice,
+            highestPrice,
+          }
+        }),
+      )
+    },
+    {
+      use: [laggyMiddleware],
+    },
+  )
 
   const arrow = useCallback(
     (field: string) => {
@@ -274,8 +284,20 @@ const Collectible = () => {
                                 <BnbUsdtPairTokenIcon ml="8px" />
                               </Flex>
                             </Td>
-                            <Td>{collection.lowestPrice.toLocaleString(undefined, { maximumFractionDigits: 5 })}</Td>
-                            <Td>{collection.highestPrice.toLocaleString(undefined, { maximumFractionDigits: 5 })}</Td>
+                            <Td>
+                              {collection.lowestPrice ? (
+                                collection.lowestPrice.toLocaleString(undefined, { maximumFractionDigits: 5 })
+                              ) : (
+                                <Skeleton width={36} height={20} />
+                              )}
+                            </Td>
+                            <Td>
+                              {collection.highestPrice ? (
+                                collection.highestPrice.toLocaleString(undefined, { maximumFractionDigits: 5 })
+                              ) : (
+                                <Skeleton width={36} height={20} />
+                              )}
+                            </Td>
                             <Td>{collection.numberTokensListed}</Td>
                             <Td>{collection?.totalSupply}</Td>
                           </tr>

--- a/src/views/Nft/market/Collections/index.tsx
+++ b/src/views/Nft/market/Collections/index.tsx
@@ -63,6 +63,13 @@ export const Arrow = styled.div`
   }
 `
 
+const getNewSortDirection = (oldSortField: string, newSortField: string, oldSortDirection: boolean) => {
+  if (oldSortField !== newSortField) {
+    return newSortField !== SORT_FIELD.lowestPrice
+  }
+  return !oldSortDirection
+}
+
 const Collectible = () => {
   const { t } = useTranslation()
   const { data: shuffledCollections } = useGetShuffledCollections()
@@ -111,7 +118,7 @@ const Collectible = () => {
     (newField: string) => {
       setPage(1)
       setSortField(newField)
-      setSortDirection(sortField !== newField ? true : !sortDirection)
+      setSortDirection(getNewSortDirection(sortField, newField, sortDirection))
     },
     [sortDirection, sortField],
   )

--- a/src/views/Nft/market/Collections/index.tsx
+++ b/src/views/Nft/market/Collections/index.tsx
@@ -76,10 +76,14 @@ const Collectible = () => {
   >(shuffledCollections && shuffledCollections.length ? ['collectionsWithPrice'] : null, async () => {
     return Promise.all(
       shuffledCollections.map(async (collection) => {
+        const [lowestPrice, highestPrice] = await Promise.all([
+          getLeastMostPriceInCollection(collection.address, 'asc'),
+          getLeastMostPriceInCollection(collection.address, 'desc'),
+        ])
         return {
           ...collection,
-          lowestPrice: await getLeastMostPriceInCollection(collection.address, 'asc'),
-          highestPrice: await getLeastMostPriceInCollection(collection.address, 'desc'),
+          lowestPrice,
+          highestPrice,
         }
       }),
     )


### PR DESCRIPTION
It will reduce the amount of requests drastically, currently there is 54 price requests (2 per collection least and most) when user visits the collection page by default which is not needed.

To reproduce 

1. Go to collection list page
2. See the graphql network requests