### PR TITLE
fix: Link inside Booster tooltip cannot be clicked in mobile

### DIFF
--- a/packages/uikit/src/hooks/useTooltip/types.ts
+++ b/packages/uikit/src/hooks/useTooltip/types.ts
@@ -12,6 +12,7 @@ export interface TooltipOptions {
   arrowPadding?: Padding;
   tooltipPadding?: Padding;
   tooltipOffset?: [number, number];
+  hideTimeout?: number;
 }
 
 export type TriggerType = "click" | "hover" | "focus";

--- a/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -35,6 +35,7 @@ const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipR
     arrowPadding = 16,
     tooltipPadding = { left: 16, right: 16 },
     tooltipOffset = [0, 10],
+    hideTimeout = 100,
   } = options;
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
   const [tooltipElement, setTooltipElement] = useState<HTMLElement | null>(null);
@@ -42,7 +43,7 @@ const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipR
 
   const [visible, setVisible] = useState(false);
   const isHoveringOverTooltip = useRef(false);
-  const hideTimeout = useRef<number>();
+  const hideTimeoutRef = useRef<number>();
 
   const hideTooltip = useCallback(
     (e: Event) => {
@@ -53,24 +54,24 @@ const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipR
       };
 
       if (trigger === "hover") {
-        if (hideTimeout.current) {
-          window.clearTimeout(hideTimeout.current);
+        if (hideTimeoutRef.current) {
+          window.clearTimeout(hideTimeoutRef.current);
         }
         if (e.target === tooltipElement) {
           isHoveringOverTooltip.current = false;
         }
         if (!isHoveringOverTooltip.current) {
-          hideTimeout.current = window.setTimeout(() => {
+          hideTimeoutRef.current = window.setTimeout(() => {
             if (!isHoveringOverTooltip.current) {
               hide();
             }
-          }, 100);
+          }, hideTimeout);
         }
       } else {
         hide();
       }
     },
-    [tooltipElement, trigger]
+    [tooltipElement, trigger, hideTimeout]
   );
 
   const showTooltip = useCallback(
@@ -82,7 +83,7 @@ const useTooltip = (content: React.ReactNode, options: TooltipOptions): TooltipR
         if (e.target === targetElement) {
           // If we were about to close the tooltip and got back to it
           // then prevent closing it.
-          clearTimeout(hideTimeout.current);
+          clearTimeout(hideTimeoutRef.current);
         }
         if (e.target === tooltipElement) {
           isHoveringOverTooltip.current = true;

--- a/src/views/Farms/components/YieldBooster/components/ActionButton.tsx
+++ b/src/views/Farms/components/YieldBooster/components/ActionButton.tsx
@@ -47,6 +47,7 @@ const ActionButton: React.FC<ActionButtonPropsType> = ({ title, description, but
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(<BoosterTooltip />, {
     placement: 'top',
+    hideTimeout: 1500,
   })
 
   if (button) {

--- a/src/views/Farms/components/YieldBooster/components/ActionButton.tsx
+++ b/src/views/Farms/components/YieldBooster/components/ActionButton.tsx
@@ -8,6 +8,7 @@ import {
   TooltipText,
   useTooltip,
   LinkExternal,
+  useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import _isEmpty from 'lodash/isEmpty'
 import { ReactNode } from 'react'
@@ -43,11 +44,12 @@ const BoosterTooltip = () => {
 }
 
 const ActionButton: React.FC<ActionButtonPropsType> = ({ title, description, button, ...props }) => {
+  const { isMobile } = useMatchBreakpoints()
   let btn = null
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(<BoosterTooltip />, {
     placement: 'top',
-    hideTimeout: 1500,
+    ...(isMobile && { hideTimeout: 1500 }),
   })
 
   if (button) {


### PR DESCRIPTION
To reproduce: 

1. Go to mobile
2. Go to boosted farm
3. Tap yield booster tooltip
4. Link cannot be tapped because it disappears so quickly