### PR TITLE
fix: Transaction description in recent trxs can be off if slippage is too high and add translation support

### DIFF
--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1855,5 +1855,9 @@
   "0.0001 CAKE required for enabling extension": "0.0001 CAKE required for enabling extension",
   "Recommend choosing \"MAX\" to renew your staking position in order to keep similar yield boost.": "Recommend choosing \"MAX\" to renew your staking position in order to keep similar yield boost.",
   "Add to %wallet%": "Add to %wallet%",
-  "Add %asset% to %wallet%": "Add %asset% to %wallet%"
+  "Add %asset% to %wallet%": "Add %asset% to %wallet%",
+  "Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol%": "Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol%",
+  "Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol% to %recipientAddress%": "Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol% to %recipientAddress%",
+  "Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol%": "Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol%",
+  "Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol% to %recipientAddress%": "Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol% to %recipientAddress%"
 }

--- a/src/__tests__/translations.test.ts
+++ b/src/__tests__/translations.test.ts
@@ -26,6 +26,10 @@ const whitelist = [
   `These bunnies like their pancakes with blueberries. What's your favorite topping?`,
   "Love makes the world go 'round... but so do pancakes. And these bunnies know it.",
   `It’s sparkling syrup, pancakes, and even lottery tickets! This bunny really loves it.`,
+  'Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol%',
+  'Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol% to %recipientAddress%',
+  'Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol%',
+  'Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol% to %recipientAddress%',
 ]
 
 describe('Check translations integrity', () => {

--- a/src/components/Menu/UserMenu/TransactionRow.tsx
+++ b/src/components/Menu/UserMenu/TransactionRow.tsx
@@ -1,5 +1,6 @@
 import { BlockIcon, CheckmarkCircleIcon, Flex, Link, OpenNewIcon, RefreshIcon } from '@pancakeswap/uikit'
 import styled from 'styled-components'
+import { useTranslation } from '@pancakeswap/localization'
 import { TransactionDetails } from 'state/transactions/reducer'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { getBscScanLink } from 'utils'
@@ -44,6 +45,7 @@ const renderIcon = (txn: TransactionDetails) => {
 }
 
 const TransactionRow: React.FC<TransactionRowProps> = ({ txn }) => {
+  const { t } = useTranslation()
   const { chainId } = useActiveWeb3React()
 
   if (!txn) {
@@ -53,7 +55,11 @@ const TransactionRow: React.FC<TransactionRowProps> = ({ txn }) => {
   return (
     <TxnLink href={getBscScanLink(txn.hash, 'transaction', chainId)} external>
       <TxnIcon>{renderIcon(txn)}</TxnIcon>
-      <Summary>{txn.summary ?? txn.hash}</Summary>
+      <Summary>
+        {txn.translatableSummary
+          ? t(txn.translatableSummary.text, txn.translatableSummary.data)
+          : txn.summary ?? txn.hash}
+      </Summary>
       <TxnIcon>
         <OpenNewIcon width="24px" color="primary" />
       </TxnIcon>

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { Contract } from '@ethersproject/contracts'
-import { SwapParameters, Trade } from '@pancakeswap/sdk'
+import { SwapParameters, Trade, TradeType } from '@pancakeswap/sdk'
 import { useTranslation } from '@pancakeswap/localization'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useMemo } from 'react'
@@ -12,6 +12,7 @@ import { calculateGasMargin, isAddress } from '../utils'
 import isZero from '../utils/isZero'
 import { useSwapCallArguments } from './useSwapCallArguments'
 import { transactionErrorToUserReadableMessage } from '../utils/transactionErrorToUserReadableMessage'
+import { basisPointsToPercent } from '../utils/exchange'
 
 export enum SwapCallbackState {
   INVALID,
@@ -128,10 +129,21 @@ export function useSwapCallback(
           .then((response: any) => {
             const inputSymbol = trade.inputAmount.currency.symbol
             const outputSymbol = trade.outputAmount.currency.symbol
-            const inputAmount = trade.inputAmount.toSignificant(3)
-            const outputAmount = trade.outputAmount.toSignificant(3)
+            const pct = basisPointsToPercent(allowedSlippage)
+            const inputAmount =
+              trade.tradeType === TradeType.EXACT_INPUT
+                ? trade.inputAmount.toSignificant(3)
+                : trade.maximumAmountIn(pct).toSignificant(3)
+            const outputAmount =
+              trade.tradeType === TradeType.EXACT_OUTPUT
+                ? trade.outputAmount.toSignificant(3)
+                : trade.minimumAmountOut(pct).toSignificant(3)
 
-            const base = `Swap ${inputAmount} ${inputSymbol} for ${outputAmount} ${outputSymbol}`
+            const base = `Swap ${
+              trade.tradeType === TradeType.EXACT_OUTPUT ? 'max.' : ''
+            } ${inputAmount} ${inputSymbol} for ${
+              trade.tradeType === TradeType.EXACT_INPUT ? 'min.' : ''
+            } ${outputAmount} ${outputSymbol}`
             const withRecipient =
               recipient === account
                 ? base
@@ -159,5 +171,17 @@ export function useSwapCallback(
       },
       error: null,
     }
-  }, [trade, library, account, chainId, recipient, recipientAddress, swapCalls, gasPrice, t, addTransaction])
+  }, [
+    trade,
+    library,
+    account,
+    chainId,
+    recipient,
+    recipientAddress,
+    swapCalls,
+    gasPrice,
+    t,
+    addTransaction,
+    allowedSlippage,
+  ])
 }

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -144,15 +144,33 @@ export function useSwapCallback(
             } ${inputAmount} ${inputSymbol} for ${
               trade.tradeType === TradeType.EXACT_INPUT ? 'min.' : ''
             } ${outputAmount} ${outputSymbol}`
-            const withRecipient =
-              recipient === account
-                ? base
-                : `${base} to ${
-                    recipientAddress && isAddress(recipientAddress) ? truncateHash(recipientAddress) : recipientAddress
-                  }`
+
+            const recipientAddressText =
+              recipientAddress && isAddress(recipientAddress) ? truncateHash(recipientAddress) : recipientAddress
+
+            const withRecipient = recipient === account ? base : `${base} to ${recipientAddressText}`
+
+            const translatableWithRecipient =
+              trade.tradeType === TradeType.EXACT_OUTPUT
+                ? recipient === account
+                  ? 'Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol%'
+                  : 'Swap max. %inputAmount% %inputSymbol% for %outputAmount% %outputSymbol% to %recipientAddress%'
+                : recipient === account
+                ? 'Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol%'
+                : 'Swap %inputAmount% %inputSymbol% for min. %outputAmount% %outputSymbol% to %recipientAddress%'
 
             addTransaction(response, {
               summary: withRecipient,
+              translatableSummary: {
+                text: translatableWithRecipient,
+                data: {
+                  inputAmount,
+                  inputSymbol,
+                  outputAmount,
+                  outputSymbol,
+                  ...(recipient !== account && { recipientAddress: recipientAddressText }),
+                },
+              },
               type: 'swap',
             })
 

--- a/src/state/transactions/actions.ts
+++ b/src/state/transactions/actions.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@reduxjs/toolkit'
 import { ChainId } from '@pancakeswap/sdk'
 import { Order } from '@gelatonetwork/limit-orders-lib'
+import { ReactText } from 'react'
 
 export type TransactionType =
   | 'approve'
@@ -30,6 +31,7 @@ export const addTransaction = createAction<{
   approval?: { tokenAddress: string; spender: string }
   claim?: { recipient: string }
   summary?: string
+  translatableSummary?: { text: string; data: Record<string, ReactText> }
   type?: TransactionType
   order?: Order
 }>('transactions/addTransaction')

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -1,5 +1,5 @@
 import { TransactionResponse } from '@ethersproject/providers'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, ReactText } from 'react'
 import { useSelector } from 'react-redux'
 import { Order } from '@gelatonetwork/limit-orders-lib'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
@@ -12,6 +12,7 @@ export function useTransactionAdder(): (
   response: TransactionResponse,
   customData?: {
     summary?: string
+    translatableSummary?: { text: string; data: Record<string, ReactText> }
     approval?: { tokenAddress: string; spender: string }
     claim?: { recipient: string }
     type?: TransactionType
@@ -26,12 +27,14 @@ export function useTransactionAdder(): (
       response: TransactionResponse,
       {
         summary,
+        translatableSummary,
         approval,
         claim,
         type,
         order,
       }: {
         summary?: string
+        translatableSummary?: { text: string; data: Record<string, ReactText> }
         claim?: { recipient: string }
         approval?: { tokenAddress: string; spender: string }
         type?: TransactionType
@@ -45,7 +48,9 @@ export function useTransactionAdder(): (
       if (!hash) {
         throw Error('No transaction hash found.')
       }
-      dispatch(addTransaction({ hash, from: account, chainId, approval, summary, claim, type, order }))
+      dispatch(
+        addTransaction({ hash, from: account, chainId, approval, summary, translatableSummary, claim, type, order }),
+      )
     },
     [dispatch, chainId, account],
   )

--- a/src/state/transactions/reducer.ts
+++ b/src/state/transactions/reducer.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { ReactText } from 'react'
 import { createReducer } from '@reduxjs/toolkit'
 import { Order } from '@gelatonetwork/limit-orders-lib'
 import { confirmOrderCancellation, confirmOrderSubmission, saveOrder } from 'utils/localStorageOrders'
@@ -20,6 +21,7 @@ export interface TransactionDetails {
   type?: TransactionType
   order?: Order
   summary?: string
+  translatableSummary?: { text: string; data: Record<string, ReactText> }
   claim?: { recipient: string }
   receipt?: SerializableTransactionReceipt
   lastCheckedBlockNumber?: number
@@ -40,12 +42,15 @@ export default createReducer(initialState, (builder) =>
   builder
     .addCase(
       addTransaction,
-      (transactions, { payload: { chainId, from, hash, approval, summary, claim, type, order } }) => {
+      (
+        transactions,
+        { payload: { chainId, from, hash, approval, summary, translatableSummary, claim, type, order } },
+      ) => {
         if (transactions[chainId]?.[hash]) {
           throw Error('Attempted to add existing transaction.')
         }
         const txs = transactions[chainId] ?? {}
-        txs[hash] = { hash, approval, summary, claim, from, addedTime: now(), type, order }
+        txs[hash] = { hash, approval, summary, translatableSummary, claim, from, addedTime: now(), type, order }
         transactions[chainId] = txs
         if (order) saveOrder(chainId, from, order, true)
       },


### PR DESCRIPTION
This creates confusion to the users where there is discrepancy between onchain data and pcs website