### PR TITLE
fix: modal context initial value

### DIFF
--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, domMax, LazyMotion, m } from "framer-motion";
-import React, { createContext, useEffect, useRef, useState } from "react";
+import React, { createContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { mountAnimation, unmountAnimation } from "../../components/BottomDrawer/styles";
 import { Overlay } from "../../components/Overlay";
@@ -71,7 +71,7 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [closeOnOverlayClick, setCloseOnOverlayClick] = useState(true);
   const animationRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const setViewportHeight = () => {
       const vh = window.innerHeight * 0.01;
       document.documentElement.style.setProperty("--vh", `${vh}px`);


### PR DESCRIPTION

## Steps To Reproduce

1. use latest version of `imToken` app.
2. open browser with https://pancakeswap.finance
3. click `trade` tab
4. click `token` 

**expected**

the token list modal opened

**now**

the token list not shown


https://user-images.githubusercontent.com/10740043/186350940-1361022b-f4bc-43dd-bf6e-e304f36a7c19.mov



## Problem

the modal context will initialize the `--vh` css variable, but the handle function under `useEffect` scope which will not triggered after repaint. So the result of `window.innerHeight` will be `zero` or other some value in some device as the figure shows below.

![image](https://user-images.githubusercontent.com/10740043/186348481-b94af52c-b073-416c-a980-a620faae79e2.png)


## Resolve

for DOM measurement reason, should use `useLayoutEffect` to replace `useEffect`.