### PR TITLE
refactor: Use locale lowercase only in translations

### DIFF
--- a/packages/uikit/src/widgets/WalletModal/WalletCard.tsx
+++ b/packages/uikit/src/widgets/WalletModal/WalletCard.tsx
@@ -60,7 +60,7 @@ const WalletCard: React.FC<React.PropsWithChildren<Props>> = ({ login, walletCon
           onDismiss();
         }
       }}
-      id={`wallet-connect-${title.toLocaleLowerCase()}`}
+      id={`wallet-connect-${title.toLowerCase()}`}
     >
       <Icon width="40px" mb="8px" />
       <Text fontSize="14px">{title}</Text>

--- a/src/state/pools/helpers.ts
+++ b/src/state/pools/helpers.ts
@@ -156,8 +156,8 @@ export const transformVault = (vaultKey: VaultKey, vault: SerializedCakeVault): 
 
 export const getTokenPricesFromFarm = (farms: SerializedFarm[]) => {
   return farms.reduce((prices, farm) => {
-    const quoteTokenAddress = farm.quoteToken.address.toLocaleLowerCase()
-    const tokenAddress = farm.token.address.toLocaleLowerCase()
+    const quoteTokenAddress = farm.quoteToken.address.toLowerCase()
+    const tokenAddress = farm.token.address.toLowerCase()
     /* eslint-disable no-param-reassign */
     if (!prices[quoteTokenAddress]) {
       prices[quoteTokenAddress] = new BigNumber(farm.quoteTokenPriceBusd).toNumber()

--- a/src/utils/apr.ts
+++ b/src/utils/apr.ts
@@ -45,7 +45,7 @@ export const getFarmApr = (
   if (!cakeRewardsApr.isNaN() && cakeRewardsApr.isFinite()) {
     cakeRewardsAprAsNumber = cakeRewardsApr.toNumber()
   }
-  const lpRewardsApr = lpAprs[farmAddress?.toLocaleLowerCase()] ?? 0
+  const lpRewardsApr = lpAprs[farmAddress?.toLowerCase()] ?? 0
   return { cakeRewardsApr: cakeRewardsAprAsNumber, lpRewardsApr }
 }
 

--- a/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
+++ b/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
@@ -197,7 +197,7 @@ const ContributeModal: React.FC<React.PropsWithChildren<Props>> = ({
                 src={
                   ifo.currency.symbol === 'CAKE'
                     ? '/images/cake.svg'
-                    : `/images/farms/${currency.symbol.split(' ')[0].toLocaleLowerCase()}.svg`
+                    : `/images/farms/${currency.symbol.split(' ')[0].toLowerCase()}.svg`
                 }
                 width={24}
                 height={24}

--- a/src/views/Pottery/components/Pot/Deposit/index.tsx
+++ b/src/views/Pottery/components/Pot/Deposit/index.tsx
@@ -58,7 +58,7 @@ const Deposit: React.FC<React.PropsWithChildren> = () => {
   }, [getStatus, totalLockCake, totalLockedValue])
 
   const currentDeposit = userData.withdrawAbleData.find(
-    (data) => data.potteryVaultAddress.toLocaleLowerCase() === lastVaultAddress.toLocaleLowerCase(),
+    (data) => data.potteryVaultAddress.toLowerCase() === lastVaultAddress.toLowerCase(),
   )
 
   const depositBalance = useMemo(() => {

--- a/src/views/Profile/components/ActivityHistory/index.tsx
+++ b/src/views/Profile/components/ActivityHistory/index.tsx
@@ -45,7 +45,7 @@ const ActivityHistory = () => {
   useEffect(() => {
     const fetchAddressActivity = async () => {
       try {
-        const addressActivity = await getUserActivity(accountAddress.toLocaleLowerCase())
+        const addressActivity = await getUserActivity(accountAddress.toLowerCase())
         setSortedUserActivities(sortUserActivity(accountAddress, addressActivity))
         setIsLoading(false)
       } catch (error) {


### PR DESCRIPTION
Locale lowercase might return unexpected results when it is used in address or non-text variables