### PR TITLE
chore: Mark all position update as reduce

### DIFF
--- a/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
+++ b/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
@@ -107,19 +107,11 @@ export function UpdatePositionsReminder_() {
   })
 
   const needRetrigger = isOverRewardGrowthGlobalUserInfos?.map((u, i) => {
-    let needReduce = false
     const lmRewardGrowthInside = getRewardGrowthInsides?.[i]
-    const farm = farmsV3?.farmsWithPrice.find((f) => f.pid === (u.pid as BigNumber).toNumber())
-    if (lmRewardGrowthInside && farm) {
-      needReduce = BigNumber.from(lmRewardGrowthInside).gt(
-        // @ts-ignore
-        farm._rewardGrowthGlobalX128,
-      )
-    }
     return {
       ...u,
       lmRewardGrowthInside,
-      needReduce,
+      needReduce: true,
     }
   })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a24f1e</samp>

### Summary
🐛🧹🎁

<!--
1.  🐛 - This emoji represents a bug fix, as the change is intended to resolve a bug that prevented some users from claiming their rewards.
2.  🧹 - This emoji represents a cleanup or simplification, as the change removes some unnecessary or confusing logic and makes the code more readable and consistent.
3.  🎁 - This emoji represents a feature or improvement, as the change potentially enables more users to access their rewards and benefit from the liquidity mining program.
-->
Simplify the logic of checking if a user needs to retrigger their position to claim rewards in `UpdatePositionsReminder.tsx`. Assume that any user with a positive `lmRewardGrowthInside` value needs to retrigger their position.

> _`lmRewardGrowthInside`_
> _Assume all need retrigger_
> _Simpler logic now_

### Walkthrough
*  Simplify the logic of checking whether a user needs to retrigger their position to claim rewards ([link](https://github.com/pancakeswap/pancake-frontend/pull/6588/files?diff=unified&w=0#diff-98c6c51dabb06f56a511c769cf2dc636d8d1475303124f43cb302a3f899e4391L110-R114))


