### PR TITLE
fix: Bet results history displayed decimal amount and make it configurable

### DIFF
--- a/src/__tests__/views/predictions/components/History/helpers.test.ts
+++ b/src/__tests__/views/predictions/components/History/helpers.test.ts
@@ -3,31 +3,33 @@ import { formatBnb, formatUsd, getMultiplier, getPayout } from 'views/Prediction
 
 describe('formatUsd', () => {
   it.each([
-    [500, '$500.000'],
-    [265.22, '$265.220'],
-    [689.889, '$689.889'],
-    [10.8829, '$10.883'],
-  ])('format %i USD correctly with 3 decimals', (value, expected) => {
-    expect(formatUsd(value)).toEqual(expected)
+    [500, '$500.0000'],
+    [265.22, '$265.2200'],
+    [689.889, '$689.8890'],
+    [10.8829, '$10.8829'],
+    [10.88296, '$10.8830'],
+  ])('format %i USD correctly with 4 decimals', (value, expected) => {
+    expect(formatUsd(value, 4)).toEqual(expected)
   })
 
   it('returns 0 if USD is undefined', () => {
-    expect(formatUsd(undefined)).toEqual('$0.000')
+    expect(formatUsd(undefined, 4)).toEqual('$0.0000')
   })
 })
 
 describe('formatBnb', () => {
   it.each([
-    [20, '20.000'],
-    [265.22, '265.220'],
-    [689.889, '689.889'],
-    [10.8829, '10.883'],
-  ])('format %i BNB correctly with 3 decimals', (value, expected) => {
-    expect(formatBnb(value)).toEqual(expected)
+    [20, '20.0000'],
+    [265.22, '265.2200'],
+    [689.889, '689.8890'],
+    [10.8829, '10.8829'],
+    [10.88296, '10.8830'],
+  ])('format %i BNB correctly with 4 decimals', (value, expected) => {
+    expect(formatBnb(value, 4)).toEqual(expected)
   })
 
   it('returns 0 if BNB is undefined', () => {
-    expect(formatBnb(undefined)).toEqual('0')
+    expect(formatBnb(undefined, 4)).toEqual('0')
   })
 })
 

--- a/src/__tests__/views/predictions/helpers.test.ts
+++ b/src/__tests__/views/predictions/helpers.test.ts
@@ -48,7 +48,7 @@ describe('formatUsdv2', () => {
   `(
     'should format $priceDifference to $expectedPriceDifferenceFormatted',
     ({ priceDifference, expectedPriceDifferenceFormatted }) =>
-      expect(formatUsdv2(BigNumber.from(priceDifference), BigNumber.from(100000))).toEqual(
+      expect(formatUsdv2(BigNumber.from(priceDifference), BigNumber.from(100000), 4)).toEqual(
         expectedPriceDifferenceFormatted,
       ),
   )
@@ -79,6 +79,6 @@ describe('formatBnbv2', () => {
   `(
     'should format $priceDifference to $expectedPriceDifferenceFormatted',
     ({ priceDifference, expectedPriceDifferenceFormatted }) =>
-      expect(formatBnbv2(BigNumber.from(priceDifference))).toEqual(expectedPriceDifferenceFormatted),
+      expect(formatBnbv2(BigNumber.from(priceDifference), 4)).toEqual(expectedPriceDifferenceFormatted),
   )
 })

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -668,6 +668,7 @@ export interface PredictionConfig {
   api: string
   chainlinkOracleAddress: string
   minPriceUsdDisplayed: EthersBigNumber
+  displayedDecimals: number
   token: Token
 }
 

