### PR TITLE
feat: (pools): Add allowance approve button to lock modals

### DIFF
--- a/apps/web/src/components/ApproveConfirmButtons.tsx
+++ b/apps/web/src/components/ApproveConfirmButtons.tsx
@@ -17,6 +17,7 @@ interface ApproveConfirmButtonsProps {
   buttonArrangement?: ButtonArrangement
   confirmLabel?: string
   confirmId?: string
+  useMinWidth?: boolean
 }
 
 const StyledApproveConfirmButtonRow = styled.div`
@@ -30,11 +31,15 @@ const StyledApproveConfirmButtonRow = styled.div`
   }
 `
 
-const Button = styled(UIKitButton)`
+const Button = styled(UIKitButton)<{ useMinWidth: boolean }>`
   width: 100%;
 
   ${({ theme }) => theme.mediaQueries.md} {
+    ${({ useMinWidth }) =>
+      useMinWidth &&
+      `  
     min-width: 160px;
+  `}
   }
 `
 
@@ -68,6 +73,7 @@ const ApproveConfirmButtons: React.FC<React.PropsWithChildren<ApproveConfirmButt
   buttonArrangement = ButtonArrangement.ROW,
   confirmLabel,
   confirmId,
+  useMinWidth = true,
 }) => {
   const { t } = useTranslation()
   const confirmButtonText = confirmLabel ?? t('Confirm')
@@ -81,6 +87,7 @@ const ApproveConfirmButtons: React.FC<React.PropsWithChildren<ApproveConfirmButt
             onClick={onApprove}
             endIcon={isApproving ? spinnerIcon : undefined}
             isLoading={isApproving}
+            useMinWidth={useMinWidth}
           >
             {isApproving ? t('Enabling') : t('Enable')}
           </Button>
@@ -96,6 +103,7 @@ const ApproveConfirmButtons: React.FC<React.PropsWithChildren<ApproveConfirmButt
             disabled={isConfirmDisabled}
             isLoading={isConfirming}
             endIcon={isConfirming ? spinnerIcon : undefined}
+            useMinWidth={useMinWidth}
           >
             {isConfirming ? t('Confirming') : confirmButtonText}
           </Button>

--- a/apps/web/src/views/Pools/components/LockedPool/Common/BalanceField.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/BalanceField.tsx
@@ -20,6 +20,7 @@ interface PropsType {
   setLockedAmount: Dispatch<SetStateAction<string>>
   usedValueStaked: number | undefined
   stakingTokenBalance: BigNumber
+  needApprove: boolean
 }
 
 const BalanceField: React.FC<React.PropsWithChildren<PropsType>> = ({
@@ -31,6 +32,7 @@ const BalanceField: React.FC<React.PropsWithChildren<PropsType>> = ({
   setLockedAmount,
   usedValueStaked,
   stakingTokenBalance,
+  needApprove,
 }) => {
   const { t } = useTranslation()
   const { userNotEnoughCake, notEnoughErrorMessage } = useUserEnoughCakeValidator(lockedAmount, stakingTokenBalance)
@@ -80,12 +82,17 @@ const BalanceField: React.FC<React.PropsWithChildren<PropsType>> = ({
         </Flex>
       </Flex>
       <BalanceInput
-        isWarning={userNotEnoughCake}
+        isWarning={userNotEnoughCake || needApprove}
         value={lockedAmount}
         onUserInput={handleStakeInputChange}
         currencyValue={`~${usedValueStaked || 0} USD`}
         decimals={stakingDecimals}
       />
+      {needApprove && !userNotEnoughCake ? (
+        <Text color="failure" textAlign="right" fontSize="12px" mt="8px">
+          {t('Insufficient token allowance. Click "Enable" to approve.')}
+        </Text>
+      ) : null}
       <Flex alignItems="center" justifyContent="flex-end" mt="4px" mb="12px">
         <Flex justifyContent="flex-end" flexDirection="column">
           {userNotEnoughCake && (

--- a/apps/web/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
@@ -1,27 +1,46 @@
-import { Button, AutoRenewIcon } from '@pancakeswap/uikit'
-import { useTranslation } from '@pancakeswap/localization'
+import { useState, useEffect } from 'react'
+import ApproveConfirmButtons from 'components/ApproveConfirmButtons'
 import { useExtendEnable } from '../hooks/useExtendEnable'
 
 interface ExtendEnableProps {
+  disabled: boolean
+  hasEnoughCake: boolean
+  handleConfirmClick: () => void
+  pendingConfirmTx: boolean
   isValidAmount: boolean
   isValidDuration: boolean
 }
 
-const ExtendEnable: React.FC<React.PropsWithChildren<ExtendEnableProps>> = ({ isValidAmount, isValidDuration }) => {
-  const { t } = useTranslation()
-
+const ExtendEnable: React.FC<React.PropsWithChildren<ExtendEnableProps>> = ({
+  disabled,
+  hasEnoughCake,
+  handleConfirmClick,
+  pendingConfirmTx,
+  isValidAmount,
+  isValidDuration,
+}) => {
   const { handleEnable, pendingEnableTx } = useExtendEnable()
 
+  const [pendingEnableTxWithBalance, setPendingEnableTxWithBalance] = useState(pendingEnableTx)
+
+  useEffect(() => {
+    if (pendingEnableTx) {
+      setPendingEnableTxWithBalance(true)
+    } else if (hasEnoughCake) {
+      setPendingEnableTxWithBalance(false)
+    }
+  }, [hasEnoughCake, pendingEnableTx])
+
   return (
-    <Button
-      width="100%"
-      isLoading={pendingEnableTx}
-      endIcon={pendingEnableTx ? <AutoRenewIcon spin color="currentColor" /> : null}
-      onClick={handleEnable}
-      disabled={!(isValidAmount && isValidDuration)}
-    >
-      {pendingEnableTx ? t('Enabling') : t('Enable')}
-    </Button>
+    <ApproveConfirmButtons
+      isApproveDisabled={!(isValidAmount && isValidDuration) || hasEnoughCake}
+      isApproving={pendingEnableTxWithBalance}
+      isConfirmDisabled={!(isValidAmount && isValidDuration) || disabled || !hasEnoughCake}
+      isConfirming={pendingConfirmTx}
+      onApprove={handleEnable}
+      onConfirm={handleConfirmClick}
+      useMinWidth={false}
+    />
   )
 }
 

--- a/apps/web/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/ExtendEnable.tsx
@@ -3,7 +3,6 @@ import ApproveConfirmButtons from 'components/ApproveConfirmButtons'
 import { useExtendEnable } from '../hooks/useExtendEnable'
 
 interface ExtendEnableProps {
-  disabled: boolean
   hasEnoughCake: boolean
   handleConfirmClick: () => void
   pendingConfirmTx: boolean
@@ -12,7 +11,6 @@ interface ExtendEnableProps {
 }
 
 const ExtendEnable: React.FC<React.PropsWithChildren<ExtendEnableProps>> = ({
-  disabled,
   hasEnoughCake,
   handleConfirmClick,
   pendingConfirmTx,
@@ -35,7 +33,7 @@ const ExtendEnable: React.FC<React.PropsWithChildren<ExtendEnableProps>> = ({
     <ApproveConfirmButtons
       isApproveDisabled={!(isValidAmount && isValidDuration) || hasEnoughCake}
       isApproving={pendingEnableTxWithBalance}
-      isConfirmDisabled={!(isValidAmount && isValidDuration) || disabled || !hasEnoughCake}
+      isConfirmDisabled={!(isValidAmount && isValidDuration) || !hasEnoughCake}
       isConfirming={pendingConfirmTx}
       onApprove={handleEnable}
       onConfirm={handleConfirmClick}

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -71,7 +71,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
     VaultKey.CakeVault,
     setLastUpdated,
   )
-  const needApprove = useMemo(() => {
+  const needsApprove = useMemo(() => {
     if (cakeNeeded) {
       return ENABLE_EXTEND_LOCK_AMOUNT.gt(allowance)
     }
@@ -122,7 +122,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         />
       )}
 
-      {!needApprove && cakeNeeded ? (
+      {!needsApprove && cakeNeeded ? (
         hasEnoughBalanceToExtend ? (
           <Text fontSize="12px" mt="24px">
             {t('0.0001 CAKE will be spent to extend')}
@@ -134,14 +134,14 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         )
       ) : null}
 
-      {needApprove && cakeNeeded ? (
+      {needsApprove && cakeNeeded ? (
         <Message variant="warning" mt="24px">
           <MessageText maxWidth="200px">{t('Insufficient token allowance. Click "Enable" to approve.')}</MessageText>
         </Message>
       ) : null}
 
       <Flex mt="24px" flexDirection="column">
-        {needApprove ? (
+        {needsApprove ? (
           <Button
             width="100%"
             isLoading={cakePendingTx}
@@ -155,7 +155,6 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
             hasEnoughCake={hasEnoughBalanceToExtend}
             handleConfirmClick={handleConfirmClick}
             pendingConfirmTx={pendingTx}
-            disabled={needApprove}
             isValidAmount={isValidAmount}
             isValidDuration={isValidDuration}
           />

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -67,10 +67,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
   const needsEnable = useMemo(() => cakeNeeded && !hasEnoughBalanceToExtend, [cakeNeeded, hasEnoughBalanceToExtend])
 
   const { allowance, setLastUpdated } = useCheckVaultApprovalStatus(VaultKey.CakeVault)
-  const { handleApprove: handleCakeApprove, pendingTx: cakePendingTx } = useVaultApprove(
-    VaultKey.CakeVault,
-    setLastUpdated,
-  )
+  const { handleApprove, pendingTx: approvePendingTx } = useVaultApprove(VaultKey.CakeVault, setLastUpdated)
   const needsApprove = useMemo(() => {
     if (cakeNeeded) {
       return ENABLE_EXTEND_LOCK_AMOUNT.gt(allowance)
@@ -144,11 +141,11 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         {needsApprove ? (
           <Button
             width="100%"
-            isLoading={cakePendingTx}
-            endIcon={cakePendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
-            onClick={handleCakeApprove}
+            isLoading={approvePendingTx}
+            endIcon={approvePendingTx ? <AutoRenewIcon spin color="currentColor" /> : null}
+            onClick={handleApprove}
           >
-            {t('Enable')}
+            {approvePendingTx ? t('Enabling') : t('Enable')}
           </Button>
         ) : showEnableConfirmButtons ? (
           <ExtendEnable

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -134,11 +134,11 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         )
       ) : null}
 
-      {needApprove && (
+      {needApprove && cakeNeeded ? (
         <Message variant="warning" mt="24px">
           <MessageText maxWidth="200px">{t('Insufficient token allowance. Click "Enable" to approve.')}</MessageText>
         </Message>
-      )}
+      ) : null}
 
       <Flex mt="24px" flexDirection="column">
         {needApprove ? (

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import dynamic from 'next/dynamic'
 import { Button, AutoRenewIcon, Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
 import _noop from 'lodash/noop'
@@ -79,6 +79,14 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
     return amount.gt(allowance)
   }, [allowance, cakeNeeded, lockedAmount])
 
+  const [showEnableConfirmButtons, setShowEnableConfirmButtons] = useState(needsEnable)
+
+  useEffect(() => {
+    if (needsEnable) {
+      setShowEnableConfirmButtons(true)
+    }
+  }, [needsEnable])
+
   return (
     <>
       <Box mb="16px">
@@ -114,7 +122,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         />
       )}
 
-      {cakeNeeded ? (
+      {!needApprove && cakeNeeded ? (
         hasEnoughBalanceToExtend ? (
           <Text fontSize="12px" mt="24px">
             {t('0.0001 CAKE will be spent to extend')}
@@ -132,7 +140,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
         </Message>
       )}
 
-      <Flex mt="24px">
+      <Flex mt="24px" flexDirection="column">
         {needApprove ? (
           <Button
             width="100%"
@@ -142,8 +150,15 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
           >
             {t('Enable')}
           </Button>
-        ) : needsEnable ? (
-          <ExtendEnable isValidAmount={isValidAmount} isValidDuration={isValidDuration} />
+        ) : showEnableConfirmButtons ? (
+          <ExtendEnable
+            hasEnoughCake={hasEnoughBalanceToExtend}
+            handleConfirmClick={handleConfirmClick}
+            pendingConfirmTx={pendingTx}
+            disabled={needApprove}
+            isValidAmount={isValidAmount}
+            isValidDuration={isValidDuration}
+          />
         ) : (
           <Button
             width="100%"

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { differenceInSeconds } from 'date-fns'
 import { convertTimeToSeconds } from 'utils/timeHelper'
 import { Modal, Box, MessageText, Message, Checkbox, Flex, Text } from '@pancakeswap/uikit'
@@ -6,11 +6,13 @@ import _noop from 'lodash/noop'
 import { useTranslation } from '@pancakeswap/localization'
 import BigNumber from 'bignumber.js'
 import { useIfoCeiling } from 'state/pools/hooks'
+import { VaultKey } from 'state/types'
 import useTheme from 'hooks/useTheme'
 import { useBUSDCakeAmount } from 'hooks/useBUSDPrice'
 import { getBalanceNumber, getDecimalAmount, getBalanceAmount } from '@pancakeswap/utils/formatBalance'
 import { ONE_WEEK_DEFAULT } from 'config/constants/pools'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
+import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
 
@@ -113,6 +115,12 @@ const AddAmountModal: React.FC<React.PropsWithChildren<AddAmountModalProps>> = (
     ],
   )
 
+  const { allowance } = useCheckVaultApprovalStatus(VaultKey.CakeVault)
+  const needApprove = useMemo(() => {
+    const amount = getDecimalAmount(new BigNumber(lockedAmount))
+    return amount.gt(allowance)
+  }, [allowance, lockedAmount])
+
   return (
     <RoiCalculatorModalProvider lockedAmount={lockedAmount}>
       <Modal title={t('Add CAKE')} onDismiss={onDismiss} headerBackground={theme.colors.gradientCardHeader}>
@@ -126,6 +134,7 @@ const AddAmountModal: React.FC<React.PropsWithChildren<AddAmountModalProps>> = (
             stakingMax={currentBalance}
             setLockedAmount={setLockedAmount}
             stakingTokenBalance={stakingTokenBalance}
+            needApprove={needApprove}
           />
         </Box>
         <LockedBodyModal

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { Modal, Box } from '@pancakeswap/uikit'
 import useTheme from 'hooks/useTheme'
 import { useBUSDCakeAmount } from 'hooks/useBUSDPrice'
+import { VaultKey } from 'state/types'
+import { getDecimalAmount } from '@pancakeswap/utils/formatBalance'
 import { useTranslation } from '@pancakeswap/localization'
 import _toNumber from 'lodash/toNumber'
 import BigNumber from 'bignumber.js'
@@ -9,6 +11,7 @@ import { GenericModalProps } from '../types'
 import BalanceField from '../Common/BalanceField'
 import LockedBodyModal from '../Common/LockedModalBody'
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
+import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 
 const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = ({
   onDismiss,
@@ -21,6 +24,12 @@ const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = (
   const { t } = useTranslation()
 
   const usdValueStaked = useBUSDCakeAmount(_toNumber(lockedAmount))
+
+  const { allowance } = useCheckVaultApprovalStatus(VaultKey.CakeVault)
+  const needApprove = useMemo(() => {
+    const amount = getDecimalAmount(new BigNumber(lockedAmount))
+    return amount.gt(allowance)
+  }, [allowance, lockedAmount])
 
   return (
     <RoiCalculatorModalProvider lockedAmount={lockedAmount}>
@@ -35,6 +44,7 @@ const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = (
             stakingMax={currentBalance}
             setLockedAmount={setLockedAmount}
             stakingTokenBalance={stakingTokenBalance}
+            needApprove={needApprove}
           />
         </Box>
         <LockedBodyModal


### PR DESCRIPTION
Approve button when there is no cake allowance is missing in add/extend modals