### PR TITLE
fix: (currency-search): Currency search handle enter keyboard event for native currency of different chains

### DIFF
--- a/src/components/SearchModal/CurrencySearch.tsx
+++ b/src/components/SearchModal/CurrencySearch.tsx
@@ -158,8 +158,7 @@ function CurrencySearch({
     (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         const s = debouncedQuery.toLowerCase().trim()
-        // TODO: FIXME
-        if (s === 'bnb') {
+        if (s === native.symbol.toLowerCase().trim()) {
           handleCurrencySelect(native)
         } else if (filteredSortedTokens.length > 0) {
           if (


### PR DESCRIPTION
To review:

1. Go to currency search on swap
2. Type bnb on bsc chain
3. Press enter
4. It is expected to select native currency of the chain