### PR TITLE
fix: Leftover items from previous language in mobile menu navigation

### DIFF
--- a/packages/uikit/src/components/BottomNav/BottomNav.tsx
+++ b/packages/uikit/src/components/BottomNav/BottomNav.tsx
@@ -20,7 +20,7 @@ const BottomNav: React.FC<BottomNavProps> = ({ items = [], activeItem = "", acti
             return (
               showOnMobile && (
                 <DropdownMenu
-                  key={label}
+                  key={`${label}#${href}`}
                   items={menuItems}
                   isBottomNav
                   activeItem={activeSubItem}


### PR DESCRIPTION
To reproduce:

1. Switch language to portuguese in mobile
2. Switch back to english
3. See leftover item in bottom navigation menu