### PR TITLE
fix: (farms): Enable contract couldn't refresh view after approval

### DIFF
--- a/apps/web/src/state/farms/index.ts
+++ b/apps/web/src/state/farms/index.ts
@@ -201,8 +201,10 @@ export const fetchFarmUserDataAsync = createAsyncThunk<
       const { normalFarms, farmsWithProxy } = splitProxyFarms(farmsCanFetch)
 
       const [proxyAllowances, normalAllowances] = await Promise.all([
-        getBoostedFarmsStakeValue(farmsWithProxy, account, chainId, proxyAddress),
-        getNormalFarmsStakeValue(normalFarms, account, chainId),
+        farmsWithProxy
+          ? getBoostedFarmsStakeValue(farmsWithProxy, account, chainId, proxyAddress)
+          : Promise.resolve([]),
+        normalFarms ? getNormalFarmsStakeValue(normalFarms, account, chainId) : Promise.resolve([]),
       ])
 
       return [...proxyAllowances, ...normalAllowances]


### PR DESCRIPTION
To reproduce: 

1. Go to farms
2. Click enable farm that is not approved
3. See after successful approval it still shows enable contract until the full fetch (which is every 60 seconds)