### PR TITLE
fix: Deploy action

### DIFF
--- a/.github/workflows/deploy-apis.yml
+++ b/.github/workflows/deploy-apis.yml
@@ -1,3 +1,5 @@
+name: Deploy CF API
+
 on:
   workflow_dispatch:
     inputs:
@@ -24,6 +26,7 @@ jobs:
       deployments: write
     env:
       HAVE_CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+      IS_DEV: ${{ github.event.inputs.environment == 'dev' }}
     name: Publish API
     steps:
       - name: Checkout
@@ -31,12 +34,20 @@ jobs:
         with:
           fetch-depth: 2
 
-      # - name: Install dependencies
-      #   run: yarn install --frozen-lockfile
-
       - name: Publish
         uses: cloudflare/wrangler-action@2.0.0
+        if: ${{ (env.HAVE_CLOUDFLARE_TOKEN == 'true') && (env.IS_DEV == 'false') }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
           workingDirectory: 'apis/${{ github.event.inputs.api }}'
           command: publish --env ${{ github.event.inputs.environment }}
+
+      - name: Publish dev
+        uses: cloudflare/wrangler-action@2.0.0
+        if: ${{ (env.HAVE_CLOUDFLARE_TOKEN == 'true') && (env.IS_DEV == 'true') }}
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          workingDirectory: 'apis/${{ github.event.inputs.api }}'
+          command: publish


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 22eb984</samp>

### Summary
🚀🌐🛠️

<!--
1.  🚀 for adding a workflow name and an environment variable to the deploy-apis workflow, which enables deploying to different environments.
2.  🌐 for using different Cloudflare environments based on the input environment, which allows for testing and staging the Cloudflare API before publishing to production.
3.  🛠️ for updating the publish command to use the environment variable, which fixes the issue of hardcoding the environment name in the command.
-->
Add support for deploying Cloudflare API to different environments with a single workflow. Modify `.github/workflows/deploy-apis.yml` to use environment variables and inputs.

> _To deploy the Cloudflare API_
> _They added a workflow name `deploy-apis`_
> _And an env var to switch_
> _Between prod and dev with a glitch_
> _And a publish command that's more snappy_

### Walkthrough
*  Add a name for the workflow that deploys the Cloudflare API ([link](https://github.com/pancakeswap/pancake-frontend/pull/6555/files?diff=unified&w=0#diff-d6bb07415a4782c3dccf60d4aa0aa6b46d574011187d901d20d78a166925a587R1-R2))
*  Introduce an environment variable IS_DEV to distinguish between dev and non-dev environments ([link](https://github.com/pancakeswap/pancake-frontend/pull/6555/files?diff=unified&w=0#diff-d6bb07415a4782c3dccf60d4aa0aa6b46d574011187d901d20d78a166925a587R29))
*  Adjust the publish command to use different Cloudflare environments and account IDs based on IS_DEV ([link](https://github.com/pancakeswap/pancake-frontend/pull/6555/files?diff=unified&w=0#diff-d6bb07415a4782c3dccf60d4aa0aa6b46d574011187d901d20d78a166925a587L34-R53))


