### PR TITLE
fix: (pottery): Undefined nickname is displayed when winner has no profile

### DIFF
--- a/src/views/Pottery/components/FinishedRounds/AllHistoryCard/Winner.tsx
+++ b/src/views/Pottery/components/FinishedRounds/AllHistoryCard/Winner.tsx
@@ -37,9 +37,11 @@ const Winner: React.FC<React.PropsWithChildren<WinnerProps>> = ({ address }) => 
             <Text fontSize="12px" color="primary">
               {truncateHash(address)}
             </Text>
-            <Text fontSize="12px" color="primary">
-              {`@${profile?.username}`}
-            </Text>
+            {profile?.username && (
+              <Text fontSize="12px" color="primary">
+                {`@${profile?.username}`}
+              </Text>
+            )}
           </Box>
         </>
       ) : (


### PR DESCRIPTION
Before: 

<img width="305" alt="image" src="https://user-images.githubusercontent.com/2213635/184485019-5c2cc04a-6bf7-4857-8462-5236544b284e.png">

After: 

<img width="310" alt="image" src="https://user-images.githubusercontent.com/2213635/184484856-aa88e77c-c08c-461e-b82d-91dde9a9ceee.png">
