### PR TITLE
fix: Add liquidity overview page to the token list fetchers

### DIFF
--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -17,7 +17,7 @@ export default function Updater(): null {
   const isWindowVisible = useIsWindowVisible()
   const router = useRouter()
   const includeListUpdater = useMemo(() => {
-    return ['/swap', '/limit-orders', '/add', '/find', '/remove'].some((item) => {
+    return ['/swap', '/limit-orders', 'liquidity', '/add', '/find', '/remove'].some((item) => {
       return router.pathname.startsWith(item)
     })
   }, [router.pathname])


### PR DESCRIPTION
If it is accessed directly, token lists will not be fetched thus some of the lp's will not be seen by default, if user access the page with no cache