### PR TITLE
chore: info v3 details 

### DIFF
--- a/apps/web/src/views/Info/components/InfoTables/shared.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/shared.tsx
@@ -14,8 +14,8 @@ export const TableWrapper = styled(Flex)`
   flex-direction: column;
   gap: 16px;
   background-color: ${({ theme }) => theme.card.background};
-  border-radius: ${({ theme }) => theme.radii[0]};
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
+  border-radius: ${({ theme }) => theme.radii.card};
   ${({ theme }) => theme.mediaQueries.md} {
     border-radius: ${({ theme }) => theme.radii.card};
   }

--- a/apps/web/src/views/V3Info/components/CandleChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/CandleChart/index.tsx
@@ -88,6 +88,7 @@ const CandleChart = ({
           backgroundColor: 'transparent',
           textColor: '#565A69',
           fontFamily: 'Inter var',
+          fontSize: 14,
         },
         rightPriceScale: {
           scaleMargins: {

--- a/apps/web/src/views/V3Info/components/DensityChart/CustomToolTip.tsx
+++ b/apps/web/src/views/V3Info/components/DensityChart/CustomToolTip.tsx
@@ -7,11 +7,14 @@ import { LightCard } from '../Card'
 import { RowBetween } from '../Row'
 
 const TooltipWrapper = styled(LightCard)`
+  width: 260px;
   padding: 12px;
-  width: 320px;
   opacity: 0.6;
   font-size: 12px;
   z-index: 10;
+  ${({ theme }) => theme.mediaQueries.md} {
+    width: 320px;
+  }
 `
 
 interface CustomToolTipProps {

--- a/apps/web/src/views/V3Info/components/PoolTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/PoolTable/index.tsx
@@ -38,7 +38,7 @@ const ResponsiveGrid = styled.div`
   }
 
   @media screen and (max-width: 480px) {
-    grid-template-columns: 2.5fr repeat(1, 1fr);
+    grid-template-columns: 1.3fr 1fr;
     > *:nth-child(1) {
       display: none;
     }

--- a/apps/web/src/views/V3Info/components/TokenTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TokenTable/index.tsx
@@ -7,6 +7,7 @@ import {
   NextLinkFromReactRouter,
   SortArrowIcon,
   Text,
+  useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useTheme from 'hooks/useTheme'
@@ -46,7 +47,7 @@ const ResponsiveGrid = styled.div`
   }
 
   @media screen and (max-width: 670px) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1.3fr 1fr;
     > *:first-child {
       display: none;
     }
@@ -74,6 +75,7 @@ const ResponsiveLogo = styled(CurrencyLogo)`
 const DataRow = ({ tokenData, index, chainPath }: { tokenData: TokenData; index: number; chainPath: string }) => {
   const { theme } = useTheme()
   const chainName = useGetChainName()
+  const { isMobile } = useMatchBreakpoints()
   return (
     <LinkWrapper to={`/${v3InfoPath}${chainPath}/tokens/${tokenData.address}`}>
       <ResponsiveGrid>
@@ -82,15 +84,15 @@ const DataRow = ({ tokenData, index, chainPath }: { tokenData: TokenData; index:
           <RowFixed>
             <ResponsiveLogo address={tokenData.address} chainName={chainName} />
           </RowFixed>
-          <Text style={{ marginLeft: '6px' }}>
-            <Text ml="8px">{tokenData.symbol}</Text>
-          </Text>
+
           <Text style={{ marginLeft: '10px' }}>
             <RowFixed>
-              <HoverInlineText text={tokenData.name} />
-              <Text ml="8px" color={theme.colors.text99}>
-                ({tokenData.symbol})
-              </Text>
+              {isMobile ? <HoverInlineText text={tokenData.symbol} /> : <HoverInlineText text={tokenData.name} />}
+              {!isMobile && (
+                <Text ml="8px" color={theme.colors.text99}>
+                  ({tokenData.symbol})
+                </Text>
+              )}
             </RowFixed>
           </Text>
         </Flex>

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -298,7 +298,7 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                     )}
                   </Text>
                 </Flex>
-                <Box px="24px" height="250px">
+                <Box px="24px" height="320px">
                   {view === ChartView.TVL ? (
                     <LineChart
                       data={formattedTvlData}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5444ad3</samp>

### Summary
🪡📱📊

<!--
1.  🪡 - This emoji represents the simplification of the `TableWrapper` component by removing the redundant border-radius property. The emoji is a sewing needle, which can symbolize fixing or tidying up something.
2. 📱 - This emoji represents the adjustment of the `ResponsiveGrid` component for the `PoolTable` to have a smaller first column width on mobile devices. The emoji is a mobile phone, which can symbolize responsiveness or device compatibility.
3. 📊 - This emoji represents the update of the `TokenTable` component to use the `useMatchBreakpoints` hook and improve the readability of the token data on different device sizes. The emoji is a bar chart, which can symbolize data or information.
-->
This pull request improves the responsiveness and layout of the `TokenTable` and `PoolTable` components on the V3 info page. It also removes some unnecessary CSS code from the `TableWrapper` component.

> _We're coding for the `PoolTable`, responsive and neat_
> _We're trimming the `TableWrapper`, no border-radius repeat_
> _We're tweaking the `TokenTable`, with breakpoints and hooks_
> _We're heaving all together, on the count of three, me rooks_

### Walkthrough
*  Simplify the `TableWrapper` component by removing the redundant border-radius property ([link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-e8f08a6208b09c2416d8c1a6941b97fc1abd3e87e85730bae7dc48ffdd443fe7L17-R18))
*  Adjust the `ResponsiveGrid` component for the `PoolTable` and the `TokenTable` to have a smaller first column width on mobile devices, to avoid overflowing the table content ([link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L41-R41), [link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-9f3e1db896201b7ecebd9b554c438c5dced210b06a2fcd74098ea31c855b010aL49-R50))
*  Import the `useMatchBreakpoints` hook from the uikit library and use it in the `DataRow` component for the `TokenTable`, to conditionally render the token name or symbol depending on the device size ([link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-9f3e1db896201b7ecebd9b554c438c5dced210b06a2fcd74098ea31c855b010aR10), [link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-9f3e1db896201b7ecebd9b554c438c5dced210b06a2fcd74098ea31c855b010aR78))
*  Simplify the text layout and remove the unnecessary margin-left for the token symbol in the `DataRow` component for the `TokenTable`, and only show the token symbol in parentheses on non-mobile devices ([link](https://github.com/pancakeswap/pancake-frontend/pull/6560/files?diff=unified&w=0#diff-9f3e1db896201b7ecebd9b554c438c5dced210b06a2fcd74098ea31c855b010aL85-R95))


