### PR TITLE
fix: (pools): New pools flashing before start block

### DIFF
--- a/apps/web/src/state/pools/index.ts
+++ b/apps/web/src/state/pools/index.ts
@@ -78,6 +78,7 @@ export const initialIfoState = Object.freeze({
 
 const initialState: PoolsState = {
   data: [...poolsConfig],
+  publicDataLoaded: false,
   userDataLoaded: false,
   cakeVault: initialPoolVaultState,
   ifo: initialIfoState,
@@ -392,6 +393,7 @@ export const PoolsSlice = createSlice({
         const livePoolData = livePoolsSousIdMap[pool.sousId]
         return { ...pool, ...livePoolData }
       })
+      state.publicDataLoaded = true
     },
     // IFO
     setIfoUserCreditData: (state, action) => {

--- a/apps/web/src/state/pools/selectors.ts
+++ b/apps/web/src/state/pools/selectors.ts
@@ -9,6 +9,7 @@ import { getVaultPosition, VaultPosition } from '../../utils/cakePool'
 const selectPoolsData = (state: State) => state.pools.data
 const selectPoolData = (sousId) => (state: State) => state.pools.data.find((p) => p.sousId === sousId)
 const selectUserDataLoaded = (state: State) => state.pools.userDataLoaded
+const selectPublicDataLoaded = (state: State) => state.pools.publicDataLoaded
 const selectVault = (key: VaultKey) => (state: State) => key ? state.pools[key] : initialPoolVaultState
 const selectIfo = (state: State) => state.pools.ifo
 const selectIfoUserCredit = (state: State) => state.pools.ifo.credit ?? BIG_ZERO
@@ -19,9 +20,9 @@ export const makePoolWithUserDataLoadingSelector = (sousId) =>
   })
 
 export const poolsWithUserDataLoadingSelector = createSelector(
-  [selectPoolsData, selectUserDataLoaded],
-  (pools, userDataLoaded) => {
-    return { pools: pools.map(transformPool), userDataLoaded }
+  [selectPoolsData, selectUserDataLoaded, selectPublicDataLoaded],
+  (pools, userDataLoaded, publicDataLoaded) => {
+    return { pools: pools.map(transformPool), userDataLoaded, publicDataLoaded }
   },
 )
 
@@ -34,7 +35,7 @@ export const poolsWithVaultSelector = createSelector(
     makeVaultPoolByKey(VaultKey.CakeFlexibleSideVault),
   ],
   (poolsWithUserDataLoading, deserializedLockedCakeVault, deserializedFlexibleSideCakeVault) => {
-    const { pools, userDataLoaded } = poolsWithUserDataLoading
+    const { pools, userDataLoaded, publicDataLoaded } = poolsWithUserDataLoading
     const cakePool = pools.find((pool) => !pool.isFinished && pool.sousId === 0)
     const withoutCakePool = pools.filter((pool) => pool.sousId !== 0)
 
@@ -60,7 +61,11 @@ export const poolsWithVaultSelector = createSelector(
           ]
         : []
 
-    return { pools: [cakeAutoVault, ...cakeAutoFlexibleSideVault, ...withoutCakePool], userDataLoaded }
+    return {
+      pools: [cakeAutoVault, ...cakeAutoFlexibleSideVault, ...withoutCakePool],
+      userDataLoaded,
+      publicDataLoaded,
+    }
   },
 )
 

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -173,6 +173,7 @@ export interface PoolsState {
   cakeVault: SerializedLockedCakeVault
   cakeFlexibleSideVault: SerializedCakeVault
   userDataLoaded: boolean
+  publicDataLoaded: boolean
 }
 
 export type TeamsById = {

--- a/apps/web/src/views/Pools/index.tsx
+++ b/apps/web/src/views/Pools/index.tsx
@@ -37,7 +37,7 @@ const FinishedTextLink = styled(Link)`
 const Pools: React.FC<React.PropsWithChildren> = () => {
   const { t } = useTranslation()
   const { address: account } = useAccount()
-  const { pools, userDataLoaded } = usePoolsWithVault()
+  const { pools, userDataLoaded, publicDataLoaded } = usePoolsWithVault()
 
   usePoolsPageFetch()
 
@@ -59,7 +59,7 @@ const Pools: React.FC<React.PropsWithChildren> = () => {
         </Flex>
       </PageHeader>
       <Page>
-        <PoolControls pools={pools}>
+        <PoolControls pools={publicDataLoaded ? pools : pools.filter((pool) => pool.vaultKey)}>
           {({ chosenPools, viewMode, stakedOnly, normalizedUrlSearch, showFinishedPools }) => (
             <>
               {showFinishedPools && (


### PR DESCRIPTION
When there is a new pool in the pools list, it appears and disappears in the pools page when page is loading before it starts