### PR TITLE
chore(NFT): Filter row noWarp on mobile

### DIFF
--- a/apps/web/src/views/Nft/market/ActivityHistory/ActivityFilters.tsx
+++ b/apps/web/src/views/Nft/market/ActivityHistory/ActivityFilters.tsx
@@ -19,14 +19,9 @@ export const Container = styled(Flex)`
 const ScrollableFlexContainer = styled(Flex)`
   align-items: center;
   flex: 1;
-  flex-wrap: nowrap;
-  overflow-x: auto;
+  flex-wrap: wrap;
+  overflow-x: revert;
   -webkit-overflow-scrolling: touch;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    flex-wrap: wrap;
-    overflow-x: revert;
-  }
 `
 
 interface FiltersProps {

--- a/apps/web/src/views/Nft/market/Collection/Items/Filters.tsx
+++ b/apps/web/src/views/Nft/market/Collection/Items/Filters.tsx
@@ -75,14 +75,9 @@ const ScrollableFlexContainer = styled(Flex)`
   grid-area: attributeFilters;
   align-items: center;
   flex: 1;
-  flex-wrap: nowrap;
-  overflow-x: auto;
+  flex-wrap: wrap;
+  overflow-x: revert;
   -webkit-overflow-scrolling: touch;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    flex-wrap: wrap;
-    overflow-x: revert;
-  }
 `
 
 const Filters: React.FC<React.PropsWithChildren<FiltersProps>> = ({ address, attributes }) => {


### PR DESCRIPTION
Displaying filter rows without wrapping onto a new line on mobile devices is a more user-friendly operation.

Before:
![image](https://user-images.githubusercontent.com/109973128/227894423-993f253f-3d6e-4f2e-b4c3-03b8e67b39e5.png)

After:
![image](https://user-images.githubusercontent.com/109973128/227894459-2101b3a6-edbe-4fe6-a07c-d1d41aa3a0bb.png)
