### PR TITLE
chore: filter unknown tokens and pools from top token and pools

### DIFF
--- a/src/views/Info/Overview/index.tsx
+++ b/src/views/Info/Overview/index.tsx
@@ -53,7 +53,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   const formattedTokens = useMemo(() => {
     return Object.values(allTokens)
       .map((token) => token.data)
-      .filter((token) => token)
+      .filter((token) => token.name !== 'unknown')
   }, [allTokens])
 
   const allPoolData = useAllPoolDataSWR()
@@ -61,7 +61,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   const poolDatas = useMemo(() => {
     return Object.values(allPoolData)
       .map((pool) => pool.data)
-      .filter((pool) => pool)
+      .filter((pool) => pool.token1.name !== 'unknown' && pool.token0.name !== 'unknown')
   }, [allPoolData])
 
   const somePoolsAreLoading = useMemo(() => {


### PR DESCRIPTION
some data from the subgraph is having high volume but the name is unknown
and trace it from BSCScan and found that the price is always 0 
we decide to filter this kinds of data
{
        "derivedBNB": "0.0000000000000000005399776316480660036970204318",
        "derivedUSD": "0.0000000000000001462857753025194595650165684457",
        "id": "0x0cbac702884945d32c6fc2915973f7fe3b232861",
        "name": "unknown",
        "symbol": "unknown",
        "totalLiquidity": "128253562332102915701",
        "totalTransactions": "23078",
        "tradeVolumeUSD": "29986571.04851145127928378612487"
    },
{
        "derivedBNB": "0.000000000000000000493639438629802371325083840195",
        "derivedUSD": "0.0000000000000001337323062032550852673599219884",
        "id": "0xeb6a3e241bf6bef35f22241d91e74604a65ade13",
        "name": "unknown",
        "symbol": "unknown",
        "totalLiquidity": "3723270461015836453455",
        "totalTransactions": "9591",
        "tradeVolumeUSD": "1988670.034049221486066946861682"
    }
