### PR TITLE
feat: Blog default language get from localStorage

### DIFF
--- a/apps/blog/components/Article/AllArticle/index.tsx
+++ b/apps/blog/components/Article/AllArticle/index.tsx
@@ -11,6 +11,8 @@ import CategoriesSelector from 'components/Article/CategoriesSelector'
 import useAllArticle from 'hooks/useAllArticle'
 import useLanguage from 'hooks/useLanguage'
 import SkeletonArticle from 'components/SkeletonArticle'
+import { storageLangMap } from 'utils/getLocalStorageLanguageCode'
+import { getLanguageCodeFromLS } from 'utils/getLanguageCodeFromLS'
 
 const StyledArticleContainer = styled(Box)`
   width: 100%;
@@ -94,6 +96,14 @@ const AllArticle = () => {
     }
   }, [categoriesData, router.isReady, router.query.category])
 
+  const codeFromStorage = getLanguageCodeFromLS()
+  useEffect(() => {
+    if (codeFromStorage) {
+      const languageStorage = storageLangMap(codeFromStorage)
+      setLanguageOption(languageStorage)
+    }
+  }, [codeFromStorage])
+
   const { articlesData, isFetching } = useAllArticle({
     query,
     sortBy,
@@ -138,7 +148,12 @@ const AllArticle = () => {
             <Flex flexDirection={['column', 'row']}>
               {languageItems.length > 0 && (
                 <Box width="100%">
-                  <ArticleSortSelect title={t('Languages')} options={languageItems} setOption={setLanguageOption} />
+                  <ArticleSortSelect
+                    title={t('Languages')}
+                    languageOption={languageOption}
+                    options={languageItems}
+                    setOption={setLanguageOption}
+                  />
                 </Box>
               )}
               <Box width="100%" m={['10px 0 0 0', '0 0 0 16px', '0 0 0 16px', '0 16px']}>

--- a/apps/blog/components/Article/AllArticle/index.tsx
+++ b/apps/blog/components/Article/AllArticle/index.tsx
@@ -150,7 +150,7 @@ const AllArticle = () => {
                 <Box width="100%">
                   <ArticleSortSelect
                     title={t('Languages')}
-                    languageOption={languageOption}
+                    key={languageOption}
                     options={languageItems}
                     setOption={setLanguageOption}
                   />

--- a/apps/blog/components/Article/ArticleSortSelect.tsx
+++ b/apps/blog/components/Article/ArticleSortSelect.tsx
@@ -8,33 +8,29 @@ interface SortByItem {
 
 interface ArticleSortSelectProps {
   title: string
-  languageOption?: string
+  key?: string
   options: SortByItem[]
   setOption: (value: string) => void
 }
 
 const ArticleSortSelect: React.FC<React.PropsWithChildren<ArticleSortSelectProps>> = ({
   title,
+  key,
   options,
-  languageOption,
   setOption,
 }) => {
   const handleChange = (newOption: OptionProps) => {
     setOption(newOption.value)
   }
 
-  const placeHolderText = useMemo(() => options.find((i) => i.value === languageOption), [languageOption, options])
+  const placeHolderText = useMemo(() => options.find((i) => i.value === key), [key, options])
 
   return (
     <Box minWidth="165px">
       <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
         {title}
       </Text>
-      <Select
-        placeHolderText={languageOption ? placeHolderText?.label : ''}
-        options={options}
-        onOptionChange={handleChange}
-      />
+      <Select placeHolderText={key ? placeHolderText?.label : ''} options={options} onOptionChange={handleChange} />
     </Box>
   )
 }

--- a/apps/blog/components/Article/ArticleSortSelect.tsx
+++ b/apps/blog/components/Article/ArticleSortSelect.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, Select, OptionProps } from '@pancakeswap/uikit'
+import { useMemo } from 'react'
 
 interface SortByItem {
   label: string
@@ -7,6 +8,7 @@ interface SortByItem {
 
 interface ArticleSortSelectProps {
   title: string
+  languageOption?: string
   options: SortByItem[]
   setOption: (value: string) => void
 }
@@ -14,18 +16,25 @@ interface ArticleSortSelectProps {
 const ArticleSortSelect: React.FC<React.PropsWithChildren<ArticleSortSelectProps>> = ({
   title,
   options,
+  languageOption,
   setOption,
 }) => {
   const handleChange = (newOption: OptionProps) => {
     setOption(newOption.value)
   }
 
+  const placeHolderText = useMemo(() => options.find((i) => i.value === languageOption), [languageOption, options])
+
   return (
     <Box minWidth="165px">
       <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
         {title}
       </Text>
-      <Select options={options} onOptionChange={handleChange} />
+      <Select
+        placeHolderText={languageOption ? placeHolderText?.label : ''}
+        options={options}
+        onOptionChange={handleChange}
+      />
     </Box>
   )
 }

--- a/apps/blog/utils/getLanguageCodeFromLS.ts
+++ b/apps/blog/utils/getLanguageCodeFromLS.ts
@@ -1,0 +1,11 @@
+const LS_KEY = 'pancakeswap_language'
+
+export const getLanguageCodeFromLS = () => {
+  try {
+    const codeFromStorage = localStorage.getItem(LS_KEY)
+
+    return codeFromStorage || 'en'
+  } catch {
+    return 'en'
+  }
+}

--- a/apps/blog/utils/getLocalStorageLanguageCode.ts
+++ b/apps/blog/utils/getLocalStorageLanguageCode.ts
@@ -1,0 +1,24 @@
+const storageLanguage: any = {
+  'en-US': 'en',
+  'id-ID': 'id',
+  'pt-PT': 'pt',
+  'es-ES': 'es',
+  'tr-TR': 'tr',
+  'zh-CN': 'zh-CN',
+  'ru-RU': 'ru',
+  'it-IT': 'it',
+  'ja-JP': 'ja',
+  'de-DE': 'de',
+  'vi-VN': 'vi',
+}
+// {label: 'Georgian', value: 'ka'}
+
+export const storageLangMap = (languageCode: string) => {
+  if (!languageCode) {
+    return 'en'
+  }
+  if (storageLanguage[languageCode]) {
+    return storageLanguage[languageCode]
+  }
+  return 'en'
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ee8cb8</samp>

### Summary
🌐🗃️📰

<!--
1.  🌐 - This emoji represents the global or international aspect of the language feature, as it allows users to view the blog articles in different languages.
2.  🗃️ - This emoji represents the local storage or the data persistence aspect of the language feature, as it allows users to save and retrieve their language preference from the browser.
3.  📰 - This emoji represents the blog or the news aspect of the language feature, as it allows users to access the latest information and updates from the PancakeSwap platform.
-->
The pull request adds a feature to the blog app that allows users to select and store their preferred language for the blog articles. It modifies the `Article` and `ArticleSortSelect` components and adds two utility functions `getLanguageCodeFromLS` and `storageLangMap` to handle the language preference logic and local storage access.

> _Oh, we're the coders of the PancakeSwap_
> _And we work hard to make it better_
> _We use `getLanguageCodeFromLS`_
> _To fetch the language from the browser_

### Walkthrough
*  Add utility functions to get and map language code from local storage (`getLanguageCodeFromLS`, `storageLangMap`)


