### PR TITLE
feat: Currency logo with backup url and skeleton

### DIFF
--- a/apps/web/src/utils/getTokenLogoURL.ts
+++ b/apps/web/src/utils/getTokenLogoURL.ts
@@ -35,13 +35,10 @@ const tryLogo = async (ImageSrc: string) => {
 export async function imageDecodeAsync(src: string) {
   const image = new Image()
   image.src = src
-
   if (image.decode) {
     await image.decode()
     return image
   }
-
-  // jest enter this block
   return new Promise<typeof image>((resolve, reject) => {
     image.onload = () => resolve(image)
     image.onerror = reject

--- a/apps/web/src/utils/getTokenLogoURL.ts
+++ b/apps/web/src/utils/getTokenLogoURL.ts
@@ -8,15 +8,44 @@ const mapping = {
 }
 
 const getTokenLogoURL = memoize(
-  (token?: Token) => {
+  async (token?: Token) => {
     if (token && mapping[token.chainId]) {
-      return `https://assets-cdn.trustwallet.com/blockchains/${mapping[token.chainId]}/assets/${getAddress(
-        token.address,
-      )}/logo.png`
+      let logoUrl = ''
+      const checksumAddress = getAddress(token.address)
+      const trustWalletUrl = `https://assets-cdn.trustwallet.com/blockchains/${
+        mapping[token.chainId]
+      }/assets/${checksumAddress}/logo.png`
+      logoUrl = await tryLogo(trustWalletUrl)
+      if (logoUrl === '') logoUrl = `https://tokens.pancakeswap.finance/images/${checksumAddress}.png`
+      return logoUrl
     }
     return null
   },
   (t) => `${t.chainId}#${t.address}`,
 )
+
+const tryLogo = async (ImageSrc: string) => {
+  try {
+    return (await imageDecodeAsync(ImageSrc)).src
+  } catch {
+    return ''
+  }
+}
+
+export async function imageDecodeAsync(src: string) {
+  const image = new Image()
+  image.src = src
+
+  if (image.decode) {
+    await image.decode()
+    return image
+  }
+
+  // jest enter this block
+  return new Promise<typeof image>((resolve, reject) => {
+    image.onload = () => resolve(image)
+    image.onerror = reject
+  })
+}
 
 export default getTokenLogoURL

--- a/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
@@ -1,5 +1,6 @@
 import { Token } from '@pancakeswap/sdk'
-import { useMemo } from 'react'
+import { SkeletonV2 } from '@pancakeswap/uikit'
+import { useEffect, useState } from 'react'
 import { multiChainId } from 'state/info/constant'
 import styled from 'styled-components'
 import getTokenLogoURL from '../../../../utils/getTokenLogoURL'
@@ -21,11 +22,15 @@ export const CurrencyLogo: React.FC<
     chainName?: 'ETH' | 'BSC'
   }>
 > = ({ address, size = '24px', chainName = 'BSC', ...rest }) => {
-  const src = useMemo(() => {
-    return getTokenLogoURL(new Token(multiChainId[chainName], address, 18, ''))
+  const [src, setSrc] = useState<string>(null)
+  useEffect(() => {
+    getTokenLogoURL(new Token(multiChainId[chainName], address, 18, '')).then((url) => setSrc(url))
   }, [address, chainName])
-
-  return <StyledLogo size={size} src={src} alt="token logo" {...rest} />
+  return (
+    <SkeletonV2 width={size} height={size} isDataReady={Boolean(size)} borderRadius={`${size}`}>
+      <StyledLogo size={size} src={src} alt="token logo" {...rest} />
+    </SkeletonV2>
+  )
 }
 
 const DoubleCurrencyWrapper = styled.div`

--- a/packages/uikit/src/components/Skeleton/Skeleton.tsx
+++ b/packages/uikit/src/components/Skeleton/Skeleton.tsx
@@ -106,6 +106,7 @@ export const SkeletonV2: React.FC<React.PropsWithChildren<SkeletonV2Props>> = ({
   wrapperProps,
   skeletonTop = "0",
   skeletonLeft = "0",
+  style,
   width,
   height,
   mr,
@@ -115,7 +116,7 @@ export const SkeletonV2: React.FC<React.PropsWithChildren<SkeletonV2Props>> = ({
   const animationRef = useRef<HTMLDivElement>(null);
   const skeletonRef = useRef<HTMLDivElement>(null);
   return (
-    <SkeletonWrapper width={width} height={height} mr={mr} ml={ml} {...wrapperProps}>
+    <SkeletonWrapper width={width} height={height} mr={mr} ml={ml} {...wrapperProps} style={style}>
       <LazyMotion features={domAnimation}>
         <AnimatePresence>
           {isDataReady && (

--- a/packages/uikit/src/components/Skeleton/types.ts
+++ b/packages/uikit/src/components/Skeleton/types.ts
@@ -26,4 +26,5 @@ export interface SkeletonV2Props extends SpaceProps, LayoutProps, BorderRadiusPr
   wrapperProps?: SpaceProps & LayoutProps;
   skeletonTop?: string;
   skeletonLeft?: string;
+  style?: React.CSSProperties;
 }


### PR DESCRIPTION
add a backup URL for the Currency logo component
and use SkeletonV2 to add Skeleton for it

![demo](https://user-images.githubusercontent.com/99634186/198554374-2dda6d6e-7176-4a35-a4e3-6e928d4d01b4.gif)

WOM had no icon from TrustWallet and the backup one works
<img width="784" alt="demo1" src="https://user-images.githubusercontent.com/99634186/198546266-1977b19f-7ade-4435-a2e2-e86b73c153a7.png">

<img width="775" alt="demo2" src="https://user-images.githubusercontent.com/99634186/198545959-34539fe0-4c1e-469e-aef8-000155079a72.png">