### PR TITLE
fix: Anniversary error when network change

### DIFF
--- a/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/src/components/GlobalCheckClaimStatus/index.tsx
@@ -35,7 +35,8 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
   const { toastSuccess } = useToast()
   const { t } = useTranslation()
   const [canClaimAnniversaryPoints, setCanClaimAnniversaryPoints] = useState(false)
-  const { canClaim, claimAnniversaryPoints } = useAnniversaryAchievementContract()
+  const { claimAnniversaryPoints } = useAnniversaryAchievementContract()
+  const { canClaim } = useAnniversaryAchievementContract(false)
   const { fetchWithCatchTxError } = useCatchTxError()
   const [onPresentAnniversaryModal] = useModal(
     <AnniversaryAchievementModal

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -248,9 +248,9 @@ export const useBunnySpecialXmasContract = () => {
   return useMemo(() => getBunnySpecialXmasContract(signer), [signer])
 }
 
-export const useAnniversaryAchievementContract = () => {
-  const { data: signer } = useSigner()
-  return useMemo(() => getAnniversaryAchievementContract(signer), [signer])
+export const useAnniversaryAchievementContract = (withSignerIfPossible = true) => {
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  return useMemo(() => getAnniversaryAchievementContract(providerOrSigner), [providerOrSigner])
 }
 
 export const useNftSaleContract = () => {


### PR DESCRIPTION
It happens when network change from eth to bsc

Uncaught (in promise) Error: underlying network changed (event="changed", network={"name":"homestead","chainId":1,"ensAddress":"0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"}, detectedNetwork={"name":"bnb","chainId":56,"ensAddress":null,"_defaultProvider":null}, code=NETWORK_ERROR, version=providers/5.6.8)
