### PR TITLE
chore: Bump up recharts and remove hover updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-redux": "^8.0.4",
     "react-transition-group": "^4.4.5",
     "react-window": "^1.8.7",
-    "recharts": "2.1.12",
+    "recharts": "2.1.15",
     "redux-persist": "^6.0.0",
     "remark-gfm": "^1.0.0",
     "split-grid": "^1.0.11",

--- a/src/views/Info/components/InfoCharts/BarChart/index.tsx
+++ b/src/views/Info/components/InfoCharts/BarChart/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import { BarChart, ResponsiveContainer, XAxis, YAxis, Tooltip, Bar } from 'recharts'
 import useTheme from 'hooks/useTheme'
 import { formatAmount } from 'utils/formatInfoNumbers'
@@ -31,17 +31,6 @@ const CustomBar = ({
       <rect x={x} y={y} fill={fill} width={width} height={height} rx="2" />
     </g>
   )
-}
-
-// Calls setHoverValue and setHoverDate when part of chart is hovered
-// Note: this NEEDs to be wrapped inside component and useEffect, if you plug it as is it will create big render problems (try and see console)
-const HoverUpdater = ({ locale, payload, setHoverValue, setHoverDate }) => {
-  useEffect(() => {
-    setHoverValue(payload.value)
-    setHoverDate(payload.time.toLocaleString(locale, { year: 'numeric', day: 'numeric', month: 'short' }))
-  }, [locale, payload.value, payload.time, setHoverValue, setHoverDate])
-
-  return null
 }
 
 const Chart = ({ data, setHoverValue, setHoverDate }: LineChartProps) => {
@@ -89,14 +78,17 @@ const Chart = ({ data, setHoverValue, setHoverDate }: LineChartProps) => {
         <Tooltip
           cursor={{ fill: theme.colors.backgroundDisabled }}
           contentStyle={{ display: 'none' }}
-          formatter={(tooltipValue, name, props) => (
-            <HoverUpdater
-              locale={locale}
-              payload={props.payload}
-              setHoverValue={setHoverValue}
-              setHoverDate={setHoverDate}
-            />
-          )}
+          formatter={(tooltipValue, name, props) => {
+            setHoverValue(props.payload.value)
+            setHoverDate(
+              props.payload.time.toLocaleString(locale, {
+                year: 'numeric',
+                day: 'numeric',
+                month: 'short',
+              }),
+            )
+            return null
+          }}
         />
         <Bar
           dataKey="value"

--- a/src/views/Info/components/InfoCharts/LineChart/index.tsx
+++ b/src/views/Info/components/InfoCharts/LineChart/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import { ResponsiveContainer, XAxis, YAxis, Tooltip, AreaChart, Area } from 'recharts'
 import useTheme from 'hooks/useTheme'
 import { formatAmount } from 'utils/formatInfoNumbers'
@@ -10,17 +10,6 @@ export type LineChartProps = {
   setHoverValue: Dispatch<SetStateAction<number | undefined>> // used for value on hover
   setHoverDate: Dispatch<SetStateAction<string | undefined>> // used for label of value
 } & React.HTMLAttributes<HTMLDivElement>
-
-// Calls setHoverValue and setHoverDate when part of chart is hovered
-// Note: this NEEDs to be wrapped inside component and useEffect, if you plug it as is it will create big render problems (try and see console)
-const HoverUpdater = ({ locale, payload, setHoverValue, setHoverDate }) => {
-  useEffect(() => {
-    setHoverValue(payload.value)
-    setHoverDate(payload.time.toLocaleString(locale, { year: 'numeric', day: 'numeric', month: 'short' }))
-  }, [locale, payload.value, payload.time, setHoverValue, setHoverDate])
-
-  return null
-}
 
 /**
  * Note: remember that it needs to be mounted inside the container with fixed height
@@ -77,14 +66,17 @@ const LineChart = ({ data, setHoverValue, setHoverDate }: LineChartProps) => {
         <Tooltip
           cursor={{ stroke: theme.colors.secondary }}
           contentStyle={{ display: 'none' }}
-          formatter={(tooltipValue, name, props) => (
-            <HoverUpdater
-              locale={locale}
-              payload={props.payload}
-              setHoverValue={setHoverValue}
-              setHoverDate={setHoverDate}
-            />
-          )}
+          formatter={(tooltipValue, name, props) => {
+            setHoverValue(props.payload.value)
+            setHoverDate(
+              props.payload.time.toLocaleString(locale, {
+                year: 'numeric',
+                day: 'numeric',
+                month: 'short',
+              }),
+            )
+            return null
+          }}
         />
         <Area dataKey="value" type="monotone" stroke={theme.colors.secondary} fill="url(#gradient)" strokeWidth={2} />
       </AreaChart>

--- a/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/src/views/Predictions/components/ChainlinkChart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { ResponsiveContainer, XAxis, YAxis, Tooltip, AreaChart, Area, Dot } from 'recharts'
 import useTheme from 'hooks/useTheme'
 import { LineChartLoader } from 'views/Info/components/ChartLoaders'
@@ -81,15 +81,6 @@ type ChartData = {
   answer: string
   roundId: string
   startedAt: number
-}
-
-const HoverUpdater = ({ payload }) => {
-  const mutate = useChartHoverMutate()
-  useEffect(() => {
-    mutate(payload)
-  }, [mutate, payload])
-
-  return null
 }
 
 function useChartHover() {
@@ -256,7 +247,10 @@ const Chart = ({
         <Tooltip
           cursor={{ stroke: theme.colors.textSubtle, strokeDasharray: '3 3' }}
           contentStyle={{ display: 'none' }}
-          formatter={(_, __, props) => <HoverUpdater payload={props.payload} />}
+          formatter={(tooltipValue, name, props) => {
+            mutate(props.payload)
+            return null
+          }}
         />
         <Area
           dataKey="answer"

--- a/src/views/Swap/components/Chart/SwapLineChart.tsx
+++ b/src/views/Swap/components/Chart/SwapLineChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import { ResponsiveContainer, XAxis, YAxis, Tooltip, AreaChart, Area } from 'recharts'
 import useTheme from 'hooks/useTheme'
 import { LineChartLoader } from 'views/Info/components/ChartLoaders'
@@ -12,25 +12,6 @@ export type SwapLineChartProps = {
   isChangePositive: boolean
   timeWindow: PairDataTimeWindowEnum
 } & React.HTMLAttributes<HTMLDivElement>
-
-// Calls setHoverValue and setHoverDate when part of chart is hovered
-// Note: this NEEDs to be wrapped inside component and useEffect, if you plug it as is it will create big render problems (try and see console)
-const HoverUpdater = ({ locale, payload, setHoverValue, setHoverDate }) => {
-  useEffect(() => {
-    setHoverValue(payload.value)
-    setHoverDate(
-      payload.time.toLocaleString(locale, {
-        year: 'numeric',
-        month: 'short',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-      }),
-    )
-  }, [locale, payload.value, payload.time, setHoverValue, setHoverDate])
-
-  return null
-}
 
 const getChartColors = ({ isChangePositive }) => {
   return isChangePositive
@@ -103,14 +84,19 @@ const LineChart = ({ data, setHoverValue, setHoverDate, isChangePositive, timeWi
         <Tooltip
           cursor={{ stroke: theme.colors.textDisabled }}
           contentStyle={{ display: 'none' }}
-          formatter={(tooltipValue, name, props) => (
-            <HoverUpdater
-              locale={locale}
-              payload={props.payload}
-              setHoverValue={setHoverValue}
-              setHoverDate={setHoverDate}
-            />
-          )}
+          formatter={(tooltipValue, name, props) => {
+            setHoverValue(props.payload.value)
+            setHoverDate(
+              props.payload.time.toLocaleString(locale, {
+                year: 'numeric',
+                month: 'short',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+              }),
+            )
+            return null
+          }}
         />
         <Area dataKey="value" type="linear" stroke={colors.stroke} fill="url(#gradient)" strokeWidth={2} />
       </AreaChart>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5320,6 +5320,42 @@
   dependencies:
     "@types/tern" "*"
 
+"@types/d3-color@^2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.3.tgz#8bc4589073c80e33d126345542f588056511fe82"
+  integrity sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==
+
+"@types/d3-interpolate@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz#78eddf7278b19e48e8652603045528d46897aba0"
+  integrity sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==
+  dependencies:
+    "@types/d3-color" "^2"
+
+"@types/d3-path@^2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-2.0.2.tgz#6052f38f6186319769dfabab61b5514b0e02c75c"
+  integrity sha512-3YHpvDw9LzONaJzejXLOwZ3LqwwkoXb9LI2YN7Hbd6pkGo5nIlJ09ul4bQhBN4hQZJKmUpX8HkVqbzgUKY48cg==
+
+"@types/d3-scale@^3.0.0":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
+  integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
+  dependencies:
+    "@types/d3-time" "^2"
+
+"@types/d3-shape@^2.0.0":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-2.1.3.tgz#35d397b9e687abaa0de82343b250b9897b8cacf3"
+  integrity sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==
+  dependencies:
+    "@types/d3-path" "^2"
+
+"@types/d3-time@^2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
+  integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
+
 "@types/estree@*", "@types/estree@^0.0.51":
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
@@ -17421,11 +17457,14 @@ recharts-scale@^0.4.4:
   dependencies:
     decimal.js-light "^2.4.1"
 
-recharts@2.1.12:
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.1.12.tgz#2cbc87b0ed386a1328e9bab2b808a5fbce22e59f"
-  integrity sha512-dAzEuc9AjM+IF0A33QzEdBEUnyGKJcGUPa0MYm0vd38P3WouQjrj2egBrCNInE7ZcQwN+z3MoT7Rw03u8nP9HA==
+recharts@2.1.15:
+  version "2.1.15"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.1.15.tgz#896ad292ae10ad9eb528b30ad919a99d7da8948e"
+  integrity sha512-16VMAvrsdqkEe7sT9uyJ1F+OZzrC6+5eW+pVSU04SVO6O5Nr5lY78h/uKMjsZJTN0nfOfgV7YfHZcivtqgPU9g==
   dependencies:
+    "@types/d3-interpolate" "^2.0.0"
+    "@types/d3-scale" "^3.0.0"
+    "@types/d3-shape" "^2.0.0"
     classnames "^2.2.5"
     d3-interpolate "^2.0.0"
     d3-scale "^3.0.0"


### PR DESCRIPTION
New version of recharts doesn't allow to use jsx component as a formatter in tooltip

To review:

Check swap, info and prediction chainlink charts