### PR TITLE
perf: Prevent ui lag when chaning input on swap page

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -18,7 +18,7 @@ import { computeSlippageAdjustedAmounts } from 'utils/exchange'
 import getLpAddress from 'utils/getLpAddress'
 import { multicallv2 } from 'utils/multicall'
 import { getTokenAddress } from 'views/Swap/components/Chart/utils'
-import { useBestTrade } from 'views/Swap/SmartSwap/hooks/useBestTrade'
+import { useBestAMMTrade } from 'hooks/useBestAMMTrade'
 import { useAccount } from 'wagmi'
 import useSWRImmutable from 'swr/immutable'
 import { SLOW_INTERVAL } from 'config/constants'
@@ -69,12 +69,22 @@ export function useSingleTokenSwapInfo(
   outputCurrencyId: string | undefined,
   outputCurrency: Currency | undefined,
 ): { [key: string]: number } {
-  const token0Address = getTokenAddress(inputCurrencyId)
-  const token1Address = getTokenAddress(outputCurrencyId)
+  const token0Address = useMemo(() => getTokenAddress(inputCurrencyId), [inputCurrencyId])
+  const token1Address = useMemo(() => getTokenAddress(outputCurrencyId), [outputCurrencyId])
 
-  const parsedAmount = tryParseAmount('1', inputCurrency ?? undefined)
+  const amount = useMemo(() => tryParseAmount('1', inputCurrency ?? undefined), [inputCurrency])
 
-  const bestTradeExactIn = useBestTrade(parsedAmount, outputCurrency ?? undefined, TradeType.EXACT_INPUT)
+  const { trade: bestTradeExactIn } = useBestAMMTrade({
+    amount,
+    currency: outputCurrency,
+    baseCurrency: inputCurrency,
+    tradeType: TradeType.EXACT_INPUT,
+    v2Swap: true,
+    v3Swap: true,
+    stableSwap: true,
+    type: 'quoter',
+    autoRevalidate: false,
+  })
   if (!inputCurrency || !outputCurrency || !bestTradeExactIn) {
     return null
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0061cd5</samp>

### Summary
🔄🚀🌐

<!--
1.  🔄 This emoji represents the swap logic and UI, as it suggests exchanging or switching something.
2.  🚀 This emoji represents the improvement and optimization of the performance and consistency, as it suggests speed and efficiency.
3.  🌐 This emoji represents the support for different AMM protocols and quoter mode, as it suggests diversity and connectivity.
-->
Improved swap logic and UI by using a custom hook that supports multiple AMM protocols and quoter mode. Optimized performance and consistency of a single token swap hook by using the custom hook and memoizing inputs.

> _Sing, O Muse, of the cunning swap logic and UI_
> _That the skilled developer wrought with a custom hook_
> _`useBestAMMTrade`, which supports many protocols_
> _And quoter mode, to find the best deal for the user._

### Walkthrough
* Replace the `useBestTrade` hook with the `useBestAMMTrade` hook, which supports different AMM protocols and quoter mode, to improve the swap logic and UI ([link](https://github.com/pancakeswap/pancake-frontend/pull/6547/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L21-R21))
* Refactor the `useSingleTokenSwapInfo` hook to use the `useBestAMMTrade` hook and memoize the inputs, to optimize the performance and consistency of the hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6547/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L72-R87))


