### PR TITLE
feat(Liquidity): Display fiat value

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -564,14 +564,16 @@ export default function PoolPage() {
                           <Text small mr="4px">
                             <FormattedCurrencyAmount currencyAmount={positionValueUpper} />
                           </Text>
-                          <Text color="textSubtle" small>
+                        </Flex>
+                        <RowBetween justifyContent="flex-end">
+                          <Text fontSize="10px" color="textSubtle" mr="4px">
                             {positionValueUpper && priceValueUpper
                               ? `~$${priceValueUpper
                                   .quote(positionValueUpper?.wrapped)
                                   .toFixed(2, { groupSeparator: ',' })}`
                               : ''}
                           </Text>
-                        </Flex>
+                        </RowBetween>
                       </AutoRow>
                       <AutoRow justifyContent="space-between">
                         <Flex>
@@ -584,14 +586,16 @@ export default function PoolPage() {
                           <Text small mr="4px">
                             <FormattedCurrencyAmount currencyAmount={positionValueLower} />
                           </Text>
-                          <Text color="textSubtle" small>
+                        </Flex>
+                        <RowBetween justifyContent="flex-end">
+                          <Text fontSize="10px" color="textSubtle" mr="4px">
                             {positionValueLower && priceValueLower
                               ? `~$${priceValueLower
                                   .quote(positionValueLower?.wrapped)
                                   .toFixed(2, { groupSeparator: ',' })}`
                               : ''}
                           </Text>
-                        </Flex>
+                        </RowBetween>
                       </AutoRow>
                     </LightGreyCard>
                   </Box>
@@ -639,12 +643,14 @@ export default function PoolPage() {
                         </Flex>
                         <Flex justifyContent="center">
                           <Text small>{feeValueUpper ? formatCurrencyAmount(feeValueUpper, 4, locale) : '-'}</Text>
-                          <Text color="textSubtle" ml="4px" small>
+                        </Flex>
+                        <RowBetween justifyContent="flex-end">
+                          <Text fontSize="10px" color="textSubtle" ml="4px">
                             {feeValueUpper && priceValueUpper
                               ? `~$${priceValueUpper.quote(feeValueUpper?.wrapped).toFixed(2, { groupSeparator: ',' })}`
                               : ''}
                           </Text>
-                        </Flex>
+                        </RowBetween>
                       </AutoRow>
                       <AutoRow justifyContent="space-between">
                         <Flex>
@@ -655,12 +661,14 @@ export default function PoolPage() {
                         </Flex>
                         <Flex justifyContent="center">
                           <Text small>{feeValueLower ? formatCurrencyAmount(feeValueLower, 4, locale) : '-'}</Text>
-                          <Text color="textSubtle" ml="4px" small>
+                        </Flex>
+                        <RowBetween justifyContent="flex-end">
+                          <Text fontSize="10px" color="textSubtle" ml="4px">
                             {feeValueLower && priceValueLower
                               ? `~$${priceValueLower.quote(feeValueLower?.wrapped).toFixed(2, { groupSeparator: ',' })}`
                               : ''}
                           </Text>
-                        </Flex>
+                        </RowBetween>
                       </AutoRow>
                     </LightGreyCard>
                   </Box>

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -343,6 +343,8 @@ export default function PoolPage() {
 
   const positionValueUpper = inverted ? position?.amount0 : position?.amount1
   const positionValueLower = inverted ? position?.amount1 : position?.amount0
+  const priceValueUpper = inverted ? price0 : price1
+  const priceValueLower = inverted ? price1 : price0
 
   // check if price is within range
   const below = pool && typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
@@ -562,6 +564,13 @@ export default function PoolPage() {
                           <Text small mr="4px">
                             <FormattedCurrencyAmount currencyAmount={positionValueUpper} />
                           </Text>
+                          <Text color="textSubtle" small>
+                            {positionValueUpper && priceValueUpper
+                              ? `~$${priceValueUpper
+                                  .quote(positionValueUpper?.wrapped)
+                                  .toFixed(2, { groupSeparator: ',' })}`
+                              : ''}
+                          </Text>
                         </Flex>
                       </AutoRow>
                       <AutoRow justifyContent="space-between">
@@ -574,6 +583,13 @@ export default function PoolPage() {
                         <Flex justifyContent="center">
                           <Text small mr="4px">
                             <FormattedCurrencyAmount currencyAmount={positionValueLower} />
+                          </Text>
+                          <Text color="textSubtle" small>
+                            {positionValueLower && priceValueLower
+                              ? `~$${priceValueLower
+                                  .quote(positionValueLower?.wrapped)
+                                  .toFixed(2, { groupSeparator: ',' })}`
+                              : ''}
                           </Text>
                         </Flex>
                       </AutoRow>
@@ -621,7 +637,14 @@ export default function PoolPage() {
                             {feeValueUpper?.currency?.symbol}
                           </Text>
                         </Flex>
-                        <Text small>{feeValueUpper ? formatCurrencyAmount(feeValueUpper, 4, locale) : '-'}</Text>
+                        <Flex>
+                          <Text small>{feeValueUpper ? formatCurrencyAmount(feeValueUpper, 4, locale) : '-'}</Text>
+                          <Text color="textSubtle" ml="4px" small>
+                            {feeValueUpper && priceValueUpper
+                              ? `~$${priceValueUpper.quote(feeValueUpper?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                              : ''}
+                          </Text>
+                        </Flex>
                       </AutoRow>
                       <AutoRow justifyContent="space-between">
                         <Flex>
@@ -630,7 +653,14 @@ export default function PoolPage() {
                             {feeValueLower?.currency?.symbol}
                           </Text>
                         </Flex>
-                        <Text small>{feeValueLower ? formatCurrencyAmount(feeValueLower, 4, locale) : '-'}</Text>
+                        <Flex>
+                          <Text small>{feeValueLower ? formatCurrencyAmount(feeValueLower, 4, locale) : '-'}</Text>
+                          <Text color="textSubtle" ml="4px" small>
+                            {feeValueLower && priceValueLower
+                              ? `~$${priceValueLower.quote(feeValueLower?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                              : ''}
+                          </Text>
+                        </Flex>
                       </AutoRow>
                     </LightGreyCard>
                   </Box>

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -637,7 +637,7 @@ export default function PoolPage() {
                             {feeValueUpper?.currency?.symbol}
                           </Text>
                         </Flex>
-                        <Flex>
+                        <Flex justifyContent="center">
                           <Text small>{feeValueUpper ? formatCurrencyAmount(feeValueUpper, 4, locale) : '-'}</Text>
                           <Text color="textSubtle" ml="4px" small>
                             {feeValueUpper && priceValueUpper
@@ -653,7 +653,7 @@ export default function PoolPage() {
                             {feeValueLower?.currency?.symbol}
                           </Text>
                         </Flex>
-                        <Flex>
+                        <Flex justifyContent="center">
                           <Text small>{feeValueLower ? formatCurrencyAmount(feeValueLower, 4, locale) : '-'}</Text>
                           <Text color="textSubtle" ml="4px" small>
                             {feeValueLower && priceValueLower

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
@@ -91,12 +91,14 @@ export const PositionPreview = ({
               <Text mr="8px">
                 <FormattedCurrencyAmount currencyAmount={position.amount0} />
               </Text>
-              <Text color="textSubtle" ml="4px" small>
+            </RowFixed>
+            <RowBetween justifyContent="flex-end">
+              <Text fontSize="10px" color="textSubtle" ml="4px" mr="8px">
                 {position.amount0 && price0
                   ? `~$${price0.quote(position.amount0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
                   : ''}
               </Text>
-            </RowFixed>
+            </RowBetween>
           </RowBetween>
           <RowBetween>
             <RowFixed>
@@ -107,12 +109,14 @@ export const PositionPreview = ({
               <Text mr="8px">
                 <FormattedCurrencyAmount currencyAmount={position.amount1} />
               </Text>
-              <Text color="textSubtle" ml="4px" small>
+            </RowFixed>
+            <RowBetween justifyContent="flex-end">
+              <Text fontSize="10px" color="textSubtle" ml="4px" mr="8px">
                 {position.amount1 && price1
                   ? `~$${price1.quote(position.amount1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
                   : ''}
               </Text>
-            </RowFixed>
+            </RowBetween>
           </RowBetween>
           <Divider />
           <RowBetween>

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
@@ -5,6 +5,7 @@ import { Position } from '@pancakeswap/v3-sdk'
 import { LightGreyCard } from 'components/Card'
 import { DoubleCurrencyLogo } from 'components/Logo'
 import CurrencyLogo from 'components/Logo/CurrencyLogo'
+import { useStablecoinPrice } from 'hooks/useBUSDPrice'
 import { formatTickPrice } from 'hooks/v3/utils/formatTickPrice'
 import JSBI from 'jsbi'
 import { ReactNode, useState, useCallback } from 'react'
@@ -58,6 +59,9 @@ export const PositionPreview = ({
   const priceLower = sorted ? position.token0PriceLower : position.token0PriceUpper.invert()
   const priceUpper = sorted ? position.token0PriceUpper : position.token0PriceLower.invert()
 
+  const price0 = useStablecoinPrice(position.pool.token0 ?? undefined, !!position.amount0)
+  const price1 = useStablecoinPrice(position.pool.token1 ?? undefined, !!position.amount1)
+
   const handleRateChange = useCallback(() => {
     setBaseCurrency(quoteCurrency)
   }, [quoteCurrency])
@@ -87,6 +91,11 @@ export const PositionPreview = ({
               <Text mr="8px">
                 <FormattedCurrencyAmount currencyAmount={position.amount0} />
               </Text>
+              <Text color="textSubtle" ml="4px" small>
+                {position.amount0 && price0
+                  ? `~$${price0.quote(position.amount0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                  : ''}
+              </Text>
             </RowFixed>
           </RowBetween>
           <RowBetween>
@@ -97,6 +106,11 @@ export const PositionPreview = ({
             <RowFixed>
               <Text mr="8px">
                 <FormattedCurrencyAmount currencyAmount={position.amount1} />
+              </Text>
+              <Text color="textSubtle" ml="4px" small>
+                {position.amount1 && price1
+                  ? `~$${price1.quote(position.amount1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                  : ''}
               </Text>
             </RowFixed>
           </RowBetween>

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -30,6 +30,7 @@ import { useMasterchefV3, useV3NFTPositionManagerContract } from 'hooks/useContr
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import { useDerivedV3BurnInfo } from 'hooks/v3/useDerivedV3BurnInfo'
 import { useV3PositionFromTokenId, useV3TokenIdsByAccount } from 'hooks/v3/useV3Positions'
+import { useStablecoinPrice } from 'hooks/useBUSDPrice'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo, useState } from 'react'
 import { useTransactionAdder } from 'state/transactions/hooks'
@@ -216,6 +217,9 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
   ])
 
   const removed = position?.liquidity?.eq(0)
+
+  const price0 = useStablecoinPrice(liquidityValue0?.currency?.wrapped ?? undefined, !!feeValue0)
+  const price1 = useStablecoinPrice(liquidityValue1?.currency?.wrapped ?? undefined, !!feeValue1)
 
   function modalHeader() {
     return (
@@ -409,6 +413,11 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(liquidityValue0, 4, locale)}</Text>
+                  <Text color="textSubtle" ml="4px" small>
+                    {liquidityValue0 && price0
+                      ? `~$${price0.quote(liquidityValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                      : ''}
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="space-between" as="label" alignItems="center" mb="8px">
@@ -420,6 +429,11 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(liquidityValue1, 4, locale)}</Text>
+                  <Text color="textSubtle" ml="4px" small>
+                    {liquidityValue1 && price1
+                      ? `~$${price1.quote(liquidityValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                      : ''}
+                  </Text>
                 </Flex>
               </Flex>
               <Divider />
@@ -432,6 +446,11 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(feeValue0, 4, locale)}</Text>
+                  <Text color="textSubtle" ml="4px" small>
+                    {feeValue0 && price0
+                      ? `~$${price0.quote(feeValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                      : ''}
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="space-between" mb="8px" as="label" alignItems="center">
@@ -443,6 +462,11 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(feeValue1, 4, locale)}</Text>
+                  <Text color="textSubtle" ml="4px" small>
+                    {feeValue1 && price1
+                      ? `~$${price1.quote(feeValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                      : ''}
+                  </Text>
                 </Flex>
               </Flex>
             </LightGreyCard>

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -404,7 +404,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
               {t('You will receive')}
             </Text>
             <LightGreyCard>
-              <Flex justifyContent="space-between" mb="8px" as="label" alignItems="center">
+              <Flex justifyContent="space-between" as="label" alignItems="center">
                 <Flex alignItems="center">
                   <CurrencyLogo currency={liquidityValue0?.currency} />
                   <Text small color="textSubtle" id="remove-liquidity-tokena-symbol" ml="4px">
@@ -413,14 +413,16 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(liquidityValue0, 4, locale)}</Text>
-                  <Text color="textSubtle" ml="4px" small>
-                    {liquidityValue0 && price0
-                      ? `~$${price0.quote(liquidityValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
-                      : ''}
-                  </Text>
                 </Flex>
               </Flex>
-              <Flex justifyContent="space-between" as="label" alignItems="center" mb="8px">
+              <Flex justifyContent="flex-end" mb="8px">
+                <Text fontSize="10px" color="textSubtle" ml="4px">
+                  {liquidityValue0 && price0
+                    ? `~$${price0.quote(liquidityValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                    : ''}
+                </Text>
+              </Flex>
+              <Flex justifyContent="space-between" as="label" alignItems="center">
                 <Flex alignItems="center">
                   <CurrencyLogo currency={liquidityValue1?.currency} />
                   <Text small color="textSubtle" id="remove-liquidity-tokenb-symbol" ml="4px">
@@ -429,15 +431,17 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(liquidityValue1, 4, locale)}</Text>
-                  <Text color="textSubtle" ml="4px" small>
-                    {liquidityValue1 && price1
-                      ? `~$${price1.quote(liquidityValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
-                      : ''}
-                  </Text>
                 </Flex>
               </Flex>
+              <Flex justifyContent="flex-end" mb="8px">
+                <Text fontSize="10px" color="textSubtle" ml="4px">
+                  {liquidityValue1 && price1
+                    ? `~$${price1.quote(liquidityValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                    : ''}
+                </Text>
+              </Flex>
               <Divider />
-              <Flex justifyContent="space-between" mb="8px" as="label" alignItems="center">
+              <Flex justifyContent="space-between" as="label" alignItems="center">
                 <Flex alignItems="center">
                   <CurrencyLogo currency={feeValue0?.currency} />
                   <Text small color="textSubtle" id="remove-liquidity-tokena-symbol" ml="4px">
@@ -446,14 +450,16 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(feeValue0, 4, locale)}</Text>
-                  <Text color="textSubtle" ml="4px" small>
-                    {feeValue0 && price0
-                      ? `~$${price0.quote(feeValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
-                      : ''}
-                  </Text>
                 </Flex>
               </Flex>
-              <Flex justifyContent="space-between" mb="8px" as="label" alignItems="center">
+              <Flex justifyContent="flex-end" mb="8px">
+                <Text fontSize="10px" color="textSubtle" ml="4px">
+                  {feeValue0 && price0
+                    ? `~$${price0.quote(feeValue0?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                    : ''}
+                </Text>
+              </Flex>
+              <Flex justifyContent="space-between" as="label" alignItems="center">
                 <Flex alignItems="center">
                   <CurrencyLogo currency={feeValue1?.currency} />
                   <Text small color="textSubtle" id="remove-liquidity-tokena-symbol" ml="4px">
@@ -462,12 +468,14 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                 </Flex>
                 <Flex>
                   <Text small>{formatCurrencyAmount(feeValue1, 4, locale)}</Text>
-                  <Text color="textSubtle" ml="4px" small>
-                    {feeValue1 && price1
-                      ? `~$${price1.quote(feeValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
-                      : ''}
-                  </Text>
                 </Flex>
+              </Flex>
+              <Flex justifyContent="flex-end" mb="8px">
+                <Text fontSize="10px" color="textSubtle" ml="4px">
+                  {feeValue1 && price1
+                    ? `~$${price1.quote(feeValue1?.wrapped).toFixed(2, { groupSeparator: ',' })}`
+                    : ''}
+                </Text>
               </Flex>
             </LightGreyCard>
           </AutoColumn>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3baa094</samp>

### Summary
💵📈🎨

<!--
1.  💵 - This emoji represents the addition of the dollar value of the liquidity position and the fees, which is a useful feature for users who want to see how much their liquidity is worth and how much they can earn from fees.
2.  📈 - This emoji represents the improvement of the UI layout, which makes the interface more user-friendly and visually appealing, as well as more responsive to different screen sizes and orientations.
3.  🎨 - This emoji represents the general enhancement of the design and style of the interface, which adds some color, contrast, and spacing to make the elements more distinct and harmonious.
-->
This pull request enhances the liquidity position page by showing the dollar value and fees of the tokens, and by improving the UI layout. It modifies the file `apps/web/src/pages/liquidity/[tokenId].tsx`.

> _Oh, we're the savvy sailors of the Uniswap sea_
> _We swap our tokens high and low with liquidity_
> _We like to see our profits and our fees displayed_
> _So we pull the code from this pull request and say hooray!_

### Walkthrough
*  Display approximate dollar values of liquidity position and fees in UI ([link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR346-R347), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR567-R573), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR587-R593), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL624-R647), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL633-R663))
  * Define `priceValueUpper` and `priceValueLower` variables to store price values of upper and lower tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR346-R347))
  * Add text elements to show dollar values of upper and lower tokens of position, using `toFixed` and `groupSeparator` to format numbers ([link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR567-R573), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR587-R593))
  * Modify text elements to show dollar values of fees for upper and lower tokens of position, using `toFixed` and `groupSeparator` to format numbers and adding margin for spacing ([link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL624-R647), [link](https://github.com/pancakeswap/pancake-frontend/pull/6549/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL633-R663))



![image](https://user-images.githubusercontent.com/109973128/230874461-1e5a1d43-8ff6-44be-ab78-83c86a380203.png)
![image](https://user-images.githubusercontent.com/109973128/230874637-d9376769-f856-4bd9-b34a-1d50ec066ae8.png)
![image](https://user-images.githubusercontent.com/109973128/230874772-c12b946b-382e-4fbf-888d-08c8cc3f4f48.png)

