### PR TITLE
perf: (nft): Don't use object entries to reduce memory footprint

### DIFF
--- a/apps/web/src/state/nftMarket/helpers.ts
+++ b/apps/web/src/state/nftMarket/helpers.ts
@@ -15,6 +15,8 @@ import { formatBigNumber } from '@pancakeswap/utils/formatBalance'
 import { getNftMarketAddress } from 'utils/addressHelpers'
 import nftMarketAbi from 'config/abi/nftMarket.json'
 import fromPairs from 'lodash/fromPairs'
+import pickBy from 'lodash/pickBy'
+import lodashSize from 'lodash/size'
 import {
   ApiCollection,
   ApiCollections,
@@ -160,16 +162,14 @@ export const getNftsFromCollectionApi = async (
     const res = await fetch(requestPath)
     if (res.ok) {
       const data = await res.json()
-      const filteredAttributesDistribution = Object.entries(data.attributesDistribution).filter(([, value]) =>
-        Boolean(value),
-      )
-      const filteredData = Object.entries(data.data).filter(([, value]) => Boolean(value))
-      const filteredTotal = filteredData.length
+      const filteredAttributesDistribution = pickBy(data.attributesDistribution, (value) => Boolean(value))
+      const filteredData = pickBy(data.data, (value) => Boolean(value))
+      const filteredTotal = lodashSize(filteredData)
       return {
         ...data,
         total: filteredTotal,
-        attributesDistribution: fromPairs(filteredAttributesDistribution),
-        data: fromPairs(filteredData),
+        attributesDistribution: filteredAttributesDistribution,
+        data: filteredData,
       }
     }
     console.error(`API: Failed to fetch NFT tokens for ${collectionAddress} collection`, res.statusText)

--- a/apps/web/src/state/nftMarket/helpers.ts
+++ b/apps/web/src/state/nftMarket/helpers.ts
@@ -162,8 +162,8 @@ export const getNftsFromCollectionApi = async (
     const res = await fetch(requestPath)
     if (res.ok) {
       const data = await res.json()
-      const filteredAttributesDistribution = pickBy(data.attributesDistribution, (value) => Boolean(value))
-      const filteredData = pickBy(data.data, (value) => Boolean(value))
+      const filteredAttributesDistribution = pickBy(data.attributesDistribution, Boolean)
+      const filteredData = pickBy(data.data, Boolean)
       const filteredTotal = lodashSize(filteredData)
       return {
         ...data,

--- a/apps/web/src/views/Nft/market/hooks/useGetCollectionDistribution.tsx
+++ b/apps/web/src/views/Nft/market/hooks/useGetCollectionDistribution.tsx
@@ -6,7 +6,7 @@ import { multicallv2 } from 'utils/multicall'
 import pancakeBunniesAbi from 'config/abi/pancakeBunnies.json'
 import useSWRImmutable from 'swr/immutable'
 import { FetchStatus } from 'config/constants/types'
-import fromPairs from 'lodash/fromPairs'
+import mapValues from 'lodash/mapValues'
 import { pancakeBunniesAddress } from '../constants'
 
 const useGetCollectionDistribution = (collectionAddress: string) => {
@@ -64,11 +64,10 @@ export const useGetCollectionDistributionPB = () => {
         })
       } catch (error) {
         // Use nft api data if on chain multicall fails
-        const tokenListResponse = fromPairs(
-          Object.entries(apiResponse.data).map(([tokenId, tokenData]) => {
-            return [tokenId, { ...tokenData, tokenCount: apiResponse.attributesDistribution[tokenId] }]
-          }),
-        )
+        const tokenListResponse = mapValues(apiResponse.data, (tokenData, tokenId) => ({
+          ...tokenData,
+          tokenCount: apiResponse.attributesDistribution[tokenId],
+        }))
         setState({ isFetching: false, data: tokenListResponse })
       }
     }


### PR DESCRIPTION
Check nft collection listing with all items and ordered by token id works properly.