### PR TITLE
fix: Trading competition menu shows soon when loading page

### DIFF
--- a/src/components/Menu/hooks/useCompetitionStatus.ts
+++ b/src/components/Menu/hooks/useCompetitionStatus.ts
@@ -1,6 +1,6 @@
 import useSWRImmutable from 'swr/immutable'
 import { useMemo } from 'react'
-import { SmartContractPhases, LIVE, FINISHED, CLAIM, OVER } from 'config/constants/trading-competition/phases'
+import { SmartContractPhases, LIVE, REGISTRATION } from 'config/constants/trading-competition/phases'
 import { useTradingCompetitionContractMoD } from 'hooks/useContract'
 
 export const useCompetitionStatus = () => {
@@ -12,15 +12,14 @@ export const useCompetitionStatus = () => {
   })
 
   return useMemo(() => {
-    const hasCompetitionEnded = state === FINISHED || state === CLAIM || state === OVER
-    if (hasCompetitionEnded) {
-      return null
+    if (state === REGISTRATION) {
+      return 'soon'
     }
 
     if (state === LIVE) {
       return 'live'
     }
 
-    return 'soon'
+    return null
   }, [state])
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/2213635/168925279-6bade896-f9ec-4f60-b3a0-debba94c3062.mov

Other issue is currently competition banner will be flashed after competition ends when loading page