### PR TITLE
fix(LockCakePools): Extend button alignment

### DIFF
--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -319,7 +319,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
                 </Text>
                 <Text
                   lineHeight="1"
-                  mt="8px"
+                  mt="5px"
                   bold
                   fontSize="20px"
                   color={vaultPosition >= VaultPosition.LockedEnd ? '#D67E0A' : 'text'}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/205920447-9dfe0348-baa4-4ed0-9981-9d72103f3244.png)

After:
![image](https://user-images.githubusercontent.com/109973128/205920551-6b90fd15-2604-4f8e-958d-7ca3500479dc.png)

