### PR TITLE
chore(Liquidity): Default display fee tier options

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/FeeSelector.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/FeeSelector.tsx
@@ -55,7 +55,7 @@ export default function FeeSelector({
 
   const [pairState, pair] = useV2Pair(currencyA, currencyB)
 
-  const [showOptions, setShowOptions] = useState(false)
+  const [showOptions, setShowOptions] = useState(true)
   // get pool data on-chain for latest states
   const pools = usePools([
     [currencyA, currencyB, FeeAmount.LOWEST],


### PR DESCRIPTION
I think that displaying the fee tier options by default is more user-friendly for operation.