### PR TITLE
fix(Liquidity): Fix rangeTag on removeLiquidity

### DIFF
--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -359,7 +359,7 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
                   {t('Farming')}
                 </Tag>
               )}
-              <RangeTag removed={removed} outOfRange={outOfRange} />
+              <RangeTag removed={removed} outOfRange={!outOfRange} />
             </Flex>
           </AutoRow>
           <Text fontSize="12px" color="secondary" bold textTransform="uppercase" mb="4px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 643e600</samp>

### Summary
🐛🔄🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. The `outOfRange` prop was not working as expected and caused incorrect behavior in the UI.
2.  🔄 - This emoji represents a reversal or inversion, which is what the change did to the `outOfRange` prop. The prop was flipped from true to false and vice versa to match the intended logic and display.
3.  🎨 - This emoji represents a UI improvement, which is the result of the change. The change made the `RangeTag` component show the correct color and text for the position status, enhancing the user experience and visual feedback.
-->
Fixed a bug in the `RemoveLiquidity` view that displayed incorrect range tags for liquidity positions. Changed the logic of the `outOfRange` prop of the `RangeTag` component in `RemoveLiquidityV3.tsx`.

> _`RangeTag` bug fixed_
> _Inverted `outOfRange` prop_
> _Autumn leaves change color_

### Walkthrough
* Fix the color and text of the `RangeTag` component for positions that are in range or out of range ([link](https://github.com/pancakeswap/pancake-frontend/pull/6576/files?diff=unified&w=0#diff-3639b5beb9d763170cb423e83fcbcd8129c820faa28a757bf95b2d841ca14261L362-R362))


