### PR TITLE
fix: Only show banner when domain is canonical

### DIFF
--- a/apps/aptos/state/user/phishingBanner.ts
+++ b/apps/aptos/state/user/phishingBanner.ts
@@ -8,7 +8,8 @@ const hidePhishingBannerAtom = atom(
   (get) => {
     const now = Date.now()
     const last = get(phishingBannerAtom)
-    return last ? differenceInDays(now, last) >= 1 : true
+    const isPCS = typeof window !== 'undefined' && window.location.hostname === 'pancakeswap.finance'
+    return last ? differenceInDays(now, last) >= 1 && isPCS : isPCS
   },
   (_, set) => set(phishingBannerAtom, Date.now()),
 )

--- a/apps/web/src/state/user/hooks/index.tsx
+++ b/apps/web/src/state/user/hooks/index.tsx
@@ -73,12 +73,13 @@ export function usePhishingBannerManager(): [boolean, () => void] {
     AppState['user']['hideTimestampPhishingWarningBanner']
   >((state) => state.user.hideTimestampPhishingWarningBanner)
   const now = Date.now()
-  const showPhishingWarningBanner = hideTimestampPhishingWarningBanner
-    ? differenceInDays(now, hideTimestampPhishingWarningBanner) >= 1
-    : true
+  const isPCS = typeof window !== 'undefined' && window.location.hostname === 'pancakeswap.finance'
   const hideBanner = useCallback(() => {
     dispatch(hidePhishingWarningBanner())
   }, [dispatch])
+  const showPhishingWarningBanner = hideTimestampPhishingWarningBanner
+    ? differenceInDays(now, hideTimestampPhishingWarningBanner) >= 1 && isPCS
+    : isPCS
 
   return [showPhishingWarningBanner, hideBanner]
 }


### PR DESCRIPTION
Phishing banner will affect phishing bot to detect our preview domain.