### PR TITLE
perf: (farms): Don't fetch farm user data until proxy address fetched and dont fetch proxy farm data when proxy is not created

### DIFF
--- a/src/state/farms/hooks.ts
+++ b/src/state/farms/hooks.ts
@@ -34,7 +34,7 @@ export function useFarmsLength() {
 export const usePollFarmsWithUserData = () => {
   const dispatch = useAppDispatch()
   const { account, chainId } = useActiveWeb3React()
-  const { proxyAddress, isLoading: isProxyContractLoading } = useBCakeProxyContractAddress(account)
+  const { proxyAddress, proxyCreated, isLoading: isProxyContractLoading } = useBCakeProxyContractAddress(account)
   const farmFlag = useFeatureFlag(featureFarmApiAtom)
 
   useSWRImmutable(
@@ -49,7 +49,7 @@ export const usePollFarmsWithUserData = () => {
     },
   )
 
-  const name = proxyAddress
+  const name = proxyCreated
     ? ['farmsWithUserData', account, proxyAddress, chainId]
     : ['farmsWithUserData', account, chainId]
 
@@ -58,7 +58,7 @@ export const usePollFarmsWithUserData = () => {
     async () => {
       const farmsConfig = await getFarmConfig(chainId)
       const pids = farmsConfig.map((farmToFetch) => farmToFetch.pid)
-      const params = proxyAddress ? { account, pids, proxyAddress, chainId } : { account, pids, chainId }
+      const params = proxyCreated ? { account, pids, proxyAddress, chainId } : { account, pids, chainId }
 
       dispatch(fetchFarmUserDataAsync(params))
     },

--- a/src/state/farms/hooks.ts
+++ b/src/state/farms/hooks.ts
@@ -34,7 +34,7 @@ export function useFarmsLength() {
 export const usePollFarmsWithUserData = () => {
   const dispatch = useAppDispatch()
   const { account, chainId } = useActiveWeb3React()
-  const { proxyAddress } = useBCakeProxyContractAddress(account)
+  const { proxyAddress, isLoading: isProxyContractLoading } = useBCakeProxyContractAddress(account)
   const farmFlag = useFeatureFlag(featureFarmApiAtom)
 
   useSWRImmutable(
@@ -54,7 +54,7 @@ export const usePollFarmsWithUserData = () => {
     : ['farmsWithUserData', account, chainId]
 
   useSWRImmutable(
-    account && chainId ? name : null,
+    account && chainId && !isProxyContractLoading ? name : null,
     async () => {
       const farmsConfig = await getFarmConfig(chainId)
       const pids = farmsConfig.map((farmToFetch) => farmToFetch.pid)


### PR DESCRIPTION
User data loaded twice when first access to the page