### PR TITLE
perf(IFO): improve token vesting panel viable

### DIFF
--- a/src/views/Ifos/components/IfoVesting/index.tsx
+++ b/src/views/Ifos/components/IfoVesting/index.tsx
@@ -88,7 +88,7 @@ const IfoVesting: React.FC<IfoVestingProps> = () => {
   }, [fetchUserVestingData])
 
   return (
-    <StyleVestingCard isActive>
+    <StyleVestingCard isActive style={{ display: cardStatus.status === VestingStatus.NOT_TOKENS_CLAIM ? `none` : `` }}>
       <CardHeader p="16px">
         <Flex justifyContent="space-between" alignItems="center">
           <Box ml="8px">


### PR DESCRIPTION
This panel should not be displayed when no tokens vesting, it will confusion users.