### PR TITLE
feat: (swap): Add scanning risks for input token

### DIFF
--- a/src/state/lists/hooks.ts
+++ b/src/state/lists/hooks.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/sdk'
 import { EMPTY_LIST, TagInfo, TokenAddressMap, WrappedTokenInfo } from '@pancakeswap/tokens'
-import { TokenList } from '@uniswap/token-lists'
+import { TokenList, TokenInfo } from '@uniswap/token-lists'
 import { DEFAULT_LIST_OF_LISTS, OFFICIAL_LISTS } from 'config/constants/lists'
 import { atom, useAtomValue } from 'jotai'
 import mapValues from 'lodash/mapValues'
@@ -86,6 +86,27 @@ export const combinedTokenMapFromInActiveUrlsAtom = atom((get) => {
 export const combinedTokenMapFromOfficialsUrlsAtom = atom((get) => {
   const lists = get(selectorByUrlsAtom)
   return combineTokenMapsWithDefault(lists, OFFICIAL_LISTS)
+})
+
+export const tokenListFromOfficialsUrlsAtom = atom((get) => {
+  const lists: ListsState['byUrl'] = get(selectorByUrlsAtom)
+
+  const mergedTokenLists: TokenInfo[] = OFFICIAL_LISTS.reduce((acc, url) => {
+    if (lists?.[url]?.current?.tokens) {
+      acc.push(...lists?.[url]?.current.tokens)
+    }
+    return acc
+  }, [])
+
+  const mergedList =
+    mergedTokenLists.length > 0 ? [...DEFAULT_TOKEN_LIST.tokens, ...mergedTokenLists] : DEFAULT_TOKEN_LIST.tokens
+  return mapValues(
+    groupBy(
+      uniqBy(mergedList, (tokenInfo) => `${tokenInfo.chainId}#${tokenInfo.address}`),
+      'chainId',
+    ),
+    (tokenInfos) => keyBy(tokenInfos, 'address'),
+  )
 })
 
 export const combinedTokenMapFromUnsupportedUrlsAtom = atom((get) => {

--- a/src/views/Swap/components/AccessRisk/RiskMessage.tsx
+++ b/src/views/Swap/components/AccessRisk/RiskMessage.tsx
@@ -28,7 +28,7 @@ const RiskMessage: React.FC<RiskMessageProps> = ({ currency, riskTokenInfo }) =>
   return (
     <Message variant={messageVariant} icon="" mt="10px">
       <MessageText bold ml="-12px">
-        {t('%riskLevel% Risk', { riskLevel })}
+        {currency.symbol} {t('%riskLevel% Risk', { riskLevel })}
         <Flex mt="4px">
           <CurrencyLogo currency={currency} size="24px" style={{ marginRight: '8px' }} />
           <Flex flexDirection="column">

--- a/src/views/Swap/components/AccessRisk/index.tsx
+++ b/src/views/Swap/components/AccessRisk/index.tsx
@@ -131,6 +131,7 @@ const AccessRisk: React.FC<AccessRiskProps> = ({ inputCurrency, outputCurrency }
     const outputTokenCurrency = outputCurrency as any
     return (
       (inputTokenCurrency?.isNative ||
+        tokenMap?.[inputTokenCurrency?.chainId]?.[inputTokenCurrency?.address] ||
         isTokensScanning.inputRiskScanning ||
         (inputTokenCurrency?.address === currentRiskTokensInfo.inputRiskTokenInfo?.address &&
           currentRiskTokensInfo.inputRiskTokenInfo?.isSuccess)) &&
@@ -139,7 +140,7 @@ const AccessRisk: React.FC<AccessRiskProps> = ({ inputCurrency, outputCurrency }
         (outputTokenCurrency?.address === currentRiskTokensInfo.outputRiskTokenInfo?.address &&
           currentRiskTokensInfo.outputRiskTokenInfo?.isSuccess))
     )
-  }, [outputCurrency, inputCurrency, currentRiskTokensInfo, isTokensScanning])
+  }, [outputCurrency, inputCurrency, tokenMap, currentRiskTokensInfo, isTokensScanning])
 
   const handleScan = async () => {
     const currencies = { input: inputCurrency, output: outputCurrency }

--- a/src/views/Swap/components/AccessRisk/index.tsx
+++ b/src/views/Swap/components/AccessRisk/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Flex, Button, HelpIcon, useTooltip, Text, Link, useToast } from '@pancakeswap/uikit'
 import { fetchRiskToken, RiskTokenInfo } from 'views/Swap/hooks/fetchTokenRisk'
 import RiskMessage from 'views/Swap/components/AccessRisk/RiskMessage'
-import { combinedTokenMapFromOfficialsUrlsAtom } from 'state/lists/hooks'
+import { tokenListFromOfficialsUrlsAtom } from 'state/lists/hooks'
 import merge from 'lodash/merge'
 import pickBy from 'lodash/pickBy'
 import { useAtomValue } from 'jotai'
@@ -17,7 +17,7 @@ interface AccessRiskProps {
 const AccessRisk: React.FC<AccessRiskProps> = ({ inputCurrency, outputCurrency }) => {
   const { t } = useTranslation()
   const { toastInfo } = useToast()
-  const tokenMap = useAtomValue(combinedTokenMapFromOfficialsUrlsAtom)
+  const tokenMap = useAtomValue(tokenListFromOfficialsUrlsAtom)
 
   const [allTokenInfo, setAllTokenInfo] = useState<{ [key: number]: RiskTokenInfo }>({})
   const [currentRiskTokensInfo, setCurrentRiskTokensInfo] = useState<{

--- a/src/views/Swap/components/SwapForm.tsx
+++ b/src/views/Swap/components/SwapForm.tsx
@@ -275,7 +275,7 @@ export default function SwapForm({ setIsChartDisplayed, isChartDisplayed, isAcce
             />
 
             <Box style={{ display: isShowAccessToken ? 'block' : 'none' }}>
-              <AccessRisk currency={currencies[Field.OUTPUT]} />
+              <AccessRisk inputCurrency={currencies[Field.INPUT]} outputCurrency={currencies[Field.OUTPUT]} />
             </Box>
 
             {isExpertMode && recipient !== null && !showWrap ? (

--- a/src/views/Swap/components/SwapForm.tsx
+++ b/src/views/Swap/components/SwapForm.tsx
@@ -204,10 +204,6 @@ export default function SwapForm({ setIsChartDisplayed, isChartDisplayed, isAcce
     }
   }, [hasAmount, refreshBlockNumber])
 
-  const isShowAccessToken = useMemo(() => {
-    return isAccessTokenSupported && !currencies[Field.OUTPUT]?.isNative
-  }, [isAccessTokenSupported, currencies])
-
   return (
     <>
       <>
@@ -274,7 +270,7 @@ export default function SwapForm({ setIsChartDisplayed, isChartDisplayed, isAcce
               commonBasesType={CommonBasesType.SWAP_LIMITORDER}
             />
 
-            <Box style={{ display: isShowAccessToken ? 'block' : 'none' }}>
+            <Box style={{ display: isAccessTokenSupported ? 'block' : 'none' }}>
               <AccessRisk inputCurrency={currencies[Field.INPUT]} outputCurrency={currencies[Field.OUTPUT]} />
             </Box>
 


### PR DESCRIPTION
It is easier for user to know risks of input token (especially for air-drops) without switching to output first