### PR TITLE
chore(Swap): Change default price display

### DIFF
--- a/packages/uikit/src/widgets/Swap/TradePrice.tsx
+++ b/packages/uikit/src/widgets/Swap/TradePrice.tsx
@@ -1,4 +1,5 @@
 import { Price, Currency } from "@pancakeswap/swap-sdk-core";
+import { ArrowForwardIcon } from "@pancakeswap/uikit";
 import { AtomBox } from "@pancakeswap/ui/components/AtomBox";
 import { useState } from "react";
 import { balanceMaxMiniClass } from "./SwapWidget.css";
@@ -11,18 +12,17 @@ interface TradePriceProps {
 
 export function TradePrice({ price }: TradePriceProps) {
   const [showInverted, setShowInverted] = useState<boolean>(false);
-  const formattedPrice = showInverted ? price?.toSignificant(6) : price?.invert()?.toSignificant(6);
+  const formattedPrice = showInverted ? price?.invert()?.toSignificant(6) : price?.toSignificant(6);
 
   const show = Boolean(price?.baseCurrency && price?.quoteCurrency);
-  const label = showInverted
-    ? `${price?.quoteCurrency?.symbol} per ${price?.baseCurrency?.symbol}`
-    : `${price?.baseCurrency?.symbol} per ${price?.quoteCurrency?.symbol}`;
 
   return (
     <Text style={{ justifyContent: "center", alignItems: "center", display: "flex" }}>
       {show ? (
         <>
-          {formattedPrice ?? "-"} {label}
+          {`1 ${showInverted ? price?.quoteCurrency?.symbol : price?.baseCurrency?.symbol}`}
+          <ArrowForwardIcon width="16px" ml="4px" mr="4px" />
+          {`${formattedPrice} ${showInverted ? price?.baseCurrency?.symbol : price?.quoteCurrency?.symbol}`}
           <AtomBox className={balanceMaxMiniClass} onClick={() => setShowInverted(!showInverted)}>
             <AutoRenewIcon width="14px" />
           </AtomBox>

--- a/packages/uikit/src/widgets/Swap/TradePrice.tsx
+++ b/packages/uikit/src/widgets/Swap/TradePrice.tsx
@@ -12,7 +12,7 @@ interface TradePriceProps {
 
 export function TradePrice({ price }: TradePriceProps) {
   const [showInverted, setShowInverted] = useState<boolean>(false);
-  const formattedPrice = showInverted ? price?.invert()?.toSignificant(6) : price?.toSignificant(6);
+  const formattedPrice = showInverted ? price?.toSignificant(6) : price?.invert()?.toSignificant(6);
 
   const show = Boolean(price?.baseCurrency && price?.quoteCurrency);
 
@@ -20,9 +20,9 @@ export function TradePrice({ price }: TradePriceProps) {
     <Text style={{ justifyContent: "center", alignItems: "center", display: "flex" }}>
       {show ? (
         <>
-          {`1 ${showInverted ? price?.quoteCurrency?.symbol : price?.baseCurrency?.symbol}`}
+          {`1 ${showInverted ? price?.baseCurrency?.symbol : price?.quoteCurrency?.symbol}`}
           <ArrowForwardIcon width="16px" ml="4px" mr="4px" />
-          {`${formattedPrice} ${showInverted ? price?.baseCurrency?.symbol : price?.quoteCurrency?.symbol}`}
+          {`${formattedPrice} ${showInverted ? price?.quoteCurrency?.symbol : price?.baseCurrency?.symbol}`}
           <AtomBox className={balanceMaxMiniClass} onClick={() => setShowInverted(!showInverted)}>
             <AutoRenewIcon width="14px" />
           </AtomBox>


### PR DESCRIPTION
When swap from A to B, the default price display should also be A→B.

Before:
![image](https://user-images.githubusercontent.com/109973128/216997578-41534985-b6e5-4fcd-9e97-75a3bbc313fd.png)

After:
![image](https://user-images.githubusercontent.com/109973128/216997811-ca5ed218-60bb-403a-92d7-7265d249e69e.png)
