### PR TITLE
fix: Coingecko list cannot be loaded in eth

### DIFF
--- a/.changeset/unlucky-schools-compare.md
+++ b/.changeset/unlucky-schools-compare.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/token-lists': patch
+---
+
+fix: Filter out tokeen with empty symbol in tokenlists

--- a/packages/token-lists/package.json
+++ b/packages/token-lists/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "ajv": "^6.12.3",
+    "lodash": "^4.17.21",
     "@pancakeswap/swap-sdk-core": "*"
   },
   "peerDependencies": {

--- a/packages/token-lists/react/getTokenList.ts
+++ b/packages/token-lists/react/getTokenList.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-continue */
 /* eslint-disable no-await-in-loop */
-import { TokenList } from '@pancakeswap/token-lists'
+import { TokenList, TokenInfo } from '@pancakeswap/token-lists'
 import uriToHttp from '@pancakeswap/utils/uriToHttp'
+import remove from 'lodash/remove'
 import Ajv from 'ajv'
 import schema from '../schema/pancakeswap.json'
 
@@ -32,6 +33,11 @@ export default async function getTokenList(listUrl: string): Promise<TokenList> 
     }
 
     const json = await response.json()
+    if (json.tokens) {
+      remove<TokenInfo>(json.tokens, (token) => {
+        return token.symbol ? token.symbol.length === 0 : true
+      })
+    }
     if (!tokenListValidator(json)) {
       const validationErrors: string =
         tokenListValidator.errors?.reduce<string>((memo, error) => {


### PR DESCRIPTION
`Failed to get list at url https://tokens.coingecko.com/uniswap/all.json Error: Token list failed validation: .tokens[2301].symbol should NOT be shorter than 1 characters; .tokens[2301].symbol should match pattern "^[a-zA-Z0-9+\-%/$.]+$";  should match "else" schema`