### PR TITLE
fix: Position tag background

### DIFF
--- a/src/views/Predictions/components/PositionTag.tsx
+++ b/src/views/Predictions/components/PositionTag.tsx
@@ -14,14 +14,16 @@ import { BetPosition } from 'state/types'
 import { useTranslation } from 'contexts/Localization'
 
 interface TagProps extends FlexProps {
+  bgColor?: string
   startIcon?: ReactNode
 }
 
-const StyledTag = styled(Flex)`
+const StyledTag = styled(Flex)<{ bgColor: TagProps['bgColor'] }>`
+  background-color: ${({ bgColor, theme }) => theme.colors[bgColor]};
   display: inline-flex;
 `
 
-export const Tag: React.FC<TagProps> = ({ bg = 'success', startIcon, children, onClick, ...props }) => {
+export const Tag: React.FC<TagProps> = ({ bgColor = 'success', startIcon, children, onClick, ...props }) => {
   const icon = startIcon || <ArrowUpIcon color="white" />
 
   return (
@@ -29,7 +31,7 @@ export const Tag: React.FC<TagProps> = ({ bg = 'success', startIcon, children, o
       alignItems="center"
       justifyContent="center"
       borderRadius="4px"
-      bg={bg}
+      bgColor={bgColor}
       py="4px"
       px="8px"
       onClick={onClick}
@@ -81,7 +83,7 @@ const PositionTag: React.FC<PositionTagProps> = ({ betPosition, children, ...pro
   }
 
   return (
-    <Tag bg={isUpPosition ? 'success' : 'failure'} startIcon={icon} {...props}>
+    <Tag bgColor={isUpPosition ? 'success' : 'failure'} startIcon={icon} {...props}>
       {children}
     </Tag>
   )


### PR DESCRIPTION
To reproduce: 

1. Go to prediction 
2. See position tags backgrounds not visible
3. In light theme mode nothing is visible


<img width="360" alt="image" src="https://user-images.githubusercontent.com/2213635/177147898-40a8b33d-7739-4d13-85f7-2451108c6edd.png">

<img width="364" alt="image" src="https://user-images.githubusercontent.com/2213635/177147774-bd20359c-1b02-4652-9e69-dd1404f0fa2b.png">

<img width="339" alt="image" src="https://user-images.githubusercontent.com/2213635/177147511-9b689143-7cc2-408e-bedc-9c17eea8b50f.png">

<img width="339" alt="image" src="https://user-images.githubusercontent.com/2213635/177147576-f94a06d5-62e4-4edc-a52f-5f49f67a8c47.png">

