### PR TITLE
fix: (swap): Query params from previous network causes to tokens to not get loaded

### DIFF
--- a/src/config/constants/exchange.ts
+++ b/src/config/constants/exchange.ts
@@ -114,3 +114,5 @@ export const GELATO_HANDLER = 'pancakeswap'
 export const GENERIC_GAS_LIMIT_ORDER_EXECUTION = BigNumber.from(500000)
 
 export const LIMIT_ORDERS_DOCS_URL = 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/limit-orders'
+
+export const EXCHANGE_PAGE_PATHS = ['/swap', '/limit-orders', 'liquidity', '/add', '/find', '/remove']

--- a/src/hooks/useActiveWeb3React.ts
+++ b/src/hooks/useActiveWeb3React.ts
@@ -1,6 +1,7 @@
 import { useWeb3React } from '@pancakeswap/wagmi'
 import { useRouter, NextRouter } from 'next/router'
 import { useEffect } from 'react'
+import { EXCHANGE_PAGE_PATHS } from 'config/constants/exchange'
 import { isChainSupported } from 'utils/wagmi'
 import { useProvider } from 'wagmi'
 import { ChainId } from '@pancakeswap/sdk'
@@ -21,11 +22,14 @@ export function useNetworkConnectorUpdater() {
     const parsedQueryChainId = Number(router.query.chainId)
     if (!parsedQueryChainId && chainId === ChainId.BSC) return
     if (parsedQueryChainId !== chainId && isChainSupported(chainId)) {
+      const removeQueriesFromPath = EXCHANGE_PAGE_PATHS.some((item) => {
+        return router.pathname.startsWith(item)
+      })
       const uriHash = getHashFromRouter(router)?.[0]
       router.replace(
         {
           query: {
-            ...router.query,
+            ...(!removeQueriesFromPath && router.query),
             chainId,
           },
           ...(uriHash && { hash: uriHash }),

--- a/src/state/lists/updater.ts
+++ b/src/state/lists/updater.ts
@@ -3,6 +3,7 @@ import { useFetchListCallback } from '@pancakeswap/token-lists'
 import { acceptListUpdate, updateListVersion } from '@pancakeswap/token-lists/src/actions'
 import { getVersionUpgrade, VersionUpgrade } from '@uniswap/token-lists'
 import { UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
+import { EXCHANGE_PAGE_PATHS } from 'config/constants/exchange'
 import useWeb3Provider from 'hooks/useActiveWeb3React'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
@@ -16,7 +17,7 @@ export default function Updater(): null {
   const isWindowVisible = useIsWindowVisible()
   const router = useRouter()
   const includeListUpdater = useMemo(() => {
-    return ['/swap', '/limit-orders', 'liquidity', '/add', '/find', '/remove'].some((item) => {
+    return EXCHANGE_PAGE_PATHS.some((item) => {
       return router.pathname.startsWith(item)
     })
   }, [router.pathname])


### PR DESCRIPTION
To reproduce:

1. Go to a swap page that contains output&input currency params

http://pancakeswap.finance/swap?chainId=56&inputCurrency=0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82&outputCurrency=BNB

2. Change network
3. See default tokens of new network not get loaded correctly