### PR TITLE
fix(aptos-IFO): Fix vesting balance display decimals

### DIFF
--- a/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoVestingCard/ReleasedTokenInfo.tsx
+++ b/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoVestingCard/ReleasedTokenInfo.tsx
@@ -61,7 +61,7 @@ const ReleasedTokenInfo: React.FC<React.PropsWithChildren<ReleasedTokenInfoProps
           </Flex>
           <Box ml="auto">
             <Text fontSize="14px" bold as="span">
-              {`${getFullDisplayBalance(amountReleased, token.decimals, token.decimals)} `}
+              {`${getFullDisplayBalance(amountReleased, token.decimals, 4)} `}
             </Text>
             <Text fontSize="14px" as="span">
               {`(${amount.releasedPercentageDisplay}%)`}
@@ -77,7 +77,7 @@ const ReleasedTokenInfo: React.FC<React.PropsWithChildren<ReleasedTokenInfoProps
           </Flex>
           <Box ml="auto">
             <Text fontSize="14px" bold as="span">
-              {`${getFullDisplayBalance(amountInVesting, token.decimals, token.decimals)} `}
+              {`${getFullDisplayBalance(amountInVesting, token.decimals, 4)} `}
             </Text>
             <Text fontSize="14px" as="span">
               {`(${amount.inVestingPercentageDisplay}%)`}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/218241709-69626f5f-4f94-40fa-a3c7-28c4dd56b36c.png)

After:
![image](https://user-images.githubusercontent.com/109973128/218241724-c857cec0-bfa6-4531-b2e7-c28b948be456.png)
