### PR TITLE
fix: (liquidity): Add liquidity pair distribution

### DIFF
--- a/apps/web/src/views/AddLiquidity/components/ConfirmAddLiquidityModal.tsx
+++ b/apps/web/src/views/AddLiquidity/components/ConfirmAddLiquidityModal.tsx
@@ -59,11 +59,14 @@ const ConfirmAddLiquidityModal: React.FC<
     const amountCurrencyA = parsedAmounts[Field.CURRENCY_A]
       ? _toNumber(parsedAmounts[Field.CURRENCY_A]?.toSignificant(6))
       : 0
+    // If there is no price fallback to compare only amounts
+    const currencyAToCurrencyB = parseFloat(price?.toSignificant(4)) || 1
+    const normalizedAmountCurrencyA = currencyAToCurrencyB * amountCurrencyA
     const amountCurrencyB = parsedAmounts[Field.CURRENCY_B]
       ? _toNumber(parsedAmounts[Field.CURRENCY_B]?.toSignificant(6))
       : 0
 
-    percent = amountCurrencyA / (amountCurrencyA + amountCurrencyB)
+    percent = normalizedAmountCurrencyA / (normalizedAmountCurrencyA + amountCurrencyB)
   }
 
   const modalHeader = useCallback(() => {


### PR DESCRIPTION
Add Liquidity confirm modal pair distribution chart currently based on amount which results one currency shown larger than the other on the chart 

To reproduce

1. Add liquidity
2. Select bnb and cake
3. Add amount to both
4. See chart in confirm modal