### PR TITLE
fix: (ifo): Trigger wallet data fetch when account change

### DIFF
--- a/apps/web/src/state/pools/hooks.ts
+++ b/apps/web/src/state/pools/hooks.ts
@@ -171,7 +171,7 @@ export const useFetchIfo = () => {
   )
 
   useSWRImmutable(
-    account && 'fetchIfoUserData',
+    account && ['fetchIfoUserData', account],
     async () => {
       batch(() => {
         dispatch(fetchCakePoolUserDataAsync(account))


### PR DESCRIPTION
To reproduce: 

1. Go to ifo with account
2. Change account from wallet
3. See it still shows previous account wallet data until the next interval