### PR TITLE
fix(aptos): Roundup maxGasAmount

### DIFF
--- a/apps/aptos/hooks/useSimulationAndSendTransaction.ts
+++ b/apps/aptos/hooks/useSimulationAndSendTransaction.ts
@@ -26,7 +26,7 @@ export default function useSimulationAndSendTransaction() {
       let options
 
       if (Array.isArray(results)) {
-        const maxGasAmount = results[0].gas_used * SAFE_FACTOR
+        const maxGasAmount = Math.ceil(results[0].gas_used * SAFE_FACTOR)
         const gasUnitPrice = results[0].gas_unit_price
 
         options = { max_gas_amount: maxGasAmount, gas_unit_price: gasUnitPrice }


### PR DESCRIPTION
Wallet Fewcha will show an error when maxGasAmount has decimals.

![Screenshot 2022-11-15 at 6 43 29 PM](https://user-images.githubusercontent.com/98292246/201900291-d22677e8-f584-41c9-84ee-dbf9f9044de0.png)