### PR TITLE
chore(Profile): Modify ChangeProfilePicFlow margin

### DIFF
--- a/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
+++ b/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
@@ -125,7 +125,7 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
               {t('Change Profile Pic')}
             </Button>
           )}
-          <DangerOutline width="100%" onClick={goToRemove}>
+          <DangerOutline width="100%" mt="24px" onClick={goToRemove}>
             {t('Remove Profile Pic')}
           </DangerOutline>
         </>

--- a/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
+++ b/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
@@ -32,11 +32,7 @@ const DangerOutline = styled(Button).attrs({ variant: 'secondary' })`
     opacity: 0.8;
   }
 `
-const ChangeProfilePicWrapper = styled(Flex)`
-  border-bottom: 1px;
-  border-style: solid;
-  border-color: ${({ theme }) => theme.colors.cardBorder};
-`
+
 const AvatarWrapper = styled.div`
   height: 64px;
   width: 64px;
@@ -108,7 +104,7 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
             </MessageText>
           </Message>
           {showCakeRequireFlow ? (
-            <ChangeProfilePicWrapper mb="16px" pb="16px">
+            <Flex mb="16px" pb="16px">
               <ApproveConfirmButtons
                 isApproveDisabled={isProfileCostsLoading || hasMinimumCakeRequired}
                 isApproving={pendingEnableTx}
@@ -118,7 +114,7 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
                 onConfirm={needsApproval === true ? goToApprove : goToChange}
                 confirmLabel={t('Change Profile Pic')}
               />
-            </ChangeProfilePicWrapper>
+            </Flex>
           ) : (
             <Button
               width="100%"

--- a/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
+++ b/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
@@ -32,13 +32,11 @@ const DangerOutline = styled(Button).attrs({ variant: 'secondary' })`
     opacity: 0.8;
   }
 `
-
-const RemoveProfilePicWrapper = styled(Flex)`
-  border-top: 1px;
+const ChangeProfilePicWrapper = styled(Flex)`
+  border-bottom: 1px;
   border-style: solid;
   border-color: ${({ theme }) => theme.colors.cardBorder};
 `
-
 const AvatarWrapper = styled.div`
   height: 64px;
   width: 64px;
@@ -110,7 +108,7 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
             </MessageText>
           </Message>
           {showCakeRequireFlow ? (
-            <Flex mb="8px">
+            <ChangeProfilePicWrapper mb="16px" pb="16px">
               <ApproveConfirmButtons
                 isApproveDisabled={isProfileCostsLoading || hasMinimumCakeRequired}
                 isApproving={pendingEnableTx}
@@ -120,7 +118,7 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
                 onConfirm={needsApproval === true ? goToApprove : goToChange}
                 confirmLabel={t('Change Profile Pic')}
               />
-            </Flex>
+            </ChangeProfilePicWrapper>
           ) : (
             <Button
               width="100%"
@@ -131,11 +129,9 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
               {t('Change Profile Pic')}
             </Button>
           )}
-          <RemoveProfilePicWrapper>
-            <DangerOutline width="100%" mt="16px" onClick={goToRemove}>
-              {t('Remove Profile Pic')}
-            </DangerOutline>
-          </RemoveProfilePicWrapper>
+          <DangerOutline width="100%" onClick={goToRemove}>
+            {t('Remove Profile Pic')}
+          </DangerOutline>
         </>
       ) : showCakeRequireFlow ? (
         <Flex mb="8px">

--- a/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
+++ b/apps/web/src/views/Profile/components/EditProfileModal/StartView.tsx
@@ -33,6 +33,12 @@ const DangerOutline = styled(Button).attrs({ variant: 'secondary' })`
   }
 `
 
+const RemoveProfilePicWrapper = styled(Flex)`
+  border-top: 1px;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.colors.cardBorder};
+`
+
 const AvatarWrapper = styled.div`
   height: 64px;
   width: 64px;
@@ -125,9 +131,11 @@ const StartPage: React.FC<React.PropsWithChildren<StartPageProps>> = ({ goToAppr
               {t('Change Profile Pic')}
             </Button>
           )}
-          <DangerOutline width="100%" mt="24px" onClick={goToRemove}>
-            {t('Remove Profile Pic')}
-          </DangerOutline>
+          <RemoveProfilePicWrapper>
+            <DangerOutline width="100%" mt="16px" onClick={goToRemove}>
+              {t('Remove Profile Pic')}
+            </DangerOutline>
+          </RemoveProfilePicWrapper>
         </>
       ) : showCakeRequireFlow ? (
         <Flex mb="8px">


### PR DESCRIPTION
When there is no CAKE in the wallet, the Enable flow for ChangeProfilePic will appear, causing users to mistakenly think that they need to Enable first before being able to RemoveProfilePic. Therefore, the marginTop of RemoveProfilePic has been increased.

Before:
![image](https://user-images.githubusercontent.com/109973128/227838950-a9735fce-e9f0-444c-805d-9fa72edb6397.png)

After
![image](https://user-images.githubusercontent.com/109973128/227845369-54cb9b15-dd43-490a-8eb5-8e1ca8f41019.png)