### PR TITLE
chore(Prediction): Modify ChainLink image placement on mobile

### DIFF
--- a/apps/web/src/views/Predictions/Mobile.tsx
+++ b/apps/web/src/views/Predictions/Mobile.tsx
@@ -58,13 +58,15 @@ const Mobile: React.FC<React.PropsWithChildren> = () => {
               <Box width="100%">
                 <Menu />
                 {status === PredictionStatus.LIVE ? <Positions view={view} /> : <LoadingSection />}
-                <PowerLinkStyle href="https://chain.link/" external>
-                  <img
-                    src="/images/powered-by-chainlink.svg"
-                    alt="Powered by ChainLink"
-                    style={{ width: '170px', maxHeight: '100%' }}
-                  />
-                </PowerLinkStyle>
+                <Flex justifyContent="right">
+                  <PowerLinkStyle href="https://chain.link/" external>
+                    <img
+                      src="/images/powered-by-chainlink.svg"
+                      alt="Powered by ChainLink"
+                      style={{ width: '170px', maxHeight: '100%' }}
+                    />
+                  </PowerLinkStyle>
+                </Flex>
               </Box>
             )}
           </Flex>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/109973128/224033897-381518e0-2839-4928-b2e2-4ed250cd6793.png)

After:
![image](https://user-images.githubusercontent.com/109973128/224033963-b0804ff9-b7a5-4144-a604-fcd25de0e0ef.png)
