### PR TITLE
chore: (competition banner): Change trade now text to register when in registration phase

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1691,5 +1691,6 @@
   "Mobox Competition": "Mobox Competition",
   "Mobox Trading Competition": "Mobox Trading Competition",
   "$80,000 in Prizes with Tokens and NFTs!": "$80,000 in Prizes with Tokens and NFTs!",
-  "In addition to token prizes there are NFT rewards (estimated worth of ~$40,000 at the time of writing):": "In addition to token prizes there are NFT rewards (estimated worth of ~$40,000 at the time of writing):"
+  "In addition to token prizes there are NFT rewards (estimated worth of ~$40,000 at the time of writing):": "In addition to token prizes there are NFT rewards (estimated worth of ~$40,000 at the time of writing):",
+  "Register Now": "Register Now"
 }

--- a/src/views/Home/components/Banners/CompetitionBanner.tsx
+++ b/src/views/Home/components/Banners/CompetitionBanner.tsx
@@ -57,7 +57,7 @@ const CompetitionBanner = () => {
           <NextLinkFromReactRouter to="/competition">
             <Button>
               <Text color="invertedContrast" bold fontSize="16px" mr="4px">
-                {t('Trade Now')}
+                {t('Register Now')}
               </Text>
               <ArrowForwardIcon color="invertedContrast" />
             </Button>


### PR DESCRIPTION
Imho it is better to indicate user to first register competition before trading