### PR TITLE
chore: Use local logo assets

### DIFF
--- a/packages/uikit/src/components/CurrencyLogo/utils.ts
+++ b/packages/uikit/src/components/CurrencyLogo/utils.ts
@@ -10,9 +10,9 @@ const mapping: { [key: number]: string } = {
 export const getTokenLogoURL = memoize(
   (token?: Token) => {
     if (token && mapping[token.chainId]) {
-      return `https://assets-cdn.trustwallet.com/blockchains/${mapping[token.chainId]}/assets/${getAddress(
+      return `/images${token.chainId === ChainId.BSC ? "" : `/${token.chainId}`}/tokens/${getAddress(
         token.address
-      )}/logo.png`;
+      )}.png`;
     }
     return null;
   },
@@ -22,9 +22,7 @@ export const getTokenLogoURL = memoize(
 export const getTokenLogoURLByAddress = memoize(
   (address?: string, chainId?: number) => {
     if (address && chainId && mapping[chainId]) {
-      return `https://assets-cdn.trustwallet.com/blockchains/${mapping[chainId]}/assets/${getAddress(
-        address
-      )}/logo.png`;
+      return `/images${chainId === ChainId.BSC ? "" : `/${chainId}`}/tokens/${getAddress(address)}.png`;
     }
     return null;
   },

--- a/packages/uikit/src/widgets/RoiCalculator/DepositAmount.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/DepositAmount.tsx
@@ -118,7 +118,7 @@ const TokenDisplayRow = memo(function TokenDisplayRow({
     <RowBetween>
       <Flex>
         <CurrencyLogo currency={currency} />
-        <Text color="textSubtle" ml="0.25em">
+        <Text color="textSubtle" ml="0.5em">
           {currency.symbol}
         </Text>
       </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b24c85d</samp>

### Summary
📏🚀🛡️

<!--
1.  📏 for increasing the margin
2. 🚀 for improving performance
3. 🛡️ for reducing dependency
-->
Replaced TrustWallet assets with local images for currency logos and improved UI alignment in `RoiCalculator` widget. These changes enhance the performance and user experience of the frontend.

> _Oh we're the coders of the `TokenDisplayRow`_
> _We like to tweak the margin and the logo_
> _We pull the images from our local store_
> _And we don't need TrustWallet anymore_

### Walkthrough
* Use local images for currency logos instead of external assets from TrustWallet to improve performance and reduce dependency on third-party services ([link](https://github.com/pancakeswap/pancake-frontend/pull/6580/files?diff=unified&w=0#diff-7deb472f34cafe26dd54d7936b6e694673570a38a9cc6694b511062b1e8b01d9L13-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/6580/files?diff=unified&w=0#diff-7deb472f34cafe26dd54d7936b6e694673570a38a9cc6694b511062b1e8b01d9L25-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/6580/files?diff=unified&w=0#diff-ba6dc2c1d26eb37991d5b55bcde597dfa35d6db7bf8abf53cc93ab3aff02544fL121-R121))


