### PR TITLE
perf: Dont load floating pancakes wrapper on mobile

### DIFF
--- a/src/views/Home/components/Footer.tsx
+++ b/src/views/Home/components/Footer.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Flex, Heading, Text, Link } from '@pancakeswap/uikit'
+import { Flex, Heading, Text, Link, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import Container from 'components/Layout/Container'
@@ -83,6 +83,7 @@ const bottomRightImage = {
 const Footer = () => {
   const { t } = useTranslation()
   const { account } = useWeb3React()
+  const { isTablet, isDesktop } = useMatchBreakpoints()
 
   return (
     <>
@@ -91,14 +92,16 @@ const Footer = () => {
           <StyledSunburst />
         </Flex>
       </BgWrapper>
-      <FloatingPancakesWrapper>
-        <TopLeftImgWrapper>
-          <CompositeImage {...topLeftImage} maxHeight="256px" />
-        </TopLeftImgWrapper>
-        <BottomRightImgWrapper>
-          <CompositeImage {...bottomRightImage} maxHeight="256px" />
-        </BottomRightImgWrapper>
-      </FloatingPancakesWrapper>
+      {(isTablet || isDesktop) && (
+        <FloatingPancakesWrapper>
+          <TopLeftImgWrapper>
+            <CompositeImage {...topLeftImage} maxHeight="256px" />
+          </TopLeftImgWrapper>
+          <BottomRightImgWrapper>
+            <CompositeImage {...bottomRightImage} maxHeight="256px" />
+          </BottomRightImgWrapper>
+        </FloatingPancakesWrapper>
+      )}
       <Wrapper>
         <Heading mb="24px" scale="xl" color="white">
           {t('Start in seconds.')}


### PR DESCRIPTION
Currently it is done by css visibility property which renders component and loads images regardless of dimension