### PR TITLE
chore(NetworkSwitcher): Change tooltip placement to bottom

### DIFF
--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -148,7 +148,7 @@ export const NetworkSwitcher = () => {
   const symbol = NATIVE[foundChain?.id]?.symbol ?? foundChain?.nativeCurrency?.symbol
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     t('Unable to switch network. Please try it on your wallet'),
-    { placement: 'auto' },
+    { placement: 'bottom' },
   )
 
   const cannotChangeNetwork = !canSwitch


### PR DESCRIPTION
Appearing on the left will block other buttons, I think it should appear below

Before:
![image](https://user-images.githubusercontent.com/109973128/200165453-164688f4-1ff4-4620-8fed-6274d71958c5.png)

After:
![image](https://user-images.githubusercontent.com/109973128/200165474-cee95984-d8fb-405e-9b6a-98bbae5d9fd2.png)
