### PR TITLE
perf: Use img onerror for fallback instead of picture tag to not load fallback always

### DIFF
--- a/src/components/PhishingWarningBanner/index.tsx
+++ b/src/components/PhishingWarningBanner/index.tsx
@@ -79,11 +79,18 @@ const PhishingWarningBanner: React.FC = () => {
       ) : (
         <>
           <InnerContainer>
-            <picture>
-              <source type="image/webp" srcSet="/images/decorations/phishing-warning-bunny.webp" />
-              <source type="image/png" srcSet="/images/decorations/phishing-warning-bunny.png" />
-              <img src="/images/decorations/phishing-warning-bunny.png" alt="phishing-warning" width="92px" />
-            </picture>
+            <img
+              src="/images/decorations/phishing-warning-bunny.webp"
+              alt="phishing-warning"
+              width="92px"
+              onError={(e) => {
+                const fallbackSrc = '/images/decorations/phishing-warning-bunny.png'
+                if (!e.currentTarget.src.endsWith(fallbackSrc)) {
+                  // eslint-disable-next-line no-param-reassign
+                  e.currentTarget.src = fallbackSrc
+                }
+              }}
+            />
             <SpeechBubble>{warningTextComponent}</SpeechBubble>
           </InnerContainer>
           <IconButton onClick={hideBanner} variant="text">

--- a/src/views/Home/components/CompositeImage.tsx
+++ b/src/views/Home/components/CompositeImage.tsx
@@ -86,18 +86,48 @@ export const getSrcSet = (base: string, imageSrc: string, extension = '.png') =>
 const CompositeImage: React.FC<ComponentProps> = ({ path, attributes, maxHeight = '512px' }) => {
   return (
     <Wrapper maxHeight={maxHeight}>
-      <picture>
-        <source type="image/webp" srcSet={getSrcSet(path, attributes[0].src, '.webp')} />
-        <source type="image/png" srcSet={getSrcSet(path, attributes[0].src)} />
-        <DummyImg src={getImageUrl(path, attributes[0].src)} maxHeight={maxHeight} loading="lazy" decoding="async" />
-      </picture>
+      <DummyImg
+        srcSet={getSrcSet(path, attributes[0].src, '.webp')}
+        maxHeight={maxHeight}
+        loading="lazy"
+        decoding="async"
+        onError={(e) => {
+          const fallbackSrcSet = getSrcSet(path, attributes[0].src)
+          if (e.currentTarget.srcset !== '' && e.currentTarget.srcset !== fallbackSrcSet) {
+            // eslint-disable-next-line no-param-reassign
+            e.currentTarget.srcset = fallbackSrcSet
+          } else {
+            const fallbackSrc = getImageUrl(path, attributes[0].src)
+            if (e.currentTarget.srcset !== '' && !e.currentTarget.src.endsWith(fallbackSrc)) {
+              // eslint-disable-next-line no-param-reassign
+              e.currentTarget.srcset = ''
+              // eslint-disable-next-line no-param-reassign
+              e.currentTarget.src = fallbackSrc
+            }
+          }
+        }}
+      />
       {attributes.map((image) => (
         <ImageWrapper key={image.src}>
-          <picture>
-            <source type="image/webp" srcSet={getSrcSet(path, image.src, '.webp')} />
-            <source type="image/png" srcSet={getSrcSet(path, image.src)} />
-            <img src={getImageUrl(path, image.src)} alt={image.alt} loading="lazy" decoding="async" />
-          </picture>
+          <img
+            srcSet={getSrcSet(path, image.src, '.webp')}
+            alt={image.alt}
+            onError={(e) => {
+              const fallbackSrcSet = getSrcSet(path, image.src)
+              if (e.currentTarget.srcset !== '' && e.currentTarget.srcset !== fallbackSrcSet) {
+                // eslint-disable-next-line no-param-reassign
+                e.currentTarget.srcset = fallbackSrcSet
+              } else {
+                const fallbackSrc = getImageUrl(path, image.src)
+                if (e.currentTarget.srcset !== '' && !e.currentTarget.src.endsWith(fallbackSrc)) {
+                  // eslint-disable-next-line no-param-reassign
+                  e.currentTarget.srcset = ''
+                  // eslint-disable-next-line no-param-reassign
+                  e.currentTarget.src = fallbackSrc
+                }
+              }
+            }}
+          />
         </ImageWrapper>
       ))}
     </Wrapper>


### PR DESCRIPTION
Some browsers (safari, firefox i.e) still has a issue to load fallback even the original image is already available if picture tag is used, this causes to increase bandwidth.

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/2213635/182663687-a91ea47e-a2c5-42bb-a7f6-70719222c99f.png">

It saves ~400kb data if page loaded without cache

<img width="381" alt="image" src="https://user-images.githubusercontent.com/2213635/182666605-0b48bdc3-a964-450a-a6fc-b91185151f0a.png">

<img width="332" alt="image" src="https://user-images.githubusercontent.com/2213635/182666700-ab85951b-1bda-46ea-b3bc-6b63dfc1117e.png">


