### PR TITLE
fix: Page crash when filtering v2 candidate pools

### DIFF
--- a/apps/web/src/hooks/useV2Pools.ts
+++ b/apps/web/src/hooks/useV2Pools.ts
@@ -1,4 +1,4 @@
-import { CurrencyAmount, Pair as SDKPair, Currency, JSBI, Token, Price } from '@pancakeswap/sdk'
+import { CurrencyAmount, Pair as SDKPair, Currency, JSBI, Token, Price, ZERO } from '@pancakeswap/sdk'
 import { SmartRouter, V2Pool, BASES_TO_CHECK_TRADES_AGAINST } from '@pancakeswap/smart-router/evm'
 import { formatPrice } from '@pancakeswap/utils/formatFractions'
 import { useEffect, useMemo, useRef } from 'react'
@@ -119,6 +119,9 @@ export function useV2CandidatePoolsFromOnChain(
       baseTokenUsdPrices && poolsFromOnChain
         ? poolsFromOnChain.map((pool: V2Pool) => {
             const getAmountUsd = (amount: CurrencyAmount<Currency>) => {
+              if (amount.equalTo(ZERO)) {
+                return 0
+              }
               const price = baseTokenUsdPrices.get(amount.currency.wrapped.address)
               if (price !== undefined) {
                 return parseFloat(amount.toExact()) * price


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6937f1a</samp>

### Summary
🐛🧮🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is what the import of `ZERO` and the check for zero denominator are.
2.  🧮 - This emoji represents a calculation or math-related improvement, which is what the `getPoolWeight` function does.
3.  🚀 - This emoji represents a performance or speed enhancement, which is what the improved accuracy and stability of the V2 pools hook could lead to.
-->
Fixed a division by zero bug and imported a constant in `useV2Pools` hook. This hook provides data for the V2 liquidity pools on the web app.

> _In the depths of the pool, a lurking danger_
> _Division by zero, a fatal error_
> _But we imported `ZERO`, a constant savior_
> _Fixed the bug and improved the pool's behavior_

### Walkthrough
* Import `ZERO` constant from `@pancakeswap/sdk` to check for empty balances ([link](https://github.com/pancakeswap/pancake-frontend/pull/6565/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591L1-R1))
* Return 0 from `getPoolWeight` function if pool token amount is zero to avoid division by zero and invalid weights ([link](https://github.com/pancakeswap/pancake-frontend/pull/6565/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591R122-R124))


