### PR TITLE
chore: fix shouldUseProxyFarm issue

### DIFF
--- a/src/views/Farms/components/YieldBooster/hooks/useYieldBoosterState.ts
+++ b/src/views/Farms/components/YieldBooster/hooks/useYieldBoosterState.ts
@@ -81,13 +81,15 @@ export default function useYieldBoosterState(yieldBoosterStateArgs: UseYieldBoos
 
   return {
     state,
-    shouldUseProxyFarm: [
-      YieldBoosterState.DEACTIVE,
-      YieldBoosterState.ACTIVE,
-      YieldBoosterState.MAX,
-      YieldBoosterState.NO_LP,
-      YieldBoosterState.LOCKED_END,
-    ].includes(state),
+    shouldUseProxyFarm:
+      [
+        YieldBoosterState.DEACTIVE,
+        YieldBoosterState.ACTIVE,
+        YieldBoosterState.MAX,
+        YieldBoosterState.NO_LP,
+        YieldBoosterState.LOCKED_END,
+      ].includes(state) ||
+      (proxyCreated && state !== YieldBoosterState.NO_MIGRATE),
     refreshActivePool,
     refreshProxyAddress,
     proxyAddress,


### PR DESCRIPTION
we had a logic return true for "shouldUseProxyFarm" while lock-end 
but there's a possibility that we created a proxy for the user and the user deposited it into the proxy contract
and then the lock cake expired, the user withdraw, and decide no lock anymore.
so there's a miss match for the origin code 
in this case, we still need to use the proxy contract not the MCv2 contract