### PR TITLE
fix(aptos-Pools): Stake limit endTime

### DIFF
--- a/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
+++ b/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
@@ -110,7 +110,7 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
               stakingToken.symbol
             }`}</Text>
           </Flex>
-          {endBlock !== stakeLimitEndBlock && (
+          {poolTimeRemaining !== stakeLimitTimeRemaining && (
             <Flex justifyContent="space-between" alignItems="center">
               <Text small>{t('Max. stake limit ends in')}:</Text>
               <Flex alignItems="center">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/223331052-1bc669ad-a340-4148-83c8-1cf920d4d5e6.png)

After:
![image](https://user-images.githubusercontent.com/109973128/223331084-a33b9ee9-31ce-4179-9994-152b8792b950.png)
