### PR TITLE
fix: Locked Pool min duration extend

### DIFF
--- a/src/views/Pools/components/LockedPool/Buttons/AddCakeButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/AddCakeButton.tsx
@@ -1,8 +1,6 @@
-import { useMemo, useCallback, memo } from 'react'
+import { useCallback, memo } from 'react'
 import { Button, useModal, Skeleton } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
-import { differenceInSeconds } from 'date-fns'
-import { convertTimeToSeconds } from 'utils/timeHelper'
 import { usePool } from 'state/pools/hooks'
 import AddAmountModal from '../Modals/AddAmountModal'
 import { AddButtonProps } from '../types'
@@ -21,22 +19,13 @@ const AddCakeButton: React.FC<AddButtonProps> = ({
   } = usePool(0)
 
   const { t } = useTranslation()
-  const remainingDuration = useMemo(
-    () => differenceInSeconds(new Date(convertTimeToSeconds(lockEndTime)), new Date()),
-    [lockEndTime],
-  )
-  const passedDuration = useMemo(
-    () => differenceInSeconds(new Date(), new Date(convertTimeToSeconds(lockStartTime))),
-    [lockStartTime],
-  )
 
   const [openAddAmountModal] = useModal(
     <AddAmountModal
-      passedDuration={passedDuration}
       currentLockedAmount={currentLockedAmount}
-      remainingDuration={remainingDuration}
       currentBalance={currentBalance}
       stakingToken={stakingToken}
+      lockStartTime={lockStartTime}
       lockEndTime={lockEndTime}
       stakingTokenBalance={stakingTokenBalance}
     />,

--- a/src/views/Pools/components/LockedPool/hooks/useLockedPool.tsx
+++ b/src/views/Pools/components/LockedPool/hooks/useLockedPool.tsx
@@ -11,7 +11,7 @@ import useToast from 'hooks/useToast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { fetchCakeVaultUserData } from 'state/pools'
 import { Token } from '@pancakeswap/sdk'
-import { vaultPoolConfig, ONE_WEEK_DEFAULT } from 'config/constants/pools'
+import { ONE_WEEK_DEFAULT, vaultPoolConfig } from 'config/constants/pools'
 import { VaultKey } from 'state/types'
 
 import { ToastDescriptionWithTx } from 'components/Toast'

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -60,8 +60,7 @@ export interface AddAmountModalProps {
   stakingToken: Token
   currentBalance: BigNumber
   currentLockedAmount: BigNumber
-  passedDuration: number
-  remainingDuration: number
+  lockStartTime?: string
   lockEndTime?: string
   stakingTokenBalance: BigNumber
 }


### PR DESCRIPTION
fixing when 1 week locked cake trying to renew the extension, there're some seconds gaps between firing the txn and confirmation.

Add 30s buffer in this case