### PR TITLE
fix(Blog): Key naming

### DIFF
--- a/apps/blog/components/Article/AllArticle/index.tsx
+++ b/apps/blog/components/Article/AllArticle/index.tsx
@@ -150,7 +150,7 @@ const AllArticle = () => {
                 <Box width="100%">
                   <ArticleSortSelect
                     title={t('Languages')}
-                    key={languageOption}
+                    value={languageOption}
                     options={languageItems}
                     setOption={setLanguageOption}
                   />

--- a/apps/blog/components/Article/ArticleSortSelect.tsx
+++ b/apps/blog/components/Article/ArticleSortSelect.tsx
@@ -8,14 +8,14 @@ interface SortByItem {
 
 interface ArticleSortSelectProps {
   title: string
-  key?: string
+  value?: string
   options: SortByItem[]
   setOption: (value: string) => void
 }
 
 const ArticleSortSelect: React.FC<React.PropsWithChildren<ArticleSortSelectProps>> = ({
   title,
-  key,
+  value,
   options,
   setOption,
 }) => {
@@ -23,14 +23,14 @@ const ArticleSortSelect: React.FC<React.PropsWithChildren<ArticleSortSelectProps
     setOption(newOption.value)
   }
 
-  const placeHolderText = useMemo(() => options.find((i) => i.value === key), [key, options])
+  const placeHolderText = useMemo(() => options.find((i) => i.value === value), [value, options])
 
   return (
     <Box minWidth="165px">
       <Text fontSize="12px" textTransform="uppercase" color="textSubtle" fontWeight={600} mb="4px">
         {title}
       </Text>
-      <Select placeHolderText={key ? placeHolderText?.label : ''} options={options} onOptionChange={handleChange} />
+      <Select placeHolderText={value ? placeHolderText?.label : ''} options={options} onOptionChange={handleChange} />
     </Box>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 23c02a4</samp>

### Summary
🔤🔄🚚

<!--
1.  🔤 - This emoji represents renaming or changing text, which is what happened to the `key` prop and the placeholder text.
2. 🔄 - This emoji represents changing or updating something, which is what happened to the logic of the `ArticleSortSelect` component to use the new prop name.
3. 🚚 - This emoji represents moving or relocating something, which is what happened to the `key` prop value, which was moved to the `value` prop.
-->
Renamed the `key` prop of the `ArticleSortSelect` component to `value` to align with the `Select` component and avoid confusion with React. Updated the placeholder text logic and the usage of the component in `AllArticle`.

> _`key` prop becomes `value`_
> _clearer name for sorting articles_
> _autumn leaves change too_

### Walkthrough
*  Rename `key` prop to `value` in `ArticleSortSelect` component and its usage to avoid confusion with React `key` prop and match `Select` component's prop name ([link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcL153-R153), [link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L11-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L18-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L26-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L33-R33))
* Update `placeHolderText` variable and prop in `ArticleSortSelect` component to use `value` prop instead of `key` prop to find and display the matching option label ([link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L26-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/6603/files?diff=unified&w=0#diff-75dad8d1bcee0392e9624183a176a934d85b68bff4cf13369359b0ed0f41a898L33-R33))


