### PR TITLE
fix: (farms): Memoize farm selector to avoid infinite rerenders

### DIFF
--- a/src/state/farms/hooks.ts
+++ b/src/state/farms/hooks.ts
@@ -103,7 +103,7 @@ export const usePollCoreFarmData = () => {
 
 export const useFarms = (): DeserializedFarmsState => {
   const { chainId } = useActiveWeb3React()
-  return useSelector(farmSelector(chainId))
+  return useSelector(useMemo(() => farmSelector(chainId), [chainId]))
 }
 
 export const useFarmsPoolLength = (): number => {


### PR DESCRIPTION
If the result is used in some hook that triggers a render too, then there will be infinite renders. 

This fix also reduces the call to the memoized selector since no new selector is created on each render.