### PR TITLE
refactor: Use cached big number in farms fetching

### DIFF
--- a/src/state/farms/fetchFarms.ts
+++ b/src/state/farms/fetchFarms.ts
@@ -1,6 +1,6 @@
 import { SerializedFarmConfig } from 'config/constants/types'
 import BigNumber from 'bignumber.js'
-import { BIG_TEN, BIG_ZERO } from '../../utils/bigNumber'
+import { BIG_TEN, BIG_ZERO, BIG_TWO } from '../../utils/bigNumber'
 import { fetchPublicFarmsData } from './fetchPublicFarmData'
 import { fetchMasterChefData } from './fetchMasterChefData'
 import { SerializedFarm } from '../types'
@@ -28,7 +28,7 @@ const fetchFarms = async (farmsToFetch: SerializedFarmConfig[]): Promise<Seriali
     const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
 
     // Total staked in LP, in quote token value
-    const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
+    const lpTotalInQuoteToken = quoteTokenAmountMc.times(BIG_TWO)
 
     const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
     const poolWeight = totalRegularAllocPoint ? allocPoint.div(new BigNumber(totalRegularAllocPoint)) : BIG_ZERO

--- a/src/state/farmsV1/fetchFarms.ts
+++ b/src/state/farmsV1/fetchFarms.ts
@@ -1,6 +1,6 @@
 import { SerializedFarmConfig } from 'config/constants/types'
 import BigNumber from 'bignumber.js'
-import { BIG_TEN, BIG_ZERO } from '../../utils/bigNumber'
+import { BIG_TEN, BIG_ZERO, BIG_TWO } from '../../utils/bigNumber'
 import { fetchPublicFarmsData } from './fetchPublicFarmData'
 import { fetchMasterChefData } from './fetchMasterChefData'
 
@@ -25,7 +25,7 @@ const fetchFarms = async (farmsToFetch: SerializedFarmConfig[]) => {
     const quoteTokenAmountMc = quoteTokenAmountTotal.times(lpTokenRatio)
 
     // Total staked in LP, in quote token value
-    const lpTotalInQuoteToken = quoteTokenAmountMc.times(new BigNumber(2))
+    const lpTotalInQuoteToken = quoteTokenAmountMc.times(BIG_TWO)
 
     const allocPoint = info ? new BigNumber(info.allocPoint?._hex) : BIG_ZERO
     const poolWeight = totalAllocPoint ? allocPoint.div(new BigNumber(totalAllocPoint)) : BIG_ZERO

--- a/src/utils/bigNumber.ts
+++ b/src/utils/bigNumber.ts
@@ -3,6 +3,7 @@ import { BigNumber as EthersBigNumber } from '@ethersproject/bignumber'
 
 export const BIG_ZERO = new BigNumber(0)
 export const BIG_ONE = new BigNumber(1)
+export const BIG_TWO = new BigNumber(2)
 export const BIG_NINE = new BigNumber(9)
 export const BIG_TEN = new BigNumber(10)
 


### PR DESCRIPTION
Currently it creates ~200 same bignumber objects when fetching farms