### PR TITLE
fix: (farms): Boost button not fully clickable

### DIFF
--- a/src/views/Farms/components/YieldBooster/components/BoostedAction.tsx
+++ b/src/views/Farms/components/YieldBooster/components/BoostedAction.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { AutoRenewIcon } from '@pancakeswap/uikit'
+import { AutoRenewIcon, Button } from '@pancakeswap/uikit'
 import { ReactNode, useCallback, useContext } from 'react'
 
 import { NextLinkFromReactRouter } from 'components/NextLink'
@@ -53,9 +53,12 @@ const BoostedAction: React.FunctionComponent<BoostedActionPropsType> = ({
             title={`${t('Up to')} ${boostMultiplierDisplay}x`}
             description={t('Lock CAKE to activate yield booster')}
             style={{ whiteSpace: 'nowrap' }}
-          >
-            <NextLinkFromReactRouter to="/pools">{t('Go to Pool')}</NextLinkFromReactRouter>
-          </ActionButton>
+            button={
+              <NextLinkFromReactRouter to="/pools">
+                <Button> {t('Go to Pool')}</Button>
+              </NextLinkFromReactRouter>
+            }
+          />
         )
       case YieldBoosterState.LOCKED_END:
         return (
@@ -63,9 +66,12 @@ const BoostedAction: React.FunctionComponent<BoostedActionPropsType> = ({
             title={`${t('Up to')} ${boostMultiplierDisplay}x`}
             description={t('Lock CAKE is ended. Re-lock CAKE to activate yield booster')}
             style={{ whiteSpace: 'nowrap' }}
-          >
-            <NextLinkFromReactRouter to="/pools">{t('Go to Pool')}</NextLinkFromReactRouter>
-          </ActionButton>
+            button={
+              <NextLinkFromReactRouter to="/pools">
+                <Button> {t('Go to Pool')}</Button>
+              </NextLinkFromReactRouter>
+            }
+          />
         )
       case YieldBoosterState.NO_PROXY_CREATED:
         return (


### PR DESCRIPTION
To reproduce:

Go to farms
Boosted farms boost button not redirecting to pools when clicking outside of the text 