### PR TITLE
perf: (currency-search): Don't convert all tokens in lists to token instance when in currency search

### DIFF
--- a/apps/aptos/components/SearchModal/ImportRow.tsx
+++ b/apps/aptos/components/SearchModal/ImportRow.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react'
+import { CSSProperties, useMemo } from 'react'
 import { Currency, Token } from '@pancakeswap/aptos-swap-sdk'
 import {
   Button,
@@ -12,8 +12,7 @@ import {
   ListLogo,
 } from '@pancakeswap/uikit'
 import { CurrencyLogo } from 'components/Logo/CurrencyLogo'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
-import { useCombinedInactiveList } from 'state/lists/hooks'
+import { useAllLists, useInactiveListUrls } from 'state/lists/hooks'
 import styled from 'styled-components'
 import { useIsUserAddedToken, useIsTokenActive } from 'hooks/Tokens'
 import { useTranslation } from '@pancakeswap/localization'
@@ -66,14 +65,27 @@ export default function ImportRow({
   setImportToken: (token: Token) => void
 }) {
   // globals
-  const { chainId } = useActiveWeb3React()
   const { isMobile } = useMatchBreakpoints()
 
   const { t } = useTranslation()
 
   // check if token comes from list
-  const inactiveTokenList = useCombinedInactiveList()
-  const list = chainId && inactiveTokenList?.[chainId]?.[token.address]?.list
+  const lists = useAllLists()
+  const inactiveUrls = useInactiveListUrls()
+  const tokenList = useMemo(() => {
+    let result
+    for (const url of inactiveUrls) {
+      const list = lists[url].current
+      const tokenInList = list?.tokens.some(
+        (tokenInfo) => tokenInfo.address === token.address && tokenInfo.chainId === token.chainId,
+      )
+      if (tokenInList) {
+        result = list
+        break
+      }
+    }
+    return result
+  }, [token, inactiveUrls, lists])
 
   // check if already active on list or local storage tokens
   const isAdded = useIsUserAddedToken(token)
@@ -100,12 +112,12 @@ export default function ImportRow({
             </Text>
           </NameOverflow>
         </AutoRow>
-        {list && list.logoURI && (
+        {tokenList && tokenList.logoURI && (
           <RowFixed>
             <Text fontSize={isMobile ? '10px' : '14px'} mr="4px" color="textSubtle">
-              {t('via')} {list.name}
+              {t('via')} {tokenList.name}
             </Text>
-            <ListLogo logoURI={list.logoURI} size="12px" />
+            <ListLogo logoURI={tokenList.logoURI} size="12px" />
           </RowFixed>
         )}
       </AutoColumn>

--- a/apps/aptos/state/lists/hooks.ts
+++ b/apps/aptos/state/lists/hooks.ts
@@ -193,16 +193,6 @@ export function useCombinedInactiveList(): TokenAddressMap {
   return useAtomValue(combinedTokenMapFromInActiveUrlsAtom)
 }
 
-// list of tokens not supported on interface, used to show warnings and prevent swaps and adds
-export function useUnsupportedTokenList(): TokenAddressMap {
-  return useAtomValue(combinedTokenMapFromUnsupportedUrlsAtom)
-}
-
-// list of warning tokens on interface, used to show warnings and prevent adds
-export function useWarningTokenList(): TokenAddressMap {
-  return useAtomValue(combinedTokenMapFromWarningUrlsAtom)
-}
-
 export function useIsListActive(url: string): boolean {
   const activeListUrls = useActiveListUrls()
   return useMemo(() => Boolean(activeListUrls?.includes(url)), [activeListUrls, url])

--- a/apps/web/src/components/SearchModal/ImportToken.tsx
+++ b/apps/web/src/components/SearchModal/ImportToken.tsx
@@ -151,13 +151,24 @@ function ImportToken({ tokens, handleCurrencySelect }: ImportProps) {
           disabled={!confirmed}
           onClick={() => {
             tokens.forEach((token) => {
-              const inactiveToken = chainId && inactiveTokenList?.[token.chainId]?.[token.address]
+              let tokenInList
+              for (const url of inactiveUrls) {
+                const list = lists[url].current
+                tokenInList = list?.tokens.find(
+                  (tokenInfo) => tokenInfo.address === token.address && tokenInfo.chainId === token.chainId,
+                )
+                if (tokenInList) {
+                  break
+                }
+              }
+
+              const inactiveToken = chainId && tokenInList
               let tokenToAdd = token
               if (inactiveToken) {
                 tokenToAdd = new WrappedTokenInfo({
                   ...token,
-                  logoURI: inactiveToken.token.logoURI,
-                  name: token.name || inactiveToken.token.name,
+                  logoURI: inactiveToken.logoURI,
+                  name: token.name || inactiveToken.name,
                 })
               }
               addToken(tokenToAdd)

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -137,7 +137,7 @@ export const combinedTokenMapFromOfficialsUrlsAtom = atom((get) => {
 export const tokenListFromOfficialsUrlsAtom = atom((get) => {
   const lists: ListsState['byUrl'] = get(selectorByUrlsAtom)
 
-  const mergedTokenLists: TokenInfo[] = OFFICIAL_LISTS.reduce((acc, url) => {
+  const mergedTokenLists = OFFICIAL_LISTS.reduce((acc, url) => {
     if (lists?.[url]?.current?.tokens) {
       acc.push(...lists?.[url]?.current.tokens)
     }

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@pancakeswap/sdk'
-import { TokenAddressMap as TTokenAddressMap, WrappedTokenInfo, TokenList, TokenInfo } from '@pancakeswap/token-lists'
+import { TokenAddressMap as TTokenAddressMap, WrappedTokenInfo, TokenList } from '@pancakeswap/token-lists'
 import { ListsState } from '@pancakeswap/token-lists/react'
 import {
   DEFAULT_LIST_OF_LISTS,

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -102,16 +102,13 @@ export const combinedTokenInfoMapFromInActiveUrlsAtom = atom((get) => {
         const current = lists[currentUrl]?.current
         if (!current) return allTokens
         try {
-          const groupedTokenMap: { [chainId: string]: TokenInfo[] } = groupBy(
-            uniqBy(current.tokens, (tokenInfo) => `${tokenInfo.chainId}#${tokenInfo.address}`),
-            (tokenInfo) => tokenInfo.chainId,
-          )
-
-          const tokenInfoAddressMap = fromPairs(
-            Object.entries(groupedTokenMap).map(([chainId, tokenInfoList]) => [
-              chainId,
-              fromPairs(tokenInfoList.map((tokenInfo) => [tokenInfo.address, { token: tokenInfo, list: current }])),
-            ]),
+          const tokenInfoAddressMap = mapValues(
+            groupBy(
+              uniqBy(current.tokens, (tokenInfo) => `${tokenInfo.chainId}#${tokenInfo.address}`),
+              'chainId',
+            ),
+            (tokenInfoList) =>
+              mapValues(keyBy(tokenInfoList, 'address'), (tokenInfo) => ({ token: tokenInfo, list: current })),
           )
 
           // add chain id item if not exist


### PR DESCRIPTION
It improves performance significantly when searching tokens in low-end mobile devices