### PR TITLE
fix: (nft): Nft activity metadata uniq function iteratee

### DIFF
--- a/src/views/Nft/market/ActivityHistory/ActivityHistory.tsx
+++ b/src/views/Nft/market/ActivityHistory/ActivityHistory.tsx
@@ -166,7 +166,11 @@ const ActivityHistory: React.FC<ActivityHistoryProps> = ({ collection }) => {
                   <TableLoader />
                 ) : (
                   activitiesSlice.map((activity) => {
-                    const nftMeta = nftMetadata.find((metaNft) => metaNft.tokenId === activity.nft.tokenId)
+                    const nftMeta = nftMetadata.find(
+                      (metaNft) =>
+                        metaNft.tokenId === activity.nft.tokenId &&
+                        metaNft.collectionAddress.toLowerCase() === activity.nft?.collection.id.toLowerCase(),
+                    )
                     return (
                       <ActivityRow
                         key={`${activity.marketEvent}#${activity.nft.tokenId}#${activity.timestamp}#${activity.tx}`}

--- a/src/views/Nft/market/ActivityHistory/utils/fetchActivityNftMetadata.tsx
+++ b/src/views/Nft/market/ActivityHistory/utils/fetchActivityNftMetadata.tsx
@@ -14,7 +14,8 @@ export const fetchActivityNftMetadata = async (activities: Activity[]): Promise<
       .map((activity): TokenIdWithCollectionAddress => {
         return { tokenId: activity.nft.tokenId, collectionAddress: activity.nft.collection.id }
       }),
-    'tokenId',
+    (tokenWithCollectionAddress) =>
+      `${tokenWithCollectionAddress.tokenId}#${tokenWithCollectionAddress.collectionAddress}`,
   )
 
   const [bunniesMetadata, nfts] = await Promise.all([

--- a/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
+++ b/src/views/Nft/market/Profile/components/ActivityHistory/index.tsx
@@ -115,7 +115,11 @@ const ActivityHistory = () => {
                 <TableLoader />
               ) : (
                 activitiesSlice.map((activity) => {
-                  const nftMeta = nftMetadata.find((metaNft) => metaNft.tokenId === activity.nft.tokenId)
+                  const nftMeta = nftMetadata.find(
+                    (metaNft) =>
+                      metaNft.tokenId === activity.nft.tokenId &&
+                      metaNft.collectionAddress.toLowerCase() === activity.nft?.collection.id.toLowerCase(),
+                  )
                   return (
                     <ActivityRow
                       key={`${activity.nft.tokenId}${activity.timestamp}`}


### PR DESCRIPTION
Reduces calculation in collections activity by half

To review

1. Go to nft collection activity and see metadata loading properly

There is a bug as well that if two nfts with same id with different collections, metadata of one of them loaded with wrong or cannot be loaded.