### PR TITLE
chore: Update error text

### DIFF
--- a/apps/web/src/state/multicall/updater.tsx
+++ b/apps/web/src/state/multicall/updater.tsx
@@ -240,7 +240,7 @@ export default function Updater(): null {
             }
           })
           .catch((error: any) => {
-            const REVERT_STR = 'execution reverted'
+            const REVERT_STR = 'revert exception'
 
             // when revert error, should not update new state and keep current state.
             if (error instanceof CancelledError || error?.message?.indexOf(REVERT_STR) >= 0) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8e143a6</samp>

### Summary
🐛📞🛠️

<!--
1.  🐛 Bug fix: This emoji represents the main purpose of the change, which is to fix a bug that caused incorrect state updates.
2.  📞 Call: This emoji represents the domain of the change, which is related to contract calls and multicall functionality.
3.  🛠️ Refactor: This emoji represents the nature of the change, which is a minor refactor of a constant value and a comment.
-->
Fixed a bug in `useMulticallCallback` hook that caused incorrect state updates when a contract call reverted. Changed the `REVERT_STR` constant in `updater.tsx` to match the multicall contract error message.

> _`REVERT_STR` changed_
> _To match multicall error_
> _State updates better_

### Walkthrough
*  Fix state update bug when multicall reverts ([link](https://github.com/pancakeswap/pancake-frontend/pull/6561/files?diff=unified&w=0#diff-bfd062baaa17d4fb8942e2902016d461de7a5fb4c84002d53123186349e9df1eL243-R243))


