### PR TITLE
fix: (info): Info page shows wrong info when access stableswap page with different chain name

### DIFF
--- a/apps/web/src/views/Info/index.tsx
+++ b/apps/web/src/views/Info/index.tsx
@@ -14,15 +14,22 @@ export const InfoPageLayout = ({ children }) => {
   const router = useRouter()
   const chainName = useGetChainName()
   const { t } = useTranslation()
+  const isStableSwap = router.query.type === 'stableSwap'
 
   useEffect(() => {
     if (account && chainId === ChainId.BSC && router.query.chainName === 'eth')
       router.replace('/info', undefined, { shallow: true })
-    if (account && chainId === ChainId.ETHEREUM && router.query.chainName !== 'eth')
+    else if (account && chainId === ChainId.ETHEREUM && router.query.chainName !== 'eth')
       router.replace('/info/eth', undefined, { shallow: true })
-  }, [chainId, account, chainName, router])
+    else if (isStableSwap && router.query.chainName) {
+      if (router.query.chainName === 'eth') {
+        router.replace('/info/eth', undefined, { shallow: true })
+      } else {
+        router.replace('/info?type=stableSwap', undefined, { shallow: true })
+      }
+    }
+  }, [isStableSwap, chainId, account, chainName, router])
 
-  const isStableSwap = router.query.type === 'stableSwap'
   return (
     <>
       {chainName === 'BSC' && (


### PR DESCRIPTION
To reproduce: 

1. Try to access page without account
https://pancakeswap.finance/info/eth?type=stableSwap

2. Access page when account is connected to eth
https://pancakeswap.finance/info/eth/pairs?type=stableSwap

