### PR TITLE
perf: (pools): Don't fetch finished pools data when in live tab except user stakes in pools

### DIFF
--- a/apps/web/src/state/pools/fetchPools.ts
+++ b/apps/web/src/state/pools/fetchPools.ts
@@ -52,16 +52,19 @@ export const fetchPoolsBlockLimits = async () => {
   })
 }
 
-const poolsBalanceOf = poolsConfig.map((poolConfig) => {
-  return {
-    address: poolConfig.stakingToken.address,
-    name: 'balanceOf',
-    params: [getAddress(poolConfig.contractAddress)],
-  }
-})
+const poolsBalanceOf = (fetchFinishedPools: boolean) =>
+  poolsConfig
+    .filter((p) => (fetchFinishedPools ? p.isFinished : !p.isFinished))
+    .map((poolConfig) => {
+      return {
+        address: poolConfig.stakingToken.address,
+        name: 'balanceOf',
+        params: [getAddress(poolConfig.contractAddress)],
+      }
+    })
 
-export const fetchPoolsTotalStaking = async () => {
-  const poolsTotalStaked = await multicall(erc20ABI, poolsBalanceOf)
+export const fetchPoolsTotalStaking = async (fetchFinishedPools: boolean) => {
+  const poolsTotalStaked = await multicall(erc20ABI, poolsBalanceOf(fetchFinishedPools))
 
   return poolsConfig.map((p, index) => ({
     sousId: p.sousId,

--- a/apps/web/src/state/pools/fetchPoolsUser.ts
+++ b/apps/web/src/state/pools/fetchPoolsUser.ts
@@ -1,7 +1,6 @@
 import poolsConfig from 'config/constants/pools'
 import sousChefABI from 'config/abi/sousChef.json'
 import erc20ABI from 'config/abi/erc20.json'
-import { SerializedPoolConfig } from 'config/constants/types'
 import multicall from 'utils/multicall'
 import { getAddress } from 'utils/addressHelpers'
 import { bscRpcProvider } from 'utils/providers'
@@ -10,13 +9,18 @@ import uniq from 'lodash/uniq'
 import fromPairs from 'lodash/fromPairs'
 import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 
+import { Pool } from '@pancakeswap/uikit'
+import { SerializedWrappedToken } from '@pancakeswap/token-lists'
 // Pool 0, Cake / Cake is a different kind of contract (master chef)
 // BNB pools use the native BNB token (wrapping ? unwrapping is done at the contract level)
 const nonBnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol !== 'BNB')
 const bnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol === 'BNB')
 const nonMasterPools = poolsConfig.filter((pool) => pool.sousId !== 0)
 
-const filterPools = (p: SerializedPoolConfig, fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number) => {
+const filterPools = (
+  p: Pool.SerializedPoolConfig<SerializedWrappedToken>,
+  fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number,
+) => {
   if (!isUndefinedOrNull(fetchPoolOrPools)) {
     if (fetchPoolOrPools === 'finishedPools') {
       return p.isFinished

--- a/apps/web/src/state/pools/fetchPoolsUser.ts
+++ b/apps/web/src/state/pools/fetchPoolsUser.ts
@@ -7,6 +7,7 @@ import { bscRpcProvider } from 'utils/providers'
 import BigNumber from 'bignumber.js'
 import uniq from 'lodash/uniq'
 import fromPairs from 'lodash/fromPairs'
+import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 
 // Pool 0, Cake / Cake is a different kind of contract (master chef)
 // BNB pools use the native BNB token (wrapping ? unwrapping is done at the contract level)
@@ -14,20 +15,34 @@ const nonBnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol !== 'B
 const bnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol === 'BNB')
 const nonMasterPools = poolsConfig.filter((pool) => pool.sousId !== 0)
 
-export const fetchPoolsAllowance = async (account) => {
-  const calls = nonBnbPools.map((pool) => ({
-    address: pool.stakingToken.address,
-    name: 'allowance',
-    params: [account, getAddress(pool.contractAddress)],
-  }))
+export const fetchPoolsAllowance = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
+  const calls = nonBnbPools
+    .filter(
+      (p) =>
+        (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
+        (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
+    )
+    .map((pool) => ({
+      address: pool.stakingToken.address,
+      name: 'allowance',
+      params: [account, getAddress(pool.contractAddress)],
+    }))
 
   const allowances = await multicall(erc20ABI, calls)
   return fromPairs(nonBnbPools.map((pool, index) => [pool.sousId, new BigNumber(allowances[index]).toJSON()]))
 }
 
-export const fetchUserBalances = async (account) => {
+export const fetchUserBalances = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
   // Non BNB pools
-  const tokens = uniq(nonBnbPools.map((pool) => pool.stakingToken.address))
+  const tokens = uniq(
+    nonBnbPools
+      .filter(
+        (p) =>
+          (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
+          (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
+      )
+      .map((pool) => pool.stakingToken.address),
+  )
   const calls = tokens.map((token) => ({
     address: token,
     name: 'balanceOf',
@@ -55,24 +70,32 @@ export const fetchUserBalances = async (account) => {
   return { ...poolTokenBalances, ...bnbBalances }
 }
 
-export const fetchUserStakeBalances = async (account) => {
-  const calls = nonMasterPools.map((p) => ({
-    address: getAddress(p.contractAddress),
-    name: 'userInfo',
-    params: [account],
-  }))
+export const fetchUserStakeBalances = async (account: string, sousId: number = null) => {
+  const calls = nonMasterPools
+    .filter((p) => (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true))
+    .map((p) => ({
+      address: getAddress(p.contractAddress),
+      name: 'userInfo',
+      params: [account],
+    }))
   const userInfo = await multicall(sousChefABI, calls)
   return fromPairs(
     nonMasterPools.map((pool, index) => [pool.sousId, new BigNumber(userInfo[index].amount._hex).toJSON()]),
   )
 }
 
-export const fetchUserPendingRewards = async (account) => {
-  const calls = nonMasterPools.map((p) => ({
-    address: getAddress(p.contractAddress),
-    name: 'pendingReward',
-    params: [account],
-  }))
+export const fetchUserPendingRewards = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
+  const calls = nonMasterPools
+    .filter(
+      (p) =>
+        (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
+        (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
+    )
+    .map((p) => ({
+      address: getAddress(p.contractAddress),
+      name: 'pendingReward',
+      params: [account],
+    }))
   const res = await multicall(sousChefABI, calls)
   return fromPairs(nonMasterPools.map((pool, index) => [pool.sousId, new BigNumber(res[index]).toJSON()]))
 }

--- a/apps/web/src/state/pools/fetchPoolsUser.ts
+++ b/apps/web/src/state/pools/fetchPoolsUser.ts
@@ -15,14 +15,22 @@ const nonBnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol !== 'B
 const bnbPools = poolsConfig.filter((pool) => pool.stakingToken.symbol === 'BNB')
 const nonMasterPools = poolsConfig.filter((pool) => pool.sousId !== 0)
 
-export const fetchPoolsAllowance = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
+export const fetchPoolsAllowance = async (
+  account: string,
+  fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number,
+) => {
   const calls = nonBnbPools
     .filter((p) => {
-      if (!isUndefinedOrNull(sousId)) {
-        return p.sousId === sousId
-      }
-      if (!isUndefinedOrNull(fetchFinishedPools)) {
-        return fetchFinishedPools ? p.isFinished : !p.isFinished
+      if (!isUndefinedOrNull(fetchPoolOrPools)) {
+        if (fetchPoolOrPools === 'finishedPools') {
+          return p.isFinished
+        }
+        if (fetchPoolOrPools === 'nonFinishedPools') {
+          return !p.isFinished
+        }
+        if (Number.isFinite(fetchPoolOrPools)) {
+          return p.sousId === fetchPoolOrPools
+        }
       }
       return true
     })
@@ -36,16 +44,24 @@ export const fetchPoolsAllowance = async (account: string, fetchFinishedPools: b
   return fromPairs(nonBnbPools.map((pool, index) => [pool.sousId, new BigNumber(allowances[index]).toJSON()]))
 }
 
-export const fetchUserBalances = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
+export const fetchUserBalances = async (
+  account: string,
+  fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number,
+) => {
   // Non BNB pools
   const tokens = uniq(
     nonBnbPools
       .filter((p) => {
-        if (!isUndefinedOrNull(sousId)) {
-          return p.sousId === sousId
-        }
-        if (!isUndefinedOrNull(fetchFinishedPools)) {
-          return fetchFinishedPools ? p.isFinished : !p.isFinished
+        if (!isUndefinedOrNull(fetchPoolOrPools)) {
+          if (fetchPoolOrPools === 'finishedPools') {
+            return p.isFinished
+          }
+          if (fetchPoolOrPools === 'nonFinishedPools') {
+            return !p.isFinished
+          }
+          if (Number.isFinite(fetchPoolOrPools)) {
+            return p.sousId === fetchPoolOrPools
+          }
         }
         return true
       })
@@ -92,14 +108,22 @@ export const fetchUserStakeBalances = async (account: string, sousId: number = n
   )
 }
 
-export const fetchUserPendingRewards = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
+export const fetchUserPendingRewards = async (
+  account: string,
+  fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number,
+) => {
   const calls = nonMasterPools
     .filter((p) => {
-      if (!isUndefinedOrNull(sousId)) {
-        return p.sousId === sousId
-      }
-      if (!isUndefinedOrNull(fetchFinishedPools)) {
-        return fetchFinishedPools ? p.isFinished : !p.isFinished
+      if (!isUndefinedOrNull(fetchPoolOrPools)) {
+        if (fetchPoolOrPools === 'finishedPools') {
+          return p.isFinished
+        }
+        if (fetchPoolOrPools === 'nonFinishedPools') {
+          return !p.isFinished
+        }
+        if (Number.isFinite(fetchPoolOrPools)) {
+          return p.sousId === fetchPoolOrPools
+        }
       }
       return true
     })

--- a/apps/web/src/state/pools/fetchPoolsUser.ts
+++ b/apps/web/src/state/pools/fetchPoolsUser.ts
@@ -17,11 +17,15 @@ const nonMasterPools = poolsConfig.filter((pool) => pool.sousId !== 0)
 
 export const fetchPoolsAllowance = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
   const calls = nonBnbPools
-    .filter(
-      (p) =>
-        (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
-        (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
-    )
+    .filter((p) => {
+      if (!isUndefinedOrNull(sousId)) {
+        return p.sousId === sousId
+      }
+      if (!isUndefinedOrNull(fetchFinishedPools)) {
+        return fetchFinishedPools ? p.isFinished : !p.isFinished
+      }
+      return true
+    })
     .map((pool) => ({
       address: pool.stakingToken.address,
       name: 'allowance',
@@ -36,11 +40,15 @@ export const fetchUserBalances = async (account: string, fetchFinishedPools: boo
   // Non BNB pools
   const tokens = uniq(
     nonBnbPools
-      .filter(
-        (p) =>
-          (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
-          (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
-      )
+      .filter((p) => {
+        if (!isUndefinedOrNull(sousId)) {
+          return p.sousId === sousId
+        }
+        if (!isUndefinedOrNull(fetchFinishedPools)) {
+          return fetchFinishedPools ? p.isFinished : !p.isFinished
+        }
+        return true
+      })
       .map((pool) => pool.stakingToken.address),
   )
   const calls = tokens.map((token) => ({
@@ -86,11 +94,15 @@ export const fetchUserStakeBalances = async (account: string, sousId: number = n
 
 export const fetchUserPendingRewards = async (account: string, fetchFinishedPools: boolean, sousId: number = null) => {
   const calls = nonMasterPools
-    .filter(
-      (p) =>
-        (!isUndefinedOrNull(fetchFinishedPools) ? (fetchFinishedPools ? p.isFinished : !p.isFinished) : true) &&
-        (!isUndefinedOrNull(sousId) ? p.sousId === sousId : true),
-    )
+    .filter((p) => {
+      if (!isUndefinedOrNull(sousId)) {
+        return p.sousId === sousId
+      }
+      if (!isUndefinedOrNull(fetchFinishedPools)) {
+        return fetchFinishedPools ? p.isFinished : !p.isFinished
+      }
+      return true
+    })
     .map((p) => ({
       address: getAddress(p.contractAddress),
       name: 'pendingReward',

--- a/apps/web/src/state/pools/hooks.ts
+++ b/apps/web/src/state/pools/hooks.ts
@@ -116,7 +116,12 @@ export const usePoolsPageFetch = (fetchFinishedPools: boolean) => {
   useFastRefreshEffect(() => {
     if (fetchFinishedPools) {
       if (account) {
-        dispatch(fetchPoolsUserDataAsync({ account, fetchFinishedPools }))
+        dispatch(
+          fetchPoolsUserDataAsync({
+            account,
+            fetchPoolOrPools: fetchFinishedPools ? 'finishedPools' : 'nonFinishedPools',
+          }),
+        )
       }
     } else {
       batch(() => {
@@ -124,7 +129,12 @@ export const usePoolsPageFetch = (fetchFinishedPools: boolean) => {
         dispatch(fetchCakeFlexibleSideVaultPublicData())
         dispatch(fetchIfoPublicDataAsync())
         if (account) {
-          dispatch(fetchPoolsUserDataAsync({ account, fetchFinishedPools }))
+          dispatch(
+            fetchPoolsUserDataAsync({
+              account,
+              fetchPoolOrPools: fetchFinishedPools ? 'finishedPools' : 'nonFinishedPools',
+            }),
+          )
           dispatch(fetchCakeVaultUserData({ account }))
           dispatch(fetchCakeFlexibleSideVaultUserData({ account }))
         }

--- a/apps/web/src/state/pools/index.ts
+++ b/apps/web/src/state/pools/index.ts
@@ -251,14 +251,14 @@ export const fetchPoolsStakingLimitsAsync = () => async (dispatch, getState) => 
 
 export const fetchPoolsUserDataAsync = createAsyncThunk<
   { sousId: number; allowance: any; stakingTokenBalance: any; stakedBalance: any; pendingReward: any }[],
-  { account: string; fetchFinishedPools: boolean }
->('pool/fetchPoolsUserData', async ({ account, fetchFinishedPools }, { rejectWithValue }) => {
+  { account: string; fetchPoolOrPools: 'finishedPools' | 'nonFinishedPools' | number }
+>('pool/fetchPoolsUserData', async ({ account, fetchPoolOrPools }, { rejectWithValue }) => {
   try {
     const [allowances, stakingTokenBalances, stakedBalances, pendingRewards] = await Promise.all([
-      fetchPoolsAllowance(account, fetchFinishedPools),
-      fetchUserBalances(account, fetchFinishedPools),
+      fetchPoolsAllowance(account, fetchPoolOrPools),
+      fetchUserBalances(account, fetchPoolOrPools),
       fetchUserStakeBalances(account),
-      fetchUserPendingRewards(account, fetchFinishedPools),
+      fetchUserPendingRewards(account, fetchPoolOrPools),
     ])
 
     const userData = poolsConfig.map((pool) => ({
@@ -278,7 +278,7 @@ export const updateUserAllowance = createAsyncThunk<
   { sousId: number; field: string; value: any },
   { sousId: number; account: string }
 >('pool/updateUserAllowance', async ({ sousId, account }) => {
-  const allowances = await fetchPoolsAllowance(account, null, sousId)
+  const allowances = await fetchPoolsAllowance(account, sousId)
   return { sousId, field: 'allowance', value: allowances[sousId] }
 })
 
@@ -286,7 +286,7 @@ export const updateUserBalance = createAsyncThunk<
   { sousId: number; field: string; value: any },
   { sousId: number; account: string }
 >('pool/updateUserBalance', async ({ sousId, account }) => {
-  const tokenBalances = await fetchUserBalances(account, null, sousId)
+  const tokenBalances = await fetchUserBalances(account, sousId)
   return { sousId, field: 'stakingTokenBalance', value: tokenBalances[sousId] }
 })
 
@@ -302,7 +302,7 @@ export const updateUserPendingReward = createAsyncThunk<
   { sousId: number; field: string; value: any },
   { sousId: number; account: string }
 >('pool/updateUserPendingReward', async ({ sousId, account }) => {
-  const pendingRewards = await fetchUserPendingRewards(account, null, sousId)
+  const pendingRewards = await fetchUserPendingRewards(account, sousId)
   return { sousId, field: 'pendingReward', value: pendingRewards[sousId] }
 })
 

--- a/apps/web/src/views/Pools/index.tsx
+++ b/apps/web/src/views/Pools/index.tsx
@@ -39,7 +39,7 @@ const Pools: React.FC<React.PropsWithChildren> = () => {
   const { address: account } = useAccount()
   const { pools, userDataLoaded } = usePoolsWithVault()
 
-  usePoolsPageFetch()
+  usePoolsPageFetch(showFinishedPools)
 
   return (
     <>

--- a/apps/web/src/views/Pools/index.tsx
+++ b/apps/web/src/views/Pools/index.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { useRouter } from 'next/router'
 
 import { useAccount } from 'wagmi'
 import { Heading, Flex, Image, Text, Link, FlexLayout, PageHeader, Loading, Pool, ViewMode } from '@pancakeswap/uikit'
@@ -35,11 +36,13 @@ const FinishedTextLink = styled(Link)`
 `
 
 const Pools: React.FC<React.PropsWithChildren> = () => {
+  const router = useRouter()
   const { t } = useTranslation()
   const { address: account } = useAccount()
   const { pools, userDataLoaded } = usePoolsWithVault()
+  const fetchFinishedPools = router.pathname.includes('history')
 
-  usePoolsPageFetch(showFinishedPools)
+  usePoolsPageFetch(fetchFinishedPools)
 
   return (
     <>


### PR DESCRIPTION
User stakes data needed to show dot on finished tab button to indicate there are stakes in finished pools

It also reduces calls when user harvest or stake on one pool. (Currently it updates all pools data which is unnecessary)