### PR TITLE
fix: Contract errors when accessing bsc only supported page with another chain

### DIFF
--- a/apps/web/src/hooks/limitOrders/useGelatoLimitOrdersLib.ts
+++ b/apps/web/src/hooks/limitOrders/useGelatoLimitOrdersLib.ts
@@ -7,7 +7,7 @@ import { useActiveChainId } from '../useActiveChainId'
 
 const useGelatoLimitOrdersLib = (): GelatoLimitOrders | undefined => {
   const { chainId } = useActiveChainId()
-  const providerOrSigner = useProviderOrSigner()
+  const providerOrSigner = useProviderOrSigner(true, true)
 
   return useMemo(() => {
     if (!chainId || !providerOrSigner) {

--- a/apps/web/src/hooks/useContract.ts
+++ b/apps/web/src/hooks/useContract.ts
@@ -10,7 +10,6 @@ import {
   Zap,
 } from 'config/abi/types'
 import zapAbi from 'config/abi/zap.json'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useProviderOrSigner } from 'hooks/useProviderOrSigner'
 import { useMemo } from 'react'
 import { getMulticallAddress, getPredictionsV1Address, getZapAddress } from 'utils/addressHelpers'
@@ -109,7 +108,7 @@ export const useERC721 = (address: string, withSignerIfPossible = true) => {
 }
 
 export const useCake = (): { reader: Cake; signer: Cake } => {
-  const providerOrSigner = useProviderOrSigner()
+  const providerOrSigner = useProviderOrSigner(true, true)
   return useMemo(
     () => ({
       reader: getCakeContract(null),
@@ -130,12 +129,12 @@ export const usePancakeBunnies = () => {
 }
 
 export const useProfileContract = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getProfileContract(providerOrSigner), [providerOrSigner])
 }
 
 export const useLotteryV2Contract = () => {
-  const providerOrSigner = useProviderOrSigner()
+  const providerOrSigner = useProviderOrSigner(true, true)
   return useMemo(() => getLotteryV2Contract(providerOrSigner), [providerOrSigner])
 }
 
@@ -171,22 +170,22 @@ export const useClaimRefundContract = () => {
 }
 
 export const useTradingCompetitionContractEaster = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getTradingCompetitionContractEaster(providerOrSigner), [providerOrSigner])
 }
 
 export const useTradingCompetitionContractFanToken = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getTradingCompetitionContractFanToken(providerOrSigner), [providerOrSigner])
 }
 
 export const useTradingCompetitionContractMobox = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getTradingCompetitionContractMobox(providerOrSigner), [providerOrSigner])
 }
 
 export const useTradingCompetitionContractMoD = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getTradingCompetitionContractMoD(providerOrSigner), [providerOrSigner])
 }
 
@@ -226,7 +225,7 @@ export const usePredictionsContract = (address: string, tokenSymbol: string) => 
 }
 
 export const useChainlinkOracleContract = (address, withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getChainlinkOracleContract(address, providerOrSigner), [providerOrSigner, address])
 }
 
@@ -251,7 +250,7 @@ export const useBunnySpecialXmasContract = () => {
 }
 
 export const useAnniversaryAchievementContract = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getAnniversaryAchievementContract(providerOrSigner), [providerOrSigner])
 }
 
@@ -266,7 +265,7 @@ export const usePancakeSquadContract = () => {
 }
 
 export const useFarmAuctionContract = (withSignerIfPossible = true) => {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getFarmAuctionContract(providerOrSigner), [providerOrSigner])
 }
 
@@ -296,9 +295,7 @@ export function useContract<T extends Contract = Contract>(
   ABI: any,
   withSignerIfPossible = true,
 ): T | null {
-  const { provider } = useActiveWeb3React()
-
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible) ?? provider
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
 
   const canReturnContract = useMemo(() => address && ABI && providerOrSigner, [address, ABI, providerOrSigner])
 
