### PR TITLE
fix: Avoid undefined from provider

### DIFF
--- a/apps/web/src/config/wallet.ts
+++ b/apps/web/src/config/wallet.ts
@@ -38,7 +38,7 @@ const isMetamaskInstalled = () => {
     return true
   }
 
-  if (window.ethereum?.providers.some((p) => p.isMetaMask)) {
+  if (window.ethereum?.providers?.some((p) => p.isMetaMask)) {
     return true
   }
 


### PR DESCRIPTION
When provider is undefined, it causes error