### PR TITLE
fix: Missing quote when gas estimation failed

### DIFF
--- a/packages/smart-router/evm/v3-router/gasModel.ts
+++ b/packages/smart-router/evm/v3-router/gasModel.ts
@@ -109,19 +109,23 @@ export async function createGasModel({
 
     let gasCostInToken: CurrencyAmount<Currency> = CurrencyAmount.fromRawAmount(quoteCurrency.wrapped, 0)
     let gasCostInUSD: CurrencyAmount<Currency> = CurrencyAmount.fromRawAmount(usdToken, 0)
-    if (isQuoteNative) {
-      gasCostInToken = totalGasCostNativeCurrency
-    }
-    if (!isQuoteNative && nativePool) {
-      const price = getTokenPrice(nativePool, nativeWrappedToken, quoteCurrency.wrapped)
-      gasCostInToken = price.quote(totalGasCostNativeCurrency)
-    }
 
-    if (usdPool) {
-      const nativeTokenUsdPrice = getTokenPrice(usdPool, nativeWrappedToken, usdToken)
-      gasCostInUSD = nativeTokenUsdPrice.quote(totalGasCostNativeCurrency)
-    }
+    try {
+      if (isQuoteNative) {
+        gasCostInToken = totalGasCostNativeCurrency
+      }
+      if (!isQuoteNative && nativePool) {
+        const price = getTokenPrice(nativePool, nativeWrappedToken, quoteCurrency.wrapped)
+        gasCostInToken = price.quote(totalGasCostNativeCurrency)
+      }
 
+      if (usdPool) {
+        const nativeTokenUsdPrice = getTokenPrice(usdPool, nativeWrappedToken, usdToken)
+        gasCostInUSD = nativeTokenUsdPrice.quote(totalGasCostNativeCurrency)
+      }
+    } catch (e) {
+      // console.warn('Cannot estimate gas cost', e)
+    }
     return {
       gasEstimate: baseGasUse,
       gasCostInToken,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 504852e</samp>

### Summary
🐛🚀🔇

<!--
1.  🐛 - This emoji represents a bug fix, since the try-catch block prevents a potential error from crashing the app.
2.  🚀 - This emoji represents a feature, since the gas estimation logic and UI are part of the smart router feature that enhances the user experience and functionality of the app.
3.  🔇 - This emoji represents a comment, since the console warning was commented out and no longer visible in the code.
-->
Added error handling for gas cost calculation in `gasModel.ts`. Prevented app crash and removed console warning.

> _`getTokenPrice` fails_
> _Gas cost in token and USD_
> _Fall leaves catch errors_

### Walkthrough
*  Wrap gas cost calculation in try-catch block to handle errors from `getTokenPrice` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6528/files?diff=unified&w=0#diff-4d4da5392cbf672ed01f6a6585fdb3e16c7bb62f8bcbfb86dc42ae3358cfcd73L112-R128))

