### PR TITLE
chore: Change default trustwallet logo url

### DIFF
--- a/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/src/views/Info/components/CurrencyLogo/index.tsx
@@ -19,7 +19,7 @@ export const CurrencyLogo: React.FC<{
   const src = useMemo(() => {
     const checksummedAddress = isAddress(address)
     if (checksummedAddress) {
-      return `https://assets.trustwalletapp.com/blockchains/smartchain/assets/${checksummedAddress}/logo.png`
+      return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/smartchain/assets/${checksummedAddress}/logo.png`
     }
     return null
   }, [address])


### PR DESCRIPTION
Before:
<img width="1256" alt="Screenshot 2022-05-07 at 3 42 20 PM" src="https://user-images.githubusercontent.com/98292246/167244370-1b9df291-503a-407f-84f9-7f5ff1520f72.png">

After:
<img width="1260" alt="Screenshot 2022-05-07 at 3 42 30 PM" src="https://user-images.githubusercontent.com/98292246/167244376-b47743c1-3b5b-431d-9c80-883068c0fe6f.png">

