### PR TITLE
perf: Global claim only run in BSC chain

### DIFF
--- a/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/src/components/GlobalCheckClaimStatus/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { useModal, useToast } from '@pancakeswap/uikit'
 import { useWeb3React } from '@pancakeswap/wagmi'
+import { ChainId } from '@pancakeswap/sdk'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { useAnniversaryAchievementContract } from 'hooks/useContract'
 import useCatchTxError from 'hooks/useCatchTxError'
@@ -16,8 +17,8 @@ interface GlobalCheckClaimStatusProps {
 const enable = true
 
 const GlobalCheckClaimStatus: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusProps>> = (props) => {
-  const { account } = useWeb3React()
-  if (!enable) {
+  const { account, chainId } = useWeb3React()
+  if (!enable || chainId !== ChainId.BSC) {
     return null
   }
   return <GlobalCheckClaim key={account} {...props} />


### PR DESCRIPTION
Only check when chainId is BSC, if not other chain providers will error