### PR TITLE
fix: (prediction): Soon cards entry start time

### DIFF
--- a/apps/web/src/state/predictions/index.ts
+++ b/apps/web/src/state/predictions/index.ts
@@ -431,27 +431,6 @@ export const predictionsSlice = createSlice({
       state.rounds = newRounds
     })
 
-    // Initialize predictions
-    builder.addCase(initializePredictions.fulfilled, (state, action) => {
-      const { status, currentEpoch, intervalSeconds, rounds, claimableStatuses, ledgers } = action.payload
-      const futureRounds: ReduxNodeRound[] = []
-      const currentRound = rounds[currentEpoch]
-
-      for (let i = 1; i <= FUTURE_ROUND_COUNT; i++) {
-        futureRounds.push(makeFutureRoundResponse(currentEpoch + i, currentRound.startTimestamp + intervalSeconds * i))
-      }
-
-      return {
-        ...state,
-        status,
-        currentEpoch,
-        intervalSeconds,
-        claimableStatuses,
-        ledgers,
-        rounds: merge({}, rounds, makeRoundData(futureRounds)),
-      }
-    })
-
     // History from the node
     builder.addCase(fetchNodeHistory.pending, (state) => {
       state.isFetchingHistory = true

--- a/apps/web/src/state/predictions/index.ts
+++ b/apps/web/src/state/predictions/index.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { BigNumber } from '@ethersproject/bignumber'
 import { formatUnits } from '@ethersproject/units'
-import maxBy from 'lodash/maxBy'
 import merge from 'lodash/merge'
 import range from 'lodash/range'
 import pickBy from 'lodash/pickBy'
@@ -19,13 +18,7 @@ import {
   PredictionConfig,
 } from 'state/types'
 import { FetchStatus } from 'config/constants/types'
-import {
-  FUTURE_ROUND_COUNT,
-  LEADERBOARD_MIN_ROUNDS_PLAYED,
-  PAST_ROUND_COUNT,
-  ROUNDS_PER_PAGE,
-  ROUND_BUFFER,
-} from './config'
+import { FUTURE_ROUND_COUNT, LEADERBOARD_MIN_ROUNDS_PLAYED, PAST_ROUND_COUNT, ROUNDS_PER_PAGE } from './config'
 import {
   makeFutureRoundResponse,
   makeRoundData,
@@ -84,8 +77,8 @@ type PredictionInitialization = Pick<
   PredictionsState,
   'status' | 'currentEpoch' | 'intervalSeconds' | 'minBetAmount' | 'rounds' | 'ledgers' | 'claimableStatuses'
 >
-export const initializePredictions = createAsyncThunk<PredictionInitialization, string, { extra: PredictionConfig }>(
-  'predictions/initialize',
+export const fetchPredictionData = createAsyncThunk<PredictionInitialization, string, { extra: PredictionConfig }>(
+  'predictions/fetchPredictionData',
   async (account = null, { extra }) => {
     // Static values
     const marketData = await getPredictionData(extra.address)
@@ -122,55 +115,6 @@ export const initializePredictions = createAsyncThunk<PredictionInitialization, 
     ])
 
     return merge({}, initializedData, {
-      ledgers: makeLedgerData(account, ledgerResponses, epochs),
-      claimableStatuses,
-    })
-  },
-)
-
-export const fetchPredictionData = createAsyncThunk<PredictionInitialization, string, { extra: PredictionConfig }>(
-  'predictions/fetchPredictionData',
-  async (account = null, { extra }) => {
-    const { status, currentEpoch, intervalSeconds, minBetAmount } = await getPredictionData(extra.address)
-    const liveCurrentAndRecent = [currentEpoch, currentEpoch - 1, currentEpoch - 2]
-
-    const roundsResponse = await getRoundsData(liveCurrentAndRecent, extra.address)
-    const roundData = roundsResponse.reduce((accum, round) => {
-      if (!round) {
-        return accum
-      }
-
-      const reduxNodeRound = serializePredictionsRoundsResponse(round)
-
-      return {
-        ...accum,
-        [reduxNodeRound.epoch.toString()]: reduxNodeRound,
-      }
-    }, {})
-
-    const publicData = {
-      status,
-      currentEpoch,
-      intervalSeconds,
-      minBetAmount,
-      rounds: roundData,
-      ledgers: {},
-      claimableStatuses: {},
-    }
-
-    if (!account) {
-      return publicData
-    }
-
-    const epochs =
-      currentEpoch > PAST_ROUND_COUNT ? range(currentEpoch, currentEpoch - PAST_ROUND_COUNT) : [currentEpoch]
-
-    const [ledgerResponses, claimableStatuses] = await Promise.all([
-      getLedgerData(account, epochs, extra.address), // Bet data
-      getClaimStatuses(account, epochs, extra.address), // Claim statuses
-    ])
-
-    return merge({}, publicData, {
       ledgers: makeLedgerData(account, ledgerResponses, epochs),
       claimableStatuses,
     })
@@ -470,16 +414,13 @@ export const predictionsSlice = createSlice({
         return Number(key) > state.currentEpoch - PAST_ROUND_COUNT
       })
 
-      // If the round has change add a new future round
-      if (state.currentEpoch !== currentEpoch) {
-        const newestRound = maxBy(Object.values(state.rounds), 'epoch')
-        const futureRound = makeFutureRoundResponse(
-          newestRound.epoch + 1,
-          newestRound.startTimestamp + intervalSeconds + ROUND_BUFFER,
-        )
-
-        newRounds = { ...newRounds, [futureRound.epoch]: futureRound }
+      const futureRounds: ReduxNodeRound[] = []
+      const currentRound = rounds[currentEpoch]
+      for (let i = 1; i <= FUTURE_ROUND_COUNT; i++) {
+        futureRounds.push(makeFutureRoundResponse(currentEpoch + i, currentRound.startTimestamp + intervalSeconds * i))
       }
+
+      newRounds = { ...newRounds, ...makeRoundData(futureRounds) }
 
       state.status = status
       state.currentEpoch = currentEpoch

--- a/apps/web/src/views/Predictions/components/RoundCard/SoonRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/SoonRoundCard.tsx
@@ -2,8 +2,6 @@ import { Card, CardBody, Text, WaitIcon } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { NodeRound, BetPosition } from 'state/types'
 import useTheme from 'hooks/useTheme'
-import { useGetIntervalSeconds } from 'state/predictions/hooks'
-import { ROUND_BUFFER } from 'state/predictions/config'
 import { formatRoundTime } from '../../helpers'
 import useCountdown from '../../hooks/useCountdown'
 import { RoundResultBox } from '../RoundResult'
@@ -15,8 +13,7 @@ interface SoonRoundCardProps {
 }
 
 const SoonRoundCard: React.FC<React.PropsWithChildren<SoonRoundCardProps>> = ({ round }) => {
-  const intervalSeconds = useGetIntervalSeconds()
-  const { secondsRemaining } = useCountdown(round.startTimestamp + intervalSeconds + ROUND_BUFFER)
+  const { secondsRemaining } = useCountdown(round.startTimestamp)
   const countdown = formatRoundTime(secondsRemaining)
   const { t } = useTranslation()
   const { theme } = useTheme()

--- a/apps/web/src/views/Predictions/hooks/usePollPredictions.ts
+++ b/apps/web/src/views/Predictions/hooks/usePollPredictions.ts
@@ -1,7 +1,7 @@
 import { useAccount } from 'wagmi'
 import { useGetPredictionsStatus } from 'state/predictions/hooks'
 import { fetchPredictionData } from 'state/predictions'
-import { PredictionStatus } from 'state/types'
+import { useInitialBlock } from 'state/block/hooks'
 import useSWR from 'swr'
 import useLocalDispatch from 'contexts/LocalRedux/useLocalDispatch'
 
@@ -10,17 +10,13 @@ const POLL_TIME_IN_SECONDS = 10
 const usePollPredictions = () => {
   const dispatch = useLocalDispatch()
   const { address: account } = useAccount()
-  const status = useGetPredictionsStatus()
+  const initialBlock = useInitialBlock()
 
-  useSWR(
-    status !== PredictionStatus.INITIAL ? ['predictions', account] : null,
-    () => dispatch(fetchPredictionData(account)),
-    {
-      refreshInterval: POLL_TIME_IN_SECONDS * 1000,
-      refreshWhenHidden: true,
-      refreshWhenOffline: true,
-    },
-  )
+  useSWR(initialBlock > 0 ? ['predictions', account] : null, () => dispatch(fetchPredictionData(account)), {
+    refreshInterval: POLL_TIME_IN_SECONDS * 1000,
+    refreshWhenHidden: true,
+    refreshWhenOffline: true,
+  })
 }
 
 export default usePollPredictions

--- a/apps/web/src/views/Predictions/hooks/usePollPredictions.ts
+++ b/apps/web/src/views/Predictions/hooks/usePollPredictions.ts
@@ -1,9 +1,9 @@
 import { useAccount } from 'wagmi'
-import { useGetPredictionsStatus } from 'state/predictions/hooks'
 import { fetchPredictionData } from 'state/predictions'
 import { useInitialBlock } from 'state/block/hooks'
 import useSWR from 'swr'
 import useLocalDispatch from 'contexts/LocalRedux/useLocalDispatch'
+import { useConfig } from '../context/ConfigProvider'
 
 const POLL_TIME_IN_SECONDS = 10
 
@@ -11,12 +11,17 @@ const usePollPredictions = () => {
   const dispatch = useLocalDispatch()
   const { address: account } = useAccount()
   const initialBlock = useInitialBlock()
+  const { address: predictionsAddress } = useConfig()
 
-  useSWR(initialBlock > 0 ? ['predictions', account] : null, () => dispatch(fetchPredictionData(account)), {
-    refreshInterval: POLL_TIME_IN_SECONDS * 1000,
-    refreshWhenHidden: true,
-    refreshWhenOffline: true,
-  })
+  useSWR(
+    initialBlock > 0 ? ['predictions', account, predictionsAddress] : null,
+    () => dispatch(fetchPredictionData(account)),
+    {
+      refreshInterval: POLL_TIME_IN_SECONDS * 1000,
+      refreshWhenHidden: true,
+      refreshWhenOffline: true,
+    },
+  )
 }
 
 export default usePollPredictions

--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -1,5 +1,4 @@
 import { useModal, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { useAccount } from 'wagmi'
 import { PageMeta } from 'components/Layout/Page'
 import { useEffect, useRef } from 'react'
 import { useChartView, useIsChartPaneOpen } from 'state/predictions/hooks'
@@ -49,7 +48,6 @@ function Warnings() {
 
 const Predictions = () => {
   const { isDesktop } = useMatchBreakpoints()
-  const { address: account } = useAccount()
 
   useAccountLocalEventListener()
 

--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -2,13 +2,10 @@ import { useModal, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useAccount } from 'wagmi'
 import { PageMeta } from 'components/Layout/Page'
 import { useEffect, useRef } from 'react'
-import { useInitialBlock } from 'state/block/hooks'
-import { initializePredictions } from 'state/predictions'
 import { useChartView, useIsChartPaneOpen } from 'state/predictions/hooks'
 import { PredictionsChartView } from 'state/types'
 import { useAccountLocalEventListener } from 'hooks/useAccountLocalEventListener'
 import { useUserPredictionChainlinkChartDisclaimerShow, useUserPredictionChartDisclaimerShow } from 'state/user/hooks'
-import useLocalDispatch from 'contexts/LocalRedux/useLocalDispatch'
 
 import ChartDisclaimer from './components/ChartDisclaimer'
 import ChainlinkChartDisclaimer from './components/ChainlinkChartDisclaimer'
@@ -53,17 +50,8 @@ function Warnings() {
 const Predictions = () => {
   const { isDesktop } = useMatchBreakpoints()
   const { address: account } = useAccount()
-  const dispatch = useLocalDispatch()
-  const initialBlock = useInitialBlock()
 
   useAccountLocalEventListener()
-
-  useEffect(() => {
-    if (initialBlock > 0) {
-      // Do not start initialization until the first block has been retrieved
-      dispatch(initializePredictions(account))
-    }
-  }, [initialBlock, dispatch, account])
 
   usePollPredictions()
 


### PR DESCRIPTION
It also reduces calls when first access. (currently when page is accessed it does initializepredictions then swr interval fetch prediction call). It is now refactored to use only interval fetch calls therefore when page is accessed it will only do that