### PR TITLE
fix: Alignment of connect wallet modal in wide mobile screens

### DIFF
--- a/packages/uikit/src/widgets/WalletModal/ConnectModal.tsx
+++ b/packages/uikit/src/widgets/WalletModal/ConnectModal.tsx
@@ -70,7 +70,7 @@ const ConnectModal: React.FC<Props> = ({ login, onDismiss = () => null, displayC
         </ModalTitle>
         <ModalCloseButton onDismiss={onDismiss} />
       </ModalHeader>
-      <ModalBody width={["320px", null, "340px"]}>
+      <ModalBody minWidth={["320px", null, "340px"]}>
         <WalletWrapper py="24px" maxHeight="453px" overflowY="auto">
           <Grid gridTemplateColumns="1fr 1fr">
             {displayListConfig.map((wallet) => (


### PR DESCRIPTION
To reproduce:

1. Click connect wallet on wide mobile screens (higher than 320px)
2. See alignment of inner components is broken