### PR TITLE
fix: Missing translation on modals max button

### DIFF
--- a/src/views/FarmAuction/components/PlaceBidModal.tsx
+++ b/src/views/FarmAuction/components/PlaceBidModal.tsx
@@ -221,7 +221,9 @@ const PlaceBidModal: React.FC<PlaceBidModalProps> = ({
             variant="tertiary"
             onClick={() => setPercentageValue(1)}
           >
-            MAX
+            <Text small color="currentColor" textTransform="uppercase">
+              {t('Max')}
+            </Text>
           </Button>
         </Flex>
         <Flex flexDirection="column">

--- a/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -370,7 +370,9 @@ const BuyTicketsModal: React.FC<BuyTicketsModalProps> = ({ onDismiss }) => {
           )}
           {oneHundredPercentOfBalance >= 1 && (
             <NumTicketsToBuyButton onClick={() => handleNumberButtonClick(oneHundredPercentOfBalance)}>
-              MAX
+              <Text small color="currentColor" textTransform="uppercase">
+                {t('Max')}
+              </Text>
             </NumTicketsToBuyButton>
           )}
         </ShortcutButtonsWrapper>


### PR DESCRIPTION
To reproduce: 

1. Go to lottery buy ticket
2. Change language
3. See max button translation not applied