### PR TITLE
perf: Use memo in bnb balances hook to not serialize on each render

### DIFF
--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -25,7 +25,7 @@ export function useBNBBalances(uncheckedAddresses?: (string | undefined)[]): {
   const results = useSingleContractMultipleData(
     multicallContract,
     'getEthBalance',
-    addresses.map((address) => [address]),
+    useMemo(() => addresses.map((address) => [address]), [addresses]),
   )
 
   return useMemo(
@@ -106,7 +106,8 @@ export function useCurrencyBalances(
 
   const tokenBalances = useTokenBalances(account, tokens)
   const containsBNB: boolean = useMemo(() => currencies?.some((currency) => currency === ETHER) ?? false, [currencies])
-  const bnbBalance = useBNBBalances(containsBNB ? [account] : [])
+  const uncheckedAddresses = useMemo(() => (containsBNB ? [account] : []), [containsBNB, account])
+  const bnbBalance = useBNBBalances(uncheckedAddresses)
 
   return useMemo(
     () =>


### PR DESCRIPTION
Reduces serialization operations in trade components, 

https://github.com/pancakeswap/pancake-frontend/blob/cb158e544df04dbac559516bcb6c932a283b9e18/src/state/multicall/hooks.ts#L59 

calls dependency that is passed by useBNBBalances will be memoized thus serialization operation will not be processed on each render
