### PR TITLE
fix: Can return contract check in useContract hook

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -292,7 +292,7 @@ function useContract<T extends Contract = Contract>(
   )
 
   const canReturnContract = useMemo(
-    () => (address && ABI && withSignerIfPossible ? library : true),
+    () => address && ABI && (withSignerIfPossible ? library : true),
     [address, ABI, library, withSignerIfPossible],
   )
 


### PR DESCRIPTION
Currently there is no issue since abi and address are not null or if it is error will be fetched in catch block below but it is good to fix it 