### PR TITLE
feat(Aptos-IFO): StartTime and endTime use tooltip

### DIFF
--- a/apps/aptos/views/Ifos/components/IfoFoldableCard/Timer.tsx
+++ b/apps/aptos/views/Ifos/components/IfoFoldableCard/Timer.tsx
@@ -1,12 +1,16 @@
 import { useTranslation } from '@pancakeswap/localization'
 import styled from 'styled-components'
-import { Flex, Heading, PocketWatchIcon, Text, Skeleton, Link, TimerIcon } from '@pancakeswap/uikit'
+import { Flex, Heading, PocketWatchIcon, Text, Skeleton, TimerIcon, useTooltip } from '@pancakeswap/uikit'
 import getTimePeriods from '@pancakeswap/utils/getTimePeriods'
 import { PublicIfoData } from 'views/Ifos/types'
 import { getStatus } from 'views/Ifos/hooks/helpers'
 
 interface Props {
   publicIfoData: PublicIfoData
+}
+interface TimeTooltipComponentProps {
+  label: string
+  time: number
 }
 
 const GradientText = styled(Heading)`
@@ -21,6 +25,29 @@ const FlexGap = styled(Flex)<{ gap: string }>`
   gap: ${({ gap }) => gap};
 `
 
+const TimeTooltipComponent: React.FC<React.PropsWithChildren<TimeTooltipComponentProps>> = ({ label, time }) => {
+  const {
+    t,
+    currentLanguage: { locale },
+  } = useTranslation()
+
+  return (
+    <>
+      <Text bold>{t(label)}:</Text>
+      <Text>
+        {new Date(time * 1000).toLocaleString(locale, {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true,
+        })}
+      </Text>
+    </>
+  )
+}
+
 export const SoonTimer: React.FC<React.PropsWithChildren<Props>> = ({ publicIfoData }) => {
   const { t } = useTranslation()
   const { startTime, endTime } = publicIfoData
@@ -33,12 +60,20 @@ export const SoonTimer: React.FC<React.PropsWithChildren<Props>> = ({ publicIfoD
 
   const status = getStatus(currentTime, startTime, endTime)
 
+  const {
+    targetRef: startTimeTargetRef,
+    tooltip: startTimeTooltip,
+    tooltipVisible: startTimeTooltipVisible,
+  } = useTooltip(<TimeTooltipComponent label="Start Time" time={startTime} />, {
+    placement: 'top',
+  })
+
   return (
     <Flex justifyContent="center" position="relative">
       {status === 'idle' ? (
         <Skeleton animation="pulse" variant="rect" width="100%" height="48px" />
       ) : (
-        <Link external href="/" color="secondary">
+        <Flex ref={startTimeTargetRef}>
           <FlexGap gap="8px" alignItems="center">
             <Heading as="h3" scale="lg" color="secondary">
               {t('Start in')}
@@ -69,7 +104,8 @@ export const SoonTimer: React.FC<React.PropsWithChildren<Props>> = ({ publicIfoD
             </FlexGap>
           </FlexGap>
           <TimerIcon ml="4px" color="secondary" />
-        </Link>
+          {startTimeTooltipVisible && startTimeTooltip}
+        </Flex>
       )}
     </Flex>
   )
@@ -108,12 +144,21 @@ const LiveTimer: React.FC<React.PropsWithChildren<Props>> = ({ publicIfoData }) 
   const status = getStatus(currentTime, startTime, endTime)
 
   const timeUntil = getTimePeriods(secondsUntilEnd)
+
+  const {
+    targetRef: endTimeTargetRef,
+    tooltip: endTimeTooltip,
+    tooltipVisible: endTimeTooltipVisible,
+  } = useTooltip(<TimeTooltipComponent label="End Time" time={endTime} />, {
+    placement: 'top',
+  })
+
   return (
     <Flex justifyContent="center" position="relative">
       {status === 'idle' ? (
         <Skeleton animation="pulse" variant="rect" width="100%" height="48px" />
       ) : (
-        <Link external href="/" color="white">
+        <Flex color="white" ref={endTimeTargetRef}>
           <PocketWatchIcon width="42px" mr="8px" />
           <FlexGap gap="8px" alignItems="center">
             <LiveNowHeading textTransform="uppercase" as="h3">{`${t('Live Now')}!`}</LiveNowHeading>
@@ -141,8 +186,11 @@ const LiveTimer: React.FC<React.PropsWithChildren<Props>> = ({ publicIfoData }) 
               </>
             </FlexGap>
           </FlexGap>
-          <TimerIcon ml="4px" color="white" />
-        </Link>
+          <span>
+            <TimerIcon ml="4px" mt="10px" color="white" />
+          </span>
+          {endTimeTooltipVisible && endTimeTooltip}
+        </Flex>
       )}
     </Flex>
   )


### PR DESCRIPTION
At present, aptos does not have the block time page, so Link should not be used, and it is better to use tooltip to display time instead.

![image](https://user-images.githubusercontent.com/109973128/217718264-ceaac97f-3793-429b-9eaf-669a6a2e3307.png)
