### PR TITLE
fix: (pools): Vault Extend modal flickers when max selected

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockDurationField.tsx
@@ -20,9 +20,10 @@ const LockDurationField: React.FC<React.PropsWithChildren<LockDurationFieldProps
   isOverMax,
   currentDuration,
   currentDurationLeft,
+  isMaxSelected,
+  setIsMaxSelected,
 }) => {
   const { t } = useTranslation()
-  const [isMaxSelected, setIsMaxSelected] = useState(false)
 
   const maxAvailableDuration = currentDurationLeft ? MAX_LOCK_DURATION - currentDurationLeft : MAX_LOCK_DURATION
 

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { Button, AutoRenewIcon, Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
@@ -40,6 +40,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
     prepConfirmArg,
     defaultDuration: isRenew && avgLockDurationsInSeconds,
   })
+  const [isMaxSelected, setIsMaxSelected] = useState(false)
 
   const { isValidAmount, isValidDuration, isOverMax }: ModalValidator = useMemo(() => {
     return typeof validator === 'function'
@@ -73,6 +74,8 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
               currentDurationLeft={currentDurationLeft}
               setDuration={setDuration}
               duration={duration}
+              isMaxSelected={isMaxSelected}
+              setIsMaxSelected={setIsMaxSelected}
             />
           </>
         )}
@@ -81,6 +84,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         customOverview({
           isValidDuration,
           duration,
+          isMaxSelected,
         })
       ) : (
         <Overview

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -61,7 +61,15 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   )
 
   const customOverview = useCallback(
-    ({ isValidDuration, duration }) => (
+    ({
+      isValidDuration,
+      duration,
+      isMaxSelected,
+    }: {
+      isValidDuration: boolean
+      duration: number
+      isMaxSelected?: boolean
+    }) => (
       <Overview
         lockStartTime={
           currentDuration + duration > MAX_LOCK_DURATION ? Math.floor(Date.now() / 1000).toString() : lockStartTime
@@ -70,7 +78,11 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
         openCalculator={_noop}
         duration={currentDuration || duration}
         newDuration={
-          currentDuration + duration > MAX_LOCK_DURATION ? currentDurationLeft + duration : currentDuration + duration
+          isMaxSelected
+            ? MAX_LOCK_DURATION
+            : currentDuration + duration > MAX_LOCK_DURATION
+            ? currentDurationLeft + duration
+            : currentDuration + duration
         }
         lockedAmount={currentLockedAmount}
         usdValueStaked={usdValueStaked}

--- a/apps/web/src/views/Pools/components/LockedPool/types/index.ts
+++ b/apps/web/src/views/Pools/components/LockedPool/types/index.ts
@@ -86,7 +86,15 @@ export interface LockedModalBodyPropsType {
   currentDurationLeft?: number
   isRenew?: boolean
   validator?: (arg: ValidatorArg) => ModalValidator
-  customOverview?: ({ isValidDuration, duration }: { isValidDuration: boolean; duration: number }) => React.ReactElement
+  customOverview?: ({
+    isValidDuration,
+    duration,
+    isMaxSelected,
+  }: {
+    isValidDuration: boolean
+    duration: number
+    isMaxSelected?: boolean
+  }) => React.ReactElement
 }
 
 export interface ExtendDurationButtonPropsType {
@@ -129,6 +137,8 @@ export interface LockDurationFieldPropsType {
   isOverMax: boolean
   currentDuration?: number
   currentDurationLeft?: number
+  isMaxSelected: boolean
+  setIsMaxSelected: Dispatch<SetStateAction<boolean>>
 }
 
 export interface LockedStakingApyPropsType {

--- a/apps/web/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
+++ b/apps/web/src/views/Pools/components/Vault/VaultRoiCalculatorModal.tsx
@@ -50,6 +50,8 @@ export const VaultRoiCalculatorModal = ({
     return cakeVaultView === 0 ? flexibleApy : getLockedApy(duration)
   }, [cakeVaultView, getLockedApy, flexibleApy, duration])
 
+  const [isMaxSelected, setIsMaxSelected] = useState(false)
+
   return (
     <RoiCalculatorModal
       account={account}
@@ -101,7 +103,13 @@ export const VaultRoiCalculatorModal = ({
     >
       {cakeVaultView && (
         <Box mt="16px">
-          <LockDurationField duration={duration} setDuration={setDuration} isOverMax={false} />
+          <LockDurationField
+            duration={duration}
+            setDuration={setDuration}
+            isOverMax={false}
+            isMaxSelected={isMaxSelected}
+            setIsMaxSelected={setIsMaxSelected}
+          />
         </Box>
       )}
     </RoiCalculatorModal>


### PR DESCRIPTION
To reproduce

1. Go to cake pool
2. Click extend
3. Click max
4. See it flickers because boost factor and apy counts up again