### PR TITLE
fix: (pool): Extend duration check based on current duration causes locked vault to not extend

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1777,5 +1777,7 @@
   "Select a Network": "Select a Network",
   "LP Rewards APR": "LP Rewards APR",
   "Limit Orders": "Limit Orders",
-  "0.0001 CAKE needed to extend lock": "0.0001 CAKE needed to extend lock"
+  "0.0001 CAKE will be spent to extend": "0.0001 CAKE will be spent to extend",
+  "0.0001 CAKE required for enabling extension": "0.0001 CAKE required for enabling extension",
+  "Recommend choosing \"MAX\" to renew your staking position in order to keep similar yield boost.": "Recommend choosing \"MAX\" to renew your staking position in order to keep similar yield boost."
 }

--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1776,5 +1776,6 @@
   "The vested tokens will be released linearly over a period of %weeks% weeks.": "The vested tokens will be released linearly over a period of %weeks% weeks.",
   "Select a Network": "Select a Network",
   "LP Rewards APR": "LP Rewards APR",
-  "Limit Orders": "Limit Orders"
+  "Limit Orders": "Limit Orders",
+  "0.0001 CAKE needed to extend lock": "0.0001 CAKE needed to extend lock"
 }

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -39,9 +39,7 @@ import { getFullDecimalMultiplier } from 'utils/getFullDecimalMultiplier'
 import { VaultRoiCalculatorModal } from '../Vault/VaultRoiCalculatorModal'
 import ConvertToLock from '../LockedPool/Common/ConvertToLock'
 import FeeSummary from './FeeSummary'
-
-// min deposit and withdraw amount
-const MIN_AMOUNT = new BigNumber(10000000000000)
+import { MIN_LOCK_AMOUNT } from '../../helpers'
 
 interface VaultStakeModalProps {
   pool: DeserializedPool
@@ -149,7 +147,7 @@ const VaultStakeModal: React.FC<VaultStakeModalProps> = ({
 
   const handleWithdrawal = async () => {
     // trigger withdrawAll function if the withdrawal will leave 0.00001 CAKE or less
-    const isWithdrawingAll = stakingMax.minus(convertedStakeAmount).lte(MIN_AMOUNT)
+    const isWithdrawingAll = stakingMax.minus(convertedStakeAmount).lte(MIN_LOCK_AMOUNT)
 
     const receipt = await fetchWithCatchTxError(() => {
       // .toString() being called to fix a BigNumber error in prod

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -17,7 +17,10 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
 }) => {
   const nowInSeconds = Math.floor(Date.now() / 1000)
   const currentDuration = useMemo(() => Number(lockEndTime) - Number(lockStartTime), [lockEndTime, lockStartTime])
-  const currentDurationLeftInSeconds = useMemo(() => Number(lockEndTime) - nowInSeconds, [lockEndTime, nowInSeconds])
+  const currentDurationLeft = useMemo(
+    () => Math.max(Number(lockEndTime) - nowInSeconds, 0),
+    [lockEndTime, nowInSeconds],
+  )
 
   const [openExtendDurationModal] = useModal(
     <ExtendDurationModal
@@ -25,9 +28,9 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
       currentBalance={currentBalance}
-      lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}
+      currentDurationLeft={currentDurationLeft}
     />,
     true,
     true,
@@ -36,10 +39,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
 
   return (
     <Button
-      disabled={
-        Number.isFinite(currentDurationLeftInSeconds) &&
-        MAX_LOCK_DURATION - currentDurationLeftInSeconds < ONE_WEEK_DEFAULT
-      }
+      disabled={Number.isFinite(currentDurationLeft) && MAX_LOCK_DURATION - currentDurationLeft < ONE_WEEK_DEFAULT}
       onClick={openExtendDurationModal}
       width="100%"
       {...rest}

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -16,7 +16,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
   children,
   ...rest
 }) => {
-  const nowInSeconds = Date.now() / 1000
+  const nowInSeconds = Math.floor(Date.now() / 1000)
   const currentDuration = useMemo(() => Number(lockEndTime) - Number(lockStartTime), [lockEndTime, lockStartTime])
   const currentDurationLeftInSeconds = useMemo(() => Number(lockEndTime) - nowInSeconds, [lockEndTime, nowInSeconds])
 

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -10,7 +10,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
   stakingToken,
   currentLockedAmount,
   currentBalance,
-  checkEnoughBalanceToExtend,
+  extendLockedPosition,
   lockEndTime,
   lockStartTime,
   children,
@@ -26,7 +26,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
       currentBalance={currentBalance}
-      checkEnoughBalanceToExtend={checkEnoughBalanceToExtend}
+      extendLockedPosition={extendLockedPosition}
       lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -23,6 +23,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       modalTitle={modalTitle}
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
+      lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}
     />,

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -10,7 +10,6 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
   stakingToken,
   currentLockedAmount,
   currentBalance,
-  extendLockedPosition,
   lockEndTime,
   lockStartTime,
   children,
@@ -26,7 +25,6 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
       currentBalance={currentBalance}
-      extendLockedPosition={extendLockedPosition}
       lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -9,6 +9,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
   modalTitle,
   stakingToken,
   currentLockedAmount,
+  currentBalance,
   lockEndTime,
   lockStartTime,
   children,
@@ -23,6 +24,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       modalTitle={modalTitle}
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
+      currentBalance={currentBalance}
       lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}

--- a/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
+++ b/src/views/Pools/components/LockedPool/Buttons/ExtendDurationButton.tsx
@@ -10,6 +10,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
   stakingToken,
   currentLockedAmount,
   currentBalance,
+  checkEnoughBalanceToExtend,
   lockEndTime,
   lockStartTime,
   children,
@@ -25,6 +26,7 @@ const ExtendDurationButton: React.FC<ExtendDurationButtonPropsType & ButtonProps
       stakingToken={stakingToken}
       lockStartTime={lockStartTime}
       currentBalance={currentBalance}
+      checkEnoughBalanceToExtend={checkEnoughBalanceToExtend}
       lockEndTime={lockEndTime}
       currentLockedAmount={currentLockedAmount}
       currentDuration={currentDuration}

--- a/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
+++ b/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
@@ -1,0 +1,28 @@
+import { Button, AutoRenewIcon } from '@pancakeswap/uikit'
+import { useTranslation } from 'contexts/Localization'
+import { useExtendEnable } from '../hooks/useExtendEnable'
+
+interface ExtendEnableProps {
+  isValidAmount: boolean
+  isValidDuration: boolean
+}
+
+const ExtendEnable: React.FC<ExtendEnableProps> = ({ isValidAmount, isValidDuration }) => {
+  const { t } = useTranslation()
+
+  const { handleEnable, pendingEnableTx } = useExtendEnable()
+
+  return (
+    <Button
+      width="100%"
+      isLoading={pendingEnableTx}
+      endIcon={pendingEnableTx ? <AutoRenewIcon spin color="currentColor" /> : null}
+      onClick={handleEnable}
+      disabled={!(isValidAmount && isValidDuration)}
+    >
+      {pendingEnableTx ? t('Enabling') : t('Enable')}
+    </Button>
+  )
+}
+
+export default ExtendEnable

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -2,6 +2,7 @@ import { Text, Flex, Button, Input, Box } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 import _toNumber from 'lodash/toNumber'
+import { ONE_WEEK_DEFAULT } from 'config/constants/pools'
 import { secondsToWeeks, weeksToSeconds } from '../../utils/formatSecondsToWeeks'
 import { LockDurationFieldPropsType } from '../types'
 
@@ -55,6 +56,7 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
             mt="4px"
             mr={['2px', '2px', '4px', '4px']}
             scale="sm"
+            disabled={maxAvailableDuration < ONE_WEEK_DEFAULT}
             variant={maxAvailableDuration === duration ? 'subtle' : 'tertiary'}
           >
             {t('Max')}

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -1,4 +1,5 @@
-import { Text, Flex, Button, Input, Box } from '@pancakeswap/uikit'
+import { useState } from 'react'
+import { Text, Flex, Button, Input, Box, Message, MessageText } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 import _toNumber from 'lodash/toNumber'
@@ -18,9 +19,11 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
   setDuration,
   isOverMax,
   currentDurationLeft,
+  extendLockedPosition,
   maxAvailableDuration,
 }) => {
   const { t } = useTranslation()
+  const [isMaxSelected, setIsMaxSelected] = useState(false)
 
   return (
     <>
@@ -39,7 +42,10 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
             return (
               <Button
                 key={week}
-                onClick={() => setDuration(weekSeconds)}
+                onClick={() => {
+                  setIsMaxSelected(false)
+                  setDuration(weekSeconds)
+                }}
                 mt="4px"
                 mr={['2px', '2px', '4px', '4px']}
                 scale="sm"
@@ -52,12 +58,15 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
           })}
           <Button
             key={maxAvailableDuration}
-            onClick={() => setDuration(maxAvailableDuration)}
+            onClick={() => {
+              setIsMaxSelected(true)
+              setDuration(maxAvailableDuration)
+            }}
             mt="4px"
             mr={['2px', '2px', '4px', '4px']}
             scale="sm"
             disabled={maxAvailableDuration < ONE_WEEK_DEFAULT}
-            variant={maxAvailableDuration === duration ? 'subtle' : 'tertiary'}
+            variant={isMaxSelected ? 'subtle' : 'tertiary'}
           >
             {t('Max')}
           </Button>
@@ -70,6 +79,7 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
           pattern="^[0-9]+$"
           inputMode="numeric"
           onChange={(e) => {
+            setIsMaxSelected(false)
             const weeks = _toNumber(e?.target?.value)
 
             // Prevent large number input which cause NaN
@@ -86,6 +96,13 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
         <Text fontSize="12px" textAlign="right" color="failure">
           {t('Total lock duration exceeds 52 weeks')}
         </Text>
+      )}
+      {extendLockedPosition && !isMaxSelected && (
+        <Message variant="warning">
+          <MessageText maxWidth="200px">
+            {t('Recommend choosing "MAX" to renew your staking position in order to keep similar yield boost.')}
+          </MessageText>
+        </Message>
       )}
     </>
   )

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -18,7 +18,6 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
   duration,
   setDuration,
   isOverMax,
