### PR TITLE
chore(Farms): Adjust the placement of the ViewContract

### DIFF
--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -195,10 +195,10 @@ const ActionPanel: React.FunctionComponent<React.PropsWithChildren<ActionPanelPr
             </StyledLinkExternal>
           </StakeContainer>
         )}
+        <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
         <StyledLinkExternal isBscScan href={bsc}>
           {t('View Contract')}
         </StyledLinkExternal>
-        <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
       </InfoContainer>
       <ActionContainer>
         {shouldUseProxyFarm ? (

--- a/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
@@ -60,12 +60,12 @@ export const DetailsSection: React.FC<React.PropsWithChildren<ExpandableSectionP
       {!removed && (
         <StyledLinkExternal href={addLiquidityUrl}>{t("Get %symbol%", { symbol: lpLabel })}</StyledLinkExternal>
       )}
+      {infoAddress && <StyledLinkExternal href={infoAddress}>{t("See Pair Info")}</StyledLinkExternal>}
       {scanAddressLink && (
         <StyledLinkExternal isBscScan href={scanAddressLink}>
           {t("View Contract")}
         </StyledLinkExternal>
       )}
-      {infoAddress && <StyledLinkExternal href={infoAddress}>{t("See Pair Info")}</StyledLinkExternal>}
     </Wrapper>
   );
 };


### PR DESCRIPTION
I think the placement of ViewContract should be consistent with pools.

![image](https://user-images.githubusercontent.com/109973128/216771846-d326f10c-4655-415c-97c0-a0b52e308528.png)


Before:
![image](https://user-images.githubusercontent.com/109973128/216771783-e4cf15a2-9a8c-46d1-b0f1-a9d2a7340c97.png)

After:
![image](https://user-images.githubusercontent.com/109973128/216771790-f53c6608-ebe3-4c3c-80a4-15f2668f1aa1.png)
