### PR TITLE
fix(Farms): Fix BoostedActionPanel broken on mobile

### DIFF
--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -133,7 +133,7 @@ const ActionPanel: React.FunctionComponent<React.PropsWithChildren<ActionPanelPr
 
   const farm = details
 
-  const { isDesktop } = useMatchBreakpoints()
+  const { isDesktop, isMobile } = useMatchBreakpoints()
 
   const {
     t,
@@ -220,7 +220,7 @@ const ActionPanel: React.FunctionComponent<React.PropsWithChildren<ActionPanelPr
           </HarvestActionContainer>
         )}
         {farm?.boosted && (
-          <ActionContainerSection style={{ minHeight: 124.5 }}>
+          <ActionContainerSection style={{ minHeight: isMobile ? 165 : 124.5 }}>
             <BoostedAction
               title={(status) => (
                 <ActionTitles>

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -220,7 +220,7 @@ const ActionPanel: React.FunctionComponent<React.PropsWithChildren<ActionPanelPr
           </HarvestActionContainer>
         )}
         {farm?.boosted && (
-          <ActionContainerSection style={{ minHeight: isMobile ? 165 : 124.5 }}>
+          <ActionContainerSection style={{ minHeight: isMobile ? "auto" : 124.5 }}>
             <BoostedAction
               title={(status) => (
                 <ActionTitles>

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -220,7 +220,7 @@ const ActionPanel: React.FunctionComponent<React.PropsWithChildren<ActionPanelPr
           </HarvestActionContainer>
         )}
         {farm?.boosted && (
-          <ActionContainerSection style={{ minHeight: isMobile ? "auto" : 124.5 }}>
+          <ActionContainerSection style={{ minHeight: isMobile ? 'auto' : 124.5 }}>
             <BoostedAction
               title={(status) => (
                 <ActionTitles>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/223753761-c74c6f1b-1814-49d4-9404-748d04d67ff4.png)

After:
![image](https://user-images.githubusercontent.com/109973128/223753459-fc0e2888-30b6-4082-91e0-442fee4a327e.png)
