### PR TITLE
refactor: Separate price helper lps

### DIFF
--- a/src/config/constants/priceHelperLps/farms/1.ts
+++ b/src/config/constants/priceHelperLps/farms/1.ts
@@ -1,5 +1,5 @@
 // import { serializeTokens } from 'utils/serializeTokens'
-import { SerializedFarmConfig } from '../types'
+import { SerializedFarmConfig } from '../../types'
 // import { ethereumTokens } from '../tokens'
 
 // const serializedTokens = serializeTokens(ethereumTokens)

--- a/src/config/constants/priceHelperLps/farms/5.ts
+++ b/src/config/constants/priceHelperLps/farms/5.ts
@@ -1,5 +1,5 @@
 import { goerliTestnetTokens, serializeToken } from '@pancakeswap/tokens'
-import { SerializedFarmConfig } from '../types'
+import { SerializedFarmConfig } from '../../types'
 
 const priceHelperLps: SerializedFarmConfig[] = [
   {

--- a/src/config/constants/priceHelperLps/farms/56.ts
+++ b/src/config/constants/priceHelperLps/farms/56.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/src/config/constants/priceHelperLps/farms/97.ts
+++ b/src/config/constants/priceHelperLps/farms/97.ts
@@ -1,5 +1,5 @@
 // import { bscTestnetTokens } from '@pancakeswap/tokens'
-import { SerializedFarmConfig } from '../types'
+import { SerializedFarmConfig } from '../../types'
 
 const priceHelperLps: SerializedFarmConfig[] = []
 

--- a/src/config/constants/priceHelperLps/index.ts
+++ b/src/config/constants/priceHelperLps/index.ts
@@ -1,19 +1,38 @@
 import { ChainId } from '@pancakeswap/sdk'
-import BscPriceHelper from './56'
-import BscTestnetPriceHelper from './97'
-import EthereumPriceHelper from './1'
-import GoerliPriceHelper from './5'
+import FarmsBscPriceHelper from './farms/56'
+import FarmsBscTestnetPriceHelper from './farms/97'
+import FarmsEthereumPriceHelper from './farms/1'
+import FarmsGoerliPriceHelper from './farms/5'
+import PoolsBscPriceHelper from './pools/56'
+import PoolsBscTestnetPriceHelper from './pools/97'
+import PoolsEthereumPriceHelper from './pools/1'
+import PoolsGoerliPriceHelper from './pools/5'
 
-export const getPriceHelperLpFiles = (chainId: ChainId) => {
+export const getFarmsPriceHelperLpFiles = (chainId: ChainId) => {
   switch (chainId) {
     case ChainId.BSC:
-      return BscPriceHelper
+      return FarmsBscPriceHelper
     case ChainId.BSC_TESTNET:
-      return BscTestnetPriceHelper
+      return FarmsBscTestnetPriceHelper
     case ChainId.ETHEREUM:
-      return EthereumPriceHelper
+      return FarmsEthereumPriceHelper
     case ChainId.GOERLI:
-      return GoerliPriceHelper
+      return FarmsGoerliPriceHelper
+    default:
+      return []
+  }
+}
+
+export const getPoolsPriceHelperLpFiles = (chainId: ChainId) => {
+  switch (chainId) {
+    case ChainId.BSC:
+      return PoolsBscPriceHelper
+    case ChainId.BSC_TESTNET:
+      return PoolsBscTestnetPriceHelper
+    case ChainId.ETHEREUM:
+      return PoolsEthereumPriceHelper
+    case ChainId.GOERLI:
+      return PoolsGoerliPriceHelper
     default:
       return []
   }

--- a/src/config/constants/priceHelperLps/pools/1.ts
+++ b/src/config/constants/priceHelperLps/pools/1.ts
@@ -1,0 +1,9 @@
+// import { serializeTokens } from 'utils/serializeTokens'
+import { SerializedFarmConfig } from '../../types'
+// import { ethereumTokens } from '../tokens'
+
+// const serializedTokens = serializeTokens(ethereumTokens)
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/src/config/constants/priceHelperLps/pools/5.ts
+++ b/src/config/constants/priceHelperLps/pools/5.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/src/config/constants/priceHelperLps/pools/56.ts
+++ b/src/config/constants/priceHelperLps/pools/56.ts
@@ -1,5 +1,5 @@
 import { bscTokens, serializeToken } from '@pancakeswap/tokens'
-import { SerializedFarmConfig } from '../types'
+import { SerializedFarmConfig } from '../../types'
 
 const priceHelperLps: SerializedFarmConfig[] = [
   /**
@@ -15,13 +15,6 @@ const priceHelperLps: SerializedFarmConfig[] = [
     lpAddress: '0x3147F98B8f9C53Acdf8F16332eaD12B592a1a4ae',
     token: bscTokens.ankr,
     quoteToken: bscTokens.wbnb,
-  },
-  {
-    pid: null,
-    lpSymbol: 'ANTEX-BUSD LP',
-    lpAddress: '0x4DcB7b3b0E8914DC0e6D366521604cD23E7991E1',
-    token: bscTokens.antex,
-    quoteToken: bscTokens.busd,
   },
 ].map((p) => ({ ...p, token: serializeToken(p.token), quoteToken: serializeToken(p.quoteToken) }))
 

--- a/src/config/constants/priceHelperLps/pools/97.ts
+++ b/src/config/constants/priceHelperLps/pools/97.ts
@@ -1,0 +1,6 @@
+// import { bscTestnetTokens } from '../tokens'
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/src/state/farms/index.ts
+++ b/src/state/farms/index.ts
@@ -14,7 +14,7 @@ import masterchefABI from 'config/abi/masterchef.json'
 import { getMasterChefAddress } from 'utils/addressHelpers'
 import { getBalanceAmount } from 'utils/formatBalance'
 import type { AppState } from 'state'
-import { getPriceHelperLpFiles } from 'config/constants/priceHelperLps'
+import { getFarmsPriceHelperLpFiles } from 'config/constants/priceHelperLps'
 import splitProxyFarms from 'views/Farms/components/YieldBooster/helpers/splitProxyFarms'
 import { getFarmConfig } from 'config/constants/farms/index'
 import fetchFarms from './fetchFarms'
@@ -80,7 +80,7 @@ export const fetchFarmsPublicDataAsync = createAsyncThunk<
     const farmsCanFetch = farmsConfig.filter(
       (farmConfig) => pids.includes(farmConfig.pid) && poolLengthAsBigNumber.gt(farmConfig.pid),
     )
-    const priceHelperLpsConfig = getPriceHelperLpFiles(chainId)
+    const priceHelperLpsConfig = getFarmsPriceHelperLpFiles(chainId)
 
     const farms = await fetchFarms(farmsCanFetch.concat(priceHelperLpsConfig), chainId)
     const farmsWithPrices = farms.length > 0 ? getFarmsPrices(farms, chainId) : []

--- a/src/state/farmsV1/index.ts
+++ b/src/state/farmsV1/index.ts
@@ -9,7 +9,7 @@ import { createAsyncThunk, createSlice, isAnyOf } from '@reduxjs/toolkit'
 import stringify from 'fast-json-stable-stringify'
 import { getFarmConfig } from 'config/constants/farms'
 import type { AppState } from 'state'
-import { getPriceHelperLpFiles } from 'config/constants/priceHelperLps/index'
+import { getFarmsPriceHelperLpFiles } from 'config/constants/priceHelperLps/index'
 import fetchFarms from './fetchFarms'
 import getFarmsPrices from './getFarmsPrices'
 import {
@@ -44,7 +44,7 @@ export const fetchFarmsPublicDataAsync = createAsyncThunk<
     const farmsCanFetch = farmsToFetch.filter((f) => poolLength.gt(f.v1pid))
 
     // Add price helper farms
-    const priceHelperLpsConfig = getPriceHelperLpFiles(56)
+    const priceHelperLpsConfig = getFarmsPriceHelperLpFiles(56)
     const farmsWithPriceHelpers = farmsCanFetch.concat(priceHelperLpsConfig)
 
     const farms = await fetchFarms(farmsWithPriceHelpers)

--- a/src/state/pools/index.ts
+++ b/src/state/pools/index.ts
@@ -20,7 +20,7 @@ import { multicallv2 } from 'utils/multicall'
 import { bscTokens } from '@pancakeswap/tokens'
 import { getBalanceNumber } from 'utils/formatBalance'
 import { bscRpcProvider } from 'utils/providers'
-import { getPriceHelperLpFiles } from 'config/constants/priceHelperLps/index'
+import { getPoolsPriceHelperLpFiles } from 'config/constants/priceHelperLps/index'
 import fetchFarms from '../farms/fetchFarms'
 import getFarmsPrices from '../farms/getFarmsPrices'
 import {
@@ -145,7 +145,7 @@ export const fetchPoolsPublicDataAsync =
       const blockLimitsSousIdMap = fromPairs(blockLimits.map((entry) => [entry.sousId, entry]))
       const totalStakingsSousIdMap = fromPairs(totalStakings.map((entry) => [entry.sousId, entry]))
 
-      const priceHelperLpsConfig = getPriceHelperLpFiles(chainId)
+      const priceHelperLpsConfig = getPoolsPriceHelperLpFiles(chainId)
       const activePriceHelperLpsConfig = priceHelperLpsConfig.filter((priceHelperLpConfig) => {
         return (
           poolsConfig


### PR DESCRIPTION
Currently we fetch the price helper lps twice when in pools page