### PR TITLE
perf(aptos): Token list external url

### DIFF
--- a/apps/aptos/components/SearchModal/ManageLists.tsx
+++ b/apps/aptos/components/SearchModal/ManageLists.tsx
@@ -99,7 +99,7 @@ const ListRow = memo(function ListRow({ listUrl }: { listUrl: string }) {
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     <div>
       <Text>{list && listVersionLabel(list.version)}</Text>
-      <LinkExternal external href={`https://tokenlists.org/token-list?url=${listUrl}`}>
+      <LinkExternal external href={listUrl}>
         {t('See')}
       </LinkExternal>
       <Button variant="danger" scale="xs" onClick={handleRemoveList} disabled={Object.keys(listsByUrl).length === 1}>


### PR DESCRIPTION
Link to `https://tokenlists.org/token-list` will show empty page.
We can just redirect to the token list url

![Screenshot 2022-11-17 at 9 08 07 PM](https://user-images.githubusercontent.com/98292246/202454727-8d18c706-aff0-4da2-ad02-f7f41f341a42.png)
