### PR TITLE
perf: Disable price auto update when getting token usd price from amm

### DIFF
--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -86,6 +86,7 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
     maxSplits: 0,
     maxHops: baseTradeAgainst ? 2 : 3,
     enabled: enableLlama ? !isLoading && !priceFromLlama : shouldEnabled,
+    autoRevalidate: false,
   })
 
   const price = useMemo(() => {

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -56,7 +56,7 @@ interface useBestAMMTradeOptions extends Options {
 }
 
 export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeOptions) {
-  const { amount, baseCurrency, currency } = params
+  const { amount, baseCurrency, currency, autoRevalidate } = params
   const isWrapping = useIsWrapping(baseCurrency, currency, amount?.toExact())
   const isOffChainEnabled = useMemo(
     () =>
@@ -68,15 +68,18 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
   )
   const isQuoterEnabled = useMemo(() => !isWrapping && (type === 'quoter' || type === 'all'), [type, isWrapping])
 
+  const offChainAutoRevalidate = typeof autoRevalidate === 'boolean' ? autoRevalidate : isOffChainEnabled
   const bestTradeFromOffchain = useBestAMMTradeFromOffchain({
     ...params,
     enabled: isOffChainEnabled,
-    autoRevalidate: isOffChainEnabled,
+    autoRevalidate: offChainAutoRevalidate,
   })
+  const quoterAutoRevalidate =
+    typeof autoRevalidate === 'boolean' ? autoRevalidate : isQuoterEnabled && !isOffChainEnabled
   const bestTradeFromQuoter = useBestAMMTradeFromQuoter({
     ...params,
     enabled: isQuoterEnabled,
-    autoRevalidate: isQuoterEnabled && !isOffChainEnabled,
+    autoRevalidate: quoterAutoRevalidate,
   })
   return useMemo(() => {
     const { trade: tradeFromOffchain } = bestTradeFromOffchain


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 55ff220</samp>

### Summary
🚫🔄📈

<!--
1.  🚫 - This emoji represents the disabling of automatic revalidation for the `useStablecoinPrice` hook, as it indicates something is blocked or prohibited.
2.  🔄 - This emoji represents the enabling or disabling of automatic revalidation for the `useBestAMMTrade` hook, as it indicates something is refreshed or updated based on a condition or option.
3.  📈 - This emoji represents the fetching of the price and the best trade, as it indicates something is increasing or improving in value or performance.
-->
This pull request adds an `autoRevalidate` option to two hooks, `useBestAMMTrade` and `useStablecoinPrice`, that fetch data from different sources. This option allows the caller to control whether the data should be updated automatically or not, depending on the use case and performance needs.

> _To fetch stablecoin prices, we use `useStablecoinPrice`_
> _But we don't want to revalidate, that would not be nice_
> _So we add an option_
> _To stop the re-fetchin'_
> _And make our hook more efficient and precise_

### Walkthrough
*  Add `autoRevalidate` option to `useBestAMMTradeOptions` interface to control revalidation of best trade data ([link](https://github.com/pancakeswap/pancake-frontend/pull/6529/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL59-R59))
*  Use `autoRevalidate` option in `useBestAMMTrade` hook to pass appropriate values to source hooks `useBestAMMTradeFromOffchain` and `useBestAMMTradeFromQuoter` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6529/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL71-R82))
*  Disable automatic revalidation of stablecoin price data in `useStablecoinPrice` hook by setting `autoRevalidate` option to `false` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6529/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaR89))

