### PR TITLE
fix: Flexible cake withdraw bug

### DIFF
--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -152,9 +152,12 @@ const VaultStakeModal: React.FC<React.PropsWithChildren<VaultStakeModalProps>> =
     const receipt = await fetchWithCatchTxError(() => {
       // .toString() being called to fix a BigNumber error in prod
       // as suggested here https://github.com/ChainSafe/web3.js/issues/2077
-      return isWithdrawingAll
-        ? callWithGasPrice(vaultPoolContract, 'withdrawAll', undefined, callOptions)
-        : callWithGasPrice(vaultPoolContract, 'withdrawByAmount', [convertedStakeAmount.toString()], callOptions)
+      if (isWithdrawingAll) {
+        return callWithGasPrice(vaultPoolContract, 'withdrawAll', undefined, callOptions)
+      }
+
+      const methodsName = pool.vaultKey === VaultKey.CakeVault ? 'withdrawByAmount' : 'withdraw'
+      return callWithGasPrice(vaultPoolContract, methodsName, [convertedStakeAmount.toString()], callOptions)
     })
 
     if (receipt?.status) {

--- a/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -158,11 +158,12 @@ const VaultStakeModal: React.FC<React.PropsWithChildren<VaultStakeModalProps>> =
         return callWithGasPrice(vaultPoolContract, 'withdrawAll', undefined, callOptions)
       }
 
-      const { sharesAsBigNumber } = convertCakeToShares(convertedStakeAmount, pricePerFullShare)
-      const methodsName = pool.vaultKey === VaultKey.CakeVault ? 'withdrawByAmount' : 'withdraw'
-      const withdrawAmount =
-        pool.vaultKey === VaultKey.CakeVault ? convertedStakeAmount.toString() : sharesAsBigNumber.toString()
-      return callWithGasPrice(vaultPoolContract, methodsName, [withdrawAmount], callOptions)
+      if (pool.vaultKey === VaultKey.CakeFlexibleSideVault) {
+        const { sharesAsBigNumber } = convertCakeToShares(convertedStakeAmount, pricePerFullShare)
+        return callWithGasPrice(vaultPoolContract, 'withdraw', [sharesAsBigNumber.toString()], callOptions)
+      }
+
+      return callWithGasPrice(vaultPoolContract, 'withdrawByAmount', [convertedStakeAmount.toString()], callOptions)
     })
 
     if (receipt?.status) {


### PR DESCRIPTION
The flexible cake contract did not have `withdrawByAmount` methods,
so will cause an error when the user did not withdraw all the amount.