### PR TITLE
fix(TabMenu): Tab active should highlight when active

### DIFF
--- a/packages/uikit/src/components/TabMenu/TabMenu.tsx
+++ b/packages/uikit/src/components/TabMenu/TabMenu.tsx
@@ -39,17 +39,23 @@ const ButtonMenu: React.FC<React.PropsWithChildren<TabMenuProps>> = ({
   children,
   fullWidth,
   gap,
+  isColorInverse = false,
 }) => {
   return (
     <Wrapper p={["0 4px", "0 16px"]} fullWidth={fullWidth}>
       <Inner fullWidth={fullWidth} gap={gap}>
         {Children.map(children, (child: ReactElement, index) => {
           const isActive = activeIndex === index;
+          const color = isActive ? "backgroundAlt" : "textSubtle";
+          const inverseColor = isActive ? "textSubtle" : "backgroundAlt";
+          const backgroundColor = isActive ? "textSubtle" : "input";
+          const inverseBackgroundColor = isActive ? "input" : "textSubtle";
+
           return cloneElement(child, {
             isActive,
             onClick: onItemClick ? () => onItemClick(index) : undefined,
-            color: isActive ? "backgroundAlt" : "textSubtle",
-            backgroundColor: isActive ? "textSubtle" : "input",
+            color: isColorInverse ? inverseColor : color,
+            backgroundColor: isColorInverse ? inverseBackgroundColor : backgroundColor,
           });
         })}
       </Inner>

--- a/packages/uikit/src/components/TabMenu/TabMenu.tsx
+++ b/packages/uikit/src/components/TabMenu/TabMenu.tsx
@@ -48,8 +48,8 @@ const ButtonMenu: React.FC<React.PropsWithChildren<TabMenuProps>> = ({
           return cloneElement(child, {
             isActive,
             onClick: onItemClick ? () => onItemClick(index) : undefined,
-            color: isActive ? "textSubtle" : "backgroundAlt",
-            backgroundColor: isActive ? "input" : "textSubtle",
+            color: isActive ? "backgroundAlt" : "textSubtle",
+            backgroundColor: isActive ? "textSubtle" : "input",
           });
         })}
       </Inner>

--- a/packages/uikit/src/components/TabMenu/types.ts
+++ b/packages/uikit/src/components/TabMenu/types.ts
@@ -6,6 +6,7 @@ export interface TabMenuProps {
   children: React.ReactElement[];
   fullWidth?: boolean;
   gap?: string;
+  isColorInverse?: boolean;
 }
 export interface TabProps extends ColorProps {
   isActive?: boolean;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/195634685-45609390-f8e3-4dd3-878a-80ab1b9a1e6a.png)

After:
![image](https://user-images.githubusercontent.com/109973128/195634955-2282dedb-7b5f-4e0d-ab05-ffa6ddc2d248.png)
