### PR TITLE
fix: (activity): Invisible view bscscan button text on mobile nft activity transaction details

### DIFF
--- a/src/views/Nft/market/components/Activity/MobileModal.tsx
+++ b/src/views/Nft/market/components/Activity/MobileModal.tsx
@@ -1,4 +1,4 @@
-import { InjectedModalProps, Modal, Flex, Text, Button, Link, BinanceIcon, Box } from '@pancakeswap/uikit'
+import { InjectedModalProps, Modal, Flex, Text, Button, BinanceIcon, Box } from '@pancakeswap/uikit'
 import { Price } from '@pancakeswap/sdk'
 import useTheme from 'hooks/useTheme'
 import { Activity, NftToken } from 'state/nftMarket/types'
@@ -100,7 +100,7 @@ const MobileModal: React.FC<MobileModalProps> = ({
           </Flex>
         </LightGreyCard>
         <Flex flexDirection="column" pt="16px" alignItems="center">
-          <Button as={Link} external href={getBscScanLink(activity.tx, 'transaction', chainId)}>
+          <Button as="a" external href={getBscScanLink(activity.tx, 'transaction', chainId)}>
             {t('View on BscScan')}
           </Button>
         </Flex>


### PR DESCRIPTION
<img width="404" alt="image" src="https://user-images.githubusercontent.com/2213635/180904441-07666f6a-dc54-4b32-afca-54e4949c1636.png">


This only happens on production build though. @chef-jojo I couldn't find the root cause of this issue, do you have an idea?