### PR TITLE
refactor: Use css text transform for uppercase instead of toLocaleUppercase

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -117,10 +117,7 @@ export default function CurrencyInputPanel({
 }: CurrencyInputPanelProps) {
   const { account } = useActiveWeb3React()
   const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
-  const {
-    t,
-    currentLanguage: { locale },
-  } = useTranslation()
+  const { t } = useTranslation()
 
   const token = pair ? pair.liquidityToken : currency?.isToken ? currency : null
   const tokenAddress = token ? isAddress(token.address) : null
@@ -236,8 +233,8 @@ export default function CurrencyInputPanel({
               </Text>
             )}
             {account && currency && !disabled && showMaxButton && label !== 'To' && (
-              <Button onClick={onMax} scale="xs" variant="secondary">
-                {t('Max').toLocaleUpperCase(locale)}
+              <Button onClick={onMax} scale="xs" variant="secondary" style={{ textTransform: 'uppercase' }}>
+                {t('Max')}
               </Button>
             )}
           </InputRow>

--- a/src/components/RoiCalculatorModal/index.tsx
+++ b/src/components/RoiCalculatorModal/index.tsx
@@ -225,11 +225,12 @@ const RoiCalculatorModal: React.FC<React.PropsWithChildren<RoiCalculatorModalPro
               p="4px 16px"
               width="128px"
               variant="tertiary"
+              style={{ textTransform: 'uppercase' }}
               onClick={() =>
                 setPrincipalFromUSDValue(getBalanceNumber(stakingTokenBalance.times(stakingTokenPrice)).toString())
               }
             >
-              {t('My Balance').toLocaleUpperCase()}
+              {t('My Balance')}
             </Button>
             <span ref={targetRef}>
               <HelpIcon width="16px" height="16px" color="textSubtle" />

--- a/src/views/Pottery/components/WinRateModal/ButtonMenu.tsx
+++ b/src/views/Pottery/components/WinRateModal/ButtonMenu.tsx
@@ -41,10 +41,11 @@ const ButtonMenu: React.FC<React.PropsWithChildren<ButtonMenuProps>> = ({
         p="4px 16px"
         width="128px"
         variant="tertiary"
+        style={{ textTransform: 'uppercase' }}
         disabled={!stakingTokenBalance.isFinite() || stakingTokenBalance.lte(0) || !account}
         onClick={() => setPrincipalFromUSDValue(getBalanceNumber(stakingTokenBalance.times(cakePrice)).toString())}
       >
-        {t('My Balance').toLocaleUpperCase()}
+        {t('My Balance')}
       </Button>
       <span ref={targetRef}>
         <HelpIcon width="16px" height="16px" color="textSubtle" />


### PR DESCRIPTION
toLocaleUppercase uses locale of system default unless explicitly passed which results wrong conversion on some languages, therefore css text transform is better option 