### PR TITLE
fix: Missing auction hosting ends info in community farms

### DIFF
--- a/src/config/constants/farms.ts
+++ b/src/config/constants/farms.ts
@@ -52,6 +52,7 @@ const farms: SerializedFarmConfig[] = [
     token: serializedTokens.peak,
     quoteToken: serializedTokens.wbnb,
     isCommunity: true,
+    auctionHostingStartSeconds: 1654772400,
   },
   {
     pid: 93,
@@ -64,6 +65,7 @@ const farms: SerializedFarmConfig[] = [
     token: serializedTokens.happy,
     quoteToken: serializedTokens.wbnb,
     isCommunity: true,
+    auctionHostingStartSeconds: 1654772400,
   },
   {
     pid: 94,
@@ -76,6 +78,7 @@ const farms: SerializedFarmConfig[] = [
     token: serializedTokens.wzrd,
     quoteToken: serializedTokens.busd,
     isCommunity: true,
+    auctionHostingStartSeconds: 1654772400,
   },
   {
     pid: 40,


### PR DESCRIPTION
@ChefMomota Sorry, I was wrong about removing auction hosting property for community farms, I remember that it is needed to show auction hosting ends info for them.