### PR TITLE
revert: Use box allow passing style props

### DIFF
--- a/packages/uikit/src/__tests__/widgets/modal.test.tsx
+++ b/packages/uikit/src/__tests__/widgets/modal.test.tsx
@@ -92,7 +92,7 @@ it("renders correctly", () => {
       width: 48px;
     }
 
-    .c0 {
+    .c1 {
       min-width: 320px;
     }
 
@@ -146,8 +146,7 @@ it("renders correctly", () => {
       max-height: calc(90vh - 73px);
     }
 
-    .c1 {
-      overflow: hidden;
+    .c0 {
       background: var(--colors-backgroundAlt);
       box-shadow: 0px 20px 36px -8px rgba(14,14,44,0.1),0px 1px 1px rgba(0,0,0,0.05);
       border: 1px solid var(--colors-cardBorder);
@@ -197,7 +196,7 @@ it("renders correctly", () => {
     }
 
     @media screen and (min-width:852px) {
-      .c1 {
+      .c0 {
         width: auto;
         position: auto;
         bottom: auto;
@@ -207,46 +206,49 @@ it("renders correctly", () => {
     }
 
     <div
-        class="c0 c1"
-        minwidth="320px"
+        class="c0"
       >
         <div
-          class="c2"
+          class="c1"
         >
           <div
-            class="c3 c4"
+            class="c2"
           >
-            <h2
-              class="c5 c6"
-              color="text"
-              font-size="16px"
+            <div
+              class="c3 c4"
             >
-              Title
-            </h2>
+              <h2
+                class="c5 c6"
+                color="text"
+                font-size="16px"
+              >
+                Title
+              </h2>
+            </div>
+            <button
+              aria-label="Close the dialog"
+              class="c7 c8"
+              scale="md"
+            >
+              <svg
+                class="c9"
+                color="primary"
+                viewBox="0 0 24 24"
+                width="20px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M18.3 5.70997C17.91 5.31997 17.28 5.31997 16.89 5.70997L12 10.59L7.10997 5.69997C6.71997 5.30997 6.08997 5.30997 5.69997 5.69997C5.30997 6.08997 5.30997 6.71997 5.69997 7.10997L10.59 12L5.69997 16.89C5.30997 17.28 5.30997 17.91 5.69997 18.3C6.08997 18.69 6.71997 18.69 7.10997 18.3L12 13.41L16.89 18.3C17.28 18.69 17.91 18.69 18.3 18.3C18.69 17.91 18.69 17.28 18.3 16.89L13.41 12L18.3 7.10997C18.68 6.72997 18.68 6.08997 18.3 5.70997Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
           </div>
-          <button
-            aria-label="Close the dialog"
-            class="c7 c8"
-            scale="md"
+          <div
+            class="c10 c3 c11"
           >
-            <svg
-              class="c9"
-              color="primary"
-              viewBox="0 0 24 24"
-              width="20px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M18.3 5.70997C17.91 5.31997 17.28 5.31997 16.89 5.70997L12 10.59L7.10997 5.69997C6.71997 5.30997 6.08997 5.30997 5.69997 5.69997C5.30997 6.08997 5.30997 6.71997 5.69997 7.10997L10.59 12L5.69997 16.89C5.30997 17.28 5.30997 17.91 5.69997 18.3C6.08997 18.69 6.71997 18.69 7.10997 18.3L12 13.41L16.89 18.3C17.28 18.69 17.91 18.69 18.3 18.3C18.69 17.91 18.69 17.28 18.3 16.89L13.41 12L18.3 7.10997C18.68 6.72997 18.68 6.08997 18.3 5.70997Z"
-                fill="currentColor"
-              />
-            </svg>
-          </button>
-        </div>
-        <div
-          class="c10 c3 c11"
-        >
-          body
+            body
+          </div>
         </div>
       </div>
     </DocumentFragment>

--- a/packages/uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/uikit/src/widgets/Modal/Modal.tsx
@@ -22,7 +22,6 @@ export const ModalWrapper = ({
   return (
     // @ts-ignore
     <ModalContainer
-      as={Box}
       drag={isMobile && !hideCloseButton ? "y" : false}
       dragConstraints={{ top: 0, bottom: 600 }}
       dragElastic={{ top: 0 }}

--- a/packages/uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/uikit/src/widgets/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import { ModalBody, ModalHeader, ModalTitle, ModalContainer, ModalCloseButton, M
 import { ModalProps, ModalWrapperProps } from "./types";
 import { useMatchBreakpoints } from "../../contexts";
 import { ModalV2Context } from "./ModalV2";
+import { Box } from "../../components";
 
 export const MODAL_SWIPE_TO_CLOSE_VELOCITY = 300;
 
@@ -21,6 +22,7 @@ export const ModalWrapper = ({
   return (
     // @ts-ignore
     <ModalContainer
+      as={Box}
       drag={isMobile && !hideCloseButton ? "y" : false}
       dragConstraints={{ top: 0, bottom: 600 }}
       dragElastic={{ top: 0 }}
@@ -33,9 +35,8 @@ export const ModalWrapper = ({
         if (info.velocity.y > MODAL_SWIPE_TO_CLOSE_VELOCITY && onDismiss) onDismiss();
       }}
       ref={wrapperRef}
-      {...props}
     >
-      {children}
+      <Box {...props}>{children}</Box>
     </ModalContainer>
   );
 };

--- a/packages/uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/uikit/src/widgets/Modal/Modal.tsx
@@ -6,7 +6,7 @@ import { ModalBody, ModalHeader, ModalTitle, ModalContainer, ModalCloseButton, M
 import { ModalProps, ModalWrapperProps } from "./types";
 import { useMatchBreakpoints } from "../../contexts";
 import { ModalV2Context } from "./ModalV2";
-import { Box } from "../../components";
+import { Box } from "../../components/Box";
 
 export const MODAL_SWIPE_TO_CLOSE_VELOCITY = 300;
 

--- a/packages/uikit/src/widgets/Modal/styles.tsx
+++ b/packages/uikit/src/widgets/Modal/styles.tsx
@@ -62,7 +62,6 @@ export const ModalBackButton: React.FC<React.PropsWithChildren<{ onBack: ModalPr
 };
 
 export const ModalContainer = styled(MotionBox)`
-  overflow: hidden;
   background: ${({ theme }) => theme.modal.background};
   box-shadow: 0px 20px 36px -8px rgba(14, 14, 44, 0.1), 0px 1px 1px rgba(0, 0, 0, 0.05);
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e08cb47</samp>

### Summary
🚫📜📦

<!--
1.  🚫 - This emoji represents the removal of the `overflow: hidden` property, which can also be interpreted as allowing overflow or scrolling.
2.  📜 - This emoji represents the scrollable modal content, which can also be interpreted as a document or a list.
3.  📦 - This emoji represents the use of the `Box` component, which can also be interpreted as a container or a layout.
-->
Refactored the `Modal` component to use the `Box` component and removed the `overflow: hidden` property from the `ModalContainer` component. This improves the modal appearance and functionality.

> _To make the modal content scrollable_
> _The `overflow: hidden` was not viable_
> _So they removed it from `ModalContainer`_
> _And used `Box` for the modal render_
> _Now the modal is more flexible and reliable_

### Walkthrough
*  Replace `ModalContainer` with `Box` component for rendering modal content ([link](https://github.com/pancakeswap/pancake-frontend/pull/6595/files?diff=unified&w=0#diff-f4822f1319c351ac2e93d2d277e619764383f699c607416843215ac5647f953fR9), [link](https://github.com/pancakeswap/pancake-frontend/pull/6595/files?diff=unified&w=0#diff-f4822f1319c351ac2e93d2d277e619764383f699c607416843215ac5647f953fL36-R38))
* Remove `overflow: hidden` property from `ModalContainer` in `styles.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6595/files?diff=unified&w=0#diff-be5c6b6dc081b3bc89ef6efcb997fc46f6ac148bdf16bd8e1ae5d8e9fc2fc5c3L65))


