### PR TITLE
fix: Liquidity calculation error when switching tokens

### DIFF
--- a/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
@@ -212,13 +212,13 @@ export function RoiCalculator({
 
   const derivedCakeApr = useMemo(() => {
     if (
-      !currencyB ||
+      !amountA ||
+      !amountB ||
       !priceRange?.tickUpper ||
       !priceRange?.tickLower ||
       !sqrtRatioX96 ||
       !props.isFarm ||
-      !cakeAprFactor ||
-      !amountA
+      !cakeAprFactor
     ) {
       return undefined;
     }
@@ -228,9 +228,9 @@ export function RoiCalculator({
     }
 
     try {
-      const positionLiquidity = FeeCalculator.getLiquidityBySingleAmount({
-        amount: amountA,
-        currency: currencyB,
+      const positionLiquidity = FeeCalculator.getLiquidityByAmountsAndPrice({
+        amountA,
+        amountB,
         tickUpper: priceRange?.tickUpper,
         tickLower: priceRange?.tickLower,
         sqrtRatioX96,
@@ -245,7 +245,7 @@ export function RoiCalculator({
       console.error(error, amountA, priceRange, sqrtRatioX96);
       return undefined;
     }
-  }, [currencyB, priceRange, sqrtRatioX96, props.isFarm, cakeAprFactor, amountA, tickCurrent, usdValue]);
+  }, [amountA, amountB, priceRange, sqrtRatioX96, props.isFarm, cakeAprFactor, tickCurrent, usdValue]);
 
   const editedCakeApr =
     derivedCakeApr && typeof cakePriceDiffPercent === "number"

--- a/packages/uikit/src/widgets/RoiCalculator/hooks/usePriceRange.ts
+++ b/packages/uikit/src/widgets/RoiCalculator/hooks/usePriceRange.ts
@@ -75,12 +75,12 @@ export function usePriceRange({
   }, [tickSpaceLimits, invertPrice, quoteCurrency, baseCurrency]);
 
   const rightRangeTypedValue = useMemo(
-    () => (invertPrice ? formatPrice(priceLower, 6) : formatPrice(priceUpper, 6)),
+    () => (invertPrice ? formatPrice(priceLower, 18) : formatPrice(priceUpper, 18)),
     [priceLower, priceUpper, invertPrice]
   );
 
   const leftRangeTypedValue = useMemo(
-    () => (invertPrice ? formatPrice(priceUpper, 6) : formatPrice(priceLower, 6)),
+    () => (invertPrice ? formatPrice(priceUpper, 18) : formatPrice(priceLower, 18)),
     [priceLower, priceUpper, invertPrice]
   );
 

--- a/packages/uikit/src/widgets/RoiCalculator/hooks/useRoi.ts
+++ b/packages/uikit/src/widgets/RoiCalculator/hooks/useRoi.ts
@@ -1,6 +1,6 @@
 import { Currency, CurrencyAmount, Fraction, JSBI, ONE, Percent, ZERO } from "@pancakeswap/sdk";
 import { FeeAmount, FeeCalculator } from "@pancakeswap/v3-sdk";
-import { formatFraction } from "@pancakeswap/utils/formatFractions";
+import { formatFraction, parseNumberToFraction } from "@pancakeswap/utils/formatFractions";
 import { useMemo } from "react";
 
 import { useRate } from "./useRate";
@@ -18,12 +18,6 @@ interface Params extends Omit<FeeParams, "amount" | "currency"> {
   cakePrice?: number;
 }
 
-const scale = 1_000_000_000_000_000;
-
-const decimalToFraction = (decimal: number) => {
-  return new Fraction(Math.floor(decimal * scale), scale);
-};
-
 export function useRoi({
   amountA,
   amountB,
@@ -38,8 +32,8 @@ export function useRoi({
 }: Params) {
   const fee24h = useFee24h({
     ...rest,
-    amount: amountA,
-    currency: amountB?.currency,
+    amountA,
+    amountB,
   });
   const principal = useMemo(
     () =>
@@ -57,7 +51,7 @@ export function useRoi({
     compoundOn,
     stakeFor,
   });
-  const fee = useMemo(() => decimalToFraction(reward), [reward]);
+  const fee = useMemo(() => parseNumberToFraction(reward, 18), [reward]);
 
   const {
     apr: cakeAprInPercent,
@@ -101,9 +95,9 @@ export function useRoi({
 
 export interface FeeParams {
   // Amount of token user input
-  amount?: CurrencyAmount<Currency>;
+  amountA?: CurrencyAmount<Currency>;
   // Currency of the other token in the pool
-  currency?: Currency;
+  amountB?: CurrencyAmount<Currency>;
   tickLower?: number;
   tickUpper?: number;
   // Average 24h historical trading volume in USD
@@ -122,8 +116,8 @@ export interface FeeParams {
 }
 
 export function useFee24h({
-  amount,
-  currency,
+  amountA,
+  amountB,
   tickLower,
   tickUpper,
   volume24H,
@@ -134,8 +128,8 @@ export function useFee24h({
 }: FeeParams) {
   return useMemo(() => {
     if (
-      !amount ||
-      !currency ||
+      !amountA ||
+      !amountB ||
       typeof tickLower !== "number" ||
       typeof tickUpper !== "number" ||
       !volume24H ||
@@ -145,9 +139,9 @@ export function useFee24h({
     ) {
       return new Fraction(ZERO, ONE);
     }
-    return FeeCalculator.getEstimatedLPFee({
-      amount,
-      currency,
+    return FeeCalculator.getEstimatedLPFeeByAmounts({
+      amountA,
+      amountB,
       tickLower,
       tickUpper,
       volume24H,
@@ -156,5 +150,5 @@ export function useFee24h({
       fee,
       protocolFee,
     });
-  }, [amount, currency, tickLower, tickUpper, volume24H, sqrtRatioX96, mostActiveLiquidity, fee, protocolFee]);
+  }, [amountA, amountB, tickLower, tickUpper, volume24H, sqrtRatioX96, mostActiveLiquidity, fee, protocolFee]);
 }

--- a/packages/v3-sdk/src/utils/feeCalculator.test.ts
+++ b/packages/v3-sdk/src/utils/feeCalculator.test.ts
@@ -155,8 +155,8 @@ describe('#getEstimatedLPFee', () => {
     const sqrtRatioX96 = encodeSqrtRatioX96(1, 1)
     const mostActiveLiquidity = JSBI.BigInt(900)
 
-    const getLiquidityBySingleAmountSpy = vi
-      .spyOn(FeeCalculator, 'getLiquidityBySingleAmount')
+    const getLiquidityByAmountsAndPriceSpy = vi
+      .spyOn(FeeCalculator, 'getLiquidityByAmountsAndPrice')
       .mockImplementationOnce(() => JSBI.BigInt(100))
     const getLiquidityFromSqrtRatioX96Spy = vi
       .spyOn(FeeCalculator, 'getLiquidityFromSqrtRatioX96')
@@ -171,7 +171,7 @@ describe('#getEstimatedLPFee', () => {
       mostActiveLiquidity,
       fee: 500,
     })
-    expect(getLiquidityBySingleAmountSpy).toHaveBeenCalledTimes(1)
+    expect(getLiquidityByAmountsAndPriceSpy).toHaveBeenCalledTimes(1)
     expect(getLiquidityFromSqrtRatioX96Spy).toHaveBeenCalledTimes(0)
     expect(amount.equalTo(new Fraction(5, 10))).toBe(true)
   })
@@ -180,8 +180,8 @@ describe('#getEstimatedLPFee', () => {
     const sqrtRatioX96 = encodeSqrtRatioX96(1, 1)
     const mostActiveLiquidity = JSBI.BigInt(900)
 
-    const getLiquidityBySingleAmountSpy = vi
-      .spyOn(FeeCalculator, 'getLiquidityBySingleAmount')
+    const getLiquidityByAmountsAndPriceSpy = vi
+      .spyOn(FeeCalculator, 'getLiquidityByAmountsAndPrice')
       .mockImplementationOnce(() => JSBI.BigInt(100))
     const getLiquidityFromSqrtRatioX96Spy = vi
       .spyOn(FeeCalculator, 'getLiquidityFromSqrtRatioX96')
@@ -197,7 +197,7 @@ describe('#getEstimatedLPFee', () => {
       fee: 500,
       insidePercentage: new Percent(50, 100),
     })
-    expect(getLiquidityBySingleAmountSpy).toHaveBeenCalledTimes(1)
+    expect(getLiquidityByAmountsAndPriceSpy).toHaveBeenCalledTimes(1)
     expect(getLiquidityFromSqrtRatioX96Spy).toHaveBeenCalledTimes(0)
     expect(amount.equalTo(new Fraction(5, 20))).toBe(true)
   })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2886f06</samp>

### Summary
📈🔄🧪

<!--
1.  📈 - This emoji represents the increased precision and accuracy of the price range inputs and the fee estimation, as well as the support for dual-sided positions in the APR and ROI calculations.
2.  🔄 - This emoji represents the refactoring and reuse of the `parseNumberToFraction` function, as well as the changes to the useRoi and useFee24h hooks to calculate the fees based on both amounts of the LP tokens.
3.  🧪 - This emoji represents the updated test case for the `FeeCalculator.calculateFees` function, which uses the new function `FeeCalculator.getLiquidityByAmountsAndPrice` to calculate the liquidity based on the actual amounts of both tokens in the pair.
-->
Refactored and updated the RoiCalculator widget and the FeeCalculator module to support dual-sided positions for liquidity providers. This involved changing the hooks, functions, and components that calculate and display the fees, APR, and price range based on the actual amounts of both tokens in a pair. Also fixed the decimals and the test case for the fee calculation.

> _`FeeCalculator` changed_
> _More precision for LPs_
> _Autumn leaves falling_

### Walkthrough
*  Increase the precision of the price range inputs from 6 to 18 decimals for the user to specify the exact price range they want to provide liquidity for ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-a4a72dfaf8b6243fbd15605ac0d87d9df449304d8f20d6ad93eda90b5db48d75L78-R83))
*  Replace the custom decimalToFraction function with the imported parseNumberToFraction function from the @pancakeswap/utils/formatFractions module, which converts numbers to fractions with 18 decimals more consistently and accurately ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L21-L26), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L60-R54))
*  Change the useFee24h hook and the FeeParams interface to use both amountA and amountB as parameters, instead of assuming a single-sided position with a max amount of the other token, and update the call and the dependency array accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L41-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L104-R100), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L125-R120), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L137-R132), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L148-R144), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-6742d01856565eccc1c3428df12a8d033bb31e1b39958de41988031d69027852L159-R153))
*  Change the derivedCakeApr hook to use both amountA and amountB as parameters, instead of assuming a single-sided position, and update the condition, the call, and the dependency array accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aL215-R221), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aL231-R233), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aL248-R248))
*  Add the getEstimatedLPFeeByAmounts function to the FeeCalculator module, which calculates the estimated fee based on the actual amounts of both tokens, instead of assuming a single-sided position with a max amount of the other token, and use it in the useFee24h hook and the RoiCalculator component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L58-R82), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L68-R92))
*  Change the getEstimatedLPFeeWithProtocolFee function to use the getEstimatedLPFeeByAmountsWithProtocolFee function, which calculates the estimated fee with protocol fee based on the actual amounts of both tokens, instead of assuming a single-sided position with a max amount of the other token, and use it in the RoiCalculator component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L49-R73))
*  Change the tryGetEstimatedLPFee function to use the tryGetEstimatedLPFeeByAmounts function, which calculates the estimated fee based on the actual amounts of both tokens, instead of assuming a single-sided position with a max amount of the other token, and use it in the getEstimatedLPFee and the getEstimatedLPFeeWithProtocolFee functions ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L68-R92))
*  Change the EstimateFeeOptions and the EstimateFeeByAmountsOptions interfaces to use both amountA and amountB as properties, instead of amount and currency, and use them in the fee calculation functions ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L78-R100), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L49-R73))
*  Change the getLiquidityBySingleAmount function to the getLiquidityByAmountsAndPrice function, which calculates the liquidity based on the actual amounts of both tokens, instead of assuming a single-sided position with a max amount of the other token, and use it in the derivedCakeApr hook, the tryGetEstimatedLPFeeByAmounts function, and the feeCalculator.test.ts file ([link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aL231-R233), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L86-R114), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-4895c7538ecc5d1acebc919c8893d522406b8eea05afa5479cb03f3ba639512eL158-R159), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-4895c7538ecc5d1acebc919c8893d522406b8eea05afa5479cb03f3ba639512eL174-R174), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-4895c7538ecc5d1acebc919c8893d522406b8eea05afa5479cb03f3ba639512eL183-R184), [link](https://github.com/pancakeswap/pancake-frontend/pull/6577/files?diff=unified&w=0#diff-4895c7538ecc5d1acebc919c8893d522406b8eea05afa5479cb03f3ba639512eL200-R200))



