### PR TITLE
perf: Make next link prefect default to false

### DIFF
--- a/src/components/App/AppHeader.tsx
+++ b/src/components/App/AppHeader.tsx
@@ -29,7 +29,7 @@ const AppHeader: React.FC<Props> = ({ title, subtitle, helper, backTo, noConfig 
     <AppHeaderContainer>
       <Flex alignItems="center" mr={noConfig ? 0 : '16px'}>
         {backTo && (
-          <Link passHref href={backTo}>
+          <Link passHref href={backTo} prefetch={false}>
             <IconButton as="a">
               <ArrowBackIcon width="32px" />
             </IconButton>

--- a/src/components/Links/index.tsx
+++ b/src/components/Links/index.tsx
@@ -23,7 +23,7 @@ const StyledInternalLink = styled('a')`
 
 const InternalLink: React.FC<LinkProps> = ({ children, ...props }) => {
   return (
-    <Link {...props}>
+    <Link {...props} prefetch={false}>
       <StyledInternalLink>{children}</StyledInternalLink>
     </Link>
   )

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -33,7 +33,7 @@ const Menu = (props) => {
   return (
     <UikitMenu
       linkComponent={(linkProps) => {
-        return <NextLinkFromReactRouter to={linkProps.href} {...linkProps} prefetch={false} />
+        return <NextLinkFromReactRouter to={linkProps.href} {...linkProps} />
       }}
       userMenu={<UserMenu />}
       globalMenu={<GlobalSettings />}

--- a/src/components/NextLink.tsx
+++ b/src/components/NextLink.tsx
@@ -17,7 +17,7 @@ const A = styled.a``
  * temporary solution for migrating React Router to Next.js Link
  */
 export const NextLinkFromReactRouter = forwardRef<any, LinkProps>(
-  ({ to, replace, children, prefetch, ...props }, ref) => (
+  ({ to, replace, children, prefetch = false, ...props }, ref) => (
     <NextLink href={to as string} replace={replace} passHref prefetch={prefetch}>
       <A ref={ref} {...props}>
         {children}

--- a/src/views/FarmAuction/index.tsx
+++ b/src/views/FarmAuction/index.tsx
@@ -80,12 +80,12 @@ const FarmAuction = () => {
       <PageMeta />
       <StyledHeader>
         <Breadcrumbs>
-          <NextLink href="/" passHref>
+          <NextLink href="/" passHref prefetch={false}>
             <Link href="/" color="primary" style={{ fontWeight: 400 }}>
               {t('Home')}
             </Link>
           </NextLink>
-          <NextLink href="/farms" passHref>
+          <NextLink href="/farms" passHref prefetch={false}>
             <Link href="/farms" color="primary" style={{ fontWeight: 400 }}>
               {t('Farms')}
             </Link>

--- a/src/views/Farms/Farms.tsx
+++ b/src/views/Farms/Farms.tsx
@@ -361,7 +361,7 @@ const Farms: React.FC = ({ children }) => {
         <Heading scale="lg" color="text">
           {t('Stake LP tokens to earn.')}
         </Heading>
-        <NextLinkFromReactRouter to="/farms/auction" prefetch={false}>
+        <NextLinkFromReactRouter to="/farms/auction">
           <Button p="0" variant="text">
             <Text color="primary" bold fontSize="16px" mr="4px">
               {t('Community Auctions')}

--- a/src/views/NotFound.tsx
+++ b/src/views/NotFound.tsx
@@ -21,7 +21,7 @@ const NotFound = () => {
         <LogoIcon width="64px" mb="8px" />
         <Heading scale="xxl">404</Heading>
         <Text mb="16px">{t('Oops, page not found.')}</Text>
-        <Link href="/" passHref>
+        <Link href="/" passHref prefetch={false}>
           <Button as="a" scale="sm">
             {t('Back Home')}
           </Button>

--- a/src/views/Pool/index.tsx
+++ b/src/views/Pool/index.tsx
@@ -95,7 +95,7 @@ export default function Pool() {
               <Text color="textSubtle" mb="8px">
                 {t("Don't see a pool you joined?")}
               </Text>
-              <Link href="/find" passHref>
+              <Link href="/find" passHref prefetch={false}>
                 <Button id="import-pool-link" variant="secondary" scale="sm" as="a">
                   {t('Find other LP tokens')}
                 </Button>
@@ -104,7 +104,7 @@ export default function Pool() {
           )}
         </Body>
         <CardFooter style={{ textAlign: 'center' }}>
-          <Link href="/add" passHref>
+          <Link href="/add" passHref prefetch={false}>
             <Button id="join-pool-button" width="100%" startIcon={<AddIcon color="white" />}>
               {t('Add Liquidity')}
             </Button>

--- a/src/views/Predictions/Leaderboard/components/Crumbs.tsx
+++ b/src/views/Predictions/Leaderboard/components/Crumbs.tsx
@@ -9,10 +9,10 @@ const Crumbs = () => {
   return (
     <Box mb="24px">
       <Breadcrumbs>
-        <NextLink href="/" passHref>
+        <NextLink href="/" passHref prefetch={false}>
           <Link>{t('Home')}</Link>
         </NextLink>
-        <NextLink href="/prediction" passHref>
+        <NextLink href="/prediction" passHref prefetch={false}>
           <Link>{t('Prediction')}</Link>
         </NextLink>
         <Text>{t('Leaderboard')}</Text>

--- a/src/views/Predictions/components/Menu.tsx
+++ b/src/views/Predictions/components/Menu.tsx
@@ -83,7 +83,7 @@ const Menu = () => {
             </Button>
           </HelpButtonWrapper>
           <LeaderboardButtonWrapper>
-            <Link href="/prediction/leaderboard" passHref>
+            <Link href="/prediction/leaderboard" passHref prefetch={false}>
               <Button as="a" variant="subtle" width="48px">
                 <PrizeIcon color="white" />
               </Button>

--- a/src/views/Teams/Team.tsx
+++ b/src/views/Teams/Team.tsx
@@ -15,7 +15,7 @@ const Team = () => {
     <Page>
       <TeamHeader />
       <Flex mb="24px">
-        <Link href="/teams" passHref>
+        <Link href="/teams" passHref prefetch={false}>
           <Flex alignItems="center" as="a">
             <ChevronLeftIcon color="primary" />
             <Text color="primary">{t('Teams Overview')}</Text>

--- a/src/views/Teams/components/NoProfileCard.tsx
+++ b/src/views/Teams/components/NoProfileCard.tsx
@@ -19,7 +19,7 @@ const NoProfileCard = () => {
             </Heading>
             <Text>{t('You can do this at any time by clicking on your profile picture in the menu')}</Text>
           </div>
-          <Link href="/create-profile" passHref>
+          <Link href="/create-profile" passHref prefetch={false}>
             <Button as="a" id="teamsPageSetUpProfile" mt={['16px', null, 0]}>
               {t('Set up now')}
             </Button>

--- a/src/views/Teams/components/TeamListCard.tsx
+++ b/src/views/Teams/components/TeamListCard.tsx
@@ -126,7 +126,7 @@ const TeamCard: React.FC<TeamCardProps> = ({ rank, team }) => {
               </Flex>
             </Flex>
           </Info>
-          <Link href={`/teams/${team?.id}`} passHref>
+          <Link href={`/teams/${team?.id}`} passHref prefetch={false}>
             <Button as="a" variant="secondary" scale="sm">
               {t('See More')}
             </Button>

--- a/src/views/Voting/CreateProposal/index.tsx
+++ b/src/views/Voting/CreateProposal/index.tsx
@@ -168,8 +168,12 @@ const CreateProposal = () => {
       <PageMeta />
       <Box mb="48px">
         <Breadcrumbs>
-          <Link href="/">{t('Home')}</Link>
-          <Link href="/voting">{t('Voting')}</Link>
+          <Link href="/" prefetch={false}>
+            {t('Home')}
+          </Link>
+          <Link href="/voting" prefetch={false}>
+            {t('Voting')}
+          </Link>
           <Text>{t('Make a Proposal')}</Text>
         </Breadcrumbs>
       </Box>

--- a/src/views/Voting/Proposal/Overview.tsx
+++ b/src/views/Voting/Proposal/Overview.tsx
@@ -53,7 +53,7 @@ const Overview = () => {
     <Container py="40px">
       <PageMeta />
       <Box mb="40px">
-        <Link href="/voting" passHref>
+        <Link href="/voting" passHref prefetch={false}>
           <Button as="a" variant="text" startIcon={<ArrowBackIcon color="primary" width="24px" />} px="0">
             {t('Back to Vote Overview')}
           </Button>

--- a/src/views/Voting/components/Proposals/Proposals.tsx
+++ b/src/views/Voting/components/Proposals/Proposals.tsx
@@ -49,7 +49,9 @@ const Proposals = () => {
     <Container py="40px">
       <Box mb="48px">
         <Breadcrumbs>
-          <Link href="/">{t('Home')}</Link>
+          <Link href="/" prefetch={false}>
+            {t('Home')}
+          </Link>
           <Text>{t('Voting')}</Text>
         </Breadcrumbs>
       </Box>


### PR DESCRIPTION
Test it especially on mobile for checking degradation on responsiveness because even prefetch is false it will still be enabled in desktop when the link is hovered on see https://github.com/vercel/next.js/blob/15354e9b42201df8c2102f2ba2f3cfcca1e561c0/docs/api-reference/next/link.md?plain=1#L60
 
