### PR TITLE
fix: Farm DepositModal and WithdrawModal

### DIFF
--- a/packages/uikit/src/widgets/Farm/components/DepositModal/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/DepositModal/index.tsx
@@ -129,7 +129,8 @@ const DepositModal: React.FC<React.PropsWithChildren<DepositModalProps>> = ({
         .dividedBy(100)
         .multipliedBy(percent)
         .toNumber()
-        .toLocaleString(undefined, { maximumFractionDigits: decimals });
+        .toLocaleString(undefined, { maximumFractionDigits: decimals })
+        .replace(/,/g, ".");
       setVal(totalAmount);
     },
     [decimals, fullBalanceNumber]

--- a/packages/uikit/src/widgets/Farm/components/WithdrawModal/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/WithdrawModal/index.tsx
@@ -56,7 +56,8 @@ const WithdrawModal: React.FC<React.PropsWithChildren<WithdrawModalProps>> = ({
         .dividedBy(100)
         .multipliedBy(percent)
         .toNumber()
-        .toLocaleString(undefined, { maximumFractionDigits: decimals });
+        .toLocaleString(undefined, { maximumFractionDigits: decimals })
+        .replace(/,/g, ".");
       setVal(totalAmount);
     },
     [decimals, fullBalanceNumber]


### PR DESCRIPTION
Issue from blockto and safepal with farm in android.
click 25%/50/75 -> it shows `,`  instead  `.`