### PR TITLE
fix: Treasury and buyback fee constants

### DIFF
--- a/src/config/constants/info.ts
+++ b/src/config/constants/info.ts
@@ -4,8 +4,8 @@ export const WEEKS_IN_YEAR = 52.1429
 
 export const TOTAL_FEE = 0.0025
 export const LP_HOLDERS_FEE = 0.0017
-export const TREASURY_FEE = 0.0003
-export const BUYBACK_FEE = 0.0005
+export const TREASURY_FEE = 0.000225
+export const BUYBACK_FEE = 0.000575
 
 export const PCS_V2_START = 1619136000 // April 23, 2021, 12:00:00 AM
 export const ONE_DAY_UNIX = 86400 // 24h * 60m * 60s


### PR DESCRIPTION
currently these constants not used but it is better to update them