### PR TITLE
fix: UseMatchBreakPoint prevMinWidth

### DIFF
--- a/packages/uikit/src/hooks/useMatchBreakpoints.ts
+++ b/packages/uikit/src/hooks/useMatchBreakpoints.ts
@@ -35,7 +35,7 @@ const mediaQueries: MediaQueries = (() => {
     const breakpoint = breakpointMap[size];
 
     // Min width for next iteration
-    prevMinWidth = breakpoint + 1;
+    prevMinWidth = breakpoint;
 
     return { ...accum, [size]: `(min-width: ${minWidth}px) and (max-width: ${breakpoint - 1}px)` };
   }, {});


### PR DESCRIPTION
@memoyil  Can you help to double check?

Width - `969px` & `967px` will show Profile & banner style was correct
Width - `968px` will jump to next breakPoint.

Before:
![Screenshot 2022-07-12 at 1 48 29 PM](https://user-images.githubusercontent.com/98292246/178418050-60c98838-3056-4c74-9ae1-c39a6031f775.png)


After:
![Screenshot 2022-07-12 at 1 48 18 PM](https://user-images.githubusercontent.com/98292246/178418141-71839569-bc6b-42ed-b6f2-022e27c46add.png)