-  currentDurationLeft,
   extendLockedPosition,
   maxAvailableDuration,
 }) => {
@@ -49,7 +48,7 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
                 mt="4px"
                 mr={['2px', '2px', '4px', '4px']}
                 scale="sm"
-                disabled={currentDurationLeft && weekSeconds + currentDurationLeft > maxAvailableDuration}
+                disabled={weekSeconds > maxAvailableDuration}
                 variant={weekSeconds === duration ? 'subtle' : 'tertiary'}
               >
                 {week}W

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -20,7 +20,6 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
   duration,
   setDuration,
   isOverMax,
-  extendLockedPosition,
   currentDuration,
   lockEndTime,
   setUpdatedLockStartTime,
@@ -135,7 +134,7 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
           {t('Total lock duration exceeds 52 weeks')}
         </Text>
       )}
-      {extendLockedPosition && !isMaxSelected && (
+      {currentDuration && !isMaxSelected && (
         <Message variant="warning">
           <MessageText maxWidth="240px">
             {t('Recommend choosing "MAX" to renew your staking position in order to keep similar yield boost.')}

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { differenceInSeconds } from 'date-fns'
 import { convertTimeToSeconds } from 'utils/timeHelper'
 import { Text, Flex, Button, Input, Box, Message, MessageText } from '@pancakeswap/uikit'
@@ -43,6 +43,19 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
     [calculateRemainingDuration],
   )
 
+  useEffect(() => {
+    if (currentDuration) {
+      const now = new Date()
+      if (currentDuration + duration > MAX_LOCK_DURATION) {
+        setUpdatedLockStartTime(Math.floor(now.getTime() / 1000).toString())
+        setUpdatedLockDuration(calculateRemainingDuration(now) + duration)
+      } else {
+        setUpdatedLockStartTime(null)
+        setUpdatedLockDuration(null)
+      }
+    }
+  }, [calculateRemainingDuration, currentDuration, duration, setUpdatedLockDuration, setUpdatedLockStartTime])
+
   return (
     <>
       <Box mb="16px">
@@ -63,16 +76,6 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
                 onClick={() => {
                   setIsMaxSelected(false)
                   setDuration(weekSeconds)
-                  if (currentDuration) {
-                    const now = new Date()
-                    if (currentDuration + weekSeconds > MAX_LOCK_DURATION) {
-                      setUpdatedLockStartTime(Math.floor(now.getTime() / 1000).toString())
-                      setUpdatedLockDuration(calculateRemainingDuration(now) + weekSeconds)
-                    } else {
-                      setUpdatedLockStartTime(null)
-                      setUpdatedLockDuration(null)
-                    }
-                  }
                 }}
                 mt="4px"
                 mr={['2px', '2px', '4px', '4px']}
@@ -91,10 +94,6 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
               const now = new Date()
               const maxAvailableDuration = calculateMaxAvailableDuration(now)
               setDuration(maxAvailableDuration)
-              if (currentDuration) {
-                setUpdatedLockStartTime(Math.floor(now.getTime() / 1000).toString())
-                setUpdatedLockDuration(calculateRemainingDuration(now) + maxAvailableDuration)
-              }
             }}
             mt="4px"
             mr={['2px', '2px', '4px', '4px']}

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -99,7 +99,7 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
       )}
       {extendLockedPosition && !isMaxSelected && (
         <Message variant="warning">
-          <MessageText maxWidth="200px">
+          <MessageText maxWidth="240px">
             {t('Recommend choosing "MAX" to renew your staking position in order to keep similar yield boost.')}
           </MessageText>
         </Message>

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -2,6 +2,7 @@ import { Text, Flex, Button, Input, Box } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 import _toNumber from 'lodash/toNumber'
+import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 import { secondsToWeeks, weeksToSeconds } from '../../utils/formatSecondsToWeeks'
 import { LockDurationFieldPropsType } from '../types'
 
@@ -12,7 +13,12 @@ const StyledInput = styled(Input)`
   margin-right: 8px;
 `
 
-const LockDurationField: React.FC<LockDurationFieldPropsType> = ({ duration, setDuration, isOverMax }) => {
+const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
+  duration,
+  setDuration,
+  isOverMax,
+  hasEnoughBalanceToExtend,
+}) => {
   const { t } = useTranslation()
 
   return (
@@ -63,6 +69,11 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({ duration, set
       {isOverMax && (
         <Text fontSize="12px" textAlign="right" color="failure">
           {t('Total lock duration exceeds 52 weeks')}
+        </Text>
+      )}
+      {!isUndefinedOrNull(hasEnoughBalanceToExtend) && !hasEnoughBalanceToExtend && (
+        <Text fontSize="12px" textAlign="right" color="failure">
+          {t('0.0001 CAKE needed to extend lock')}
         </Text>
       )}
     </>

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -2,11 +2,10 @@ import { Text, Flex, Button, Input, Box } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from 'contexts/Localization'
 import _toNumber from 'lodash/toNumber'
-import isUndefinedOrNull from 'utils/isUndefinedOrNull'
 import { secondsToWeeks, weeksToSeconds } from '../../utils/formatSecondsToWeeks'
 import { LockDurationFieldPropsType } from '../types'
 
-const DURATIONS = [1, 5, 10, 25, 52]
+const DURATIONS = [1, 5, 10, 25]
 
 const StyledInput = styled(Input)`
   text-align: right;
@@ -17,7 +16,8 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
   duration,
   setDuration,
   isOverMax,
-  hasEnoughBalanceToExtend,
+  currentDurationLeft,
+  maxAvailableDuration,
 }) => {
   const { t } = useTranslation()
 
@@ -33,18 +33,32 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
           </Text>
         </Flex>
         <Flex flexWrap="wrap">
-          {DURATIONS.map((week) => (
-            <Button
-              key={week}
-              onClick={() => setDuration(weeksToSeconds(week))}
-              mt="4px"
-              mr={['2px', '2px', '4px', '4px']}
-              scale="sm"
-              variant={weeksToSeconds(week) === duration ? 'subtle' : 'tertiary'}
-            >
-              {week}W
-            </Button>
-          ))}
+          {DURATIONS.map((week) => {
+            const weekSeconds = weeksToSeconds(week)
+            return (
+              <Button
+                key={week}
+                onClick={() => setDuration(weekSeconds)}
+                mt="4px"
+                mr={['2px', '2px', '4px', '4px']}
+                scale="sm"
+                disabled={currentDurationLeft && weekSeconds + currentDurationLeft > maxAvailableDuration}
+                variant={weekSeconds === duration ? 'subtle' : 'tertiary'}
+              >
+                {week}W
+              </Button>
+            )
+          })}
+          <Button
+            key={maxAvailableDuration}
+            onClick={() => setDuration(maxAvailableDuration)}
+            mt="4px"
+            mr={['2px', '2px', '4px', '4px']}
+            scale="sm"
+            variant={maxAvailableDuration === duration ? 'subtle' : 'tertiary'}
+          >
+            {t('Max')}
+          </Button>
         </Flex>
       </Box>
       <Flex justifyContent="center" alignItems="center" mb="8px">
@@ -69,11 +83,6 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
       {isOverMax && (
         <Text fontSize="12px" textAlign="right" color="failure">
           {t('Total lock duration exceeds 52 weeks')}
-        </Text>
-      )}
-      {!isUndefinedOrNull(hasEnoughBalanceToExtend) && !hasEnoughBalanceToExtend && (
-        <Text fontSize="12px" textAlign="right" color="failure">
-          {t('0.0001 CAKE needed to extend lock')}
         </Text>
       )}
     </>

--- a/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -29,20 +29,17 @@ const LockDurationField: React.FC<LockDurationFieldPropsType> = ({
   const [isMaxSelected, setIsMaxSelected] = useState(false)
 
   const calculateRemainingDuration = useCallback(
-    (now: Date) => {
-      return lockEndTime
+    (now: Date) =>
+      lockEndTime
         ? differenceInSeconds(new Date(convertTimeToSeconds(lockEndTime)), now, {
             roundingMethod: 'ceil',
           })
-        : 0
-    },
+        : 0,
     [lockEndTime],
   )
 
   const calculateMaxAvailableDuration = useCallback(
-    (now: Date) => {
-      return MAX_LOCK_DURATION - calculateRemainingDuration(now)
-    },
+    (now: Date) => MAX_LOCK_DURATION - calculateRemainingDuration(now),
     [calculateRemainingDuration],
   )
 

--- a/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
@@ -54,6 +54,7 @@ const LockedActions: React.FC<LockedActionsPropsType> = ({
             lockEndTime={lockEndTime}
             lockStartTime={lockStartTime}
             stakingToken={stakingToken}
+            currentBalance={currentBalance}
             currentLockedAmount={lockedAmountAsNumber}
           >
             {t('Extend')}

--- a/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
@@ -55,7 +55,7 @@ const LockedActions: React.FC<LockedActionsPropsType> = ({
             lockStartTime={lockStartTime}
             stakingToken={stakingToken}
             currentBalance={currentBalance}
-            checkEnoughBalanceToExtend
+            extendLockedPosition
             currentLockedAmount={lockedAmountAsNumber}
           >
             {t('Extend')}

--- a/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
@@ -55,6 +55,7 @@ const LockedActions: React.FC<LockedActionsPropsType> = ({
             lockStartTime={lockStartTime}
             stakingToken={stakingToken}
             currentBalance={currentBalance}
+            checkEnoughBalanceToExtend
             currentLockedAmount={lockedAmountAsNumber}
           >
             {t('Extend')}

--- a/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedActions.tsx
@@ -55,7 +55,6 @@ const LockedActions: React.FC<LockedActionsPropsType> = ({
             lockStartTime={lockStartTime}
             stakingToken={stakingToken}
             currentBalance={currentBalance}
-            extendLockedPosition
             currentLockedAmount={lockedAmountAsNumber}
           >
             {t('Extend')}

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -36,25 +36,19 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
     prepConfirmArg,
   })
 
-  const {
-    isValidAmount,
-    isValidDuration,
-    isOverMax,
-    maxAvailableDuration,
-    currentDuration,
-    currentDurationLeft,
-  }: ModalValidator = useMemo(() => {
-    return typeof validator === 'function'
-      ? validator({
-          duration,
-        })
-      : {
-          isValidAmount: lockedAmount?.toNumber() > 0 && getBalanceAmount(currentBalance).gte(lockedAmount),
-          isValidDuration: duration > 0 && duration <= MAX_LOCK_DURATION,
-          isOverMax: duration > MAX_LOCK_DURATION,
-          maxAvailableDuration: MAX_LOCK_DURATION,
-        }
-  }, [validator, currentBalance, lockedAmount, duration])
+  const { isValidAmount, isValidDuration, isOverMax, maxAvailableDuration, currentDuration }: ModalValidator =
+    useMemo(() => {
+      return typeof validator === 'function'
+        ? validator({
+            duration,
+          })
+        : {
+            isValidAmount: lockedAmount?.toNumber() > 0 && getBalanceAmount(currentBalance).gte(lockedAmount),
+            isValidDuration: duration > 0 && duration <= MAX_LOCK_DURATION,
+            isOverMax: duration > MAX_LOCK_DURATION,
+            maxAvailableDuration: MAX_LOCK_DURATION,
+          }
+    }, [validator, currentBalance, lockedAmount, duration])
 
   const cakeNeeded = useMemo(
     () => isValidDuration && extendLockedPosition && currentDuration + duration > MAX_LOCK_DURATION,
@@ -76,7 +70,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
               setDuration={setDuration}
               duration={duration}
               extendLockedPosition
-              currentDurationLeft={currentDurationLeft}
             />
           </>
         )}

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import dynamic from 'next/dynamic'
 import { Button, AutoRenewIcon, Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
@@ -22,7 +22,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   lockedAmount,
   currentBalance,
   currentDuration,
-  lockEndTime,
+  currentDurationLeft,
   editAmountOnly,
   prepConfirmArg,
   validator,
@@ -36,9 +36,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
     lockedAmount,
     prepConfirmArg,
   })
-
-  const [updatedLockStartTime, setUpdatedLockStartTime] = useState<string>()
-  const [updatedLockDuration, setUpdatedLockDuration] = useState<number>()
 
   const { isValidAmount, isValidDuration, isOverMax }: ModalValidator = useMemo(() => {
     return typeof validator === 'function'
@@ -68,11 +65,8 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           <>
             <LockDurationField
               isOverMax={isOverMax}
-              lockEndTime={lockEndTime}
-              currentDuration={currentDuration}
+              currentDurationLeft={currentDurationLeft}
               setDuration={setDuration}
-              setUpdatedLockStartTime={setUpdatedLockStartTime}
-              setUpdatedLockDuration={setUpdatedLockDuration}
               duration={duration}
             />
           </>
@@ -82,8 +76,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
         customOverview({
           isValidDuration,
           duration,
-          updatedLockStartTime,
-          updatedLockDuration,
         })
       ) : (
         <Overview

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -23,7 +23,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   currentBalance,
   currentDuration,
   lockEndTime,
-  extendLockedPosition,
   editAmountOnly,
   prepConfirmArg,
   validator,
@@ -54,8 +53,8 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   }, [validator, currentBalance, lockedAmount, duration])
 
   const cakeNeeded = useMemo(
-    () => isValidDuration && extendLockedPosition && currentDuration + duration > MAX_LOCK_DURATION,
-    [isValidDuration, extendLockedPosition, currentDuration, duration],
+    () => isValidDuration && currentDuration && currentDuration + duration > MAX_LOCK_DURATION,
+    [isValidDuration, currentDuration, duration],
   )
 
   const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gte(MIN_LOCK_AMOUNT), [currentBalance])
@@ -75,7 +74,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
               setUpdatedLockStartTime={setUpdatedLockStartTime}
               setUpdatedLockDuration={setUpdatedLockDuration}
               duration={duration}
-              extendLockedPosition
             />
           </>
         )}

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { Button, AutoRenewIcon, Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
@@ -22,6 +22,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   lockedAmount,
   currentBalance,
   currentDuration,
+  lockEndTime,
   extendLockedPosition,
   editAmountOnly,
   prepConfirmArg,
@@ -37,7 +38,10 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
     prepConfirmArg,
   })
 
-  const { isValidAmount, isValidDuration, isOverMax, maxAvailableDuration }: ModalValidator = useMemo(() => {
+  const [updatedLockStartTime, setUpdatedLockStartTime] = useState<string>()
+  const [updatedLockDuration, setUpdatedLockDuration] = useState<number>()
+
+  const { isValidAmount, isValidDuration, isOverMax }: ModalValidator = useMemo(() => {
     return typeof validator === 'function'
       ? validator({
           duration,
@@ -46,7 +50,6 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           isValidAmount: lockedAmount?.toNumber() > 0 && getBalanceAmount(currentBalance).gte(lockedAmount),
           isValidDuration: duration > 0 && duration <= MAX_LOCK_DURATION,
           isOverMax: duration > MAX_LOCK_DURATION,
-          maxAvailableDuration: MAX_LOCK_DURATION,
         }
   }, [validator, currentBalance, lockedAmount, duration])
 
@@ -66,8 +69,11 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           <>
             <LockDurationField
               isOverMax={isOverMax}
-              maxAvailableDuration={maxAvailableDuration}
+              lockEndTime={lockEndTime}
+              currentDuration={currentDuration}
               setDuration={setDuration}
+              setUpdatedLockStartTime={setUpdatedLockStartTime}
+              setUpdatedLockDuration={setUpdatedLockDuration}
               duration={duration}
               extendLockedPosition
             />
@@ -78,8 +84,8 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
         customOverview({
           isValidDuration,
           duration,
-          updatedLockStartTime: currentDuration + duration > MAX_LOCK_DURATION ? Math.floor(Date.now() / 1000) : null,
-          updatedNewDuration: currentDuration + duration > MAX_LOCK_DURATION ? MAX_LOCK_DURATION : null,
+          updatedLockStartTime,
+          updatedLockDuration,
         })
       ) : (
         <Overview

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -12,7 +12,7 @@ import { LockedModalBodyPropsType, ModalValidator } from '../types'
 import Overview from './Overview'
 import LockDurationField from './LockDurationField'
 import useLockedPool from '../hooks/useLockedPool'
-import { MIN_LOCK_AMOUNT } from '../../../helpers'
+import { ENABLE_EXTEND_LOCK_AMOUNT } from '../../../helpers'
 
 const ExtendEnable = dynamic(() => import('./ExtendEnable'), { ssr: false })
 
@@ -54,7 +54,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
     [isValidDuration, currentDuration, duration],
   )
 
-  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gte(MIN_LOCK_AMOUNT), [currentBalance])
+  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gte(ENABLE_EXTEND_LOCK_AMOUNT), [currentBalance])
 
   const needsEnable = useMemo(() => cakeNeeded && !hasEnoughBalanceToExtend, [cakeNeeded, hasEnoughBalanceToExtend])
 
@@ -95,7 +95,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
             {t('0.0001 CAKE will be spent to extend')}
           </Text>
         ) : (
-          <Message variant="warning">
+          <Message variant="warning" mt="24px">
             <MessageText maxWidth="200px">{t('0.0001 CAKE required for enabling extension')}</MessageText>
           </Message>
         ))}

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -12,13 +12,14 @@ import { LockedModalBodyPropsType, ModalValidator } from '../types'
 import Overview from './Overview'
 import LockDurationField from './LockDurationField'
 import useLockedPool from '../hooks/useLockedPool'
+import { MIN_LOCK_AMOUNT } from '../../../helpers'
 
 const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   stakingToken,
   onDismiss,
   lockedAmount,
   currentBalance,
-  hasEnoughBalanceToExtend,
+  checkEnoughBalanceToExtend,
   editAmountOnly,
   prepConfirmArg,
   validator,
@@ -44,6 +45,11 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           isOverMax: duration > MAX_LOCK_DURATION,
         }
   }, [validator, currentBalance, lockedAmount, duration])
+
+  const hasEnoughBalanceToExtend = useMemo(
+    () => (checkEnoughBalanceToExtend ? (currentBalance ? currentBalance.gte(MIN_LOCK_AMOUNT) : false) : null),
+    [currentBalance, checkEnoughBalanceToExtend],
+  )
 
   return (
     <>
@@ -81,11 +87,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
           onClick={handleConfirmClick}
           disabled={
-            !(
-              isValidAmount &&
-              isValidDuration &&
-              (!isUndefinedOrNull(hasEnoughBalanceToExtend) ? hasEnoughBalanceToExtend : true)
-            )
+            !(isValidAmount && isValidDuration && (checkEnoughBalanceToExtend ? hasEnoughBalanceToExtend : true))
           }
         >
           {pendingTx ? t('Confirming') : t('Confirm')}

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -21,6 +21,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   onDismiss,
   lockedAmount,
   currentBalance,
+  currentDuration,
   extendLockedPosition,
   editAmountOnly,
   prepConfirmArg,
@@ -36,19 +37,18 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
     prepConfirmArg,
   })
 
-  const { isValidAmount, isValidDuration, isOverMax, maxAvailableDuration, currentDuration }: ModalValidator =
-    useMemo(() => {
-      return typeof validator === 'function'
-        ? validator({
-            duration,
-          })
-        : {
-            isValidAmount: lockedAmount?.toNumber() > 0 && getBalanceAmount(currentBalance).gte(lockedAmount),
-            isValidDuration: duration > 0 && duration <= MAX_LOCK_DURATION,
-            isOverMax: duration > MAX_LOCK_DURATION,
-            maxAvailableDuration: MAX_LOCK_DURATION,
-          }
-    }, [validator, currentBalance, lockedAmount, duration])
+  const { isValidAmount, isValidDuration, isOverMax, maxAvailableDuration }: ModalValidator = useMemo(() => {
+    return typeof validator === 'function'
+      ? validator({
+          duration,
+        })
+      : {
+          isValidAmount: lockedAmount?.toNumber() > 0 && getBalanceAmount(currentBalance).gte(lockedAmount),
+          isValidDuration: duration > 0 && duration <= MAX_LOCK_DURATION,
+          isOverMax: duration > MAX_LOCK_DURATION,
+          maxAvailableDuration: MAX_LOCK_DURATION,
+        }
+  }, [validator, currentBalance, lockedAmount, duration])
 
   const cakeNeeded = useMemo(
     () => isValidDuration && extendLockedPosition && currentDuration + duration > MAX_LOCK_DURATION,

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -78,7 +78,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
         customOverview({
           isValidDuration,
           duration,
-          updatedLockStartTime: currentDuration + duration > MAX_LOCK_DURATION ? Date.now() / 1000 : null,
+          updatedLockStartTime: currentDuration + duration > MAX_LOCK_DURATION ? Math.floor(Date.now() / 1000) : null,
           updatedNewDuration: currentDuration + duration > MAX_LOCK_DURATION ? MAX_LOCK_DURATION : null,
         })
       ) : (

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -75,15 +75,9 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
               maxAvailableDuration={maxAvailableDuration}
               setDuration={setDuration}
               duration={duration}
+              extendLockedPosition
               currentDurationLeft={currentDurationLeft}
             />
-            {extendLockedPosition && maxAvailableDuration !== duration && (
-              <Message variant="warning">
-                <MessageText maxWidth="200px">
-                  {t('Recommend choosing "MAX" to renew your staking position in order to keep similar yield boost.')}
-                </MessageText>
-              </Message>
-            )}
           </>
         )}
       </Box>
@@ -91,6 +85,8 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
         customOverview({
           isValidDuration,
           duration,
+          updatedLockStartTime: currentDuration + duration > MAX_LOCK_DURATION ? Date.now() / 1000 : null,
+          updatedNewDuration: currentDuration + duration > MAX_LOCK_DURATION ? MAX_LOCK_DURATION : null,
         })
       ) : (
         <Overview
@@ -110,9 +106,9 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
             {t('0.0001 CAKE will be spent to extend')}
           </Text>
         ) : (
-          <Text fontSize="12px" mt="24px" color="failure">
-            {t('0.0001 CAKE required for enabling extension')}
-          </Text>
+          <Message variant="warning">
+            <MessageText maxWidth="200px">{t('0.0001 CAKE required for enabling extension')}</MessageText>
+          </Message>
         ))}
 
       <Flex mt="24px">

--- a/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'contexts/Localization'
 import { MAX_LOCK_DURATION } from 'config/constants/pools'
 import { getBalanceAmount } from 'utils/formatBalance'
 import { useIfoCeiling } from 'state/pools/hooks'
+import isUndefinedOrNull from 'utils/isUndefinedOrNull'
+
 import { LockedModalBodyPropsType, ModalValidator } from '../types'
 
 import Overview from './Overview'
@@ -16,6 +18,7 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   onDismiss,
   lockedAmount,
   currentBalance,
+  hasEnoughBalanceToExtend,
   editAmountOnly,
   prepConfirmArg,
   validator,
@@ -45,7 +48,14 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
   return (
     <>
       <Box mb="16px">
-        {editAmountOnly || <LockDurationField isOverMax={isOverMax} setDuration={setDuration} duration={duration} />}
+        {editAmountOnly || (
+          <LockDurationField
+            isOverMax={isOverMax}
+            setDuration={setDuration}
+            duration={duration}
+            hasEnoughBalanceToExtend={hasEnoughBalanceToExtend}
+          />
+        )}
       </Box>
       {customOverview ? (
         customOverview({
@@ -70,7 +80,13 @@ const LockedModalBody: React.FC<LockedModalBodyPropsType> = ({
           isLoading={pendingTx}
           endIcon={pendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
           onClick={handleConfirmClick}
-          disabled={!(isValidAmount && isValidDuration)}
+          disabled={
+            !(
+              isValidAmount &&
+              isValidDuration &&
+              (!isUndefinedOrNull(hasEnoughBalanceToExtend) ? hasEnoughBalanceToExtend : true)
+            )
+          }
         >
           {pendingTx ? t('Confirming') : t('Confirm')}
         </Button>

--- a/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
@@ -42,7 +42,7 @@ const RenewDuration = ({ setCheckedState, checkedState }) => {
     </>
   )
 }
-// add 60s buffer in order to make sure minium duration by pass on renew extension
+// add 60s buffer in order to make sure minimum duration by pass on renew extension
 const MIN_DURATION_BUFFER = 60
 
 const AddAmountModal: React.FC<AddAmountModalProps> = ({

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -57,9 +57,12 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: extendLockedPosition ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber() : 0,
+      finalLockedAmount:
+        extendLockedPosition && currentDuration + duration > MAX_LOCK_DURATION
+          ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
+          : 0,
     }),
-    [stakingToken.decimals, extendLockedPosition],
+    [stakingToken.decimals, extendLockedPosition, currentDuration],
   )
 
   const customOverview = useCallback(

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -7,11 +7,16 @@ import { MAX_LOCK_DURATION } from 'config/constants/pools'
 import { useTranslation } from 'contexts/Localization'
 import BigNumber from 'bignumber.js'
 import { useIfoCeiling } from 'state/pools/hooks'
+
+import { getBalanceAmount } from 'utils/formatBalance'
 import StaticAmount from '../Common/StaticAmount'
 import LockedBodyModal from '../Common/LockedModalBody'
 import Overview from '../Common/Overview'
 import { ExtendDurationModal } from '../types'
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
+
+// min deposit and withdraw amount
+const MIN_AMOUNT = new BigNumber(10000000000000)
 
 const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   modalTitle,
@@ -19,6 +24,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   onDismiss,
   currentLockedAmount,
   currentDuration,
+  currentBalance,
   lockStartTime,
   lockEndTime,
 }) => {
@@ -46,7 +52,13 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     [currentLockedAmount, lockEndTime],
   )
 
-  const prepConfirmArg = useCallback(({ duration }) => ({ finalDuration: duration, finalLockedAmount: 0 }), [])
+  const prepConfirmArg = useCallback(
+    ({ duration }) => ({
+      finalDuration: duration,
+      finalLockedAmount: currentBalance ? getBalanceAmount(MIN_AMOUNT, stakingToken.decimals).toNumber() : 0,
+    }),
+    [stakingToken.decimals, currentBalance],
+  )
 
   const customOverview = useCallback(
     ({ isValidDuration, duration }) => (
@@ -82,6 +94,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
+          hasEnoughBalanceToExtend={currentBalance?.gt(MIN_AMOUNT)}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -14,7 +14,7 @@ import LockedBodyModal from '../Common/LockedModalBody'
 import Overview from '../Common/Overview'
 import { ExtendDurationModal } from '../types'
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
-import { MIN_LOCK_AMOUNT } from '../../../helpers'
+import { ENABLE_EXTEND_LOCK_AMOUNT } from '../../../helpers'
 
 const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   modalTitle,
@@ -53,7 +53,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
       finalDuration: duration,
       finalLockedAmount:
         currentDuration && currentDuration + duration > MAX_LOCK_DURATION
-          ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
+          ? getBalanceAmount(ENABLE_EXTEND_LOCK_AMOUNT, stakingToken.decimals).toNumber()
           : 0,
     }),
     [stakingToken.decimals, currentDuration],

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -37,8 +37,8 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     ({ duration }) => {
       const isValidAmount = currentLockedAmount && currentLockedAmount > 0
       const nowInSeconds = Math.floor(Date.now() / 1000)
-      const currentDurationLeftInSeconds = Math.max(Number(lockEndTime) - nowInSeconds, 0)
-      const totalDuration = currentDurationLeftInSeconds + duration
+      const currentDurationLeft = Math.max(Number(lockEndTime) - nowInSeconds, 0)
+      const totalDuration = currentDurationLeft + duration
 
       const isValidDuration = duration > 0 && totalDuration > 0 && totalDuration <= MAX_LOCK_DURATION
 
@@ -47,8 +47,8 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isValidDuration,
         isOverMax: totalDuration > MAX_LOCK_DURATION,
         currentDuration,
-        currentDurationLeft: currentDurationLeftInSeconds,
-        maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeftInSeconds,
+        currentDurationLeft,
+        maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeft,
       }
     },
     [currentDuration, currentLockedAmount, lockEndTime],

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -47,7 +47,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isValidDuration,
         isOverMax: totalDuration > MAX_LOCK_DURATION,
         currentDuration,
-        currentDurationLeft,
         maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeft,
       }
     },

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -22,9 +22,9 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   onDismiss,
   currentLockedAmount,
   currentDuration,
+  currentDurationLeft,
   currentBalance,
   lockStartTime,
-  lockEndTime,
 }) => {
   const { theme } = useTheme()
   const ceiling = useIfoCeiling()
@@ -35,8 +35,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const validator = useCallback(
     ({ duration }) => {
       const isValidAmount = currentLockedAmount && currentLockedAmount > 0
-      const nowInSeconds = Math.floor(Date.now() / 1000)
-      const currentDurationLeft = Math.max(Number(lockEndTime) - nowInSeconds, 0)
       const totalDuration = currentDurationLeft + duration
 
       const isValidDuration = duration > 0 && totalDuration > 0 && totalDuration <= MAX_LOCK_DURATION
@@ -47,7 +45,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isOverMax: totalDuration > MAX_LOCK_DURATION,
       }
     },
-    [currentLockedAmount, lockEndTime],
+    [currentLockedAmount, currentDurationLeft],
   )
 
   const prepConfirmArg = useCallback(
@@ -62,20 +60,24 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   )
 
   const customOverview = useCallback(
-    ({ isValidDuration, duration, updatedLockStartTime, updatedLockDuration }) => (
+    ({ isValidDuration, duration }) => (
       <Overview
-        lockStartTime={updatedLockStartTime || lockStartTime}
+        lockStartTime={
+          currentDuration + duration > MAX_LOCK_DURATION ? Math.floor(Date.now() / 1000).toString() : lockStartTime
+        }
         isValidDuration={isValidDuration}
         openCalculator={_noop}
         duration={currentDuration || duration}
-        newDuration={updatedLockDuration || currentDuration + duration}
+        newDuration={
+          currentDuration + duration > MAX_LOCK_DURATION ? currentDurationLeft + duration : currentDuration + duration
+        }
         lockedAmount={currentLockedAmount}
         usdValueStaked={usdValueStaked}
         showLockWarning={!+lockStartTime}
         ceiling={ceiling}
       />
     ),
-    [lockStartTime, currentDuration, currentLockedAmount, usdValueStaked, ceiling],
+    [lockStartTime, currentDuration, currentLockedAmount, currentDurationLeft, usdValueStaked, ceiling],
   )
 
   return (
@@ -97,7 +99,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
           stakingToken={stakingToken}
           currentBalance={currentBalance}
           currentDuration={currentDuration}
-          lockEndTime={lockEndTime}
+          currentDurationLeft={currentDurationLeft}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -53,7 +53,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: currentBalance?.gt(MIN_LOCK_AMOUNT)
+      finalLockedAmount: currentBalance?.gte(MIN_LOCK_AMOUNT)
         ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
         : 0,
     }),
@@ -77,7 +77,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     [lockStartTime, currentDuration, currentLockedAmount, usdValueStaked, ceiling],
   )
 
-  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gt(MIN_LOCK_AMOUNT), [currentBalance])
+  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gte(MIN_LOCK_AMOUNT), [currentBalance])
 
   return (
     <RoiCalculatorModalProvider lockedAmount={currentLockedAmount}>

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -36,7 +36,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const validator = useCallback(
     ({ duration }) => {
       const isValidAmount = currentLockedAmount && currentLockedAmount > 0
-      const nowInSeconds = Date.now() / 1000
+      const nowInSeconds = Math.floor(Date.now() / 1000)
       const currentDurationLeftInSeconds = Math.max(Number(lockEndTime) - nowInSeconds, 0)
       const totalDuration = currentDurationLeftInSeconds + duration
 
@@ -48,7 +48,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isOverMax: totalDuration > MAX_LOCK_DURATION,
         currentDuration,
         currentDurationLeft: currentDurationLeftInSeconds,
-        maxAvailableDuration: Math.trunc(MAX_LOCK_DURATION - currentDurationLeftInSeconds),
+        maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeftInSeconds,
       }
     },
     [currentDuration, currentLockedAmount, lockEndTime],

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -23,7 +23,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   currentLockedAmount,
   currentDuration,
   currentBalance,
-  checkEnoughBalanceToExtend,
+  extendLockedPosition,
   lockStartTime,
   lockEndTime,
 }) => {
@@ -57,11 +57,9 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: checkEnoughBalanceToExtend
-        ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
-        : 0,
+      finalLockedAmount: extendLockedPosition ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber() : 0,
     }),
-    [stakingToken.decimals, checkEnoughBalanceToExtend],
+    [stakingToken.decimals, extendLockedPosition],
   )
 
   const customOverview = useCallback(
@@ -98,7 +96,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
-          extendLockedPosition={checkEnoughBalanceToExtend}
+          extendLockedPosition={extendLockedPosition}
           currentBalance={currentBalance}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -20,6 +20,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   currentLockedAmount,
   currentDuration,
   lockStartTime,
+  lockEndTime,
 }) => {
   const { theme } = useTheme()
   const ceiling = useIfoCeiling()
@@ -30,7 +31,9 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const validator = useCallback(
     ({ duration }) => {
       const isValidAmount = currentLockedAmount && currentLockedAmount > 0
-      const totalDuration = currentDuration + duration
+      const nowInSeconds = Date.now() / 1000
+      const currentDurationLeftInSeconds = Math.max(Number(lockEndTime) - nowInSeconds, 0)
+      const totalDuration = currentDurationLeftInSeconds + duration
 
       const isValidDuration = duration > 0 && totalDuration > 0 && totalDuration <= MAX_LOCK_DURATION
 
@@ -40,7 +43,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isOverMax: totalDuration > MAX_LOCK_DURATION,
       }
     },
-    [currentLockedAmount, currentDuration],
+    [currentLockedAmount, lockEndTime],
   )
 
   const prepConfirmArg = useCallback(({ duration }) => ({ finalDuration: duration, finalLockedAmount: 0 }), [])

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Modal, Box } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
 import useTheme from 'hooks/useTheme'
@@ -55,7 +55,9 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: currentBalance ? getBalanceAmount(MIN_AMOUNT, stakingToken.decimals).toNumber() : 0,
+      finalLockedAmount: currentBalance?.gt(MIN_AMOUNT)
+        ? getBalanceAmount(MIN_AMOUNT, stakingToken.decimals).toNumber()
+        : 0,
     }),
     [stakingToken.decimals, currentBalance],
   )
@@ -77,6 +79,8 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     [lockStartTime, currentDuration, currentLockedAmount, usdValueStaked, ceiling],
   )
 
+  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gt(MIN_AMOUNT), [currentBalance])
+
   return (
     <RoiCalculatorModalProvider lockedAmount={currentLockedAmount}>
       <Modal
@@ -94,7 +98,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
-          hasEnoughBalanceToExtend={currentBalance?.gt(MIN_AMOUNT)}
+          hasEnoughBalanceToExtend={hasEnoughBalanceToExtend}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -46,7 +46,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isValidAmount,
         isValidDuration,
         isOverMax: totalDuration > MAX_LOCK_DURATION,
-        maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeft,
       }
     },
     [currentLockedAmount, lockEndTime],
@@ -64,13 +63,13 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   )
 
   const customOverview = useCallback(
-    ({ isValidDuration, duration, updatedLockStartTime, updatedNewDuration }) => (
+    ({ isValidDuration, duration, updatedLockStartTime, updatedLockDuration }) => (
       <Overview
         lockStartTime={updatedLockStartTime || lockStartTime}
         isValidDuration={isValidDuration}
         openCalculator={_noop}
         duration={currentDuration || duration}
-        newDuration={updatedNewDuration || currentDuration + duration}
+        newDuration={updatedLockDuration || currentDuration + duration}
         lockedAmount={currentLockedAmount}
         usdValueStaked={usdValueStaked}
         showLockWarning={!+lockStartTime}
@@ -100,6 +99,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
           extendLockedPosition={extendLockedPosition}
           currentBalance={currentBalance}
           currentDuration={currentDuration}
+          lockEndTime={lockEndTime}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -46,11 +46,10 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isValidAmount,
         isValidDuration,
         isOverMax: totalDuration > MAX_LOCK_DURATION,
-        currentDuration,
         maxAvailableDuration: MAX_LOCK_DURATION - currentDurationLeft,
       }
     },
-    [currentDuration, currentLockedAmount, lockEndTime],
+    [currentLockedAmount, lockEndTime],
   )
 
   const prepConfirmArg = useCallback(
@@ -100,6 +99,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
           stakingToken={stakingToken}
           extendLockedPosition={extendLockedPosition}
           currentBalance={currentBalance}
+          currentDuration={currentDuration}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -14,9 +14,7 @@ import LockedBodyModal from '../Common/LockedModalBody'
 import Overview from '../Common/Overview'
 import { ExtendDurationModal } from '../types'
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
-
-// min deposit and withdraw amount
-const MIN_AMOUNT = new BigNumber(10000000000000)
+import { MIN_LOCK_AMOUNT } from '../../../helpers'
 
 const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   modalTitle,
@@ -55,8 +53,8 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: currentBalance?.gt(MIN_AMOUNT)
-        ? getBalanceAmount(MIN_AMOUNT, stakingToken.decimals).toNumber()
+      finalLockedAmount: currentBalance?.gt(MIN_LOCK_AMOUNT)
+        ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
         : 0,
     }),
     [stakingToken.decimals, currentBalance],
@@ -79,7 +77,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     [lockStartTime, currentDuration, currentLockedAmount, usdValueStaked, ceiling],
   )
 
-  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gt(MIN_AMOUNT), [currentBalance])
+  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gt(MIN_LOCK_AMOUNT), [currentBalance])
 
   return (
     <RoiCalculatorModalProvider lockedAmount={currentLockedAmount}>

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -46,9 +46,12 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isValidAmount,
         isValidDuration,
         isOverMax: totalDuration > MAX_LOCK_DURATION,
+        currentDuration,
+        currentDurationLeft: currentDurationLeftInSeconds,
+        maxAvailableDuration: MAX_LOCK_DURATION - currentDuration,
       }
     },
-    [currentLockedAmount, lockEndTime],
+    [currentDuration, currentLockedAmount, lockEndTime],
   )
 
   const prepConfirmArg = useCallback(
@@ -95,7 +98,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
-          checkEnoughBalanceToExtend={checkEnoughBalanceToExtend}
+          extendLockedPosition={checkEnoughBalanceToExtend}
           currentBalance={currentBalance}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -23,7 +23,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   currentLockedAmount,
   currentDuration,
   currentBalance,
-  extendLockedPosition,
   lockStartTime,
   lockEndTime,
 }) => {
@@ -55,11 +54,11 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     ({ duration }) => ({
       finalDuration: duration,
       finalLockedAmount:
-        extendLockedPosition && currentDuration + duration > MAX_LOCK_DURATION
+        currentDuration && currentDuration + duration > MAX_LOCK_DURATION
           ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
           : 0,
     }),
-    [stakingToken.decimals, extendLockedPosition, currentDuration],
+    [stakingToken.decimals, currentDuration],
   )
 
   const customOverview = useCallback(
@@ -96,7 +95,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
-          extendLockedPosition={extendLockedPosition}
           currentBalance={currentBalance}
           currentDuration={currentDuration}
           lockEndTime={lockEndTime}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -48,7 +48,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         isOverMax: totalDuration > MAX_LOCK_DURATION,
         currentDuration,
         currentDurationLeft: currentDurationLeftInSeconds,
-        maxAvailableDuration: MAX_LOCK_DURATION - currentDuration,
+        maxAvailableDuration: Math.trunc(MAX_LOCK_DURATION - currentDurationLeftInSeconds),
       }
     },
     [currentDuration, currentLockedAmount, lockEndTime],

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -66,13 +66,13 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   )
 
   const customOverview = useCallback(
-    ({ isValidDuration, duration }) => (
+    ({ isValidDuration, duration, updatedLockStartTime, updatedNewDuration }) => (
       <Overview
-        lockStartTime={lockStartTime}
+        lockStartTime={updatedLockStartTime || lockStartTime}
         isValidDuration={isValidDuration}
         openCalculator={_noop}
         duration={currentDuration || duration}
-        newDuration={currentDuration + duration}
+        newDuration={updatedNewDuration || currentDuration + duration}
         lockedAmount={currentLockedAmount}
         usdValueStaked={usdValueStaked}
         showLockWarning={!+lockStartTime}

--- a/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { Modal, Box } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
 import useTheme from 'hooks/useTheme'
@@ -23,6 +23,7 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   currentLockedAmount,
   currentDuration,
   currentBalance,
+  checkEnoughBalanceToExtend,
   lockStartTime,
   lockEndTime,
 }) => {
@@ -53,11 +54,11 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const prepConfirmArg = useCallback(
     ({ duration }) => ({
       finalDuration: duration,
-      finalLockedAmount: currentBalance?.gte(MIN_LOCK_AMOUNT)
+      finalLockedAmount: checkEnoughBalanceToExtend
         ? getBalanceAmount(MIN_LOCK_AMOUNT, stakingToken.decimals).toNumber()
         : 0,
     }),
-    [stakingToken.decimals, currentBalance],
+    [stakingToken.decimals, checkEnoughBalanceToExtend],
   )
 
   const customOverview = useCallback(
@@ -77,8 +78,6 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
     [lockStartTime, currentDuration, currentLockedAmount, usdValueStaked, ceiling],
   )
 
-  const hasEnoughBalanceToExtend = useMemo(() => currentBalance?.gte(MIN_LOCK_AMOUNT), [currentBalance])
-
   return (
     <RoiCalculatorModalProvider lockedAmount={currentLockedAmount}>
       <Modal
@@ -96,7 +95,8 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         </Box>
         <LockedBodyModal
           stakingToken={stakingToken}
-          hasEnoughBalanceToExtend={hasEnoughBalanceToExtend}
+          checkEnoughBalanceToExtend={checkEnoughBalanceToExtend}
+          currentBalance={currentBalance}
           onDismiss={onDismiss}
           lockedAmount={new BigNumber(currentLockedAmount)}
           validator={validator}

--- a/src/views/Pools/components/LockedPool/hooks/useExtendEnable.tsx
+++ b/src/views/Pools/components/LockedPool/hooks/useExtendEnable.tsx
@@ -1,0 +1,51 @@
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useIsTransactionPending } from 'state/transactions/hooks'
+import { getFullDisplayBalance } from 'utils/formatBalance'
+import { useAppDispatch } from 'state'
+import { updateUserBalance } from 'state/pools'
+import { ETHER } from '@pancakeswap/sdk'
+import { CAKE } from 'config/constants/tokens'
+import tryParseAmount from 'utils/tryParseAmount'
+import { useTradeExactOut } from 'hooks/Trades'
+import { useSwapCallback } from 'hooks/useSwapCallback'
+import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import { INITIAL_ALLOWED_SLIPPAGE } from 'config/constants'
+import { MIN_LOCK_AMOUNT } from '../../../helpers'
+
+export const useExtendEnable = () => {
+  const { account, chainId } = useActiveWeb3React()
+  const dispatch = useAppDispatch()
+  const [pendingEnableTx, setPendingEnableTx] = useState(false)
+  const [transactionHash, setTransactionHash] = useState<string>()
+  const isTransactionPending = useIsTransactionPending(transactionHash)
+  const swapAmount = useMemo(() => getFullDisplayBalance(MIN_LOCK_AMOUNT), [])
+
+  const parsedAmount = tryParseAmount(swapAmount, CAKE[chainId])
+
+  const trade = useTradeExactOut(ETHER, parsedAmount)
+
+  const { callback: swapCallback } = useSwapCallback(trade, INITIAL_ALLOWED_SLIPPAGE, null)
+
+  useEffect(() => {
+    if (pendingEnableTx && transactionHash && !isTransactionPending) {
+      dispatch(updateUserBalance({ sousId: 0, account }))
+      setPendingEnableTx(isTransactionPending)
+    }
+  }, [account, dispatch, transactionHash, pendingEnableTx, isTransactionPending])
+
+  const handleEnable = useCallback(() => {
+    if (!swapCallback) {
+      return
+    }
+    setPendingEnableTx(true)
+    swapCallback()
+      .then((hash) => {
+        setTransactionHash(hash)
+      })
+      .catch(() => {
+        setPendingEnableTx(false)
+      })
+  }, [swapCallback])
+
+  return { handleEnable, pendingEnableTx }
+}

--- a/src/views/Pools/components/LockedPool/hooks/useExtendEnable.tsx
+++ b/src/views/Pools/components/LockedPool/hooks/useExtendEnable.tsx
@@ -10,7 +10,7 @@ import { useTradeExactOut } from 'hooks/Trades'
 import { useSwapCallback } from 'hooks/useSwapCallback'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { INITIAL_ALLOWED_SLIPPAGE } from 'config/constants'
-import { MIN_LOCK_AMOUNT } from '../../../helpers'
+import { ENABLE_EXTEND_LOCK_AMOUNT } from '../../../helpers'
 
 export const useExtendEnable = () => {
   const { account, chainId } = useActiveWeb3React()
@@ -18,7 +18,7 @@ export const useExtendEnable = () => {
   const [pendingEnableTx, setPendingEnableTx] = useState(false)
   const [transactionHash, setTransactionHash] = useState<string>()
   const isTransactionPending = useIsTransactionPending(transactionHash)
-  const swapAmount = useMemo(() => getFullDisplayBalance(MIN_LOCK_AMOUNT), [])
+  const swapAmount = useMemo(() => getFullDisplayBalance(ENABLE_EXTEND_LOCK_AMOUNT), [])
 
   const parsedAmount = tryParseAmount(swapAmount, CAKE[chainId])
 

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -30,6 +30,7 @@ export interface ExtendDurationModal {
   onDismiss?: VoidFn
   modalTitle?: string
   currentDuration: number
+  currentBalance?: BigNumber
   lockStartTime: string
   lockEndTime: string
 }
@@ -77,6 +78,7 @@ export interface LockedModalBodyPropsType {
   onDismiss?: VoidFn
   stakingToken: Token
   currentBalance?: BigNumber
+  hasEnoughBalanceToExtend?: boolean
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
@@ -87,6 +89,7 @@ export interface LockedModalBodyPropsType {
 export interface ExtendDurationButtonPropsType {
   stakingToken: Token
   currentLockedAmount: number
+  currentBalance?: BigNumber
   lockEndTime: string
   lockStartTime: string
   children: React.ReactNode
@@ -120,6 +123,7 @@ export interface LockDurationFieldPropsType {
   duration: number
   setDuration: Dispatch<SetStateAction<number>>
   isOverMax: boolean
+  hasEnoughBalanceToExtend?: boolean
 }
 
 export interface LockedStakingApyPropsType {

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -30,9 +30,9 @@ export interface ExtendDurationModal {
   onDismiss?: VoidFn
   modalTitle?: string
   currentDuration: number
+  currentDurationLeft: number
   currentBalance?: BigNumber
   lockStartTime: string
-  lockEndTime: string
 }
 
 export interface AddButtonProps {
@@ -82,19 +82,9 @@ export interface LockedModalBodyPropsType {
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
   currentDuration?: number
-  lockEndTime?: string
+  currentDurationLeft?: number
   validator?: (arg: ValidatorArg) => ModalValidator
-  customOverview?: ({
-    isValidDuration,
-    duration,
-    updatedLockStartTime,
-    updatedLockDuration,
-  }: {
-    isValidDuration: boolean
-    duration: number
-    updatedLockStartTime: string
-    updatedLockDuration: number
-  }) => React.ReactElement
+  customOverview?: ({ isValidDuration, duration }: { isValidDuration: boolean; duration: number }) => React.ReactElement
 }
 
 export interface ExtendDurationButtonPropsType {
@@ -134,11 +124,7 @@ export interface LockDurationFieldPropsType {
   duration: number
   setDuration: Dispatch<SetStateAction<number>>
   isOverMax: boolean
-  currentDuration?: number
-  lockEndTime?: string
-  setUpdatedLockStartTime?: (startTime: string) => void
-  setUpdatedLockDuration?: (duration: number) => void
-  extendLockedPosition?: boolean
+  currentDurationLeft?: number
 }
 
 export interface LockedStakingApyPropsType {

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -73,13 +73,16 @@ export interface ModalValidator {
   isValidAmount: boolean
   isValidDuration: boolean
   isOverMax: boolean
+  maxAvailableDuration: number
+  currentDuration?: number
+  currentDurationLeft?: number
 }
 
 export interface LockedModalBodyPropsType {
   onDismiss?: VoidFn
   stakingToken: Token
   currentBalance?: BigNumber
-  checkEnoughBalanceToExtend?: boolean
+  extendLockedPosition?: boolean
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
@@ -125,7 +128,8 @@ export interface LockDurationFieldPropsType {
   duration: number
   setDuration: Dispatch<SetStateAction<number>>
   isOverMax: boolean
-  hasEnoughBalanceToExtend?: boolean
+  maxAvailableDuration: number
+  currentDurationLeft?: number
 }
 
 export interface LockedStakingApyPropsType {

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -73,7 +73,6 @@ export interface ModalValidator {
   isValidAmount: boolean
   isValidDuration: boolean
   isOverMax: boolean
-  maxAvailableDuration: number
 }
 
 export interface LockedModalBodyPropsType {
@@ -85,17 +84,18 @@ export interface LockedModalBodyPropsType {
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
   currentDuration?: number
+  lockEndTime?: string
   validator?: (arg: ValidatorArg) => ModalValidator
   customOverview?: ({
     isValidDuration,
     duration,
     updatedLockStartTime,
-    updatedNewDuration,
+    updatedLockDuration,
   }: {
     isValidDuration: boolean
     duration: number
-    updatedLockStartTime: number
-    updatedNewDuration: number
+    updatedLockStartTime: string
+    updatedLockDuration: number
   }) => React.ReactElement
 }
 
@@ -137,7 +137,10 @@ export interface LockDurationFieldPropsType {
   duration: number
   setDuration: Dispatch<SetStateAction<number>>
   isOverMax: boolean
-  maxAvailableDuration: number
+  currentDuration?: number
+  lockEndTime?: string
+  setUpdatedLockStartTime?: (startTime: string) => void
+  setUpdatedLockDuration?: (duration: number) => void
   extendLockedPosition?: boolean
 }
 

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -87,7 +87,17 @@ export interface LockedModalBodyPropsType {
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
   validator?: (arg: ValidatorArg) => ModalValidator
-  customOverview?: ({ isValidDuration: boolean, duration: number }) => React.ReactElement
+  customOverview?: ({
+    isValidDuration,
+    duration,
+    updatedLockStartTime,
+    updatedNewDuration,
+  }: {
+    isValidDuration: boolean
+    duration: number
+    updatedLockStartTime: number
+    updatedNewDuration: number
+  }) => React.ReactElement
 }
 
 export interface ExtendDurationButtonPropsType {
@@ -129,6 +139,7 @@ export interface LockDurationFieldPropsType {
   setDuration: Dispatch<SetStateAction<number>>
   isOverMax: boolean
   maxAvailableDuration: number
+  extendLockedPosition?: boolean
   currentDurationLeft?: number
 }
 

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -140,7 +140,6 @@ export interface LockDurationFieldPropsType {
   isOverMax: boolean
   maxAvailableDuration: number
   extendLockedPosition?: boolean
-  currentDurationLeft?: number
 }
 
 export interface LockedStakingApyPropsType {

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -31,7 +31,6 @@ export interface ExtendDurationModal {
   modalTitle?: string
   currentDuration: number
   currentBalance?: BigNumber
-  extendLockedPosition?: boolean
   lockStartTime: string
   lockEndTime: string
 }
@@ -79,7 +78,6 @@ export interface LockedModalBodyPropsType {
   onDismiss?: VoidFn
   stakingToken: Token
   currentBalance?: BigNumber
-  extendLockedPosition?: boolean
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
@@ -103,7 +101,6 @@ export interface ExtendDurationButtonPropsType {
   stakingToken: Token
   currentLockedAmount: number
   currentBalance?: BigNumber
-  extendLockedPosition?: boolean
   lockEndTime: string
   lockStartTime: string
   children: React.ReactNode

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -31,6 +31,7 @@ export interface ExtendDurationModal {
   modalTitle?: string
   currentDuration: number
   lockStartTime: string
+  lockEndTime: string
 }
 
 export interface AddButtonProps {

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -31,6 +31,7 @@ export interface ExtendDurationModal {
   modalTitle?: string
   currentDuration: number
   currentBalance?: BigNumber
+  checkEnoughBalanceToExtend?: boolean
   lockStartTime: string
   lockEndTime: string
 }
@@ -78,7 +79,7 @@ export interface LockedModalBodyPropsType {
   onDismiss?: VoidFn
   stakingToken: Token
   currentBalance?: BigNumber
-  hasEnoughBalanceToExtend?: boolean
+  checkEnoughBalanceToExtend?: boolean
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
@@ -90,6 +91,7 @@ export interface ExtendDurationButtonPropsType {
   stakingToken: Token
   currentLockedAmount: number
   currentBalance?: BigNumber
+  checkEnoughBalanceToExtend?: boolean
   lockEndTime: string
   lockStartTime: string
   children: React.ReactNode

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -31,7 +31,7 @@ export interface ExtendDurationModal {
   modalTitle?: string
   currentDuration: number
   currentBalance?: BigNumber
-  checkEnoughBalanceToExtend?: boolean
+  extendLockedPosition?: boolean
   lockStartTime: string
   lockEndTime: string
 }
@@ -94,7 +94,7 @@ export interface ExtendDurationButtonPropsType {
   stakingToken: Token
   currentLockedAmount: number
   currentBalance?: BigNumber
-  checkEnoughBalanceToExtend?: boolean
+  extendLockedPosition?: boolean
   lockEndTime: string
   lockStartTime: string
   children: React.ReactNode

--- a/src/views/Pools/components/LockedPool/types/index.ts
+++ b/src/views/Pools/components/LockedPool/types/index.ts
@@ -74,8 +74,6 @@ export interface ModalValidator {
   isValidDuration: boolean
   isOverMax: boolean
   maxAvailableDuration: number
-  currentDuration?: number
-  currentDurationLeft?: number
 }
 
 export interface LockedModalBodyPropsType {
@@ -86,6 +84,7 @@ export interface LockedModalBodyPropsType {
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement
   prepConfirmArg?: PrepConfirmArg
+  currentDuration?: number
   validator?: (arg: ValidatorArg) => ModalValidator
   customOverview?: ({
     isValidDuration,

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -323,6 +323,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool }) => {
                       lockEndTime={(vaultData as DeserializedLockedCakeVault).userData.lockEndTime}
                       lockStartTime={(vaultData as DeserializedLockedCakeVault).userData.lockStartTime}
                       stakingToken={stakingToken}
+                      currentBalance={stakingTokenBalance}
                       currentLockedAmount={cakeAsNumberBalance}
                     >
                       {t('Extend')}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -324,6 +324,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool }) => {
                       lockStartTime={(vaultData as DeserializedLockedCakeVault).userData.lockStartTime}
                       stakingToken={stakingToken}
                       currentBalance={stakingTokenBalance}
+                      checkEnoughBalanceToExtend
                       currentLockedAmount={cakeAsNumberBalance}
                     >
                       {t('Extend')}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -324,7 +324,6 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool }) => {
                       lockStartTime={(vaultData as DeserializedLockedCakeVault).userData.lockStartTime}
                       stakingToken={stakingToken}
                       currentBalance={stakingTokenBalance}
-                      extendLockedPosition
                       currentLockedAmount={cakeAsNumberBalance}
                     >
                       {t('Extend')}

--- a/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -324,7 +324,7 @@ const Staked: React.FunctionComponent<StackedActionProps> = ({ pool }) => {
                       lockStartTime={(vaultData as DeserializedLockedCakeVault).userData.lockStartTime}
                       stakingToken={stakingToken}
                       currentBalance={stakingTokenBalance}
-                      checkEnoughBalanceToExtend
+                      extendLockedPosition
                       currentLockedAmount={cakeAsNumberBalance}
                     >
                       {t('Extend')}

--- a/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
+++ b/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
@@ -10,7 +10,6 @@ import { getRoi } from 'utils/compoundApyHelpers'
 
 import LockDurationField from '../LockedPool/Common/LockDurationField'
 import { weeksToSeconds } from '../utils/formatSecondsToWeeks'
-import { MAX_LOCK_DURATION } from '../../../../config/constants/pools'
 
 export const VaultRoiCalculatorModal = ({
   pool,
@@ -92,12 +91,7 @@ export const VaultRoiCalculatorModal = ({
     >
       {cakeVaultView && (
         <Box mt="16px">
-          <LockDurationField
-            duration={duration}
-            setDuration={setDuration}
-            isOverMax={false}
-            maxAvailableDuration={MAX_LOCK_DURATION}
-          />
+          <LockDurationField duration={duration} setDuration={setDuration} isOverMax={false} />
         </Box>
       )}
     </RoiCalculatorModal>

--- a/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
+++ b/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
@@ -10,6 +10,7 @@ import { getRoi } from 'utils/compoundApyHelpers'
 
 import LockDurationField from '../LockedPool/Common/LockDurationField'
 import { weeksToSeconds } from '../utils/formatSecondsToWeeks'
+import { MAX_LOCK_DURATION } from '../../../../config/constants/pools'
 
 export const VaultRoiCalculatorModal = ({
   pool,
@@ -91,7 +92,12 @@ export const VaultRoiCalculatorModal = ({
     >
       {cakeVaultView && (
         <Box mt="16px">
-          <LockDurationField duration={duration} setDuration={setDuration} isOverMax={false} />
+          <LockDurationField
+            duration={duration}
+            setDuration={setDuration}
+            isOverMax={false}
+            maxAvailableDuration={MAX_LOCK_DURATION}
+          />
         </Box>
       )}
     </RoiCalculatorModal>

--- a/src/views/Pools/helpers.tsx
+++ b/src/views/Pools/helpers.tsx
@@ -6,6 +6,9 @@ import { getApy } from 'utils/compoundApyHelpers'
 import { getBalanceNumber, getFullDisplayBalance, getDecimalAmount } from 'utils/formatBalance'
 import memoize from 'lodash/memoize'
 
+// min deposit and withdraw amount
+export const MIN_LOCK_AMOUNT = new BigNumber(10000000000000)
+
 export const convertSharesToCake = (
   shares: BigNumber,
   cakePerFullShare: BigNumber,

--- a/src/views/Pools/helpers.tsx
+++ b/src/views/Pools/helpers.tsx
@@ -9,6 +9,8 @@ import memoize from 'lodash/memoize'
 // min deposit and withdraw amount
 export const MIN_LOCK_AMOUNT = new BigNumber(10000000000000)
 
+export const ENABLE_EXTEND_LOCK_AMOUNT = new BigNumber(100000000000000)
+
 export const convertSharesToCake = (
   shares: BigNumber,
   cakePerFullShare: BigNumber,


### PR DESCRIPTION
Extend duration check currently being done based on current duration (instead of left current duration) which causes issue when extending.

To reproduce

1. Go to locked pool
2. Click extend 
3. Put value that should not extend 52 weeks (if you have 10 weeks of locked pool and only 2 weeks left to put 50 weeks should not give an error)
4. See error and confirm button is disabled