### PR TITLE
fix: add price helper for XCAD syrup pool

### DIFF
--- a/apps/web/src/config/constants/priceHelperLps/pools/56.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/56.ts
@@ -23,6 +23,13 @@ const priceHelperLps: SerializedFarmConfig[] = [
     lpSymbol: 'WBNB-SIS LP',
     lpAddress: '0xbCA9057666872B7b7CfC9718E68C96c64d69E1Ad',
   },
+  {
+    pid: null,
+    token: bscTokens.xcad,
+    quoteToken: bscTokens.busd,
+    lpSymbol: 'XCAD-BUSD LP',
+    lpAddress: '0x43d86605F8d22407b959D668B2689eafba23571B',
+  },
 ].map((p) => ({ ...p, token: p.token.serialize, quoteToken: p.quoteToken.serialize }))
 
 export default priceHelperLps


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a28656b</samp>

### Summary
🚀🍰🤝

<!--
1.  🚀 - This emoji represents a new feature or improvement, and can be used to indicate that the change adds a new pool configuration for the XCAD-BUSD LP token.
2.  🍰 - This emoji represents the CAKE token, which is the reward for staking in the pool. It can be used to indicate that the change is related to the CAKE ecosystem and incentives.
3.  🤝 - This emoji represents a partnership or collaboration, and can be used to indicate that the change involves a cross-chain or cross-project integration with XCAD Network, which is a platform for creating and trading NFTs based on social media influencers.
-->
Add a new pool for XCAD-BUSD LP tokens to the price helper LPs feature. This feature helps users find the best prices for swapping tokens on PancakeSwap.

> _Stake `XCAD-BUSD`_
> _Earn CAKE in the new pool_
> _Autumn harvest time_

### Walkthrough
*  Add new pool configurations for various LP tokens to enable staking and earning CAKE rewards ([link](https://github.com/pancakeswap/pancake-frontend/pull/6570/files?diff=unified&w=0#diff-aedc95b3922e945e8e57ddcbadee3aed8a870eaca5cccd8aa241671272e76ab8R26-R32),                            


