### PR TITLE
refactor: Use path instead of uikit library for all widgets

### DIFF
--- a/packages/uikit/src/widgets/Farm/components/FarmTabButtons.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmTabButtons.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Flex, Text } from "@pancakeswap/uikit";
 import styled from "styled-components";
 import { useRouter } from "next/router";
 import { useTranslation } from "@pancakeswap/localization";
 import { NextLinkFromReactRouter } from "../../../components/NextLink";
 import { NotificationDot } from "../../../components/NotificationDot";
 import { ButtonMenu, ButtonMenuItem } from "../../../components/ButtonMenu";
+import { Text } from "../../../components/Text";
+import { Flex } from "../../../components/Box";
 
 const Wrapper = styled.div`
   display: flex;

--- a/packages/uikit/src/widgets/Liquidity/AddLiquidity/ChoosePairView.tsx
+++ b/packages/uikit/src/widgets/Liquidity/AddLiquidity/ChoosePairView.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from "@pancakeswap/localization";
 import { AtomBox } from "@pancakeswap/ui/components/AtomBox";
-import { AddIcon, Box, CardBody, CardFooter, Text } from "@pancakeswap/uikit";
+import { CardBody, CardFooter } from "../../../components/Card";
+import { Box } from "../../../components/Box";
+import { Text } from "../../../components/Text";
+import { AddIcon } from "../../../components/Svg";
 
 export function ChoosePairView({
   selectCurrencyA,

--- a/packages/uikit/src/widgets/Liquidity/AprRow.tsx
+++ b/packages/uikit/src/widgets/Liquidity/AprRow.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from "@pancakeswap/localization";
-import { RowBetween, TooltipText, Text, useTooltip } from "@pancakeswap/uikit";
 import { formatAmount } from "@pancakeswap/utils/formatInfoNumbers";
+import { Text, TooltipText } from "../../components/Text";
+import { useTooltip } from "../../hooks/useTooltip";
+import { RowBetween } from "../../components/Row";
 
 export default function AprRow({ lpApr7d }: { lpApr7d: number }) {
   const { t } = useTranslation();

--- a/packages/uikit/src/widgets/Liquidity/LiquidityCardHeader.tsx
+++ b/packages/uikit/src/widgets/Liquidity/LiquidityCardHeader.tsx
@@ -1,7 +1,11 @@
-import { Text, Heading, IconButton, ArrowBackIcon, QuestionHelper } from "@pancakeswap/uikit";
 import Link from "next/link";
 import { AtomBox } from "@pancakeswap/ui";
 import styled from "styled-components";
+import { ArrowBackIcon } from "../../components/Svg";
+import { IconButton } from "../../components/Button";
+import { Text } from "../../components/Text";
+import { Heading } from "../../components/Heading";
+import { QuestionHelper } from "../../components/QuestionHelper";
 
 interface LiquidityCardHeaderProps {
   title: string;

--- a/packages/uikit/src/widgets/Liquidity/PercentSlider.tsx
+++ b/packages/uikit/src/widgets/Liquidity/PercentSlider.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from "@pancakeswap/localization";
 import { AtomBox } from "@pancakeswap/ui";
-import { Button, Slider } from "@pancakeswap/uikit";
-
 import { useCallback } from "react";
 import { useDebouncedChangeHandler } from "@pancakeswap/hooks";
+
+import { Button } from "../../components/Button";
+import { Slider } from "../../components/Slider";
 
 interface PercentSliderProps {
   onValueChanged: (value: string) => void;

--- a/packages/uikit/src/widgets/Pool/AprRowWithToolTip.tsx
+++ b/packages/uikit/src/widgets/Pool/AprRowWithToolTip.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from "react";
-import { Flex, TooltipText, useTooltip } from "@pancakeswap/uikit";
 import { useTranslation } from "@pancakeswap/localization";
+import { Flex } from "../../components/Box";
+import { TooltipText } from "../../components/Text";
+import { useTooltip } from "../../hooks";
 
 export const AprRowWithToolTip: React.FC<React.PropsWithChildren<{ questionTooltip?: ReactNode }>> = ({
   children,

--- a/packages/uikit/src/widgets/Pool/Cells/AprCell.tsx
+++ b/packages/uikit/src/widgets/Pool/Cells/AprCell.tsx
@@ -1,13 +1,16 @@
 import { BIG_ZERO } from "@pancakeswap/utils/bigNumber";
-import { Text, useMatchBreakpoints, Pool } from "@pancakeswap/uikit";
 import BigNumber from "bignumber.js";
 import { useTranslation } from "@pancakeswap/localization";
 import { createElement, FunctionComponent } from "react";
+import { CellContent, BaseCell } from "./BaseCell";
+import { useMatchBreakpoints } from "../../../contexts";
+import { Text } from "../../../components/Text";
+import { DeserializedPool } from "../types";
 
 interface AprCellProps<T> {
-  pool: Pool.DeserializedPool<T>;
+  pool: DeserializedPool<T>;
   aprComp: FunctionComponent<{
-    pool: Pool.DeserializedPool<T>;
+    pool: DeserializedPool<T>;
     stakedBalance: BigNumber;
     showIcon: boolean;
   }>;
@@ -20,8 +23,8 @@ export function AprCell<T>({ pool, aprComp }: AprCellProps<T>) {
   const stakedBalance = userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO;
 
   return (
-    <Pool.BaseCell role="cell" flex={["1 0 50px", "1 0 50px", "2 0 100px", "2 0 100px", "1 0 120px"]}>
-      <Pool.CellContent>
+    <BaseCell role="cell" flex={["1 0 50px", "1 0 50px", "2 0 100px", "2 0 100px", "1 0 120px"]}>
+      <CellContent>
         <Text fontSize="12px" color="textSubtle" textAlign="left">
           {t("APR")}
         </Text>
@@ -30,7 +33,7 @@ export function AprCell<T>({ pool, aprComp }: AprCellProps<T>) {
           stakedBalance,
           showIcon: !isMobile,
         })}
-      </Pool.CellContent>
-    </Pool.BaseCell>
+      </CellContent>
+    </BaseCell>
   );
 }

--- a/packages/uikit/src/widgets/Pool/Cells/TotalStakedCell.tsx
+++ b/packages/uikit/src/widgets/Pool/Cells/TotalStakedCell.tsx
@@ -1,9 +1,12 @@
-import { Flex, Skeleton, Text, Balance } from "@pancakeswap/uikit";
 import styled from "styled-components";
 import { useTranslation } from "@pancakeswap/localization";
 import BigNumber from "bignumber.js";
 import { getBalanceNumber } from "@pancakeswap/utils/formatBalance";
 import { BaseCell, CellContent } from "./BaseCell";
+import { Text } from "../../../components/Text";
+import { Skeleton } from "../../../components/Skeleton";
+import { Flex } from "../../../components/Box";
+import { Balance } from "../../../components/Balance";
 
 interface TotalStakedCellProps {
   stakingTokenDecimals: number;

--- a/packages/uikit/src/widgets/Pool/CollectModal.tsx
+++ b/packages/uikit/src/widgets/Pool/CollectModal.tsx
@@ -1,7 +1,12 @@
 import { useTranslation } from "@pancakeswap/localization";
-import { AutoRenewIcon, Button, Flex, Heading, Modal, Text } from "@pancakeswap/uikit";
 import { formatNumber } from "@pancakeswap/utils/formatBalance";
 import { useTheme } from "styled-components";
+import { Flex } from "../../components/Box";
+import { Heading } from "../../components/Heading";
+import { Button } from "../../components/Button";
+import { Text } from "../../components/Text";
+import { AutoRenewIcon } from "../../components/Svg";
+import { Modal } from "../Modal";
 import getThemeValue from "../../util/getThemeValue";
 
 export interface CollectModalProps {

--- a/packages/uikit/src/widgets/Pool/PoolCard.tsx
+++ b/packages/uikit/src/widgets/Pool/PoolCard.tsx
@@ -1,6 +1,9 @@
-import { CardBody, Flex, CardRibbon, Skeleton, Pool } from "@pancakeswap/uikit";
 import { useTranslation } from "@pancakeswap/localization";
 import { ReactElement } from "react";
+import { Flex } from "../../components/Box";
+import { CardBody, CardRibbon } from "../../components/Card";
+import { Skeleton } from "../../components/Skeleton";
+import { PoolCardHeader, PoolCardHeaderTitle } from "./PoolCardHeader";
 import { StyledCard } from "./StyledCard";
 import { DeserializedPool } from "./types";
 
@@ -25,10 +28,10 @@ export function PoolCard<T>({ pool, cardContent, aprRow, isStaked, cardFooter, t
       isFinished={isFinished && sousId !== 0}
       ribbon={isFinished && <CardRibbon variantColor="textDisabled" text={t("Finished")} />}
     >
-      <Pool.PoolCardHeader isStaking={isStaked} isFinished={isFinished && sousId !== 0}>
+      <PoolCardHeader isStaking={isStaked} isFinished={isFinished && sousId !== 0}>
         {totalStaked && totalStaked.gte(0) ? (
           <>
-            <Pool.PoolCardHeaderTitle
+            <PoolCardHeaderTitle
               title={isCakePool ? t("Manual") : t("Earn %asset%", { asset: earningToken?.symbol || "" })}
               subTitle={
                 isCakePool ? t("Earn CAKE, stake CAKE") : t("Stake %symbol%", { symbol: stakingToken?.symbol || "" })
@@ -45,7 +48,7 @@ export function PoolCard<T>({ pool, cardContent, aprRow, isStaked, cardFooter, t
             <Skeleton width={58} height={58} variant="circle" />
           </Flex>
         )}
-      </Pool.PoolCardHeader>
+      </PoolCardHeader>
       <CardBody>
         {aprRow}
         <Flex mt="24px" flexDirection="column">

--- a/packages/uikit/src/widgets/Pool/withCollectModal.tsx
+++ b/packages/uikit/src/widgets/Pool/withCollectModal.tsx
@@ -1,4 +1,3 @@
-import { Flex, Text, Button, Heading, Skeleton, Balance, useModal } from "@pancakeswap/uikit";
 import BigNumber from "bignumber.js";
 import { ReactElement } from "react";
 import { useTranslation } from "@pancakeswap/localization";
@@ -6,6 +5,13 @@ import { getFullDisplayBalance, getBalanceNumber, formatNumber } from "@pancakes
 import { CollectModalProps } from "./CollectModal";
 import { HarvestAction as TableHarvestAction } from "./PoolsTable/HarvestAction";
 import { HarvestActionsProps } from "./types";
+import { Flex } from "../../components/Box";
+import { Heading } from "../../components/Heading";
+import { Button } from "../../components/Button";
+import { Text } from "../../components/Text";
+import { Skeleton } from "../../components/Skeleton";
+import { Balance } from "../../components/Balance";
+import { useModal } from "../Modal";
 
 const HarvestActions: React.FC<React.PropsWithChildren<HarvestActionsProps>> = ({
   earnings,

--- a/packages/uikit/src/widgets/Pool/withStakeActions.tsx
+++ b/packages/uikit/src/widgets/Pool/withStakeActions.tsx
@@ -1,21 +1,17 @@
-import {
-  Flex,
-  Text,
-  Button,
-  IconButton,
-  AddIcon,
-  MinusIcon,
-  useModal,
-  Skeleton,
-  useTooltip,
-  Balance,
-} from "@pancakeswap/uikit";
 import BigNumber from "bignumber.js";
 import { ReactElement } from "react";
 import { useTranslation } from "@pancakeswap/localization";
 import { getBalanceNumber } from "@pancakeswap/utils/formatBalance";
 import { DeserializedPool } from "./types";
 import NotEnoughTokensModal from "../Modal/NotEnoughTokensModal";
+import { Button, IconButton } from "../../components/Button";
+import { Text } from "../../components/Text";
+import { Flex } from "../../components/Box";
+import { Balance } from "../../components/Balance";
+import { Skeleton } from "../../components/Skeleton";
+import { useModal } from "../Modal";
+import { useTooltip } from "../../hooks/useTooltip";
+import { MinusIcon, AddIcon } from "../../components/Svg";
 
 interface StakeActionsPropsType<T> {
   pool: DeserializedPool<T>;

--- a/packages/uikit/src/widgets/Swap/ExpertModal.tsx
+++ b/packages/uikit/src/widgets/Swap/ExpertModal.tsx
@@ -1,15 +1,12 @@
-import {
-  Button,
-  Text,
-  Flex,
-  Message,
-  Modal,
-  InjectedModalProps,
-  Checkbox,
-  useMatchBreakpoints,
-} from "@pancakeswap/uikit";
 import { useState } from "react";
 import { useTranslation } from "@pancakeswap/localization";
+import { Button } from "../../components/Button";
+import { Text } from "../../components/Text";
+import { Flex } from "../../components/Box";
+import { Checkbox } from "../../components/Checkbox";
+import { InjectedModalProps, Modal } from "../Modal";
+import { Message } from "../../components/Message";
+import { useMatchBreakpoints } from "../../contexts";
 
 interface ExpertModalProps extends InjectedModalProps {
   setShowConfirmExpertModal: (show: boolean) => void;

--- a/packages/uikit/src/widgets/Swap/TradePrice.tsx
+++ b/packages/uikit/src/widgets/Swap/TradePrice.tsx
@@ -1,8 +1,9 @@
 import { Price, Currency } from "@pancakeswap/swap-sdk-core";
 import { AtomBox } from "@pancakeswap/ui/components/AtomBox";
-import { Text, AutoRenewIcon } from "@pancakeswap/uikit";
 import { useState } from "react";
 import { balanceMaxMiniClass } from "./SwapWidget.css";
+import { AutoRenewIcon } from "../../components/Svg";
+import { Text } from "../../components/Text";
 
 interface TradePriceProps {
   price?: Price<Currency, Currency>;


### PR DESCRIPTION
Using library instead of path can cause issues especially on dev builds