--- a/src/views/Predictions/components/History/BetResult.tsx
+++ b/src/views/Predictions/components/History/BetResult.tsx
@@ -42,7 +42,7 @@ const BetResult: React.FC<React.PropsWithChildren<BetResultProps>> = ({ bet, res
   const { account } = useWeb3React()
   const { isRefundable } = useIsRefundable(bet.round.epoch)
   const canClaim = useGetIsClaimable(bet.round.epoch)
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
   const bnbBusdPrice = useBUSDPrice(token)
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     <Text as="p">{t('Includes your original position and your winnings, minus the %fee% fee.', { fee: '3%' })}</Text>,
@@ -152,12 +152,12 @@ const BetResult: React.FC<React.PropsWithChildren<BetResultProps>> = ({ bet, res
         </Flex>
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           <Text>{t('Your position')}</Text>
-          <Text>{`${formatBnb(bet.amount)} ${token.symbol}`}</Text>
+          <Text>{`${formatBnb(bet.amount, displayedDecimals)} ${token.symbol}`}</Text>
         </Flex>
         <Flex alignItems="start" justifyContent="space-between">
           <Text bold>{isWinner ? t('Your winnings') : t('Your Result')}:</Text>
           <Box style={{ textAlign: 'right' }}>
-            <Text bold color={resultColor}>{`${isWinner ? '+' : '-'}${formatBnb(payout)} ${token.symbol}`}</Text>
+            <Text bold color={resultColor}>{`${isWinner ? '+' : '-'}${formatBnb(payout, displayedDecimals)} ${token.symbol}`}</Text>
             <Text fontSize="12px" color="textSubtle">
               {`~$${totalPayout.toFixed(2)}`}
             </Text>
@@ -171,7 +171,9 @@ const BetResult: React.FC<React.PropsWithChildren<BetResultProps>> = ({ bet, res
                 {t('Amount to collect')}:
               </Text>
               <Flex justifyContent="end">
-                <Text fontSize="14px" color="textSubtle">{`${formatBnb(returned)} ${token.symbol}`}</Text>
+                <Text fontSize="14px" color="textSubtle">{`${formatBnb(returned, displayedDecimals)} ${
+                  token.symbol
+                }`}</Text>
                 <span ref={targetRef}>
                   <InfoIcon color="textSubtle" ml="4px" />
                 </span>

--- a/src/views/Predictions/components/History/BetResult.tsx
+++ b/src/views/Predictions/components/History/BetResult.tsx
@@ -157,7 +157,9 @@ const BetResult: React.FC<React.PropsWithChildren<BetResultProps>> = ({ bet, res
         <Flex alignItems="start" justifyContent="space-between">
           <Text bold>{isWinner ? t('Your winnings') : t('Your Result')}:</Text>
           <Box style={{ textAlign: 'right' }}>
-            <Text bold color={resultColor}>{`${isWinner ? '+' : '-'}${formatBnb(payout, displayedDecimals)} ${token.symbol}`}</Text>
+            <Text bold color={resultColor}>{`${isWinner ? '+' : '-'}${formatBnb(payout, displayedDecimals)} ${
+              token.symbol
+            }`}</Text>
             <Text fontSize="12px" color="textSubtle">
               {`~$${totalPayout.toFixed(2)}`}
             </Text>

--- a/src/views/Predictions/components/History/HistoricalBet.tsx
+++ b/src/views/Predictions/components/History/HistoricalBet.tsx
@@ -24,6 +24,7 @@ import { formatBnb, getNetPayout } from './helpers'
 import CollectWinningsButton from '../CollectWinningsButton'
 import ReclaimPositionButton from '../ReclaimPositionButton'
 import BetDetails from './BetDetails'
+import { useConfig } from '../../context/ConfigProvider'
 
 interface BetProps {
   bet: Bet
@@ -62,6 +63,7 @@ const HistoricalBet: React.FC<React.PropsWithChildren<BetProps>> = ({ bet }) => 
   const canClaim = useGetIsClaimable(bet.round.epoch)
   const dispatch = useLocalDispatch()
   const { account } = useWeb3React()
+  const { displayedDecimals } = useConfig()
 
   const toggleOpen = () => setIsOpen(!isOpen)
 
@@ -141,7 +143,7 @@ const HistoricalBet: React.FC<React.PropsWithChildren<BetProps>> = ({ bet }) => 
               </Flex>
             </>
           ) : (
-            `${resultTextPrefix}${formatBnb(payout)}`
+            `${resultTextPrefix}${formatBnb(payout, displayedDecimals)}`
           )}
         </Text>
       </>

--- a/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
+++ b/src/views/Predictions/components/History/PnlTab/PnlTab.tsx
@@ -106,7 +106,7 @@ const PnlTab: React.FC<React.PropsWithChildren<PnlTabProps>> = ({ hasBetHistory,
   const { t } = useTranslation()
   const { account } = useWeb3React()
   const currentEpoch = useGetCurrentEpoch()
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
   const bnbBusdPrice = useBUSDPrice(token)
 
   const summary = getPnlSummary(bets, currentEpoch)
@@ -141,7 +141,7 @@ const PnlTab: React.FC<React.PropsWithChildren<PnlTabProps>> = ({ hasBetHistory,
             {t('Net results')}
           </Text>
           <Text bold fontSize="24px" lineHeight="1" color={netResultIsPositive ? 'success' : 'failure'}>
-            {`${netResultIsPositive ? '+' : ''}${formatBnb(netResultAmount)} ${token.symbol}`}
+            {`${netResultIsPositive ? '+' : ''}${formatBnb(netResultAmount, displayedDecimals)} ${token.symbol}`}
           </Text>
           <Text small color="textSubtle">
             {`~$${netResultInUsd.toFixed(2)}`}
@@ -153,7 +153,7 @@ const PnlTab: React.FC<React.PropsWithChildren<PnlTabProps>> = ({ hasBetHistory,
           {t('Average return / round')}
         </Text>
         <Text bold color={avgBnbWonIsPositive ? 'success' : 'failure'}>
-          {`${avgBnbWonIsPositive ? '+' : ''}${formatBnb(avgBnbWonPerRound)} ${token.symbol}`}
+          {`${avgBnbWonIsPositive ? '+' : ''}${formatBnb(avgBnbWonPerRound, displayedDecimals)} ${token.symbol}`}
         </Text>
         <Text small color="textSubtle">
           {avgBnbWonInUsdDisplay}
@@ -165,7 +165,9 @@ const PnlTab: React.FC<React.PropsWithChildren<PnlTabProps>> = ({ hasBetHistory,
               {t('Best round: #%roundId%', { roundId: summary.won.bestRound.id })}
             </Text>
             <Flex alignItems="flex-end">
-              <Text bold color="success">{`+${formatBnb(summary.won.bestRound.payout)} ${token.symbol}`}</Text>
+              <Text bold color="success">{`+${formatBnb(summary.won.bestRound.payout, displayedDecimals)} ${
+                token.symbol
+              }`}</Text>
               <Text ml="4px" small color="textSubtle">
                 ({summary.won.bestRound.multiplier.toFixed(2)}x)
               </Text>
@@ -179,7 +181,7 @@ const PnlTab: React.FC<React.PropsWithChildren<PnlTabProps>> = ({ hasBetHistory,
         <Text mt="16px" bold color="textSubtle">
           {t('Average position entered / round')}
         </Text>
-        <Text bold>{`${formatBnb(avgPositionEntered)} ${token.symbol}`}</Text>
+        <Text bold>{`${formatBnb(avgPositionEntered, displayedDecimals)} ${token.symbol}`}</Text>
         <Text small color="textSubtle">
           {avgPositionEnteredInUsdDisplay}
         </Text>

--- a/src/views/Predictions/components/History/PnlTab/SummaryRow.tsx
+++ b/src/views/Predictions/components/History/PnlTab/SummaryRow.tsx
@@ -35,7 +35,7 @@ const SummaryRow: React.FC<React.PropsWithChildren<SummaryRowProps>> = ({ type, 
   const typeTranslationKey = type.charAt(0).toUpperCase() + type.slice(1)
   const displayAmount = type === 'won' ? summary[type].payout : amount
   const amountInUsd = multiplyPriceByAmount(bnbBusdPrice, displayAmount)
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
   const roundsInPercentsDisplay = !Number.isNaN(parseFloat(roundsInPercents)) ? `${roundsInPercents}%` : '0%'
 
   return (
@@ -54,7 +54,7 @@ const SummaryRow: React.FC<React.PropsWithChildren<SummaryRowProps>> = ({ type, 
         </Flex>
         <Flex flex="3" flexDirection="column">
           <Text bold fontSize="20px" color={color}>
-            {`${summaryTypeSigns[type]}${formatBnb(displayAmount)} ${token.symbol}`}
+            {`${summaryTypeSigns[type]}${formatBnb(displayAmount, displayedDecimals)} ${token.symbol}`}
           </Text>
           <Text fontSize="12px" color="textSubtle">
             {`~$${amountInUsd.toFixed(2)}`}

--- a/src/views/Predictions/components/History/helpers.ts
+++ b/src/views/Predictions/components/History/helpers.ts
@@ -1,12 +1,17 @@
 import { Bet, BetPosition } from 'state/types'
 import { formatNumber } from 'utils/formatBalance'
 
-export const formatUsd = (usd: number) => {
-  return `$${formatNumber(usd || 0, 3, 3)}`
+export const formatUsd = (usd: number, displayedDecimals: number) => {
+  return `$${formatNumber(usd || 0, displayedDecimals, displayedDecimals)}`
 }
 
-export const formatBnb = (bnb: number) => {
-  return bnb ? bnb.toLocaleString(undefined, { minimumFractionDigits: 3, maximumFractionDigits: 3 }) : '0'
+export const formatBnb = (bnb: number, displayedDecimals: number) => {
+  return bnb
+    ? bnb.toLocaleString(undefined, {
+        minimumFractionDigits: displayedDecimals,
+        maximumFractionDigits: displayedDecimals,
+      })
+    : '0'
 }
 
 export const getMultiplier = (total: number, amount: number) => {

--- a/src/views/Predictions/components/RoundCard/EnteredTag.tsx
+++ b/src/views/Predictions/components/RoundCard/EnteredTag.tsx
@@ -11,10 +11,10 @@ interface EnteredTagProps {
 
 const EnteredTag: React.FC<React.PropsWithChildren<EnteredTagProps>> = ({ amount, hasClaimed = false }) => {
   const { t } = useTranslation()
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
 
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
-    <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(amount)} ${token.symbol}`}</div>,
+    <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(amount, displayedDecimals)} ${token.symbol}`}</div>,
     { placement: 'bottom' },
   )
 

--- a/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
@@ -40,7 +40,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
   const { lockPrice, totalAmount, lockTimestamp, closeTimestamp } = round
   const { price, refresh } = usePollOraclePrice()
   const bufferSeconds = useGetBufferSeconds()
-  const { minPriceUsdDisplayed } = useConfig()
+  const { minPriceUsdDisplayed, displayedDecimals } = useConfig()
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
@@ -105,7 +105,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
               <LiveRoundPrice isBull={isBull} price={price} />
             </div>
             <PositionTag betPosition={isBull ? BetPosition.BULL : BetPosition.BEAR}>
-              {formatUsdv2(priceDifference, minPriceUsdDisplayed)}
+              {formatUsdv2(priceDifference, minPriceUsdDisplayed, displayedDecimals)}
             </PositionTag>
           </Flex>
           {lockPrice && <LockPriceRow lockPrice={lockPrice} />}

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -57,7 +57,7 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
   const { toastSuccess } = useToast()
   const { account } = useWeb3React()
   const dispatch = useLocalDispatch()
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
   const { lockTimestamp } = round ?? { lockTimestamp: null }
   const { isSettingPosition, position } = state
   const [isBufferPhase, setIsBufferPhase] = useState(false)
@@ -79,7 +79,7 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
     [hasEnteredUp, hasEnteredDown],
   )
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
-    <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount)} ${token.symbol}`}</div>,
+    <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount, displayedDecimals)} ${token.symbol}`}</div>,
     { placement: 'top' },
   )
 

--- a/src/views/Predictions/components/RoundResult/RoundResultHistory.tsx
+++ b/src/views/Predictions/components/RoundResult/RoundResultHistory.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from '@pancakeswap/localization'
 import { formatUsd } from '../History/helpers'
 import PositionTag from '../PositionTag'
 import { LockPriceHistoryRow, PrizePoolHistoryRow, RoundResultBox } from './styles'
+import { useConfig } from '../../context/ConfigProvider'
 
 interface RoundResultProps extends BoxProps {
   round: Round
 }
 
 const RoundResult: React.FC<React.PropsWithChildren<RoundResultProps>> = ({ round, children, ...props }) => {
+  const { displayedDecimals } = useConfig()
   const { lockPrice, closePrice, totalAmount } = round
   const betPosition = closePrice > lockPrice ? BetPosition.BULL : BetPosition.BEAR
   const isPositionUp = betPosition === BetPosition.BULL
@@ -28,9 +30,9 @@ const RoundResult: React.FC<React.PropsWithChildren<RoundResultProps>> = ({ roun
       ) : (
         <Flex alignItems="center" justifyContent="space-between" mb="16px">
           <Text color={isPositionUp ? 'success' : 'failure'} bold fontSize="24px">
-            {formatUsd(closePrice)}
+            {formatUsd(closePrice, displayedDecimals)}
           </Text>
-          <PositionTag betPosition={betPosition}>{formatUsd(priceDifference)}</PositionTag>
+          <PositionTag betPosition={betPosition}>{formatUsd(priceDifference, displayedDecimals)}</PositionTag>
         </Flex>
       )}
       {lockPrice && <LockPriceHistoryRow lockPrice={lockPrice} />}

--- a/src/views/Predictions/components/RoundResult/styles.tsx
+++ b/src/views/Predictions/components/RoundResult/styles.tsx
@@ -14,12 +14,12 @@ interface PrizePoolRowProps extends FlexProps {
   totalAmount: NodeRound['totalAmount']
 }
 
-const getPrizePoolAmount = (totalAmount: PrizePoolRowProps['totalAmount']) => {
+const getPrizePoolAmount = (totalAmount: PrizePoolRowProps['totalAmount'], displayedDecimals: number) => {
   if (!totalAmount) {
     return '0'
   }
 
-  return formatBnbv2(totalAmount)
+  return formatBnbv2(totalAmount, displayedDecimals)
 }
 
 const Row = ({ children, ...props }) => {
@@ -32,12 +32,12 @@ const Row = ({ children, ...props }) => {
 
 export const PrizePoolRow: React.FC<React.PropsWithChildren<PrizePoolRowProps>> = ({ totalAmount, ...props }) => {
   const { t } = useTranslation()
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
 
   return (
     <Row {...props}>
       <Text bold>{t('Prize Pool')}:</Text>
-      <Text bold>{`${getPrizePoolAmount(totalAmount)} ${token.symbol}`}</Text>
+      <Text bold>{`${getPrizePoolAmount(totalAmount, displayedDecimals)} ${token.symbol}`}</Text>
     </Row>
   )
 }
@@ -57,7 +57,7 @@ export const PayoutRow: React.FC<React.PropsWithChildren<PayoutRowProps>> = ({
 }) => {
   const { t } = useTranslation()
   const formattedMultiplier = `${multiplier.toLocaleString(undefined, { maximumFractionDigits: 2 })}x`
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
 
   return (
     <Row height="18px" {...props}>
@@ -69,7 +69,7 @@ export const PayoutRow: React.FC<React.PropsWithChildren<PayoutRowProps>> = ({
           {t('%multiplier% Payout', { multiplier: formattedMultiplier })}
         </Text>
         <Text mx="4px">|</Text>
-        <Text fontSize="12px" lineHeight="18px">{`${formatBnb(amount)} ${token.symbol}`}</Text>
+        <Text fontSize="12px" lineHeight="18px">{`${formatBnb(amount, displayedDecimals)} ${token.symbol}`}</Text>
       </Flex>
     </Row>
   )
@@ -81,12 +81,12 @@ interface LockPriceRowProps extends FlexProps {
 
 export const LockPriceRow: React.FC<React.PropsWithChildren<LockPriceRowProps>> = ({ lockPrice, ...props }) => {
   const { t } = useTranslation()
-  const { minPriceUsdDisplayed } = useConfig()
+  const { displayedDecimals, minPriceUsdDisplayed } = useConfig()
 
   return (
     <Row {...props}>
       <Text fontSize="14px">{t('Locked Price')}:</Text>
-      <Text fontSize="14px">{formatUsdv2(lockPrice, minPriceUsdDisplayed)}</Text>
+      <Text fontSize="14px">{formatUsdv2(lockPrice, minPriceUsdDisplayed, displayedDecimals)}</Text>
     </Row>
   )
 }
@@ -158,7 +158,7 @@ interface RoundPriceProps {
 }
 
 export const RoundPrice: React.FC<React.PropsWithChildren<RoundPriceProps>> = ({ lockPrice, closePrice }) => {
-  const { minPriceUsdDisplayed } = useConfig()
+  const { displayedDecimals, minPriceUsdDisplayed } = useConfig()
   const betPosition = getRoundPosition(lockPrice, closePrice)
   const priceDifference = getPriceDifference(closePrice, lockPrice)
 
@@ -178,12 +178,14 @@ export const RoundPrice: React.FC<React.PropsWithChildren<RoundPriceProps>> = ({
     <Flex alignItems="center" justifyContent="space-between" mb="16px">
       {closePrice ? (
         <Text color={textColor} bold fontSize="24px">
-          {formatUsdv2(closePrice, minPriceUsdDisplayed)}
+          {formatUsdv2(closePrice, minPriceUsdDisplayed, displayedDecimals)}
         </Text>
       ) : (
         <Skeleton height="34px" my="1px" />
       )}
-      <PositionTag betPosition={betPosition}>{formatUsdv2(priceDifference, minPriceUsdDisplayed)}</PositionTag>
+      <PositionTag betPosition={betPosition}>
+        {formatUsdv2(priceDifference, minPriceUsdDisplayed, displayedDecimals)}
+      </PositionTag>
     </Flex>
   )
 }
@@ -197,12 +199,12 @@ interface PrizePoolHistoryRowProps extends FlexProps {
   totalAmount: number
 }
 
-const getPrizePoolAmountHistory = (totalAmount: PrizePoolHistoryRowProps['totalAmount']) => {
+const getPrizePoolAmountHistory = (totalAmount: PrizePoolHistoryRowProps['totalAmount'], displayedDecimals: number) => {
   if (!totalAmount) {
     return '0'
   }
 
-  return formatBnb(totalAmount)
+  return formatBnb(totalAmount, displayedDecimals)
 }
 
 export const PrizePoolHistoryRow: React.FC<React.PropsWithChildren<PrizePoolHistoryRowProps>> = ({
@@ -210,12 +212,12 @@ export const PrizePoolHistoryRow: React.FC<React.PropsWithChildren<PrizePoolHist
   ...props
 }) => {
   const { t } = useTranslation()
-  const { token } = useConfig()
+  const { token, displayedDecimals } = useConfig()
 
   return (
     <Row {...props}>
       <Text bold>{t('Prize Pool')}:</Text>
-      <Text bold>{`${getPrizePoolAmountHistory(totalAmount)} ${token.symbol}`}</Text>
+      <Text bold>{`${getPrizePoolAmountHistory(totalAmount, displayedDecimals)} ${token.symbol}`}</Text>
     </Row>
   )
 }
@@ -229,11 +231,12 @@ export const LockPriceHistoryRow: React.FC<React.PropsWithChildren<LockPriceHist
   ...props
 }) => {
   const { t } = useTranslation()
+  const { displayedDecimals } = useConfig()
 
   return (
     <Row {...props}>
       <Text fontSize="14px">{t('Locked Price')}:</Text>
-      <Text fontSize="14px">{formatUsd(lockPrice)}</Text>
+      <Text fontSize="14px">{formatUsd(lockPrice, displayedDecimals)}</Text>
     </Row>
   )
 }

--- a/src/views/Predictions/context/config.ts
+++ b/src/views/Predictions/context/config.ts
@@ -13,6 +13,7 @@ export default {
     api: GRAPH_API_PREDICTION_BNB,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleBNB),
     minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
+    displayedDecimals: 4,
     token: bscTokens.bnb,
   },
   CAKE: {
@@ -20,6 +21,7 @@ export default {
     api: GRAPH_API_PREDICTION_CAKE,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleCAKE),
     minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
+    displayedDecimals: 4,
     token: bscTokens.cake,
   },
 }

--- a/src/views/Predictions/helpers.ts
+++ b/src/views/Predictions/helpers.ts
@@ -5,12 +5,12 @@ import getTimePeriods from 'utils/getTimePeriods'
 import { NegativeOne, One, Zero } from '@ethersproject/constants'
 
 const MIN_PRICE_BNB_DISPLAYED = BigNumber.from('1000000000000000')
-const DISPLAYED_DECIMALS = 4
 
 type formatPriceDifferenceProps = {
   price?: BigNumber
   minPriceDisplayed: BigNumber
   unitPrefix: string
+  displayedDecimals: number
   decimals: number
 }
 
@@ -18,24 +18,31 @@ const formatPriceDifference = ({
   price = Zero,
   minPriceDisplayed,
   unitPrefix,
+  displayedDecimals,
   decimals,
 }: formatPriceDifferenceProps) => {
   const sign = price.isNegative() ? NegativeOne : One
 
   if (price.abs().lt(minPriceDisplayed)) {
     const signedPriceToFormat = minPriceDisplayed.mul(sign)
-    return `<${unitPrefix}${formatBigNumberToFixed(signedPriceToFormat, DISPLAYED_DECIMALS, decimals)}`
+    return `<${unitPrefix}${formatBigNumberToFixed(signedPriceToFormat, displayedDecimals, decimals)}`
   }
 
-  return `${unitPrefix}${formatBigNumberToFixed(price, DISPLAYED_DECIMALS, decimals)}`
+  return `${unitPrefix}${formatBigNumberToFixed(price, displayedDecimals, decimals)}`
 }
 
-export const formatUsdv2 = (usd: BigNumber, minPriceDisplayed: BigNumber) => {
-  return formatPriceDifference({ price: usd, minPriceDisplayed, unitPrefix: '$', decimals: 8 })
+export const formatUsdv2 = (usd: BigNumber, minPriceDisplayed: BigNumber, displayedDecimals: number) => {
+  return formatPriceDifference({ price: usd, minPriceDisplayed, unitPrefix: '$', displayedDecimals, decimals: 8 })
 }
 
-export const formatBnbv2 = (bnb: BigNumber) => {
-  return formatPriceDifference({ price: bnb, minPriceDisplayed: MIN_PRICE_BNB_DISPLAYED, unitPrefix: '', decimals: 18 })
+export const formatBnbv2 = (bnb: BigNumber, displayedDecimals: number) => {
+  return formatPriceDifference({
+    price: bnb,
+    minPriceDisplayed: MIN_PRICE_BNB_DISPLAYED,
+    unitPrefix: '',
+    displayedDecimals,
+    decimals: 18,
+  })
 }
 
 export const padTime = (num: number) => num.toString().padStart(2, '0')


### PR DESCRIPTION
Bet result history shows 3 digit decimals instead of 4