### PR TITLE
fix: Don't clear connectorIdv2 when user switching account

### DIFF
--- a/src/hooks/useAccountEventListener.ts
+++ b/src/hooks/useAccountEventListener.ts
@@ -9,16 +9,20 @@ export const useAccountEventListener = () => {
 
   useEffect(() => {
     if (account && connector) {
-      const handleEvent = (isDeactive = false) => {
-        clearUserStates(dispatch, chainId, isDeactive)
+      const handleUpdateEvent = () => {
+        clearUserStates(dispatch, chainId)
       }
 
-      connector.addListener('Web3ReactDeactivate', () => handleEvent(true))
-      connector.addListener('Web3ReactUpdate', () => handleEvent())
+      const handleDeactiveEvent = () => {
+        clearUserStates(dispatch, chainId, true)
+      }
+
+      connector.addListener('Web3ReactDeactivate', handleDeactiveEvent)
+      connector.addListener('Web3ReactUpdate', handleUpdateEvent)
 
       return () => {
-        connector.removeListener('Web3ReactDeactivate', () => handleEvent(true))
-        connector.removeListener('Web3ReactUpdate', () => handleEvent())
+        connector.removeListener('Web3ReactDeactivate', handleDeactiveEvent)
+        connector.removeListener('Web3ReactUpdate', handleUpdateEvent)
       }
     }
     return undefined

--- a/src/hooks/useAccountEventListener.ts
+++ b/src/hooks/useAccountEventListener.ts
@@ -9,16 +9,16 @@ export const useAccountEventListener = () => {
 
   useEffect(() => {
     if (account && connector) {
-      const handleEvent = () => {
-        clearUserStates(dispatch, chainId)
+      const handleEvent = (isDeactive = false) => {
+        clearUserStates(dispatch, chainId, isDeactive)
       }
 
-      connector.addListener('Web3ReactDeactivate', handleEvent)
-      connector.addListener('Web3ReactUpdate', handleEvent)
+      connector.addListener('Web3ReactDeactivate', () => handleEvent(true))
+      connector.addListener('Web3ReactUpdate', () => handleEvent())
 
       return () => {
-        connector.removeListener('Web3ReactDeactivate', handleEvent)
-        connector.removeListener('Web3ReactUpdate', handleEvent)
+        connector.removeListener('Web3ReactDeactivate', () => handleEvent(true))
+        connector.removeListener('Web3ReactUpdate', () => handleEvent())
       }
     }
     return undefined

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -74,7 +74,7 @@ const useAuth = () => {
 
   const logout = useCallback(() => {
     deactivate()
-    clearUserStates(dispatch, chainId)
+    clearUserStates(dispatch, chainId, true)
   }, [deactivate, dispatch, chainId])
 
   return { login, logout }

--- a/src/utils/clearUserStates.ts
+++ b/src/utils/clearUserStates.ts
@@ -6,7 +6,7 @@ import { connectorsByName } from './web3React'
 import { LS_ORDERS } from './localStorageOrders'
 import getLocalStorageItemKeys from './getLocalStorageItemKeys'
 
-export const clearUserStates = (dispatch: Dispatch<any>, chainId: number) => {
+export const clearUserStates = (dispatch: Dispatch<any>, chainId: number, isDeactive = false) => {
   dispatch(resetUserState({ chainId }))
   Sentry.configureScope((scope) => scope.setUser(null))
   // This localStorage key is set by @web3-react/walletconnect-connector
@@ -14,7 +14,10 @@ export const clearUserStates = (dispatch: Dispatch<any>, chainId: number) => {
     connectorsByName.walletconnect.close()
     connectorsByName.walletconnect.walletConnectProvider = null
   }
-  window?.localStorage?.removeItem(connectorLocalStorageKey)
+  // Only clear localStorage when user disconnect,switch adddress no need clear it.
+  if (isDeactive) {
+    window?.localStorage?.removeItem(connectorLocalStorageKey)
+  }
   const lsOrderKeys = getLocalStorageItemKeys(LS_ORDERS)
   lsOrderKeys.forEach((lsOrderKey) => window?.localStorage?.removeItem(lsOrderKey))
 }

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { useEffect } from 'react'
 import PageSection from 'components/PageSection'
 import { useWeb3React } from '@web3-react/core'
 import useTheme from 'hooks/useTheme'

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { useEffect } from 'react'
 import PageSection from 'components/PageSection'
 import { useWeb3React } from '@web3-react/core'
 import useTheme from 'hooks/useTheme'


### PR DESCRIPTION
According to this [PR](https://github.com/pancakeswap/pancake-frontend/commit/3f6beff0ecdf7701b7caaf1b4431be991a311982). We only call `tryLogin` function  when is Dapp browse.
So that we should not remove `connectorIdv2` when switching account.


Before:

https://user-images.githubusercontent.com/98292246/169635771-edfe8484-16c2-40ec-9b62-7e85b91ebbe0.mov




After:

https://user-images.githubusercontent.com/98292246/169635825-affe56cb-c5f1-4add-80e0-3955c340aa3d.mov




