### PR TITLE
fix(wallet): Coinbase eager connect keep deeplink on mobile

### DIFF
--- a/packages/uikit/src/react-app-env.d.ts
+++ b/packages/uikit/src/react-app-env.d.ts
@@ -2,6 +2,7 @@ interface Window {
   ethereum?: {
     isMetaMask?: true;
     isOpera?: true;
+    isCoinbaseWallet?: true;
     isTrust?: true;
     providers?: any[];
     request?: (...args: any[]) => Promise<void>;

--- a/src/hooks/useEagerConnect.ts
+++ b/src/hooks/useEagerConnect.ts
@@ -69,6 +69,12 @@ const useEagerConnect = () => {
 
         return
       }
+
+      // Prevent eager connect on mobile & coinbase wallet not injected, as it keeps trying deeplink to app store.
+      if (connectorId === ConnectorNames.WalletLink && isMobile && window?.ethereum?.isCoinbaseWallet !== true) {
+        return
+      }
+
       if (connectorId === ConnectorNames.Injected) {
         const isEthereumDefined = Reflect.has(window, 'ethereum')
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -2,6 +2,7 @@ interface Window {
   ethereum?: {
     isMetaMask?: true
     isOpera?: true
+    isCoinbaseWallet?: true
     isTrust?: true
     providers?: any[]
     request?: (...args: any[]) => Promise<void>


### PR DESCRIPTION
Some dapp browser not allowing open new tab, when you accidentally click coinbase wallet, it will redirect to app store everytime on eager connect, causing not allowing switch wallet