### PR TITLE
chore: use lazy motion in MotionBox

### DIFF
--- a/packages/uikit/src/components/Box/Box.tsx
+++ b/packages/uikit/src/components/Box/Box.tsx
@@ -1,4 +1,4 @@
-import { motion } from "framer-motion";
+import { m as motion } from "framer-motion";
 import styled from "styled-components";
 import { background, border, layout, position, space, color } from "styled-system";
 import { BoxProps } from "./types";


### PR DESCRIPTION
for now, MotionBox is only used by ModalContainer
and in ModalContext there's a LazyMotion wrapper
<img width="1049" alt="" src="https://user-images.githubusercontent.com/99634186/182995386-5fc4f494-4a13-4297-a80a-6b646286b67f.png">


 