### PR TITLE
chore(Liquidity): V3 history's timestamp improvement

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -916,8 +916,9 @@ function PositionHistoryRow({
     return (
       <Box>
         <AutoRow gap="8px">
-          <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)} />
-          <Text ellipsis>{dayjs(+positionTx.timestamp * 1_000).format('YYYY/MM/DD')}</Text>
+          <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+            <Text ellipsis>{dayjs(+positionTx.timestamp * 1_000).format('YYYY/MM/DD')}</Text>
+          </LinkExternal>
         </AutoRow>
         <Text>{positionHistoryTypeText[type]}</Text>
         <AutoColumn gap="4px">
@@ -970,8 +971,9 @@ function PositionHistoryRow({
       p="16px"
     >
       <AutoRow justifyContent="center" gap="8px">
-        <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)} />
-        <Text ellipsis>{date.toLocaleString()}</Text>
+        <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+          <Text ellipsis>{date.toLocaleString()}</Text>
+        </LinkExternal>
       </AutoRow>
       <Text>{positionHistoryTypeText[type]}</Text>
       <AutoColumn gap="4px">


### PR DESCRIPTION
1) Modify icon placement
2) Make time a part of the Link, so that users can click more easily

Before:
![image](https://user-images.githubusercontent.com/109973128/229722909-90f12a13-382f-4b56-a5b3-08d48952284f.png)

After:
![image](https://user-images.githubusercontent.com/109973128/229722991-ae390f48-06de-4044-9b4e-6c7814d929f3.png)
