### PR TITLE
fix: (pottery): Winner row height in winners component when no profile

### DIFF
--- a/src/views/Pottery/components/FinishedRounds/AllHistoryCard/Winner.tsx
+++ b/src/views/Pottery/components/FinishedRounds/AllHistoryCard/Winner.tsx
@@ -37,11 +37,9 @@ const Winner: React.FC<React.PropsWithChildren<WinnerProps>> = ({ address }) => 
             <Text fontSize="12px" color="primary">
               {truncateHash(address)}
             </Text>
-            {profile?.username && (
-              <Text fontSize="12px" color="primary">
-                {`@${profile?.username}`}
-              </Text>
-            )}
+            <Text minHeight="18px" fontSize="12px" color="primary">
+              {profile?.username ? `@${profile.username}` : null}
+            </Text>
           </Box>
         </>
       ) : (


### PR DESCRIPTION
<img width="478" alt="image" src="https://user-images.githubusercontent.com/2213635/193784045-448bcea3-a2d6-4621-9ef2-aacebec04669.png">