### PR TITLE
feat: Don't hide phishing warning banner when scrolling down

### DIFF
--- a/packages/uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/uikit/src/widgets/Menu/Menu.tsx
@@ -20,12 +20,14 @@ const Wrapper = styled.div`
   width: 100%;
 `;
 
-const StyledNav = styled.nav`
+const StyledNav = styled.nav<{ showMenu: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: ${MENU_HEIGHT}px;
+  height: ${({ showMenu }) => (showMenu ? `${MENU_HEIGHT}px` : 0)};
+  transition: height 0.2s;
+  overflow: ${({ showMenu }) => (showMenu ? "visible" : "hidden")};
   background-color: ${({ theme }) => theme.nav.background};
   border-bottom: 1px solid ${({ theme }) => theme.colors.cardBorder};
   transform: translate3d(0, 0, 0);
@@ -34,12 +36,10 @@ const StyledNav = styled.nav`
   padding-right: 16px;
 `;
 
-const FixedContainer = styled.div<{ showMenu: boolean; height: number }>`
+const FixedContainer = styled.div`
   position: fixed;
-  top: ${({ showMenu, height }) => (showMenu ? 0 : `-${height}px`)};
+  top: 0;
   left: 0;
-  transition: top 0.2s;
-  height: ${({ height }) => `${height}px`};
   width: 100%;
   z-index: 20;
 `;
@@ -88,7 +88,8 @@ const Menu: React.FC<NavProps> = ({
 
   const topBannerHeight = isMobile ? TOP_BANNER_HEIGHT_MOBILE : TOP_BANNER_HEIGHT;
 
-  const totalTopMenuHeight = banner ? MENU_HEIGHT + topBannerHeight : MENU_HEIGHT;
+  const totalTopMenuHeight =
+    showMenu && banner ? MENU_HEIGHT + topBannerHeight : showMenu ? MENU_HEIGHT : topBannerHeight;
 
   useEffect(() => {
     const handleScroll = () => {
@@ -128,9 +129,9 @@ const Menu: React.FC<NavProps> = ({
   return (
     <MenuContext.Provider value={{ linkComponent }}>
       <Wrapper>
-        <FixedContainer showMenu={showMenu} height={totalTopMenuHeight}>
+        <FixedContainer>
           {banner && <TopBannerContainer height={topBannerHeight}>{banner}</TopBannerContainer>}
-          <StyledNav>
+          <StyledNav showMenu={showMenu}>
             <Flex>
               <Logo isDark={isDark} href={homeLink?.href ?? "/"} />
               {!isMobile && <MenuItems items={links} activeItem={activeItem} activeSubItem={activeSubItem} ml="24px" />}

--- a/packages/uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/uikit/src/widgets/Menu/Menu.tsx
@@ -20,17 +20,25 @@ const Wrapper = styled.div`
   width: 100%;
 `;
 
-const StyledNav = styled.nav<{ showMenu: boolean }>`
+const StyledNav = styled.nav`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  height: ${({ showMenu }) => (showMenu ? `${MENU_HEIGHT}px` : 0)};
-  transition: height 0.2s;
-  overflow: ${({ showMenu }) => (showMenu ? "visible" : "hidden")};
+  height: ${MENU_HEIGHT}px;
   background-color: ${({ theme }) => theme.nav.background};
   border-bottom: 1px solid ${({ theme }) => theme.colors.cardBorder};
   transform: translate3d(0, 0, 0);
+  transition: transform 0.2s ease;
+  transform-origin: top;
+
+  &.disabled{
+    transform: scaleY(0);
+]  }
+
+  &.enabled{
+    transform: scaleY(1);
+  }
 
   padding-left: 16px;
   padding-right: 16px;
@@ -131,7 +139,7 @@ const Menu: React.FC<NavProps> = ({
       <Wrapper>
         <FixedContainer>
           {banner && <TopBannerContainer height={topBannerHeight}>{banner}</TopBannerContainer>}
-          <StyledNav showMenu={showMenu}>
+          <StyledNav className={showMenu ? "enabled" : "disabled"}>
             <Flex>
               <Logo isDark={isDark} href={homeLink?.href ?? "/"} />
               {!isMobile && <MenuItems items={links} activeItem={activeItem} activeSubItem={activeSubItem} ml="24px" />}


### PR DESCRIPTION
To reproduce: 

1. Go to website after cleaning cache
2. See phishing warning at the top
3. See it disappears (which it shouldn't) when user scrolls down