### PR TITLE
perf: Reduce calculations in import lp pool finder

### DIFF
--- a/src/hooks/usePairs.ts
+++ b/src/hooks/usePairs.ts
@@ -69,5 +69,6 @@ export function usePairs(currencies: [Currency | undefined, Currency | undefined
 }
 
 export function usePair(tokenA?: Currency, tokenB?: Currency): [PairState, Pair | null] {
-  return usePairs([[tokenA, tokenB]])[0]
+  const pairCurrencies = useMemo<[Currency, Currency][]>(() => [[tokenA, tokenB]], [tokenA, tokenB])
+  return usePairs(pairCurrencies)[0]
 }


### PR DESCRIPTION
Each render creates a new array that triggers additional calculation and adding new generated key to multicall listeners