### PR TITLE
fix(Swap): Fix confirmSwap's tooltip placement on mobile

### DIFF
--- a/apps/aptos/components/Swap/AdvancedSwapDetails.tsx
+++ b/apps/aptos/components/Swap/AdvancedSwapDetails.tsx
@@ -37,7 +37,7 @@ function TradeSummary({
               'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
             )}
             ml="4px"
-            placement="top-start"
+            placement="top"
           />
         </RowFixed>
         <RowFixed>
@@ -57,7 +57,7 @@ function TradeSummary({
           <QuestionHelper
             text={t('The difference between the market price and estimated price due to trade size.')}
             ml="4px"
-            placement="top-start"
+            placement="top"
           />
         </RowFixed>
         <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />
@@ -78,7 +78,7 @@ function TradeSummary({
               </>
             }
             ml="4px"
-            placement="top-start"
+            placement="top"
           />
         </RowFixed>
         <Text fontSize="14px">

--- a/apps/aptos/components/Swap/SwapModalFooter.tsx
+++ b/apps/aptos/components/Swap/SwapModalFooter.tsx
@@ -71,6 +71,7 @@ export default function SwapModalFooter({
                 'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
               )}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <RowFixed>
@@ -92,6 +93,7 @@ export default function SwapModalFooter({
             <QuestionHelper
               text={t('The difference between the market price and your price due to trade size.')}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />

--- a/apps/web/src/views/Swap/MMLinkPools/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/SwapModalFooter.tsx
@@ -82,6 +82,7 @@ export default function SwapModalFooter({
                 'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
               )}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <RowFixed>
@@ -118,6 +119,7 @@ export default function SwapModalFooter({
                 </>
               }
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           {isMM ? <Text color="textSubtle">--</Text> : <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />}
@@ -160,6 +162,7 @@ export default function SwapModalFooter({
                 </>
               }
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <Text fontSize="14px">

--- a/apps/web/src/views/Swap/SmartSwap/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/SmartSwap/components/SwapModalFooter.tsx
@@ -77,6 +77,7 @@ export default function SwapModalFooter({
                 'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
               )}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <RowFixed>
@@ -98,6 +99,7 @@ export default function SwapModalFooter({
             <QuestionHelper
               text={t('The difference between the market price and your price due to trade size.')}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />
@@ -128,6 +130,7 @@ export default function SwapModalFooter({
                 </>
               }
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <Text fontSize="14px">

--- a/apps/web/src/views/Swap/StableSwap/components/StableSwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/StableSwap/components/StableSwapModalFooter.tsx
@@ -67,6 +67,7 @@ export default function StableSwapModalFooter({
                 'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
               )}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <RowFixed>

--- a/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
@@ -52,7 +52,7 @@ function TradeSummary({
               'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
             )}
             ml="4px"
-            placement="top-start"
+            placement="top"
           />
         </RowFixed>
         <RowFixed>
@@ -87,7 +87,7 @@ function TradeSummary({
                 </>
               }
               ml="4px"
-              placement="top-start"
+              placement="top"
             />
           </RowFixed>
 
@@ -143,7 +143,7 @@ function TradeSummary({
                 </>
               }
               ml="4px"
-              placement="top-start"
+              placement="top"
             />
           </RowFixed>
           <Text fontSize="14px">{`${realizedLPFee.toSignificant(4)} ${inputAmount.currency.symbol}`}</Text>

--- a/apps/web/src/views/Swap/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/components/SwapModalFooter.tsx
@@ -75,6 +75,7 @@ export default function SwapModalFooter({
                 'Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.',
               )}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <RowFixed>
@@ -96,6 +97,7 @@ export default function SwapModalFooter({
             <QuestionHelper
               text={t('The difference between the market price and your price due to trade size.')}
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <FormattedPriceImpact priceImpact={priceImpactWithoutFee} />
@@ -113,6 +115,7 @@ export default function SwapModalFooter({
                 </>
               }
               ml="4px"
+              placement="top"
             />
           </RowFixed>
           <Text fontSize="14px">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/218240144-67e5cbeb-6b8c-41bf-9887-7186bc857751.png)

After:
![image](https://user-images.githubusercontent.com/109973128/218240127-dc126724-1ec4-473b-918a-5cde6117ffca.png)
