### PR TITLE
perf: Separate label price countup from label component to reduce rerender

### DIFF
--- a/src/views/Predictions/components/Label.tsx
+++ b/src/views/Predictions/components/Label.tsx
@@ -1,16 +1,14 @@
 import { Box, CoinSwitcher, Flex, PocketWatchIcon, Text, CloseIcon } from '@pancakeswap/uikit'
 import { useTranslation } from 'contexts/Localization'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { useCountUp } from 'react-countup'
+import { useCallback, useState } from 'react'
 import { useGetCurrentRoundCloseTimestamp } from 'state/predictions/hooks'
 import { PredictionSupportedSymbol } from 'state/types'
 import styled, { keyframes } from 'styled-components'
-import { formatBigNumberToFixed } from 'utils/formatBalance'
 import { useConfig } from '../context/ConfigProvider'
 import { formatRoundTime } from '../helpers'
 import useCountdown from '../hooks/useCountdown'
-import usePollOraclePrice from '../hooks/usePollOraclePrice'
+import LabelPrice from './LabelPrice'
 
 const TOOLTIP_DISMISS_KEY = 'prediction-switcher-dismiss-tooltip'
 
@@ -56,16 +54,6 @@ const ClosingTitle = styled(Text)`
   ${({ theme }) => theme.mediaQueries.lg} {
     font-size: 20px;
     line-height: 22px;
-  }
-`
-
-const Price = styled(Text)`
-  height: 18px;
-  justify-self: start;
-  width: 70px;
-
-  ${({ theme }) => theme.mediaQueries.lg} {
-    text-align: center;
   }
 `
 
@@ -156,7 +144,6 @@ const Label = styled(Flex)<{ dir: 'left' | 'right'; backgroundOpacity?: boolean 
 `
 
 export const PricePairLabel: React.FC = () => {
-  const { price } = usePollOraclePrice()
   const { token } = useConfig()
   const router = useRouter()
   const { t } = useTranslation()
@@ -165,26 +152,10 @@ export const PricePairLabel: React.FC = () => {
     return false
   })
 
-  const priceAsNumber = parseFloat(formatBigNumberToFixed(price, 4, 8))
-  const countUpState = useCountUp({
-    start: 0,
-    end: priceAsNumber,
-    duration: 1,
-    decimals: 4,
-  })
-
-  const { countUp, update } = countUpState || {}
-
-  const updateRef = useRef(update)
-
   const onDismissTooltip = useCallback(() => {
     localStorage?.setItem(TOOLTIP_DISMISS_KEY, '1')
     setDismissTooltip(true)
   }, [])
-
-  useEffect(() => {
-    updateRef.current(priceAsNumber)
-  }, [priceAsNumber, updateRef])
 
   const onTokenSwitch = useCallback(() => {
     if (router.query.token === PredictionSupportedSymbol.CAKE) {
@@ -221,7 +192,7 @@ export const PricePairLabel: React.FC = () => {
           <Title bold textTransform="uppercase">
             {`${token.symbol}USD`}
           </Title>
-          <Price fontSize="12px">{`$${countUp}`}</Price>
+          <LabelPrice />
         </Label>
       </Box>
     </>

--- a/src/views/Predictions/components/LabelPrice.tsx
+++ b/src/views/Predictions/components/LabelPrice.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useMemo } from 'react'
+import { useCountUp } from 'react-countup'
+import { Text } from '@pancakeswap/uikit'
+import { formatBigNumberToFixed } from 'utils/formatBalance'
+import styled from 'styled-components'
+import usePollOraclePrice from '../hooks/usePollOraclePrice'
+
+const Price = styled(Text)`
+  height: 18px;
+  justify-self: start;
+  width: 70px;
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    text-align: center;
+  }
+`
+
+const LabelPrice = () => {
+  const { price } = usePollOraclePrice()
+  const priceAsNumber = useMemo(() => parseFloat(formatBigNumberToFixed(price, 4, 8)), [price])
+
+  const { countUp, update } = useCountUp({
+    start: 0,
+    end: priceAsNumber,
+    duration: 1,
+    decimals: 4,
+  })
+
+  const updateRef = useRef(update)
+
+  useEffect(() => {
+    updateRef.current(priceAsNumber)
+  }, [priceAsNumber, updateRef])
+
+  return <Price fontSize="12px">{`$${countUp}`}</Price>
+}
+
+export default LabelPrice

--- a/src/views/Predictions/components/RoundCard/LiveRoundPrice.tsx
+++ b/src/views/Predictions/components/RoundCard/LiveRoundPrice.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, memo } from 'react'
+import React, { useEffect, useRef, memo, useMemo } from 'react'
 import { useCountUp } from 'react-countup'
 import { Skeleton, TooltipText } from '@pancakeswap/uikit'
 import { formatBigNumberToFixed } from 'utils/formatBalance'
@@ -10,8 +10,8 @@ interface LiveRoundPriceProps {
 
 const LiveRoundPrice: React.FC<LiveRoundPriceProps> = ({ isBull }) => {
   const { price } = usePollOraclePrice()
+  const priceAsNumber = useMemo(() => parseFloat(formatBigNumberToFixed(price, 4, 8)), [price])
 
-  const priceAsNumber = parseFloat(formatBigNumberToFixed(price, 4, 8))
   const priceColor = isBull ? 'success' : 'failure'
 
   const { countUp, update } = useCountUp({


### PR DESCRIPTION
It rerenders too much when counting up and calls translation and other functions unnecessarily