### PR TITLE
fix: Prediction height in mobile

### DIFF
--- a/packages/uikit/src/components/CoinSwitcher/CoinSwitcher.tsx
+++ b/packages/uikit/src/components/CoinSwitcher/CoinSwitcher.tsx
@@ -13,11 +13,6 @@ export const CoinSwitcherWrapper = styled.div`
   overflow: hidden;
   cursor: pointer;
   transform: scale(0.6) translateX(-40px);
-  @media screen and (min-width: 390px) {
-    top: -70px;
-    left: 20px;
-    transform: scale(0.9) translateX(-30px);
-  }
   ${({ theme }) => theme.mediaQueries.md} {
     top: -20px;
     left: -10px;

--- a/src/views/Predictions/Mobile.tsx
+++ b/src/views/Predictions/Mobile.tsx
@@ -33,9 +33,9 @@ const View = styled.div<{ isVisible: boolean }>`
 `
 
 const PowerLinkStyle = styled.div`
-  position: absolute;
-  right: 16px;
-  bottom: 16px;
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 16px;
 `
 
 const getView = (isHistoryPaneOpen: boolean, isChartPaneOpen: boolean): PageView => {
@@ -60,7 +60,7 @@ const Mobile: React.FC = () => {
     <StyledMobile>
       <Box height="100%" overflow="hidden" position="relative">
         <View isVisible={view === PageView.POSITIONS}>
-          <Flex alignItems="center" height="100%">
+          <Flex alignItems="center" flexDirection="column">
             {status === PredictionStatus.ERROR && <ErrorNotification />}
             {status === PredictionStatus.PAUSED && <PauseNotification />}
             {[PredictionStatus.INITIAL, PredictionStatus.LIVE].includes(status) && (
@@ -69,10 +69,14 @@ const Mobile: React.FC = () => {
                 {status === PredictionStatus.LIVE ? <Positions view={view} /> : <LoadingSection />}
               </Box>
             )}
-            <PowerLinkStyle>
-              <img src="/images/powered-by-chainlink.png" alt="Powered by ChainLink" width="170px" height="48px" />
-            </PowerLinkStyle>
           </Flex>
+          <PowerLinkStyle>
+            <img
+              src="/images/powered-by-chainlink.png"
+              alt="Powered by ChainLink"
+              style={{ width: '170px', maxHeight: '100%' }}
+            />
+          </PowerLinkStyle>
         </View>
         <View isVisible={view === PageView.CHART}>
           <MobileChart />

--- a/src/views/Predictions/Mobile.tsx
+++ b/src/views/Predictions/Mobile.tsx
@@ -23,15 +23,6 @@ const StyledMobile = styled.div`
   }
 `
 
-const View = styled.div<{ isVisible: boolean }>`
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
-`
-
 const PowerLinkStyle = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -58,32 +49,28 @@ const Mobile: React.FC = () => {
 
   return (
     <StyledMobile>
-      <Box height="100%" overflow="hidden" position="relative">
-        <View isVisible={view === PageView.POSITIONS}>
-          <Flex alignItems="center" flexDirection="column">
+      <Box height="100%" overflowX="hidden" overflowY="auto">
+        {view === PageView.POSITIONS && (
+          <Flex justifyContent="center" alignItems="center" flexDirection="column" minHeight="100%">
             {status === PredictionStatus.ERROR && <ErrorNotification />}
             {status === PredictionStatus.PAUSED && <PauseNotification />}
             {[PredictionStatus.INITIAL, PredictionStatus.LIVE].includes(status) && (
-              <Box overflow="visible" width="100%">
+              <Box width="100%">
                 <Menu />
                 {status === PredictionStatus.LIVE ? <Positions view={view} /> : <LoadingSection />}
+                <PowerLinkStyle>
+                  <img
+                    src="/images/powered-by-chainlink.png"
+                    alt="Powered by ChainLink"
+                    style={{ width: '170px', maxHeight: '100%' }}
+                  />
+                </PowerLinkStyle>
               </Box>
             )}
           </Flex>
-          <PowerLinkStyle>
-            <img
-              src="/images/powered-by-chainlink.png"
-              alt="Powered by ChainLink"
-              style={{ width: '170px', maxHeight: '100%' }}
-            />
-          </PowerLinkStyle>
-        </View>
-        <View isVisible={view === PageView.CHART}>
-          <MobileChart />
-        </View>
-        <View isVisible={view === PageView.HISTORY}>
-          <History />
-        </View>
+        )}
+        {view === PageView.CHART && <MobileChart />}
+        {view === PageView.HISTORY && <History />}
       </Box>
       <MobileMenu />
     </StyledMobile>

--- a/src/views/Predictions/Mobile.tsx
+++ b/src/views/Predictions/Mobile.tsx
@@ -49,7 +49,7 @@ const Mobile: React.FC = () => {
 
   return (
     <StyledMobile>
-      <Box height="100%" overflowX="hidden" overflowY="auto">
+      <Box height="100%">
         {view === PageView.POSITIONS && (
           <Flex justifyContent="center" alignItems="center" flexDirection="column" minHeight="100%">
             {status === PredictionStatus.ERROR && <ErrorNotification />}

--- a/src/views/Predictions/components/Container.tsx
+++ b/src/views/Predictions/components/Container.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   background: ${({ theme }) => theme.colors.gradients.violetAlt};
-  height: calc(100vh - 150px);
+  @media only screen and (max-width: 576px) and (min-height: 740px) {
+    height: calc(100vh - 150px);
+  }
   ${({ theme }) => theme.mediaQueries.sm} {
     height: calc(100vh - 100px);
   }

--- a/src/views/Predictions/components/Container.tsx
+++ b/src/views/Predictions/components/Container.tsx
@@ -3,12 +3,11 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   background: ${({ theme }) => theme.colors.gradients.violetAlt};
-  height: 50%;
+  height: calc(100vh - 150px);
   ${({ theme }) => theme.mediaQueries.sm} {
     height: calc(100vh - 100px);
   }
   overflow: hidden;
-  position: relative;
 `
 
 export default memo(Container)

--- a/src/views/Predictions/components/Container.tsx
+++ b/src/views/Predictions/components/Container.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components'
 
 const Container = styled.div`
   background: ${({ theme }) => theme.colors.gradients.violetAlt};
-  height: calc(100vh - 100px);
+  height: 50%;
+  ${({ theme }) => theme.mediaQueries.sm} {
+    height: calc(100vh - 100px);
+  }
   overflow: hidden;
   position: relative;
 `

--- a/src/views/Predictions/components/Label.tsx
+++ b/src/views/Predictions/components/Label.tsx
@@ -115,10 +115,6 @@ export const Tooltip = styled.div`
   ${Text},svg {
     color: ${({ theme }) => theme.tooltip.text};
   }
-  @media screen and (min-width: 390px) {
-    top: -60px;
-    left: 120px;
-  }
   ${({ theme }) => theme.mediaQueries.md} {
     top: -10px;
     left: 81px;


### PR DESCRIPTION
To reproduce: 

1. Go to prediction in mobile with a wallet browser that has its own toolbar (metamask) in iphone7-8 size phone
2. See it doesn't show the top and bottom of the prediction card container
