### PR TITLE
chore: Change error text for approve callback estimate gas

### DIFF
--- a/apps/web/src/hooks/useApproveCallback.ts
+++ b/apps/web/src/hooks/useApproveCallback.ts
@@ -91,7 +91,7 @@ export function useApproveCallback(
       useExact = true
       return tokenContract.estimateGas.approve(spender, amountToApprove.quotient.toString()).catch(() => {
         console.error('estimate gas failure')
-        toastError(t('Error'), t('Unexpected error. Could not estimate gas for the swap.'))
+        toastError(t('Error'), t('Unexpected error. Could not estimate gas for the approve.'))
         return null
       })
     })

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1503,6 +1503,7 @@
   "Unexpected issue with estimating the gas. Please try again.": "Unexpected issue with estimating the gas. Please try again.",
   "Swap failed: %message%": "Swap failed: %message%",
   "Unexpected error. Could not estimate gas for the swap.": "Unexpected error. Could not estimate gas for the swap.",
+  "Unexpected error. Could not estimate gas for the approve.": "Unexpected error. Could not estimate gas for the approve.",
   "Farm Auction": "Farm Auction",
   "Farm Auction Winner, add liquidity at your own risk.": "Farm Auction Winner, add liquidity at your own risk.",
   "Currently showing charts from Chainlink oracle": "Currently showing charts from Chainlink oracle",


### PR DESCRIPTION
approve callback hook is also used in liquidity so it is better to use this error text when estimate gas failure