### PR TITLE
fix: MONI pool APR

### DIFF
--- a/apps/web/src/config/constants/priceHelperLps/pools/56.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/56.ts
@@ -30,6 +30,13 @@ const priceHelperLps: SerializedFarmConfig[] = [
     lpSymbol: 'XCAD-BUSD LP',
     lpAddress: '0x43d86605F8d22407b959D668B2689eafba23571B',
   },
+  {
+    pid: null,
+    token: bscTokens.moni,
+    quoteToken: bscTokens.wbnb,
+    lpSymbol: 'MONI-BNB LP',
+    lpAddress: '0xbcfd0d4a37fEb4dceAAeFa9da28CD833E5f04e9f',
+  },
 ].map((p) => ({ ...p, token: p.token.serialize, quoteToken: p.quoteToken.serialize }))
 
 export default priceHelperLps


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e750533</samp>

### Summary
🆕🌊🛠️

<!--
1.  🆕 - This emoji indicates that something new is added, such as a new pool, token, or feature.
2.  🌊 - This emoji indicates that the change involves liquidity pools, which are also known as LPs or farms. The change adds a new pool to the price helper LPs config file, which is related to liquidity provision and farming.
3.  🛠️ - This emoji indicates that the change is a fix, improvement, or adjustment to the existing code or functionality. The change provides the necessary information for the price helper LPs to calculate the price of the MONI token, which is an improvement to the price accuracy and display.
-->
Add a new price helper LP for the MONI-BNB pair. This allows the frontend to display the correct prices for the MONI token and its pools.

> _`MONI-BNB` pool_
> _price helper LPs config_
> _autumn harvest soon_

### Walkthrough
*  Add support for the MONI token and its pools to the PancakeSwap frontend
  * Add the MONI-BNB pool to the price helper LPs config file (`src/config/constants/priceHelperLps/pools/56.ts`) with its pid, token, quoteToken, lpSymbol and lpAddress values ([link](https://github.com/pancakeswap/pancake-frontend/pull/6604/files?diff=unified&w=0#diff-aedc95b3922e945e8e57ddcbadee3aed8a870eaca5cccd8aa241671272e76ab8R33-R39))


