### PR TITLE
chore: update Aptos github action setting

### DIFF
--- a/.github/workflows/updateAptosLPsAPR.yml
+++ b/.github/workflows/updateAptosLPsAPR.yml
@@ -44,4 +44,4 @@ jobs:
 
             [1]: https://github.com/peter-evans/create-pull-request
           labels: automerge
-          branch: update-lp-aprs-for-farms
+          branch: update-aptos-lp-aprs-for-farms


### PR DESCRIPTION
Make sure the branch name won't be conflict while open PR