### PR TITLE
perf: Run lists updater only when the page has currency search

### DIFF
--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 
 export default function useInterval(
@@ -9,6 +9,10 @@ export default function useInterval(
 ) {
   const savedCallback = useRef<() => void>(callback)
   const [isReadyForUpdate, setIsReadyForUpdate] = useState(false)
+
+  const tick = useCallback(() => {
+    setIsReadyForUpdate(true)
+  }, [])
 
   // Remember the latest callback.
   useEffect(() => {
@@ -24,10 +28,6 @@ export default function useInterval(
 
   // Set up the interval.
   useEffect(() => {
-    function tick() {
-      setIsReadyForUpdate(true)
-    }
-
     if (!isUndefinedOrNull(delay)) {
       if (leading) tick()
       const id = setInterval(tick, delay)
@@ -37,5 +37,5 @@ export default function useInterval(
       }
     }
     return () => setIsReadyForUpdate(false)
-  }, [delay, leading])
+  }, [delay, leading, tick])
 }

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -2,12 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 import useLastUpdated from './useLastUpdated'
 
-export default function useInterval(
-  callback: () => void,
-  delay: undefined | null | number,
-  leading = true,
-  initiateUpdate = true,
-) {
+export default function useInterval(callback: () => void, delay: undefined | null | number, leading = true) {
   const [runImmediate, setRunImmediate] = useState(leading)
   const [runAfter, setRunAfter] = useState(delay)
   const savedCallback = useRef<() => void>(callback)
@@ -30,13 +25,13 @@ export default function useInterval(
   }, [callback])
 
   useEffect(() => {
-    if (initiateUpdate && isReadyForUpdate) {
+    if (isReadyForUpdate) {
       savedCallback.current?.()
       setIsReadyForUpdate(false)
       setRunImmediate(false)
       refresh()
     }
-  }, [initiateUpdate, isReadyForUpdate, refresh])
+  }, [isReadyForUpdate, refresh])
 
   // Set up the timeout.
   useEffect(() => {

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,27 +1,41 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 
-export default function useInterval(callback: () => void, delay: null | number, leading = true) {
-  const savedCallback = useRef<() => void>()
+export default function useInterval(
+  callback: () => void,
+  delay: undefined | null | number,
+  leading = true,
+  initiateUpdate = true,
+) {
+  const savedCallback = useRef<() => void>(callback)
+  const [isReadyForUpdate, setIsReadyForUpdate] = useState(false)
 
   // Remember the latest callback.
   useEffect(() => {
     savedCallback.current = callback
   }, [callback])
 
+  useEffect(() => {
+    if (initiateUpdate && isReadyForUpdate) {
+      savedCallback.current?.()
+      setIsReadyForUpdate(false)
+    }
+  }, [initiateUpdate, isReadyForUpdate])
+
   // Set up the interval.
   useEffect(() => {
     function tick() {
-      const { current } = savedCallback
-      if (current) {
-        current()
-      }
+      setIsReadyForUpdate(true)
     }
 
-    if (delay !== null) {
+    if (!isUndefinedOrNull(delay)) {
       if (leading) tick()
       const id = setInterval(tick, delay)
-      return () => clearInterval(id)
+      return () => {
+        setIsReadyForUpdate(false)
+        clearInterval(id)
+      }
     }
-    return undefined
+    return () => setIsReadyForUpdate(false)
   }, [delay, leading])
 }

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 import useLastUpdated from './useLastUpdated'
 
-export default function useInterval(callback: () => void, delay: undefined | null | number, leading = true) {
+export default function useInterval(
+  callback: () => void,
+  delay: undefined | null | number,
+  leading = true,
+  initiateUpdate = true,
+) {
   const [runImmediate, setRunImmediate] = useState(leading)
   const [runAfter, setRunAfter] = useState(delay)
   const savedCallback = useRef<() => void>(callback)
@@ -25,13 +30,13 @@ export default function useInterval(callback: () => void, delay: undefined | nul
   }, [callback])
 
   useEffect(() => {
-    if (isReadyForUpdate) {
+    if (initiateUpdate && isReadyForUpdate) {
       savedCallback.current?.()
       setIsReadyForUpdate(false)
       setRunImmediate(false)
       refresh()
     }
-  }, [isReadyForUpdate, refresh])
+  }, [initiateUpdate, isReadyForUpdate, refresh])
 
   // Set up the timeout.
   useEffect(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router'
 import { ReactNode, useMemo } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { BLOCKED_ADDRESSES } from './config/constants'
@@ -7,13 +6,9 @@ import MulticallUpdater from './state/multicall/updater'
 import TransactionUpdater from './state/transactions/updater'
 
 export function Updaters() {
-  const router = useRouter()
-  const includeListUpdater = ['/swap', '/limit-orders', '/add', '/find', '/remove'].some((item) => {
-    return router.pathname.startsWith(item)
-  })
   return (
     <>
-      {includeListUpdater && <ListsUpdater />}
+      <ListsUpdater />
       <TransactionUpdater />
       <MulticallUpdater />
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { ReactNode, useMemo } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import { BLOCKED_ADDRESSES } from './config/constants'
@@ -6,9 +7,13 @@ import MulticallUpdater from './state/multicall/updater'
 import TransactionUpdater from './state/transactions/updater'
 
 export function Updaters() {
+  const router = useRouter()
+  const includeListUpdater = ['/swap', '/limit-orders', '/add', '/find', '/remove'].some((item) => {
+    return router.pathname.startsWith(item)
+  })
   return (
     <>
-      <ListsUpdater />
+      {includeListUpdater && <ListsUpdater />}
       <TransactionUpdater />
       <MulticallUpdater />
     </>

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -28,14 +28,14 @@ export default function Updater(): null {
 
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {
-    if (!isWindowVisible || !includeListUpdater) return
+    if (!isWindowVisible) return
     Object.keys(lists).forEach((url) =>
       fetchList(url).catch((error) => console.debug('interval list fetching error', error)),
     )
-  }, [includeListUpdater, fetchList, isWindowVisible, lists])
+  }, [fetchList, isWindowVisible, lists])
 
   // fetch all lists every 10 minutes, but only after we initialize library and page has currency input
-  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null)
+  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null, true, includeListUpdater)
 
   // whenever a list is not loaded and not loading, try again to load it
   useEffect(() => {

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -28,14 +28,14 @@ export default function Updater(): null {
 
   const fetchList = useFetchListCallback()
   const fetchAllListsCallback = useCallback(() => {
-    if (!isWindowVisible) return
+    if (!isWindowVisible || !includeListUpdater) return
     Object.keys(lists).forEach((url) =>
       fetchList(url).catch((error) => console.debug('interval list fetching error', error)),
     )
-  }, [fetchList, isWindowVisible, lists])
+  }, [includeListUpdater, fetchList, isWindowVisible, lists])
 
   // fetch all lists every 10 minutes, but only after we initialize library and page has currency input
-  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null, true, includeListUpdater)
+  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null)
 
   // whenever a list is not loaded and not loading, try again to load it
   useEffect(() => {

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -1,6 +1,7 @@
+import { useRouter } from 'next/router'
 import { useAllLists } from 'state/lists/hooks'
 import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
 import useWeb3Provider from 'hooks/useActiveWeb3React'
 import useFetchListCallback from 'hooks/useFetchListCallback'
@@ -14,6 +15,12 @@ export default function Updater(): null {
   const { library } = useWeb3Provider()
   const dispatch = useAppDispatch()
   const isWindowVisible = useIsWindowVisible()
+  const router = useRouter()
+  const includeListUpdater = useMemo(() => {
+    return ['/swap', '/limit-orders', '/add', '/find', '/remove'].some((item) => {
+      return router.pathname.startsWith(item)
+    })
+  }, [router.pathname])
 
   // get all loaded lists, and the active urls
   const lists = useAllLists()
@@ -27,8 +34,8 @@ export default function Updater(): null {
     )
   }, [fetchList, isWindowVisible, lists])
 
-  // fetch all lists every 10 minutes, but only after we initialize library
-  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null)
+  // fetch all lists every 10 minutes, but only after we initialize library and page has currency input
+  useInterval(fetchAllListsCallback, 1000 * 60 * 10, true, !!(library && includeListUpdater))
 
   // whenever a list is not loaded and not loading, try again to load it
   useEffect(() => {

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -35,7 +35,7 @@ export default function Updater(): null {
   }, [fetchList, isWindowVisible, lists])
 
   // fetch all lists every 10 minutes, but only after we initialize library and page has currency input
-  useInterval(fetchAllListsCallback, 1000 * 60 * 10, true, !!(library && includeListUpdater))
+  useInterval(fetchAllListsCallback, library ? 1000 * 60 * 10 : null, true, includeListUpdater)
 
   // whenever a list is not loaded and not loading, try again to load it
   useEffect(() => {


### PR DESCRIPTION
This will save 2-3 mb of data when visiting other pages that does not contain currency search thus token list is not needed