### PR TITLE
perf(Swap, Limit, Liquidity): Remove setting button

### DIFF
--- a/src/components/App/AppHeader.tsx
+++ b/src/components/App/AppHeader.tsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components'
-import { Text, Flex, Heading, IconButton, ArrowBackIcon, NotificationDot } from '@pancakeswap/uikit'
-import { useExpertModeManager } from 'state/user/hooks'
-import GlobalSettings from 'components/Menu/GlobalSettings'
+import { Text, Flex, Heading, IconButton, ArrowBackIcon } from '@pancakeswap/uikit'
 import Link from 'next/link'
 import Transactions from './Transactions'
 import QuestionHelper from '../QuestionHelper'
@@ -23,8 +21,6 @@ const AppHeaderContainer = styled(Flex)`
 `
 
 const AppHeader: React.FC<Props> = ({ title, subtitle, helper, backTo, noConfig = false }) => {
-  const [expertMode] = useExpertModeManager()
-
   return (
     <AppHeaderContainer>
       <Flex alignItems="center" width="100%" style={{ gap: '16px' }}>
@@ -45,9 +41,6 @@ const AppHeader: React.FC<Props> = ({ title, subtitle, helper, backTo, noConfig 
             <Heading as="h2">{title}</Heading>
             {!noConfig && (
               <Flex alignItems="center">
-                <NotificationDot show={expertMode}>
-                  <GlobalSettings />
-                </NotificationDot>
                 <Transactions />
               </Flex>
             )}

--- a/src/views/LimitOrders/components/CurrencyInputHeader.tsx
+++ b/src/views/LimitOrders/components/CurrencyInputHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import { ChartIcon, Flex, Heading, HistoryIcon, IconButton, Text, useModal, ChartDisableIcon } from '@pancakeswap/uikit'
 import TransactionsModal from 'components/App/Transactions/TransactionsModal'
-import GlobalSettings from 'components/Menu/GlobalSettings'
 
 interface Props {
   title: string
@@ -48,7 +47,6 @@ const CurrencyInputHeader: React.FC<Props> = ({ title, subtitle, setIsChartDispl
           <Heading as="h2">{title}</Heading>
         </Flex>
         <Flex flex="1" justifyContent="flex-end">
-          <GlobalSettings color="textSubtle" mr="0" />
           <IconButton onClick={onPresentTransactionsModal} variant="text" scale="sm">
             <HistoryIcon color="textSubtle" width="24px" />
           </IconButton>

--- a/src/views/Swap/components/CurrencyInputHeader.tsx
+++ b/src/views/Swap/components/CurrencyInputHeader.tsx
@@ -1,18 +1,6 @@
 import styled from 'styled-components'
-import {
-  ChartIcon,
-  Flex,
-  Heading,
-  HistoryIcon,
-  IconButton,
-  NotificationDot,
-  Text,
-  useModal,
-  ChartDisableIcon,
-} from '@pancakeswap/uikit'
+import { ChartIcon, Flex, Heading, HistoryIcon, IconButton, Text, useModal, ChartDisableIcon } from '@pancakeswap/uikit'
 import TransactionsModal from 'components/App/Transactions/TransactionsModal'
-import GlobalSettings from 'components/Menu/GlobalSettings'
-import { useExpertModeManager } from 'state/user/hooks'
 import RefreshIcon from 'components/Svg/RefreshIcon'
 import { useCallback } from 'react'
 
@@ -46,7 +34,6 @@ const CurrencyInputHeader: React.FC<Props> = ({
   hasAmount,
   onRefreshPrice,
 }) => {
-  const [expertMode] = useExpertModeManager()
   const toggleChartDisplayed = () => {
     setIsChartDisplayed((currentIsChartDisplayed) => !currentIsChartDisplayed)
   }
@@ -61,13 +48,10 @@ const CurrencyInputHeader: React.FC<Props> = ({
             {isChartDisplayed ? <ChartDisableIcon color="textSubtle" /> : <ChartIcon width="24px" color="textSubtle" />}
           </ColoredIconButton>
         )}
-        <Flex flexDirection="column" alignItems="flex-end" width="100%" mr={18}>
+        <Flex flexDirection="column" alignItems="flex-end" width="100%" mr={50}>
           <Heading as="h2">{title}</Heading>
         </Flex>
         <Flex>
-          <NotificationDot show={expertMode}>
-            <GlobalSettings color="textSubtle" mr="0" />
-          </NotificationDot>
           <IconButton onClick={onPresentTransactionsModal} variant="text" scale="sm">
             <HistoryIcon color="textSubtle" width="24px" />
           </IconButton>


### PR DESCRIPTION
The setting buttons of Swap, Limit, Liquidity are the same as those of Header, which may cause confusion for users.

e.g: Slippage Tolerance is not available for limit orders