### PR TITLE
chore(Pools): Modifty filters placement

### DIFF
--- a/packages/uikit/src/widgets/Pool/PoolTabButtons.tsx
+++ b/packages/uikit/src/widgets/Pool/PoolTabButtons.tsx
@@ -97,8 +97,8 @@ const PoolTabButtons = ({
   return (
     <ViewControls>
       {viewModeToggle}
-      {stakedOnlySwitch}
       {liveOrFinishedSwitch}
+      {stakedOnlySwitch}
     </ViewControls>
   );
 };


### PR DESCRIPTION
The arrangement of filters in Pools should be the same as that in Farms.

Before:
<img width="604" alt="截圖 2023-03-31 下午9 35 03" src="https://user-images.githubusercontent.com/109973128/229134819-2b2a5d60-1b7c-4ad2-9064-752e8a3481b3.png">

After:
<img width="526" alt="截圖 2023-03-31 下午9 35 20" src="https://user-images.githubusercontent.com/109973128/229134859-b24b6874-c497-4219-890e-3a1aa9a16c6b.png">
