### PR TITLE
fix: Make Boosted Apr calculation based on cake rewards apr

### DIFF
--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -98,7 +98,9 @@ const FarmCard: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
             <Text bold style={{ display: 'flex', alignItems: 'center' }}>
               {farm.apr ? (
                 <>
-                  {farm.boosted ? <BoostedApr mr="4px" apr={displayApr} pid={farm?.pid} /> : null}
+                  {farm.boosted ? (
+                    <BoostedApr mr="4px" lpRewardsApr={farm.lpRewardsApr} apr={farm.apr} pid={farm?.pid} />
+                  ) : null}
                   <ApyButton
                     variant="text-and-button"
                     pid={farm.pid}

--- a/src/views/Farms/components/FarmTable/Apr.tsx
+++ b/src/views/Farms/components/FarmTable/Apr.tsx
@@ -11,6 +11,7 @@ export interface AprProps {
   pid: number
   lpLabel: string
   lpSymbol: string
+  lpRewardsApr: number
   tokenAddress?: string
   quoteTokenAddress?: string
   cakePrice: BigNumber

--- a/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -138,6 +138,7 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({ farms, cake
         tokenAddress,
         quoteTokenAddress,
         cakePrice,
+        lpRewardsApr: farm.lpRewardsApr,
         originalValue: farm.apr,
       },
       farm: {

--- a/src/views/Farms/components/FarmTable/Row.tsx
+++ b/src/views/Farms/components/FarmTable/Row.tsx
@@ -137,7 +137,13 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                     <CellInner>
                       <CellLayout label={t('APR')}>
                         <Apr {...props.apr} hideButton={isSmallerScreen} strikethrough={props?.details?.boosted} />
-                        {props?.details?.boosted ? <BoostedApr apr={props?.apr?.value} pid={props.farm?.pid} /> : null}
+                        {props?.details?.boosted ? (
+                          <BoostedApr
+                            lpRewardsApr={props?.apr?.lpRewardsApr}
+                            apr={props?.apr?.originalValue}
+                            pid={props.farm?.pid}
+                          />
+                        ) : null}
                       </CellLayout>
                     </CellInner>
                   </td>
@@ -189,7 +195,13 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
             <AprMobileCell>
               <CellLayout label={t('APR')}>
                 <Apr {...props.apr} hideButton strikethrough={props?.details?.boosted} />
-                {props?.details?.boosted ? <BoostedApr apr={props?.apr?.value} pid={props.farm?.pid} /> : null}
+                {props?.details?.boosted ? (
+                  <BoostedApr
+                    lpRewardsApr={props?.apr?.lpRewardsApr}
+                    apr={props?.apr?.originalValue}
+                    pid={props.farm?.pid}
+                  />
+                ) : null}
               </CellLayout>
             </AprMobileCell>
           </td>

--- a/src/views/Farms/components/YieldBooster/components/BoostedApr.tsx
+++ b/src/views/Farms/components/YieldBooster/components/BoostedApr.tsx
@@ -9,20 +9,25 @@ import { YieldBoosterState } from '../hooks/useYieldBoosterState'
 import { YieldBoosterStateContext } from './ProxyFarmContainer'
 
 interface BoostedAprPropsType {
-  apr: string
+  apr: number
+  lpRewardsApr: number
   pid: number
   mr?: string
 }
 
 function BoostedApr(props: BoostedAprPropsType) {
-  const { apr, pid, ...rest } = props
+  const { lpRewardsApr, apr, pid, ...rest } = props
   const { boosterState, proxyAddress } = useContext(YieldBoosterStateContext)
   const { t } = useTranslation()
 
   const multiplier = useBoostMultipler({ pid, boosterState, proxyAddress })
 
   const boostedApr =
-    (!isUndefinedOrNull(multiplier) && !isUndefinedOrNull(apr) && formatNumber(_toNumber(apr) * Number(multiplier))) ||
+    (!isUndefinedOrNull(multiplier) &&
+      !isUndefinedOrNull(apr) &&
+      formatNumber(
+        _toNumber(apr) * Number(multiplier) + (!isUndefinedOrNull(lpRewardsApr) ? _toNumber(lpRewardsApr) : 0),
+      )) ||
     '0'
 
   const msg =

--- a/src/views/Migration/components/MigrationStep2/NewFarm/index.tsx
+++ b/src/views/Migration/components/MigrationStep2/NewFarm/index.tsx
@@ -85,6 +85,7 @@ const OldFarmStep1: React.FC<React.PropsWithChildren> = () => {
         tokenAddress,
         quoteTokenAddress,
         cakePrice,
+        lpRewardsApr: farm.lpRewardsApr,
         originalValue: farm.apr,
       },
       farm: {


### PR DESCRIPTION
I am not sure on this but boosted apr should be calculated based on cake rewards apr not the total apr which includes lp rewards apr. 