### PR TITLE
fix(Pottery): Fix prize being cut on mobile

### DIFF
--- a/apps/web/src/views/Pottery/components/Banner/index.tsx
+++ b/apps/web/src/views/Pottery/components/Banner/index.tsx
@@ -111,7 +111,6 @@ const Banner: React.FC<React.PropsWithChildren<BannerProps>> = ({ handleScroll }
           </Flex>
           <SkeletonV2
             isDataReady={Boolean(prizeTotal)}
-            width={['144px', '240px']}
             height={['60px', '97px']}
             wrapperProps={{ marginBottom: '8px' }}
           >


### PR DESCRIPTION
Before:
![1675520254710](https://user-images.githubusercontent.com/109973128/216772572-6cb51d1e-7d15-478d-b791-645808090f73.jpg)

After:
![image](https://user-images.githubusercontent.com/109973128/216772605-a9c09d17-63fb-4cb1-80c1-2a89d79e0b54.png)
