### PR TITLE
chore: Remove abnbc hardcoded farm filter

### DIFF
--- a/apps/web/src/views/Farms/Farms.tsx
+++ b/apps/web/src/views/Farms/Farms.tsx
@@ -188,10 +188,8 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [stableSwapOnly, setStableSwapOnly] = useState(false)
   const [farmTypesEnableCount, setFarmTypesEnableCount] = useState(0)
 
-  // NOTE: Temporarily inactive aBNBc-BNB LP on FE
   const activeFarms = farmsLP.filter(
     (farm) =>
-      farm.lpAddress !== '0x272c2CF847A49215A3A1D4bFf8760E503A06f880' &&
       farm.lpAddress !== '0xB6040A9F294477dDAdf5543a24E5463B8F2423Ae' &&
       farm.pid !== 0 &&
       farm.multiplier !== '0X' &&
@@ -200,9 +198,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   const inactiveFarms = farmsLP.filter(
     (farm) =>
-      farm.lpAddress === '0xB6040A9F294477dDAdf5543a24E5463B8F2423Ae' ||
-      farm.lpAddress === '0x272c2CF847A49215A3A1D4bFf8760E503A06f880' ||
-      (farm.pid !== 0 && farm.multiplier === '0X'),
+      farm.lpAddress === '0xB6040A9F294477dDAdf5543a24E5463B8F2423Ae' || (farm.pid !== 0 && farm.multiplier === '0X'),
   )
   const archivedFarms = farmsLP
 


### PR DESCRIPTION
It is multiplier is currently 0 therefore no hardcoded filter is needed