### PR TITLE
fix(aptos-exploreLink): Remove extra "/"

### DIFF
--- a/apps/aptos/utils/index.ts
+++ b/apps/aptos/utils/index.ts
@@ -13,16 +13,16 @@ export function getBlockExploreLink(
   if (!chain) return defaultChain.blockExplorers?.traceMove.url ?? ''
   switch (type) {
     case 'transaction': {
-      return `${chain.blockExplorers?.traceMove.url}/transaction/${data}`
+      return `${chain.blockExplorers?.traceMove.url}transaction/${data}`
     }
     case 'block': {
-      return `${chain.blockExplorers?.traceMove.url}/block/${data}`
+      return `${chain.blockExplorers?.traceMove.url}block/${data}`
     }
     case 'token': {
-      return `${chain.blockExplorers?.traceMove.url}/coin/${data}`
+      return `${chain.blockExplorers?.traceMove.url}coin/${data}`
     }
     default: {
-      return `${chain.blockExplorers?.traceMove.url}/search/${data}`
+      return `${chain.blockExplorers?.traceMove.url}search/${data}`
     }
   }
 }


### PR DESCRIPTION
There is an extra '/' in the URL and return 403.

![image](https://user-images.githubusercontent.com/109973128/220386295-bb699f2e-0b42-4376-ac02-c1688bbc1792.png)
