### PR TITLE
chore(ifo): delete 'of LP' from IFO achievements

### DIFF
--- a/src/utils/achievements.ts
+++ b/src/utils/achievements.ts
@@ -31,7 +31,7 @@ export const getAchievementDescription = (campaign: Campaign): TranslatableText 
   switch (campaign.type) {
     case 'ifo':
       return {
-        key: 'Committed more than $5 worth of LP in the %title% IFO',
+        key: 'Committed more than $5 worth in the %title% IFO',
         data: {
           title: campaign.title as string,
         },


### PR DESCRIPTION
We use cake instead LP tokens at IFOs, need delete this. 

We can't input CAKE because it's need a lot value and valuecheck codes, no need.