### PR TITLE
perf: ScrollToTop

### DIFF
--- a/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -66,7 +66,8 @@ const FarmTable: React.FC<ITableProps> = (props) => {
   const { rows } = useTable(columns, data, { sortable: true, sortColumn: 'farm' })
 
   const scrollToTop = (): void => {
-    tableWrapperEl.current.scrollIntoView({
+    window.scrollTo({
+      top: tableWrapperEl.current.offsetTop,
       behavior: 'smooth',
     })
   }

--- a/src/views/Migration/index.tsx
+++ b/src/views/Migration/index.tsx
@@ -51,7 +51,8 @@ const MigrationPage: React.FC = () => {
   }, [cakePool])
 
   const scrollToTop = (): void => {
-    tableWrapperEl.current.scrollIntoView({
+    window.scrollTo({
+      top: tableWrapperEl.current.offsetTop,
       behavior: 'smooth',
     })
   }

--- a/src/views/Pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/views/Pools/components/PoolsTable/PoolsTable.tsx
@@ -37,11 +37,14 @@ const ScrollButtonContainer = styled.div`
 const PoolsTable: React.FC<PoolsTableProps> = ({ pools, account }) => {
   const { t } = useTranslation()
   const tableWrapperEl = useRef<HTMLDivElement>(null)
+
   const scrollToTop = (): void => {
-    tableWrapperEl.current.scrollIntoView({
+    window.scrollTo({
+      top: tableWrapperEl.current.offsetTop,
       behavior: 'smooth',
     })
   }
+
   return (
     <StyledTableBorder>
       <StyledTable id="pools-table" role="table" ref={tableWrapperEl}>


### PR DESCRIPTION
According to the farm `To Top` button when has warning banner, will only stop at half of the `CAKE-BNB LP` height. 