### PR TITLE
fix: Minus zero displayed in lp rewards apr in roi calculator in farms

### DIFF
--- a/src/components/RoiCalculatorModal/RoiCalculatorFooter.tsx
+++ b/src/components/RoiCalculatorModal/RoiCalculatorFooter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import styled from 'styled-components'
 import { Flex, Box, Text, ExpandableLabel, LinkExternal, Grid, HelpIcon, useTooltip } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
@@ -72,7 +72,10 @@ const RoiCalculatorFooter: React.FC<React.PropsWithChildren<RoiCalculatorFooterP
   )
 
   const gridRowCount = isFarm ? 4 : 2
-  const lpRewardsAPR = (Number(displayApr) - apr).toFixed(2)
+  const lpRewardsAPR = useMemo(
+    () => (isFarm ? Math.max(Number(displayApr) - apr, 0).toFixed(2) : null),
+    [isFarm, displayApr, apr],
+  )
 
   return (
     <Footer p="16px" flexDirection="column">


### PR DESCRIPTION
When lp rewards apr is 0, it displays as minus zero because of the diff between display apr and apr has fractions

<img width="354" alt="Screenshot 2022-08-06 at 15 07 09" src="https://user-images.githubusercontent.com/2213635/183251880-d9d2abb3-275e-43d6-bc4d-b987a2125e56.png">
