### PR TITLE
chore(Farms): V3 farms APR cell add tooltip on mobile

### DIFF
--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   useTooltip,
   TooltipText,
+  HelpIcon,
 } from '@pancakeswap/uikit'
 import { createElement, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -307,7 +308,13 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
             <AprMobileCell>
               <CellLayout label={t('APR')}>
                 {props.type === 'v3' ? (
-                  <FarmV3ApyButton farm={props.details} />
+                  <>
+                    <FarmV3ApyButton farm={props.details} />
+                    {aprTooltip.tooltipVisible && aprTooltip.tooltip}
+                    <Flex ref={aprTooltip.targetRef}>
+                      <HelpIcon ml="4px" width="20px" height="20px" color="textSubtle" />
+                    </Flex>
+                  </>
                 ) : (
                   <>
                     <Apr


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 183a969</samp>

### Summary
🆕📊💡

<!--
1.  🆕 - This emoji can be used to indicate that a new component and feature were added to the farms table row.
2.  📊 - This emoji can be used to indicate that the feature involves displaying some data and calculations related to the APR values.
3.  💡 - This emoji can be used to indicate that the feature aims to provide some helpful information and guidance to the users.
-->
Added a tooltip to show APR calculation details for v3 farms. This helps users to see how the APR values are derived and compare different farms.

> _To explain the APR values better_
> _A `HelpIcon` was added by the setter_
> _With a tooltip to show_
> _How the numbers can grow_
> _In the v3 farms table header_

### Walkthrough
*  Add a tooltip component to show the APR calculation for the v3 farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L310-R317))
  - Import the `HelpIcon` component from the `@pancakeswap/uikit` library ([link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86R18))
  - Wrap the `FarmV3ApyButton` component in a fragment and append the `aprTooltip` object ([link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L310-R317))
  - Create a reference to the `Flex` component that contains the `HelpIcon` and pass it to the `aprTooltip.targetRef` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L310-R317))
  - Add the `HelpIcon` component to the `Flex` component with some margin and size properties ([link](https://github.com/pancakeswap/pancake-frontend/pull/6592/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L310-R317))

![image](https://user-images.githubusercontent.com/109973128/231448832-01ce4409-c4fa-4cf8-9aac-70aa4b6196b2.png)


