### PR TITLE
fix: (pools): Balance in stake modal when withdraw

### DIFF
--- a/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
+++ b/src/views/Pools/components/PoolCard/Modals/StakeModal.tsx
@@ -249,7 +249,10 @@ const StakeModal: React.FC<React.PropsWithChildren<StakeModalProps>> = ({
       )}
       <Text ml="auto" color="textSubtle" fontSize="12px" mb="8px">
         {t('Balance: %balance%', {
-          balance: getFullDisplayBalance(stakingTokenBalance, stakingToken.decimals),
+          balance: getFullDisplayBalance(
+            isRemovingStake ? userData.stakedBalance : stakingTokenBalance,
+            stakingToken.decimals,
+          ),
         })}
       </Text>
       <Slider


### PR DESCRIPTION
It shows staking token balance in user account instead of staked balance when withdraw