### PR TITLE
fix: (tooltip): Tap to tooltip causes other elements to react

### DIFF
--- a/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -88,10 +88,9 @@ const useTooltip = (content: React.ReactNode, options?: TooltipOptions): Tooltip
         if (e.target === tooltipElement) {
           isHoveringOverTooltip.current = true;
         }
-      } else {
-        e.stopPropagation();
-        e.preventDefault();
       }
+      e.stopPropagation();
+      e.preventDefault();
     },
     [tooltipElement, targetElement, trigger]
   );


### PR DESCRIPTION
To reproduce:

1. Go to farms in mobile
2. Tap apr to show tooltip
3. See action panel opens