### PR TITLE
feat(BoosterROICalculator): Use the helpicon for the cake locked tooltip

### DIFF
--- a/apps/web/src/views/Farms/components/YieldBooster/components/BCakeCalculator.tsx
+++ b/apps/web/src/views/Farms/components/YieldBooster/components/BCakeCalculator.tsx
@@ -146,22 +146,23 @@ const BCakeCalculator: React.FC<React.PropsWithChildren<BCakeCalculatorProps>> =
               >
                 $1000
               </Button>
+              <Button
+                disabled={!account || isLoading || lockedAmount.eq(0)}
+                scale="xs"
+                p="4px 16px"
+                width="128px"
+                variant="tertiary"
+                style={{ textTransform: 'uppercase' }}
+                onClick={() =>
+                  setPrincipalFromUSDValue(getBalanceNumber(lockedAmount.times(earningTokenPrice)).toFixed(2))
+                }
+              >
+                {t('My Balance')}
+              </Button>
+              <span ref={myBalanceTargetRef}>
+                <HelpIcon width="16px" height="16px" color="textSubtle" />
+              </span>
               {myBalanceTooltipVisible && myBalanceTooltip}
-              <Box ref={myBalanceTargetRef}>
-                <Button
-                  disabled={!account || isLoading || lockedAmount.eq(0)}
-                  scale="xs"
-                  p="4px 16px"
-                  width="128px"
-                  variant="tertiary"
-                  style={{ textTransform: 'uppercase' }}
-                  onClick={() =>
-                    setPrincipalFromUSDValue(getBalanceNumber(lockedAmount.times(earningTokenPrice)).toFixed(2))
-                  }
-                >
-                  {t('My Balance')}
-                </Button>
-              </Box>
             </Flex>
             <LockDurationField
               duration={duration}

--- a/apps/web/src/views/Farms/components/YieldBooster/components/BCakeCalculator.tsx
+++ b/apps/web/src/views/Farms/components/YieldBooster/components/BCakeCalculator.tsx
@@ -97,7 +97,8 @@ const BCakeCalculator: React.FC<React.PropsWithChildren<BCakeCalculatorProps>> =
     tooltip: myBalanceTooltip,
     tooltipVisible: myBalanceTooltipVisible,
   } = useTooltip(t('Boost multiplier calculation does not include profit from CAKE staking pool'), {
-    placement: 'bottom-start',
+    placement: 'top-end',
+    tooltipOffset: [20, 10],
   })
   const theme = useTheme()
 


### PR DESCRIPTION
Clicking "MY BALANCE" on a mobile device will be blocked by the tooltip, so I think it should be independent as a helpIcon.

Before:
![image](https://user-images.githubusercontent.com/109973128/213613804-081e5f27-fd51-4117-aae5-c1f4f6f2b5b9.png)

After:
![image](https://user-images.githubusercontent.com/109973128/213614397-f382b937-706a-4c97-8896-405eef176a0f.png)
