### PR TITLE
feat(Pools): When two EndsBlock are the same, only one is displayed

### DIFF
--- a/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
+++ b/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
@@ -110,24 +110,26 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
               stakingToken.symbol
             }`}</Text>
           </Flex>
-          <Flex justifyContent="space-between" alignItems="center">
-            <Text small>{t('Max. stake limit ends in')}:</Text>
-            <Flex alignItems="center">
-              <Text color="textSubtle" small>
-                {stakeLimitTimeRemaining > 0
-                  ? stakeLimitTimeObject?.totalDays
-                    ? stakeLimitTimeObject?.totalDays === 1
-                      ? t('1 day')
-                      : t('%days% days', { days: stakeLimitTimeObject?.totalDays })
-                    : t('< 1 day')
-                  : t('%days% days', { days: 0 })}
-              </Text>
-              <span ref={stakeLimitTargetRef}>
-                <TimerIcon ml="4px" color="primary" />
-                {stakeLimitTooltipVisible && stakeLimitTooltip}
-              </span>
+          {endBlock !== stakeLimitEndBlock && (
+            <Flex justifyContent="space-between" alignItems="center">
+              <Text small>{t('Max. stake limit ends in')}:</Text>
+              <Flex alignItems="center">
+                <Text color="textSubtle" small>
+                  {stakeLimitTimeRemaining > 0
+                    ? stakeLimitTimeObject?.totalDays
+                      ? stakeLimitTimeObject?.totalDays === 1
+                        ? t('1 day')
+                        : t('%days% days', { days: stakeLimitTimeObject?.totalDays })
+                      : t('< 1 day')
+                    : t('%days% days', { days: 0 })}
+                </Text>
+                <span ref={stakeLimitTargetRef}>
+                  <TimerIcon ml="4px" color="primary" />
+                  {stakeLimitTooltipVisible && stakeLimitTooltip}
+                </span>
+              </Flex>
             </Flex>
-          </Flex>
+          )}
         </>
       ) : null}
       <Flex justifyContent="space-between" alignItems="center">

--- a/apps/web/src/views/Pools/components/MaxStakeRow.tsx
+++ b/apps/web/src/views/Pools/components/MaxStakeRow.tsx
@@ -13,6 +13,7 @@ interface MaxStakeRowProps {
   stakingLimitEndBlock: number
   stakingToken: Token
   hasPoolStarted: boolean
+  endBlock: number
 }
 
 const MaxStakeRow: React.FC<React.PropsWithChildren<MaxStakeRowProps>> = ({
@@ -22,6 +23,7 @@ const MaxStakeRow: React.FC<React.PropsWithChildren<MaxStakeRowProps>> = ({
   stakingLimitEndBlock,
   stakingToken,
   hasPoolStarted,
+  endBlock,
 }) => {
   const { t } = useTranslation()
 
@@ -33,7 +35,7 @@ const MaxStakeRow: React.FC<React.PropsWithChildren<MaxStakeRowProps>> = ({
           stakingToken.symbol
         }`}</Text>
       </Flex>
-      {hasPoolStarted && (
+      {hasPoolStarted && endBlock !== stakingLimitEndBlock && (
         <Flex justifyContent="space-between" alignItems="center">
           <Text small={small}>{t('Max. stake limit ends in')}:</Text>
           <Link external href={getBlockExploreLink(stakingLimitEndBlock, 'countdown')}>

--- a/apps/web/src/views/Pools/components/PoolStatsInfo.tsx
+++ b/apps/web/src/views/Pools/components/PoolStatsInfo.tsx
@@ -95,6 +95,7 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
           stakingLimit={stakingLimit}
           stakingLimitEndBlock={stakingLimitEndBlock}
           stakingToken={stakingToken}
+          endBlock={endBlock}
         />
       )}
       {shouldShowBlockCountdown && (


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/219068719-c6aa0493-311f-4ad3-a1f4-27816cc43ac1.png)

After:
![image](https://user-images.githubusercontent.com/109973128/219068667-7ac74ef0-bcad-452a-95f9-5ff93c5f820f.png)
