### PR TITLE
fix: Cannot switch network when accessing page via url with query

### DIFF
--- a/src/components/NetworkModal/PageNetworkSupportModal.tsx
+++ b/src/components/NetworkModal/PageNetworkSupportModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Modal, Text, Grid, Box, Message, MessageText } from '@pancakeswap/uikit'
 import { ChainId } from '@pancakeswap/sdk'
 import Image from 'next/future/image'
-import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
+import { useSwitchNetwork, useSwitchNetworkLocal } from 'hooks/useSwitchNetwork'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { chains } from 'utils/wagmi'
 import { useTranslation } from '@pancakeswap/localization'
@@ -16,7 +16,8 @@ import useAuth from 'hooks/useAuth'
 export function PageNetworkSupportModal() {
   const { t } = useTranslation()
   const { switchNetworkAsync, isLoading, canSwitch } = useSwitchNetwork()
-  const { chainId, isConnected } = useActiveWeb3React()
+  const switchNetworkLocal = useSwitchNetworkLocal()
+  const { chainId, isConnected, isWrongNetwork } = useActiveWeb3React()
   const { logout } = useAuth()
 
   const foundChain = useMemo(() => chains.find((c) => c.id === chainId), [chainId])
@@ -56,7 +57,7 @@ export function PageNetworkSupportModal() {
           <Button
             variant={foundChain && lastValidPath ? 'secondary' : 'primary'}
             isLoading={isLoading}
-            onClick={() => switchNetworkAsync(ChainId.BSC)}
+            onClick={() => (isWrongNetwork ? switchNetworkLocal(ChainId.BSC) : switchNetworkAsync(ChainId.BSC))}
           >
             {t('Switch to %chain%', { chain: 'BNB Smart Chain' })}
           </Button>


### PR DESCRIPTION
To reproduce:

1. Switch network to bsc on wallet
2. Go to bsc only page with query id indicates wrong network such as https://pancakeswap.finance/nfts?chainId=1
3. See switch button in modal doesn't work