### PR TITLE
fix: (prediction): Collect winnings button not displayed in bet results

### DIFF
--- a/src/views/Predictions/components/History/BetResult.tsx
+++ b/src/views/Predictions/components/History/BetResult.tsx
@@ -129,7 +129,7 @@ const BetResult: React.FC<BetResultProps> = ({ bet, result }) => {
         </Flex>
       </Flex>
       <StyledBetResult>
-        {result === Result.WIN && !canClaim && (
+        {result === Result.WIN && canClaim && (
           <CollectWinningsButton hasClaimed={!canClaim} width="100%" mb="16px" onSuccess={handleSuccess}>
             {bet.claimed ? t('Already Collected') : t('Collect Winnings')}
           </CollectWinningsButton>


### PR DESCRIPTION
To reproduce:

1. Go prediction history
2. Go to non claimed winning bets 
3. Expand the row
4. See colelct winnings button not displayed