### PR TITLE
fix(Aptos): Max button on swap page

### DIFF
--- a/apps/aptos/utils/maxAmountSpend.ts
+++ b/apps/aptos/utils/maxAmountSpend.ts
@@ -1,5 +1,6 @@
 import { Currency, CurrencyAmount, JSBI } from '@pancakeswap/aptos-swap-sdk'
 import { BIG_INT_ZERO, MIN_APT } from 'config/constants/exchange'
+import { APTOS_COIN } from '@pancakeswap/awgmi'
 
 /**
  * Given some token amount, return the max that can be spent of it
@@ -8,7 +9,7 @@ import { BIG_INT_ZERO, MIN_APT } from 'config/constants/exchange'
 export function maxAmountSpend(currencyAmount?: CurrencyAmount<Currency>): CurrencyAmount<Currency> | undefined {
   if (!currencyAmount) return undefined
 
-  if (currencyAmount.currency?.isNative) {
+  if (currencyAmount.currency?.isNative || currencyAmount.currency?.address === APTOS_COIN) {
     if (JSBI.greaterThan(currencyAmount.quotient, MIN_APT)) {
       return CurrencyAmount.fromRawAmount(currencyAmount.currency, JSBI.subtract(currencyAmount.quotient, MIN_APT))
     }


### PR DESCRIPTION
APT `currency?.isNative` always return false.
So when clicked max will not minus 0.02 APT, cause the error when swap native token to other token.

![Screenshot 2023-01-27 at 12 02 05 PM](https://user-images.githubusercontent.com/98292246/215006939-8c86920a-dbe1-45be-a866-d50096e6a9de.png)
