### PR TITLE
fix: (aptos): Overlay still visible after closing the settings with button

### DIFF
--- a/apps/aptos/pages/swap.tsx
+++ b/apps/aptos/pages/swap.tsx
@@ -345,9 +345,11 @@ const SwapPage = () => {
   )
 
   const [indirectlyOpenConfirmModalState, setIndirectlyOpenConfirmModalState] = useState(false)
-  const [onPresentSettingsModal] = useModal(
+  const [onPresentSettingsCustomDismissModal] = useModal(
     <SettingsModalWithCustomDismiss customOnDismiss={() => setIndirectlyOpenConfirmModalState(true)} />,
   )
+
+  const [onPresentSettingsModal] = useModal(<SettingsModal />)
 
   const [onPresentConfirmModal] = useModal(
     trade && (
@@ -363,7 +365,7 @@ const SwapPage = () => {
         onConfirm={handleSwap}
         swapErrorMessage={swapErrorMessage}
         customOnDismiss={handleConfirmDismiss}
-        openSettingModal={onPresentSettingsModal}
+        openSettingModal={onPresentSettingsCustomDismissModal}
       />
     ),
     true,


### PR DESCRIPTION
To reproduce

Go to aptos exchange
Click pencil button next slippage tolerance
Close the modal with close button
See overlay still appears