### PR TITLE
feat: List Farm Auction 23

### DIFF
--- a/src/config/constants/farmAuctions.ts
+++ b/src/config/constants/farmAuctions.ts
@@ -745,6 +745,14 @@ export const whitelistedBidders: FarmAuctionBidderConfig[] =
           tokenName: 'DragonSB',
           projectSite: 'https://dragonsb.finance/',
         },
+        {
+          account: '0x3846e7A1A5dEA3F43104ed89ff0E6FfD1Cc74b6E',
+          farmName: 'PEAK-BNB',
+          tokenAddress: '0x630d98424eFe0Ea27fB1b3Ab7741907DFFEaAd78',
+          quoteToken: tokens.wbnb,
+          tokenName: 'PEAKDEFI',
+          projectSite: 'https://peakdefi.com/',
+        },
       ].map((bidderConfig) => ({
         ...bidderConfig,
         lpAddress: getLpAddress(bidderConfig.tokenAddress, bidderConfig.quoteToken),


### PR DESCRIPTION
Should we remove projects `HeroesTD` & `Everdome` on config?
Or just filter both in `Total whitelisted bidders`.
Cos if we delete from config, whoever wins before, in `Archive` will show `Unknown`.

![Screenshot 2022-06-07 at 8 12 50 AM](https://user-images.githubusercontent.com/98292246/172269524-765a944d-887e-4246-80c1-c917162c33c4.png)
 