### PR TITLE
fix: (ifo): Ifos data in history page fetch delaying and vesting information not updated on history page

### DIFF
--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/index.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/index.tsx
@@ -274,14 +274,21 @@ const IfoCard: React.FC<React.PropsWithChildren<IfoFoldableCardProps>> = ({ ifo,
   const isWindowVisible = useIsWindowVisible()
 
   useSWRImmutable(
-    (isRecentlyActive || !isPublicIfoDataInitialized) && currentBlock && ['fetchPublicIfoData', currentBlock],
+    currentBlock &&
+      (isRecentlyActive
+        ? ['fetchPublicIfoData', currentBlock, ifo.id]
+        : !isPublicIfoDataInitialized
+        ? ['fetchPublicIfoData', ifo.id]
+        : null),
     async () => {
       fetchPublicIfoData(currentBlock)
     },
   )
 
   useSWRImmutable(
-    isWindowVisible && (isRecentlyActive || !isWalletDataInitialized) && account && 'fetchWalletIfoData',
+    isWindowVisible &&
+      (isRecentlyActive || !isWalletDataInitialized) &&
+      account && ['fetchWalletIfoData', account, ifo.id],
     async () => {
       fetchWalletIfoData()
     },

--- a/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
+++ b/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
@@ -48,9 +48,12 @@ const Info: React.FC<React.PropsWithChildren<InfoProps>> = ({ poolId, data, fetc
   const currentBlock = useCurrentBlock()
   const publicIfoData = useGetPublicIfoV3Data(data.ifo)
   const { fetchIfoData: fetchPublicIfoData, isInitialized: isPublicIfoDataInitialized } = publicIfoData
-  useSWRImmutable(!isPublicIfoDataInitialized && currentBlock && ['fetchPublicIfoData', currentBlock], async () => {
-    fetchPublicIfoData(currentBlock)
-  })
+  useSWRImmutable(
+    !isPublicIfoDataInitialized && currentBlock && ['fetchPublicIfoData', currentBlock, data.ifo.id],
+    async () => {
+      fetchPublicIfoData(currentBlock)
+    },
+  )
 
   const { cliff } = publicIfoData[poolId]?.vestingInformation
   const currentTimeStamp = new Date().getTime()


### PR DESCRIPTION
Since all cards using the same swr key there is a race condition between them when new block comes

To reproduce:

Go to ifo history
See ifo infos load takes time