### PR TITLE
fix: (prediction): Open round card shows wrong entered position after refresh

### DIFF
--- a/src/config/localization/translations.json
+++ b/src/config/localization/translations.json
@@ -1760,5 +1760,6 @@
   "~%num% available to claim at sales end": "~%num% available to claim at sales end",
   "Vested percentage:": "Vested percentage:",
   "Vesting schedule:": "Vesting schedule:",
-  "Currently using Zap for liquidity provisions.": "Currently using Zap for liquidity provisions."
+  "Currently using Zap for liquidity provisions.": "Currently using Zap for liquidity provisions.",
+  "No position entered": "No position entered"
 }

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -175,7 +175,7 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
                   {t('Enter DOWN')}
                 </Button>
               </>
-            ) : (
+            ) : enteredPosition ? (
               <>
                 <div ref={targetRef}>
                   <Button disabled startIcon={getPositionEnteredIcon()} width="100%" mb="8px">
@@ -184,6 +184,15 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
                 </div>
                 <PrizePoolRow totalAmount={round.totalAmount} />
                 {tooltipVisible && tooltip}
+              </>
+            ) : (
+              <>
+                <div>
+                  <Button disabled width="100%" mb="8px">
+                    {t('No position entered')}
+                  </Button>
+                </div>
+                <PrizePoolRow totalAmount={round.totalAmount} />
               </>
             )}
           </RoundResultBox>

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useWeb3React } from '@web3-react/core'
 import {
   Card,
@@ -61,7 +61,14 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
   const { lockTimestamp } = round ?? { lockTimestamp: null }
   const { isSettingPosition, position } = state
   const [isBufferPhase, setIsBufferPhase] = useState(false)
-  const positionDisplay = position === BetPosition.BULL ? t('Up').toUpperCase() : t('Down').toUpperCase()
+  const positionDisplay = useMemo(
+    () => (position === BetPosition.BULL ? t('Up').toUpperCase() : t('Down').toUpperCase()),
+    [t, position],
+  )
+  const enteredPosition = useMemo(
+    () => (hasEnteredUp ? t('Up').toUpperCase() : hasEnteredDown ? t('Down').toUpperCase() : null),
+    [t, hasEnteredUp, hasEnteredDown],
+  )
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount)} ${token.symbol}`}</div>,
     { placement: 'top' },
@@ -172,7 +179,7 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
               <>
                 <div ref={targetRef}>
                   <Button disabled startIcon={getPositionEnteredIcon()} width="100%" mb="8px">
-                    {t('%position% Entered', { position: positionDisplay })}
+                    {t('%position% Entered', { position: enteredPosition })}
                   </Button>
                 </div>
                 <PrizePoolRow totalAmount={round.totalAmount} />

--- a/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -65,9 +65,18 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
     () => (position === BetPosition.BULL ? t('Up').toUpperCase() : t('Down').toUpperCase()),
     [t, position],
   )
-  const enteredPosition = useMemo(
+  const positionEnteredText = useMemo(
     () => (hasEnteredUp ? t('Up').toUpperCase() : hasEnteredDown ? t('Down').toUpperCase() : null),
     [t, hasEnteredUp, hasEnteredDown],
+  )
+  const positionEnteredIcon = useMemo(
+    () =>
+      hasEnteredUp ? (
+        <ArrowUpIcon color="currentColor" />
+      ) : hasEnteredDown ? (
+        <ArrowDownIcon color="currentColor" />
+      ) : null,
+    [hasEnteredUp, hasEnteredDown],
   )
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount)} ${token.symbol}`}</div>,
@@ -138,10 +147,6 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
     )
   }
 
-  const getPositionEnteredIcon = () => {
-    return position === BetPosition.BULL ? <ArrowUpIcon color="currentColor" /> : <ArrowDownIcon color="currentColor" />
-  }
-
   return (
     <CardFlip isFlipped={isSettingPosition} height="404px">
       <Card borderBackground={getBorderBackground(theme, 'next')}>
@@ -175,11 +180,11 @@ const OpenRoundCard: React.FC<OpenRoundCardProps> = ({
                   {t('Enter DOWN')}
                 </Button>
               </>
-            ) : enteredPosition ? (
+            ) : positionEnteredText ? (
               <>
                 <div ref={targetRef}>
-                  <Button disabled startIcon={getPositionEnteredIcon()} width="100%" mb="8px">
-                    {t('%position% Entered', { position: enteredPosition })}
+                  <Button disabled startIcon={positionEnteredIcon} width="100%" mb="8px">
+                    {t('%position% Entered', { position: positionEnteredText })}
                   </Button>
                 </div>
                 <PrizePoolRow totalAmount={round.totalAmount} />


### PR DESCRIPTION
To reproduce:

1. Go to prediction
2. Bet down
3. Refresh the page
4. See it displays 'Up entered'