### PR TITLE
fix: (cake pool): Expected roi calculation in other languages

### DIFF
--- a/src/utils/formatBalance.ts
+++ b/src/utils/formatBalance.ts
@@ -26,6 +26,9 @@ export const getFullDisplayBalance = (balance: BigNumber, decimals = 18, display
   return getBalanceAmount(balance, decimals).toFixed(displayDecimals)
 }
 
+/**
+ * Don't use this string value to convert back to number.
+ */
 export const formatNumber = (number: number, minPrecision = 2, maxPrecision = 2) => {
   const options = {
     minimumFractionDigits: minPrecision,

--- a/src/utils/formatBalance.ts
+++ b/src/utils/formatBalance.ts
@@ -28,6 +28,7 @@ export const getFullDisplayBalance = (balance: BigNumber, decimals = 18, display
 
 /**
  * Don't use the result to convert back to number.
+ * It uses undefined locale which uses host language as a result.
  * Languages have different decimal separators which results in inconsistency when converting back this result to number.
  */
 export const formatNumber = (number: number, minPrecision = 2, maxPrecision = 2) => {

--- a/src/utils/formatBalance.ts
+++ b/src/utils/formatBalance.ts
@@ -27,7 +27,8 @@ export const getFullDisplayBalance = (balance: BigNumber, decimals = 18, display
 }
 
 /**
- * Don't use this string value to convert back to number.
+ * Don't use the result to convert back to number.
+ * Languages have different decimal separators which results in inconsistency when converting back this result to number.
  */
 export const formatNumber = (number: number, minPrecision = 2, maxPrecision = 2) => {
   const options = {

--- a/src/views/Pools/components/LockedPool/utils/formatRoi.ts
+++ b/src/views/Pools/components/LockedPool/utils/formatRoi.ts
@@ -1,5 +1,3 @@
-import { formatNumber } from 'utils/formatBalance'
-
 interface FormatRoiArgs {
   lockedApy: string
   usdValueStaked: number
@@ -10,6 +8,10 @@ export default function formatRoi(roiArgs: FormatRoiArgs): string {
   const { lockedApy, usdValueStaked, duration } = roiArgs
 
   const roi = usdValueStaked * (Number(lockedApy) / 100) * (duration / 31449600)
+  const roiFractionDigits = roi > 10000 ? 0 : 2
 
-  return formatNumber(roi, roi > 10000 ? 0 : 2, roi > 10000 ? 0 : 2)
+  return roi.toLocaleString('en', {
+    minimumFractionDigits: roiFractionDigits,
+    maximumFractionDigits: roiFractionDigits,
+  })
 }


### PR DESCRIPTION
Root cause of the issue is, the return value is converted back to number which causes the issue if user device language is other than english

To reproduce

1. Go to locked pool with a device language german
2. Click add cake
3. Enter value to make expected roi higher than 1k
4. See it shows wrong value