### PR TITLE
fix: avoid flash of content

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -200,7 +200,7 @@ function CurrencySearch({
               currencies={filteredSortedTokens}
               inactiveCurrencies={filteredInactiveTokens}
               breakIndex={
-                Boolean(filteredInactiveTokens?.length) && filteredSortedTokens
+                Boolean(filteredInactiveTokens?.length) && Boolean(filteredSortedTokens?.length)
                   ? filteredSortedTokens.length
                   : undefined
               }


### PR DESCRIPTION
When I enter the address of a token that is part of a list that I have not yet activated I see this for a few ms:

<img src="https://user-images.githubusercontent.com/8525267/170747685-05a5ce53-ae0a-471b-b89d-31a02a30968b.png" width="320" />

and that right after:

<img src="https://user-images.githubusercontent.com/8525267/170748191-89df72d3-43b3-4a50-864a-6b822528a1d5.png" width="320" />


The first capture should not display
