### PR TITLE
fix: (prediction): To burn tooltip position in round card in mobile

### DIFF
--- a/src/views/Predictions/components/PositionTag.tsx
+++ b/src/views/Predictions/components/PositionTag.tsx
@@ -63,7 +63,7 @@ const PositionTag: React.FC<PositionTagProps> = ({ betPosition, children, ...pro
         )}
       </Text>
     </>,
-    { placement: 'right' },
+    { placement: 'top' },
   )
 
   if (betPosition === BetPosition.HOUSE) {


### PR DESCRIPTION
<img width="360" alt="image" src="https://user-images.githubusercontent.com/2213635/177293355-548fbf03-5bdc-4bf8-93b0-28caa87d03d8.png">