### PR TITLE
fix(Prediction): Fix Leaderboard sort

### DIFF
--- a/src/views/Predictions/Leaderboard/components/Filters/index.tsx
+++ b/src/views/Predictions/Leaderboard/components/Filters/index.tsx
@@ -35,9 +35,9 @@ const Filters = () => {
   const { token } = useConfig()
 
   const orderByOptions = [
+    { label: t('Rounds Played'), value: 'totalBets' },
     { label: t('Net Winnings'), value: `net${token.symbol}` },
     { label: t('Total %symbol%', { symbol: token.symbol }), value: `total${token.symbol}` },
-    { label: t('Rounds Played'), value: 'totalBets' },
     { label: t('Win Rate'), value: 'winRate' },
   ]
 


### PR DESCRIPTION
Net Winnings can't get token symbol when initializing, so change the sort sequence to solve this bug

fix #4544