@@ -346,21 +343,22 @@ export const usePotterytDrawContract = () => {
 }
 
 export function useZapContract(withSignerIfPossible = true) {
-  return useContract<Zap>(getZapAddress(), zapAbi, withSignerIfPossible)
+  const { chainId } = useActiveChainId()
+  return useContract<Zap>(getZapAddress(chainId), zapAbi, withSignerIfPossible)
 }
 
 export function useBCakeFarmBoosterContract(withSignerIfPossible = true) {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getBCakeFarmBoosterContract(providerOrSigner), [providerOrSigner])
 }
 
 export function useBCakeFarmBoosterProxyFactoryContract(withSignerIfPossible = true) {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(() => getBCakeFarmBoosterProxyFactoryContract(providerOrSigner), [providerOrSigner])
 }
 
 export function useBCakeProxyContract(proxyContractAddress: string, withSignerIfPossible = true) {
-  const providerOrSigner = useProviderOrSigner(withSignerIfPossible)
+  const providerOrSigner = useProviderOrSigner(withSignerIfPossible, true)
   return useMemo(
     () => proxyContractAddress && getBCakeProxyContract(proxyContractAddress, providerOrSigner),
     [providerOrSigner, proxyContractAddress],

--- a/apps/web/src/hooks/useProviderOrSigner.ts
+++ b/apps/web/src/hooks/useProviderOrSigner.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
+import { ChainId } from '@pancakeswap/sdk'
 import { useAccount, useProvider, useSigner } from 'wagmi'
 import { useActiveChainId } from './useActiveChainId'
 
-export const useProviderOrSigner = (withSignerIfPossible = true) => {
+export const useProviderOrSigner = (withSignerIfPossible = true, forceBSC?: boolean) => {
   const { chainId } = useActiveChainId()
-  const provider = useProvider({ chainId })
+  const provider = useProvider({ chainId: forceBSC ? ChainId.BSC : chainId })
   const { address, isConnected } = useAccount()
   const { data: signer } = useSigner()
 

--- a/apps/web/src/utils/addressHelpers.ts
+++ b/apps/web/src/utils/addressHelpers.ts
@@ -106,8 +106,8 @@ export const getPotteryDrawAddress = () => {
   return getAddress(addresses.potteryDraw)
 }
 
-export const getZapAddress = () => {
-  return getAddress(addresses.zap)
+export const getZapAddress = (chainId?: number) => {
+  return getAddress(addresses.zap, chainId)
 }
 export const getICakeAddress = () => {
   return getAddress(addresses.iCake)

--- a/apps/web/src/utils/contractHelpers.ts
+++ b/apps/web/src/utils/contractHelpers.ts
@@ -350,10 +350,6 @@ export const getPotteryDrawContract = (signer?: Signer | Provider) => {
   return getContract({ abi: potteryDrawAbi, address: getPotteryDrawAddress(), signer }) as PotteryDrawAbi
 }
 
-export const getZapContract = (signer?: Signer | Provider) => {
-  return getContract({ abi: zapAbi, address: getZapAddress(), signer }) as Zap
-}
-
 export const getIfoCreditAddressContract = (signer?: Signer | Provider) => {
   return getContract({ abi: iCakeAbi, address: getICakeAddress(), signer }) as ICake
 }

--- a/apps/web/src/views/AddLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/index.tsx
@@ -71,8 +71,6 @@ enum Steps {
   Add,
 }
 
-const zapAddress = getZapAddress()
-
 export default function AddLiquidity({ currencyA, currencyB }) {
   const router = useRouter()
   const { account, chainId, isWrongNetwork } = useActiveWeb3React()
@@ -80,6 +78,7 @@ export default function AddLiquidity({ currencyA, currencyB }) {
   const addPair = usePairAdder()
   const [zapMode] = useZapModeManager()
   const expertMode = useIsExpertMode()
+  const zapAddress = getZapAddress(chainId)
 
   const [temporarilyZapMode, setTemporarilyZapMode] = useState(true)
 
@@ -346,7 +345,7 @@ export default function AddLiquidity({ currencyA, currencyB }) {
   const addIsUnsupported = useIsTransactionUnsupported(currencies?.CURRENCY_A, currencies?.CURRENCY_B)
   const addIsWarning = useIsTransactionWarning(currencies?.CURRENCY_A, currencies?.CURRENCY_B)
 
-  const zapContract = useZapContract(true)
+  const zapContract = useZapContract()
 
   const [onPresentAddLiquidityModal] = useModal(
     <ConfirmAddLiquidityModal

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -153,7 +153,7 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
   const [signatureData, setSignatureData] = useState<{ v: number; r: string; s: string; deadline: number } | null>(null)
   const [approval, approveCallback] = useApproveCallback(
     parsedAmounts[Field.LIQUIDITY],
-    isZap ? getZapAddress() : ROUTER_ADDRESS[chainId],
+    isZap ? getZapAddress(chainId) : ROUTER_ADDRESS[chainId],
   )
 
   async function onAttemptToApprove() {
@@ -235,7 +235,7 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
   const onCurrencyAInput = useCallback((value: string): void => onUserInput(Field.CURRENCY_A, value), [onUserInput])
   const onCurrencyBInput = useCallback((value: string): void => onUserInput(Field.CURRENCY_B, value), [onUserInput])
 
-  const zapContract = useZapContract(true)
+  const zapContract = useZapContract()
 
   // tx sending
   const addTransaction = useTransactionAdder()


### PR DESCRIPTION
If user is in another chain than bsc, it uses contract address of bsc chain but uses the provider of active chain which results errors and mismatch requests. It also enables zap to be used with bsc testnet