### PR TITLE
perf: (menu): Make bnb account balance call only when dropdown user menu open

### DIFF
--- a/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
+++ b/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
@@ -115,7 +115,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
         <ChevronDownIcon color="text" width="24px" />
       </StyledUserMenu>
       <Menu style={styles.popper} ref={setTooltipRef} {...attributes.popper} isOpen={isOpen}>
-        <Box onClick={() => setIsOpen(false)}>{children}</Box>
+        <Box onClick={() => setIsOpen(false)}>{children?.({ isOpen })}</Box>
       </Menu>
     </Flex>
   );

--- a/packages/uikit/src/widgets/Menu/components/UserMenu/types.ts
+++ b/packages/uikit/src/widgets/Menu/components/UserMenu/types.ts
@@ -1,4 +1,5 @@
 import { FlexProps } from "styled-system";
+import { ReactElement } from "react";
 
 export const variants = {
   DEFAULT: "default",
@@ -14,6 +15,7 @@ export interface UserMenuProps extends FlexProps {
   text?: string;
   avatarSrc?: string;
   variant?: Variant;
+  children?: (exposedProps: { isOpen: boolean }) => ReactElement;
 }
 
 export interface UserMenuItemProps {

--- a/src/components/Menu/UserMenu/WalletUserMenuItem.tsx
+++ b/src/components/Menu/UserMenu/WalletUserMenuItem.tsx
@@ -1,18 +1,18 @@
 import { Flex, UserMenuItem, WarningIcon } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
+import { useGetBnbBalance } from 'hooks/useTokenBalance'
+import { FetchStatus } from 'config/constants/types'
+import { LOW_BNB_BALANCE } from './WalletModal'
 
 interface WalletUserMenuItemProps {
-  hasLowBnbBalance: boolean
   isWrongNetwork: boolean
   onPresentWalletModal: () => void
 }
 
-const WalletUserMenuItem: React.FC<WalletUserMenuItemProps> = ({
-  hasLowBnbBalance,
-  isWrongNetwork,
-  onPresentWalletModal,
-}) => {
+const WalletUserMenuItem: React.FC<WalletUserMenuItemProps> = ({ isWrongNetwork, onPresentWalletModal }) => {
   const { t } = useTranslation()
+  const { balance, fetchStatus } = useGetBnbBalance()
+  const hasLowBnbBalance = fetchStatus === FetchStatus.Fetched && balance.lte(LOW_BNB_BALANCE)
 
   return (
     <UserMenuItem as="button" onClick={onPresentWalletModal}>

--- a/src/components/Menu/UserMenu/index.tsx
+++ b/src/components/Menu/UserMenu/index.tsx
@@ -17,11 +17,9 @@ import { useRouter } from 'next/router'
 import { useProfile } from 'state/profile/hooks'
 import { usePendingTransactions } from 'state/transactions/hooks'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import { useGetBnbBalance } from 'hooks/useTokenBalance'
 import { useTranslation } from 'contexts/Localization'
 import { nftsBaseUrl } from 'views/Nft/market/constants'
-import { FetchStatus } from 'config/constants/types'
-import WalletModal, { WalletView, LOW_BNB_BALANCE } from './WalletModal'
+import WalletModal, { WalletView } from './WalletModal'
 import ProfileUserMenuItem from './ProfileUserMenuItem'
 import WalletUserMenuItem from './WalletUserMenuItem'
 
@@ -31,14 +29,12 @@ const UserMenu = () => {
   const { account, error } = useWeb3React()
   const { logout } = useAuth()
   const { hasPendingTransactions, pendingNumber } = usePendingTransactions()
-  const { balance, fetchStatus } = useGetBnbBalance()
   const { isInitialized, isLoading, profile } = useProfile()
   const [onPresentWalletModal] = useModal(<WalletModal initialView={WalletView.WALLET_INFO} />)
   const [onPresentTransactionModal] = useModal(<WalletModal initialView={WalletView.TRANSACTIONS} />)
   const [onPresentWrongNetworkModal] = useModal(<WalletModal initialView={WalletView.WRONG_NETWORK} />)
   const hasProfile = isInitialized && !!profile
   const avatarSrc = profile?.nft?.image?.thumbnail
-  const hasLowBnbBalance = fetchStatus === FetchStatus.Fetched && balance.lte(LOW_BNB_BALANCE)
   const [userMenuText, setUserMenuText] = useState<string>('')
   const [userMenuVariable, setUserMenuVariable] = useState<UserMenuVariant>('default')
   const isWrongNetwork: boolean = error && error instanceof UnsupportedChainIdError
@@ -64,11 +60,7 @@ const UserMenu = () => {
   const UserMenuItems = () => {
     return (
       <>
-        <WalletUserMenuItem
-          hasLowBnbBalance={hasLowBnbBalance}
-          isWrongNetwork={isWrongNetwork}
-          onPresentWalletModal={onClickWalletMenu}
-        />
+        <WalletUserMenuItem isWrongNetwork={isWrongNetwork} onPresentWalletModal={onClickWalletMenu} />
         <UserMenuItem as="button" disabled={isWrongNetwork} onClick={onPresentTransactionModal}>
           {t('Recent Transactions')}
           {hasPendingTransactions && <RefreshIcon spin />}
@@ -96,7 +88,7 @@ const UserMenu = () => {
   if (account) {
     return (
       <UIKitUserMenu account={account} avatarSrc={avatarSrc} text={userMenuText} variant={userMenuVariable}>
-        <UserMenuItems />
+        {({ isOpen }) => (isOpen ? <UserMenuItems /> : null)}
       </UIKitUserMenu>
     )
   }
@@ -104,7 +96,7 @@ const UserMenu = () => {
   if (isWrongNetwork) {
     return (
       <UIKitUserMenu text={t('Network')} variant="danger">
-        <UserMenuItems />
+        {({ isOpen }) => (isOpen ? <UserMenuItems /> : null)}
       </UIKitUserMenu>
     )
   }


### PR DESCRIPTION
It will reduce the calls where only place of bnb account balance call is in user dropdown menu (such as home page, pools, farms etc.). Other places that uses bnb account balance will not be effected from this since it is only related to dropdown menu.