### PR TITLE
feat: Use 4 digit precision when showing prediction price difference

### DIFF
--- a/src/__tests__/views/predictions/helpers.test.ts
+++ b/src/__tests__/views/predictions/helpers.test.ts
@@ -48,7 +48,9 @@ describe('formatUsdv2', () => {
   `(
     'should format $priceDifference to $expectedPriceDifferenceFormatted',
     ({ priceDifference, expectedPriceDifferenceFormatted }) =>
-      expect(formatUsdv2(BigNumber.from(priceDifference))).toEqual(expectedPriceDifferenceFormatted),
+      expect(formatUsdv2(BigNumber.from(priceDifference), BigNumber.from(100000))).toEqual(
+        expectedPriceDifferenceFormatted,
+      ),
   )
 })
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -647,6 +647,7 @@ export interface PredictionConfig {
   address: string
   api: string
   chainlinkOracleAddress: string
+  minPriceUsdDisplayed: EthersBigNumber
   token: Token
 }
 

--- a/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
@@ -15,6 +15,7 @@ import CardHeader from './CardHeader'
 import CanceledRoundCard from './CanceledRoundCard'
 import CalculatingCard from './CalculatingCard'
 import LiveRoundPrice from './LiveRoundPrice'
+import { useConfig } from '../../context/ConfigProvider'
 
 interface LiveRoundCardProps {
   round: NodeRound
@@ -39,6 +40,7 @@ const LiveRoundCard: React.FC<LiveRoundCardProps> = ({
   const { lockPrice, totalAmount, lockTimestamp, closeTimestamp } = round
   const { price, refresh } = usePollOraclePrice()
   const bufferSeconds = useGetBufferSeconds()
+  const { minPriceUsdDisplayed } = useConfig()
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
@@ -103,7 +105,7 @@ const LiveRoundCard: React.FC<LiveRoundCardProps> = ({
               <LiveRoundPrice isBull={isBull} />
             </div>
             <PositionTag betPosition={isBull ? BetPosition.BULL : BetPosition.BEAR}>
-              {formatUsdv2(priceDifference)}
+              {formatUsdv2(priceDifference, minPriceUsdDisplayed)}
             </PositionTag>
           </Flex>
           {lockPrice && <LockPriceRow lockPrice={lockPrice} />}

--- a/src/views/Predictions/components/RoundResult/styles.tsx
+++ b/src/views/Predictions/components/RoundResult/styles.tsx
@@ -75,11 +75,12 @@ interface LockPriceRowProps extends FlexProps {
 
 export const LockPriceRow: React.FC<LockPriceRowProps> = ({ lockPrice, ...props }) => {
   const { t } = useTranslation()
+  const { minPriceUsdDisplayed } = useConfig()
 
   return (
     <Row {...props}>
       <Text fontSize="14px">{t('Locked Price')}:</Text>
-      <Text fontSize="14px">{formatUsdv2(lockPrice)}</Text>
+      <Text fontSize="14px">{formatUsdv2(lockPrice, minPriceUsdDisplayed)}</Text>
     </Row>
   )
 }
@@ -151,6 +152,7 @@ interface RoundPriceProps {
 }
 
 export const RoundPrice: React.FC<RoundPriceProps> = ({ lockPrice, closePrice }) => {
+  const { minPriceUsdDisplayed } = useConfig()
   const betPosition = getRoundPosition(lockPrice, closePrice)
   const priceDifference = getPriceDifference(closePrice, lockPrice)
 
@@ -170,12 +172,12 @@ export const RoundPrice: React.FC<RoundPriceProps> = ({ lockPrice, closePrice })
     <Flex alignItems="center" justifyContent="space-between" mb="16px">
       {closePrice ? (
         <Text color={getTextColor()} bold fontSize="24px">
-          {formatUsdv2(closePrice)}
+          {formatUsdv2(closePrice, minPriceUsdDisplayed)}
         </Text>
       ) : (
         <Skeleton height="34px" my="1px" />
       )}
-      <PositionTag betPosition={betPosition}>{formatUsdv2(priceDifference)}</PositionTag>
+      <PositionTag betPosition={betPosition}>{formatUsdv2(priceDifference, minPriceUsdDisplayed)}</PositionTag>
     </Flex>
   )
 }

--- a/src/views/Predictions/context/config.ts
+++ b/src/views/Predictions/context/config.ts
@@ -3,18 +3,23 @@ import addresses from 'config/constants/contracts'
 import { GRAPH_API_PREDICTION_CAKE, GRAPH_API_PREDICTION_BNB } from 'config/constants/endpoints'
 import { getAddress } from 'utils/addressHelpers'
 import tokens from 'config/constants/tokens'
+import { BigNumber } from '@ethersproject/bignumber'
+
+const DEFAULT_MIN_PRICE_USD_DISPLAYED = BigNumber.from(10000)
 
 export default {
   BNB: {
     address: getAddress(addresses.predictionsBNB),
     api: GRAPH_API_PREDICTION_BNB,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleBNB),
+    minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
     token: tokens.bnb,
   },
   CAKE: {
     address: getAddress(addresses.predictionsCAKE),
     api: GRAPH_API_PREDICTION_CAKE,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleCAKE),
+    minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
     token: tokens.cake,
   },
 }

--- a/src/views/Predictions/helpers.ts
+++ b/src/views/Predictions/helpers.ts
@@ -4,7 +4,6 @@ import { formatBigNumberToFixed } from 'utils/formatBalance'
 import getTimePeriods from 'utils/getTimePeriods'
 import { NegativeOne, One, Zero } from '@ethersproject/constants'
 
-const MIN_PRICE_USD_DISPLAYED = BigNumber.from(100000)
 const MIN_PRICE_BNB_DISPLAYED = BigNumber.from('1000000000000000')
 const DISPLAYED_DECIMALS = 4
 
@@ -31,8 +30,8 @@ const formatPriceDifference = ({
   return `${unitPrefix}${formatBigNumberToFixed(price, DISPLAYED_DECIMALS, decimals)}`
 }
 
-export const formatUsdv2 = (usd: BigNumber) => {
-  return formatPriceDifference({ price: usd, minPriceDisplayed: MIN_PRICE_USD_DISPLAYED, unitPrefix: '$', decimals: 8 })
+export const formatUsdv2 = (usd: BigNumber, minPriceDisplayed: BigNumber) => {
+  return formatPriceDifference({ price: usd, minPriceDisplayed, unitPrefix: '$', decimals: 8 })
 }
 
 export const formatBnbv2 = (bnb: BigNumber) => {


### PR DESCRIPTION
To review: 

1. Go to prediction
2. See price difference in open/expired rounds shows 4 digit precision


Before :

<img width="679" alt="image" src="https://user-images.githubusercontent.com/2213635/177055197-94d6f7e9-a100-40f6-a8e7-d270a7d2e56d.png">

After:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/2213635/177055223-abead452-7415-4813-9049-07049991c882.png">
