### PR TITLE
chore: Show native symbol of token's of staked lp in farms staked component

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/router'
 import { usePriceCakeBusd } from 'state/farms/hooks'
 import { useAppDispatch } from 'state'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
-import { ChainId } from '@pancakeswap/sdk'
+import { ChainId, WNATIVE, NATIVE } from '@pancakeswap/sdk'
 import BigNumber from 'bignumber.js'
 import { useIsBloctoETH } from 'views/Farms'
 import { DEFAULT_TOKEN_DECIMAL } from 'config'
@@ -314,8 +314,8 @@ const StakeAction: React.FC<React.PropsWithChildren<FarmCardActionsProps>> = ({
       <FarmUI.StakedLP
         decimals={18}
         stakedBalance={stakedBalance}
-        quoteTokenSymbol={quoteToken.symbol}
-        tokenSymbol={token.symbol}
+        quoteTokenSymbol={WNATIVE[chainId]?.symbol === quoteToken.symbol ? NATIVE[chainId]?.symbol : quoteToken.symbol}
+        tokenSymbol={WNATIVE[chainId]?.symbol === token.symbol ? NATIVE[chainId]?.symbol : token.symbol}
         lpTotalSupply={lpTotalSupply}
         lpTokenPrice={lpTokenPrice}
         tokenAmountTotal={tokenAmountTotal}

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -20,7 +20,7 @@ import getLiquidityUrlPathParts from 'utils/getLiquidityUrlPathParts'
 import BigNumber from 'bignumber.js'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import { formatLpBalance } from '@pancakeswap/utils/formatBalance'
-import { ChainId } from '@pancakeswap/sdk'
+import { ChainId, WNATIVE, NATIVE } from '@pancakeswap/sdk'
 import WalletModal, { WalletView } from 'components/Menu/UserMenu/WalletModal'
 import { useAccount } from 'wagmi'
 import { useIsBloctoETH } from 'views/Farms'
@@ -381,8 +381,10 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
           <FarmUI.StakedLP
             decimals={18}
             stakedBalance={stakedBalance}
-            quoteTokenSymbol={quoteToken.symbol}
-            tokenSymbol={token.symbol}
+            quoteTokenSymbol={
+              WNATIVE[chainId]?.symbol === quoteToken.symbol ? NATIVE[chainId]?.symbol : quoteToken.symbol
+            }
+            tokenSymbol={WNATIVE[chainId]?.symbol === token.symbol ? NATIVE[chainId]?.symbol : token.symbol}
             lpTotalSupply={lpTotalSupply}
             lpTokenPrice={lpTokenPrice}
             tokenAmountTotal={tokenAmountTotal}


### PR DESCRIPTION
Instead of wbnb/weth it should be shown as bnb where farm has bnb/eth quotetoken or token, to be consistent with it is name shown in the list