### PR TITLE
fix: (swap): Refresh block number hook doesn't call the block number swr hook

### DIFF
--- a/src/state/block/hooks.ts
+++ b/src/state/block/hooks.ts
@@ -12,9 +12,10 @@ export const usePollBlockNumber = () => {
   const { chainId, provider } = useActiveWeb3React()
 
   const { data } = useSWR(
-    chainId && ['blockNumber', chainId],
+    chainId && ['blockNumberFetcher', chainId],
     async () => {
       const blockNumber = await provider.getBlockNumber()
+      mutate(['blockNumber', chainId], blockNumber)
       if (!cache.get(unstable_serialize(['initialBlockNumber', chainId]))) {
         mutate(['initialBlockNumber', chainId], blockNumber)
       }

--- a/src/views/Swap/hooks/useRefreshBlockNumber.ts
+++ b/src/views/Swap/hooks/useRefreshBlockNumber.ts
@@ -17,7 +17,7 @@ export const useRefreshBlockNumber = () => {
   useEffect(() => {
     if (!isLoading) return
 
-    mutate(['blockNumber', chainId])
+    mutate(['blockNumberFetcher', chainId])
 
     // setTimeout is used to demonstrate the loading
     // because the real loading state occurs on multicall state


### PR DESCRIPTION
Refresh button in swap pages doesn't work

Root cause is there is multiple swr hooks (useCurrentBlock, useChainCurrentBlock(depending on chainId is different than the wallet's) ) therefore when mutate function is called swr picks one of it (although both fetcher's should be undefined when wallet is in bsc network) because of the deduping interval and it never calls the actual fetcher. Making the fetcher hook with unique key solves the problem