### PR TITLE
fix: (swap): Import token modal appears if accessing swap page with unsupported network

### DIFF
--- a/apps/web/src/views/Swap/hooks/useWarningImport.tsx
+++ b/apps/web/src/views/Swap/hooks/useWarningImport.tsx
@@ -35,10 +35,11 @@ export default function useWarningImport() {
   const defaultTokens = useAllTokens()
 
   const importTokensNotInDefault =
-    urlLoadedTokens &&
-    urlLoadedTokens.filter((token: Token) => {
-      return !(token.address in defaultTokens) && token.chainId === chainId && !isWrongNetwork
-    })
+    !isWrongNetwork && urlLoadedTokens
+      ? urlLoadedTokens.filter((token: Token) => {
+          return !(token.address in defaultTokens) && token.chainId === chainId
+        })
+      : []
 
   const [onPresentSwapWarningModal] = useModal(<SwapWarningModal swapCurrency={swapWarningCurrency} />, false)
   const [onPresentImportTokenWarningModal] = useModal(

--- a/apps/web/src/views/Swap/hooks/useWarningImport.tsx
+++ b/apps/web/src/views/Swap/hooks/useWarningImport.tsx
@@ -16,7 +16,7 @@ import SwapWarningModal from '../components/SwapWarningModal'
 export default function useWarningImport() {
   const router = useRouter()
   const loadedUrlParams = useDefaultsFromURLSearch()
-  const { chainId } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveWeb3React()
 
   // swap warning state
   const [swapWarningCurrency, setSwapWarningCurrency] = useState(null)
@@ -37,7 +37,7 @@ export default function useWarningImport() {
   const importTokensNotInDefault =
     urlLoadedTokens &&
     urlLoadedTokens.filter((token: Token) => {
-      return !(token.address in defaultTokens) && token.chainId === chainId
+      return !(token.address in defaultTokens) && token.chainId === chainId && !isWrongNetwork
     })
 
   const [onPresentSwapWarningModal] = useModal(<SwapWarningModal swapCurrency={swapWarningCurrency} />, false)


### PR DESCRIPTION
To reproduce:

1. Set wallet network other than bsc and eth
2. Access http://pancakeswap.finance/swap directly
3. See behind the unsupported network modal there is import token modal and still appears after switching to correct network
