### PR TITLE
fix: (prediction): Min token displayed decimals is in wrong precision

### DIFF
--- a/apps/web/src/__tests__/views/predictions/helpers.test.ts
+++ b/apps/web/src/__tests__/views/predictions/helpers.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { formatRoundTime, padTime, formatBnbv2, formatUsdv2 } from 'views/Predictions/helpers'
+import { formatRoundTime, padTime, formatTokenv2, formatUsdv2 } from 'views/Predictions/helpers'
 
 describe('padTime', () => {
   it.each([
@@ -25,10 +25,10 @@ describe('formatRoundTime', () => {
 describe('formatUsdv2', () => {
   it.each`
     priceDifference | expectedPriceDifferenceFormatted
-    ${10}           | ${'<$0.0010'}
-    ${100}          | ${'<$0.0010'}
-    ${1000}         | ${'<$0.0010'}
-    ${10000}        | ${'<$0.0010'}
+    ${10}           | ${'<$0.0001'}
+    ${100}          | ${'<$0.0001'}
+    ${1000}         | ${'<$0.0001'}
+    ${10000}        | ${'$0.0001'}
     ${100000}       | ${'$0.0010'}
     ${1000000}      | ${'$0.0100'}
     ${10000000}     | ${'$0.1000'}
@@ -41,25 +41,23 @@ describe('formatUsdv2', () => {
     ${-10000000}    | ${'$-0.1000'}
     ${-1000000}     | ${'$-0.0100'}
     ${-100000}      | ${'$-0.0010'}
-    ${-10000}       | ${'<$-0.0010'}
-    ${-1000}        | ${'<$-0.0010'}
-    ${-100}         | ${'<$-0.0010'}
-    ${-10}          | ${'<$-0.0010'}
+    ${-10000}       | ${'$-0.0001'}
+    ${-1000}        | ${'<$-0.0001'}
+    ${-100}         | ${'<$-0.0001'}
+    ${-10}          | ${'<$-0.0001'}
   `(
     'should format $priceDifference to $expectedPriceDifferenceFormatted',
     ({ priceDifference, expectedPriceDifferenceFormatted }) =>
-      expect(formatUsdv2(BigNumber.from(priceDifference), BigNumber.from(100000), 4)).toEqual(
-        expectedPriceDifferenceFormatted,
-      ),
+      expect(formatUsdv2(BigNumber.from(priceDifference), 4)).toEqual(expectedPriceDifferenceFormatted),
   )
 })
 
-describe('formatBnbv2', () => {
+describe('formatTokenv2', () => {
   it.each`
     priceDifference             | expectedPriceDifferenceFormatted
-    ${'1000000000000'}          | ${'<0.0010'}
-    ${'10000000000000'}         | ${'<0.0010'}
-    ${'100000000000000'}        | ${'<0.0010'}
+    ${'1000000000000'}          | ${'<0.0001'}
+    ${'10000000000000'}         | ${'<0.0001'}
+    ${'100000000000000'}        | ${'0.0001'}
     ${'1000000000000000'}       | ${'0.0010'}
     ${'10000000000000000'}      | ${'0.0100'}
     ${'100000000000000000'}     | ${'0.1000'}
@@ -72,13 +70,13 @@ describe('formatBnbv2', () => {
     ${'-100000000000000000'}    | ${'-0.1000'}
     ${'-10000000000000000'}     | ${'-0.0100'}
     ${'-1000000000000000'}      | ${'-0.0010'}
-    ${'-100000000000000'}       | ${'<-0.0010'}
-    ${'-10000000000000'}        | ${'<-0.0010'}
-    ${'-1000000000000'}         | ${'<-0.0010'}
-    ${'-100000000000'}          | ${'<-0.0010'}
+    ${'-100000000000000'}       | ${'-0.0001'}
+    ${'-10000000000000'}        | ${'<-0.0001'}
+    ${'-1000000000000'}         | ${'<-0.0001'}
+    ${'-100000000000'}          | ${'<-0.0001'}
   `(
     'should format $priceDifference to $expectedPriceDifferenceFormatted',
     ({ priceDifference, expectedPriceDifferenceFormatted }) =>
-      expect(formatBnbv2(BigNumber.from(priceDifference), 4)).toEqual(expectedPriceDifferenceFormatted),
+      expect(formatTokenv2(BigNumber.from(priceDifference), 18, 4)).toEqual(expectedPriceDifferenceFormatted),
   )
 })

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -522,7 +522,6 @@ export interface PredictionConfig {
   address: string
   api: string
   chainlinkOracleAddress: string
-  minPriceUsdDisplayed: EthersBigNumber
   displayedDecimals: number
   token: Token
 }

--- a/apps/web/src/views/Predictions/components/RoundCard/EnteredTag.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/EnteredTag.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { ethersToBigNumber } from '@pancakeswap/utils/bigNumber'
 import { REWARD_RATE } from 'state/predictions/config'
 import { useConfig } from 'views/Predictions/context/ConfigProvider'
-import { formatBnbv2 } from '../../helpers'
+import { formatTokenv2 } from '../../helpers'
 
 interface EnteredTagProps {
   amount?: BigNumber
@@ -31,8 +31,8 @@ const EnteredTag: React.FC<React.PropsWithChildren<EnteredTagProps>> = ({ amount
     } else {
       tokenAmount = amount
     }
-    return formatBnbv2(tokenAmount, displayedDecimals)
-  }, [amount, displayedDecimals, hasClaimed, multiplier])
+    return formatTokenv2(tokenAmount, token.decimals, displayedDecimals)
+  }, [amount, displayedDecimals, hasClaimed, multiplier, token])
 
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
     <div style={{ whiteSpace: 'nowrap' }}>{`${formattedAmount} ${token.symbol}`}</div>,

--- a/apps/web/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
@@ -42,7 +42,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
   const { lockPrice, totalAmount, lockTimestamp, closeTimestamp } = round
   const { price, refresh } = usePollOraclePrice()
   const bufferSeconds = useGetBufferSeconds()
-  const { minPriceUsdDisplayed, displayedDecimals } = useConfig()
+  const { displayedDecimals } = useConfig()
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
@@ -114,9 +114,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
             <div ref={targetRef}>
               <LiveRoundPrice betPosition={betPosition} price={price} />
             </div>
-            <PositionTag betPosition={betPosition}>
-              {formatUsdv2(priceDifference, minPriceUsdDisplayed, displayedDecimals)}
-            </PositionTag>
+            <PositionTag betPosition={betPosition}>{formatUsdv2(priceDifference, displayedDecimals)}</PositionTag>
           </Flex>
           {lockPrice && <LockPriceRow lockPrice={lockPrice} />}
           <PrizePoolRow totalAmount={totalAmount} />

--- a/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -19,7 +19,7 @@ import { ROUND_BUFFER } from 'state/predictions/config'
 import { BetPosition, NodeLedger, NodeRound } from 'state/types'
 import { getNow } from 'utils/getNow'
 import { useConfig } from 'views/Predictions/context/ConfigProvider'
-import { formatBnbv2 } from '../../helpers'
+import { formatTokenv2 } from '../../helpers'
 import CardFlip from '../CardFlip'
 import { PrizePoolRow, RoundResultBox } from '../RoundResult'
 import CardHeader, { getBorderBackground } from './CardHeader'
@@ -79,7 +79,9 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
     [hasEnteredUp, hasEnteredDown],
   )
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
-    <div style={{ whiteSpace: 'nowrap' }}>{`${formatBnbv2(betAmount, displayedDecimals)} ${token.symbol}`}</div>,
+    <div style={{ whiteSpace: 'nowrap' }}>{`${formatTokenv2(betAmount, token.decimals, displayedDecimals)} ${
+      token.symbol
+    }`}</div>,
     { placement: 'top' },
   )
 

--- a/apps/web/src/views/Predictions/components/RoundResult/styles.tsx
+++ b/apps/web/src/views/Predictions/components/RoundResult/styles.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, FlexProps, Skeleton, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { BetPosition, NodeRound, Round } from 'state/types'
 import { useConfig } from 'views/Predictions/context/ConfigProvider'
-import { formatUsdv2, formatBnbv2, getRoundPosition, getPriceDifference } from '../../helpers'
+import { formatUsdv2, formatTokenv2, getRoundPosition, getPriceDifference } from '../../helpers'
 import { formatBnb, formatUsd } from '../History/helpers'
 import PositionTag from '../PositionTag'
 
@@ -14,12 +14,16 @@ interface PrizePoolRowProps extends FlexProps {
   totalAmount: NodeRound['totalAmount']
 }
 
-const getPrizePoolAmount = (totalAmount: PrizePoolRowProps['totalAmount'], displayedDecimals: number) => {
+const getPrizePoolAmount = (
+  totalAmount: PrizePoolRowProps['totalAmount'],
+  decimals: number,
+  displayedDecimals: number,
+) => {
   if (!totalAmount) {
     return '0'
   }
 
-  return formatBnbv2(totalAmount, displayedDecimals)
+  return formatTokenv2(totalAmount, decimals, displayedDecimals)
 }
 
 const Row = ({ children, ...props }) => {
@@ -37,7 +41,7 @@ export const PrizePoolRow: React.FC<React.PropsWithChildren<PrizePoolRowProps>> 
   return (
     <Row {...props}>
       <Text bold>{t('Prize Pool')}:</Text>
-      <Text bold>{`${getPrizePoolAmount(totalAmount, displayedDecimals)} ${token.symbol}`}</Text>
+      <Text bold>{`${getPrizePoolAmount(totalAmount, token.decimals, displayedDecimals)} ${token.symbol}`}</Text>
     </Row>
   )
 }
@@ -81,12 +85,12 @@ interface LockPriceRowProps extends FlexProps {
 
 export const LockPriceRow: React.FC<React.PropsWithChildren<LockPriceRowProps>> = ({ lockPrice, ...props }) => {
   const { t } = useTranslation()
-  const { displayedDecimals, minPriceUsdDisplayed } = useConfig()
+  const { displayedDecimals } = useConfig()
 
   return (
     <Row {...props}>
       <Text fontSize="14px">{t('Locked Price')}:</Text>
-      <Text fontSize="14px">{formatUsdv2(lockPrice, minPriceUsdDisplayed, displayedDecimals)}</Text>
+      <Text fontSize="14px">{formatUsdv2(lockPrice, displayedDecimals)}</Text>
     </Row>
   )
 }
@@ -158,7 +162,7 @@ interface RoundPriceProps {
 }
 
 export const RoundPrice: React.FC<React.PropsWithChildren<RoundPriceProps>> = ({ lockPrice, closePrice }) => {
-  const { displayedDecimals, minPriceUsdDisplayed } = useConfig()
+  const { displayedDecimals } = useConfig()
   const betPosition = getRoundPosition(lockPrice, closePrice)
   const priceDifference = getPriceDifference(closePrice, lockPrice)
 
@@ -178,14 +182,12 @@ export const RoundPrice: React.FC<React.PropsWithChildren<RoundPriceProps>> = ({
     <Flex alignItems="center" justifyContent="space-between" mb="16px">
       {closePrice ? (
         <Text color={textColor} bold fontSize="24px">
-          {formatUsdv2(closePrice, minPriceUsdDisplayed, displayedDecimals)}
+          {formatUsdv2(closePrice, displayedDecimals)}
         </Text>
       ) : (
         <Skeleton height="34px" my="1px" />
       )}
-      <PositionTag betPosition={betPosition}>
-        {formatUsdv2(priceDifference, minPriceUsdDisplayed, displayedDecimals)}
-      </PositionTag>
+      <PositionTag betPosition={betPosition}>{formatUsdv2(priceDifference, displayedDecimals)}</PositionTag>
     </Flex>
   )
 }

--- a/apps/web/src/views/Predictions/context/config.ts
+++ b/apps/web/src/views/Predictions/context/config.ts
@@ -5,14 +5,11 @@ import { getAddress } from 'utils/addressHelpers'
 import { bscTokens } from '@pancakeswap/tokens'
 import { BigNumber } from '@ethersproject/bignumber'
 
-const DEFAULT_MIN_PRICE_USD_DISPLAYED = BigNumber.from(10000)
-
 export default {
   BNB: {
     address: getAddress(addresses.predictionsBNB),
     api: GRAPH_API_PREDICTION_BNB,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleBNB),
-    minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
     displayedDecimals: 4,
     token: bscTokens.bnb,
   },
@@ -20,7 +17,6 @@ export default {
     address: getAddress(addresses.predictionsCAKE),
     api: GRAPH_API_PREDICTION_CAKE,
     chainlinkOracleAddress: getAddress(addresses.chainlinkOracleCAKE),
-    minPriceUsdDisplayed: DEFAULT_MIN_PRICE_USD_DISPLAYED,
     displayedDecimals: 4,
     token: bscTokens.cake,
   },

--- a/apps/web/src/views/Predictions/helpers.ts
+++ b/apps/web/src/views/Predictions/helpers.ts
@@ -3,8 +3,14 @@ import { BetPosition } from 'state/types'
 import { formatBigNumberToFixed } from '@pancakeswap/utils/formatBalance'
 import getTimePeriods from 'utils/getTimePeriods'
 import { NegativeOne, One, Zero } from '@ethersproject/constants'
+import memoize from 'lodash/memoize'
 
-const MIN_PRICE_BNB_DISPLAYED = BigNumber.from('1000000000000000')
+const calculateMinDisplayed = memoize(
+  (decimals: number, displayedDecimals: number): BigNumber => {
+    return BigNumber.from(10).pow(decimals).div(BigNumber.from(10).pow(displayedDecimals))
+  },
+  (decimals, displayedDecimals) => `${decimals}#${displayedDecimals}`,
+)
 
 type formatPriceDifferenceProps = {
   price?: BigNumber
@@ -30,17 +36,23 @@ const formatPriceDifference = ({
   return `${unitPrefix}${formatBigNumberToFixed(price, displayedDecimals, decimals)}`
 }
 
-export const formatUsdv2 = (usd: BigNumber, minPriceDisplayed: BigNumber, displayedDecimals: number) => {
-  return formatPriceDifference({ price: usd, minPriceDisplayed, unitPrefix: '$', displayedDecimals, decimals: 8 })
+export const formatUsdv2 = (usd: BigNumber, displayedDecimals: number) => {
+  return formatPriceDifference({
+    price: usd,
+    minPriceDisplayed: calculateMinDisplayed(8, displayedDecimals),
+    unitPrefix: '$',
+    displayedDecimals,
+    decimals: 8,
+  })
 }
 
-export const formatBnbv2 = (bnb: BigNumber, displayedDecimals: number) => {
+export const formatTokenv2 = (token: BigNumber, decimals: number, displayedDecimals: number) => {
   return formatPriceDifference({
-    price: bnb,
-    minPriceDisplayed: MIN_PRICE_BNB_DISPLAYED,
+    price: token,
+    minPriceDisplayed: calculateMinDisplayed(decimals, displayedDecimals),
     unitPrefix: '',
     displayedDecimals,
-    decimals: 18,
+    decimals,
   })
 }
 


### PR DESCRIPTION
When there is no bet Prize pool of open round shows <0.0010 instead of <0.0001. With this pr instead of using constant, min displayed price/amount calculation will be done dynamically based on decimals and displayedDecimals. 