### PR TITLE
feat: Add cake modal input empty

### DIFF
--- a/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
@@ -11,6 +11,7 @@ import useTheme from 'hooks/useTheme'
 import { useBUSDCakeAmount } from 'hooks/useBUSDPrice'
 import { getBalanceNumber, getDecimalAmount, getBalanceAmount } from 'utils/formatBalance'
 import { ONE_WEEK_DEFAULT } from 'config/constants/pools'
+import { BIG_ZERO } from 'utils/bigNumber'
 
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
 
@@ -55,10 +56,12 @@ const AddAmountModal: React.FC<AddAmountModalProps> = ({
   stakingTokenBalance,
 }) => {
   const { theme } = useTheme()
-  const [lockedAmount, setLockedAmount] = useState('0')
+  const [lockedAmount, setLockedAmount] = useState('')
   const [checkedState, setCheckedState] = useState(false)
   const { t } = useTranslation()
-  const lockedAmountAsBigNumber = new BigNumber(lockedAmount)
+  const lockedAmountAsBigNumber = !Number.isNaN(new BigNumber(lockedAmount).toNumber())
+    ? new BigNumber(lockedAmount)
+    : BIG_ZERO
   const totalLockedAmount: number = getBalanceNumber(
     currentLockedAmount.plus(getDecimalAmount(lockedAmountAsBigNumber)),
   )


### PR DESCRIPTION
Every time, open Add Cake modal need delete the zero in input.

Before:

https://user-images.githubusercontent.com/98292246/170952930-4be5c30f-8568-4455-8d6d-63f84d04201e.mov





After:

https://user-images.githubusercontent.com/98292246/170952941-b08ba128-a80c-4ef0-8aa0-fbf384c3d4a3.mov




