### PR TITLE
fix: (farms): Farms userdata reset after harvest until next fetch

### DIFF
--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -256,7 +256,10 @@ export const farmsSlice = createSlice({
       const userDataMap = fromPairs(action.payload.map((userDataEl) => [userDataEl.pid, userDataEl]))
       state.data = state.data.map((farm) => {
         const userDataEl = userDataMap[farm.pid]
-        return { ...farm, userData: userDataEl }
+        if (userDataEl) {
+            return { ...farm, userData: userDataEl }
+        }
+        return farm
       })
       state.userDataLoaded = true
     })

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -257,7 +257,7 @@ export const farmsSlice = createSlice({
       state.data = state.data.map((farm) => {
         const userDataEl = userDataMap[farm.pid]
         if (userDataEl) {
-            return { ...farm, userData: userDataEl }
+          return { ...farm, userData: userDataEl }
         }
         return farm
       })


### PR DESCRIPTION
To reproduce: 

Harvest any farm when multiple farms staked
See only the farm that is harvested userdata is available until the next userdata fetch
