### PR TITLE
feat: list XCAD syrup pool

### DIFF
--- a/apps/web/src/config/constants/pools.tsx
+++ b/apps/web/src/config/constants/pools.tsx
@@ -69,6 +69,18 @@ export const livePools: Pool.SerializedPoolConfig<SerializedWrappedToken>[] = [
     isFinished: false,
   },
   {
+    sousId: 336,
+    stakingToken: bscTokens.xcad,
+    earningToken: bscTokens.cake,
+    contractAddress: {
+      56: '0x548e422031E9063c21c84C7478EBa0f7ae9641B7',
+      97: '',
+    },
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.009548',
+    version: 3,
+  },
+  {
     sousId: 335,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.sis,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e3419bd</samp>

### Summary
🍰🎮🆕

<!--
1.  🍰 - This emoji represents the CAKE token, which is the earningToken of the new pool and the native token of PancakeSwap. It also suggests a reward or a treat for staking XCAD tokens.
2.  🎮 - This emoji represents the XCAD token, which is the stakingToken of the new pool and a token that allows users to create and monetize gaming content. It also suggests a gaming or entertainment theme for the pool.
3.  🆕 - This emoji represents the novelty or freshness of the new pool, which is one of several new pools added to the PancakeSwap frontend. It also suggests a sense of excitement or curiosity for the users.
-->
Add a new pool for staking `XCAD` and earning `CAKE` to `pools.tsx`. This is part of a larger pull request that updates the pool list on the frontend.

> _New pool for `XCAD`_
> _Stake tokens, earn some `CAKE`_
> _Autumn harvest time_

### Walkthrough
*  Add new pools for staking various tokens and earning CAKE tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/6563/files?diff=unified&w=0#diff-e908818b4901940f12fbf07467ab23f3a2ae9d6241c30818341cd8e72d47069aR72-R83),                             F0L




Please note this is a reverse syrup pool - stake XCAD earn CAKE
XCAD Token address: 0xa026ad2ceda16ca5fc28fd3c72f99e2c332c8a26
Cake token address: 0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82
Pool contract address: 0x548e422031e9063c21c84c7478eba0f7ae9641b7
Pool token rewards per block: 0.009548

