### PR TITLE
fix: Ifo and pools page crash intermittently when cake vault is in flexible mode

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
@@ -23,7 +23,7 @@ const ConvertToLock: React.FC<React.PropsWithChildren<ConvertToLockProps>> = ({
   const { isMobile } = useMatchBreakpoints()
   const isTableView = isInline && !isMobile
   const { avgLockDurationsInSeconds } = useAvgLockDuration()
-  const { lockedApy } = useVaultApy({ duration: avgLockDurationsInSeconds || MAX_LOCK_DURATION })
+  const { lockedApy } = useVaultApy({ duration: avgLockDurationsInSeconds })
 
   return (
     <Message

--- a/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
@@ -1,5 +1,6 @@
 import { Token } from '@pancakeswap/sdk'
-import { Flex, Message, MessageText, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { MAX_LOCK_DURATION } from 'config/constants/pools'
+import { Flex, Message, MessageText, useMatchBreakpoints, SkeletonV2 } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { memo } from 'react'
 import { useVaultApy } from 'hooks/useVaultApy'
@@ -22,7 +23,7 @@ const ConvertToLock: React.FC<React.PropsWithChildren<ConvertToLockProps>> = ({
   const { isMobile } = useMatchBreakpoints()
   const isTableView = isInline && !isMobile
   const { avgLockDurationsInSeconds } = useAvgLockDuration()
-  const { lockedApy } = useVaultApy({ duration: avgLockDurationsInSeconds })
+  const { lockedApy } = useVaultApy({ duration: avgLockDurationsInSeconds || MAX_LOCK_DURATION })
 
   return (
     <Message
@@ -42,11 +43,13 @@ const ConvertToLock: React.FC<React.PropsWithChildren<ConvertToLockProps>> = ({
       }
       actionInline={isTableView}
     >
-      <MessageText>
-        {t('Lock staking users are earning an average of %amount%% APY. More benefits are coming soon.', {
-          amount: lockedApy ? parseFloat(lockedApy).toFixed(2) : 0,
-        })}
-      </MessageText>
+      <SkeletonV2 isDataReady={!!(avgLockDurationsInSeconds && lockedApy)} wrapperProps={{ height: 'fit-content' }}>
+        <MessageText>
+          {t('Lock staking users are earning an average of %amount%% APY. More benefits are coming soon.', {
+            amount: lockedApy ? parseFloat(lockedApy).toFixed(2) : 0,
+          })}
+        </MessageText>
+      </SkeletonV2>
     </Message>
   )
 }

--- a/apps/web/src/views/Pools/components/LockedPool/hooks/useAvgLockDuration.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/hooks/useAvgLockDuration.tsx
@@ -18,11 +18,15 @@ export default function useAvgLockDuration() {
     const lockedCakeOriginalShares = totalLockedAmount.div(pricePerFullShare).times(DEFAULT_TOKEN_DECIMAL)
     const avgBoostRatio = lockedCakeBoostedShares.div(lockedCakeOriginalShares)
 
-    return avgBoostRatio
-      .minus(1)
-      .times(new BigNumber(DURATION_FACTOR.toString()))
-      .div(new BigNumber(BOOST_WEIGHT.toString()).div(getFullDecimalMultiplier(12)))
-      .toFixed(0)
+    return (
+      Math.round(
+        avgBoostRatio
+          .minus(1)
+          .times(new BigNumber(DURATION_FACTOR.toString()))
+          .div(new BigNumber(BOOST_WEIGHT.toString()).div(getFullDecimalMultiplier(12)))
+          .toNumber(),
+      ) || 0
+    )
   }, [totalCakeInVault, totalLockedAmount, pricePerFullShare, totalShares])
 
   const avgLockDurationsInWeeks = useMemo(
@@ -38,6 +42,6 @@ export default function useAvgLockDuration() {
   return {
     avgLockDurationsInWeeks,
     avgLockDurationsInWeeksNum,
-    avgLockDurationsInSeconds: _toNumber(avgLockDurationsInSeconds),
+    avgLockDurationsInSeconds,
   }
 }


### PR DESCRIPTION
Root cause is avglockduration hook returns NaN (which we use that value in vault apr hook) when there is no public cake vault data. It happens on ifo more than pools page, since we fetch cake user data and cake public data at the same time there and there is a possibility that we have vault user data (which triggers to add convertlock component) but no public data