### PR TITLE
feat: Add switch network error toast

### DIFF
--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1927,5 +1927,6 @@
   "Assuming the current gas price, this order will never be executed. Try increasing the number of tokens to swap in your order.": "Assuming the current gas price, this order will never be executed. Try increasing the number of tokens to swap in your order.",
   "Bridge": "Bridge",
   "Please switch network": "Please switch network",
-  "The URL you are accessing (Chain id: %chainId%) belongs to %network%; mismatching your wallet’s network. Please switch the network to continue.": "The URL you are accessing (Chain id: %chainId%) belongs to %network%; mismatching your wallet’s network. Please switch the network to continue."
+  "The URL you are accessing (Chain id: %chainId%) belongs to %network%; mismatching your wallet’s network. Please switch the network to continue.": "The URL you are accessing (Chain id: %chainId%) belongs to %network%; mismatching your wallet’s network. Please switch the network to continue.",
+  "Error connecting, please retry and confirm in wallet!": "Error connecting, please retry and confirm in wallet!"
 }

--- a/src/components/NetworkSwitcher.tsx
+++ b/src/components/NetworkSwitcher.tsx
@@ -60,6 +60,7 @@ const WrongNetworkSelect = ({ switchNetwork, chainId }) => {
     ),
     {
       placement: 'auto-start',
+      hideTimeout: 0,
     },
   )
   const { chain } = useNetwork()
@@ -77,8 +78,8 @@ const WrongNetworkSelect = ({ switchNetwork, chainId }) => {
         <Text color="textSubtle" pl="6px">
           {t('Please switch network')}
         </Text>
-        {tooltipVisible && tooltip}
       </Flex>
+      {tooltipVisible && tooltip}
       <UserMenuDivider />
       {chain && (
         <UserMenuItem ref={ref1} onClick={() => setSessionChainId(chain.id)} style={{ justifyContent: 'flex-start' }}>


### PR DESCRIPTION
Switch network will fail if user ignores the request from wallet and keep clicking it
Now just show an error toast whenever in catch error 