### PR TITLE
fix: Circle svg distribution issue in firefox

### DIFF
--- a/src/views/AddLiquidity/components/common.tsx
+++ b/src/views/AddLiquidity/components/common.tsx
@@ -27,7 +27,7 @@ const CircleSvg = ({ percent = 1, ...props }: SvgProps & { percent?: number }) =
         fill="transparent"
         stroke="#1FC7D4"
         strokeWidth="10"
-        strokeDasharray={`calc(${percent * 100} * 31.4 / 100) 31.4`}
+        strokeDasharray={`calc(${percent * 100}px * 31.4 / 100) 31.4`}
         transform="rotate(-90) translate(-20)"
       />
     </g>


### PR DESCRIPTION
To reproduce:

1. Go to add liquidity in firefox
2. Add liquidity
3. See circle graph in modal shows only one pair instead of showing 2 pieces