### PR TITLE
fix(Farm): CardView APR use tooltipText

### DIFF
--- a/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -114,6 +114,7 @@ const FarmCard: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
                     displayApr={displayApr}
                     lpRewardsApr={farm.lpRewardsApr}
                     strikethrough={farm.boosted}
+                    useTooltipText
                   />
                 </>
               ) : (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/109973128/189094396-93495c43-6402-45a7-86e2-8dd44b4eb5b3.png)
