### PR TITLE
chore: The default source of TokenLogo has been changed to PCS

### DIFF
--- a/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
@@ -32,7 +32,7 @@ export const CurrencyLogo: React.FC<
     address,
   )}.png`
 
-  return <StyledLogo size={size} srcs={[src, srcFromPCS]} alt="token logo" {...rest} />
+  return <StyledLogo size={size} srcs={[srcFromPCS, src]} alt="token logo" {...rest} />
 }
 
 const DoubleCurrencyWrapper = styled.div`


### PR DESCRIPTION
Because some images in Trust will be edited to have a transparent background, causing display issues in dark mode, PCS has been adopted as the default source.