### PR TITLE
chore: Move to finished pool

### DIFF
--- a/apps/web/src/config/constants/pools.tsx
+++ b/apps/web/src/config/constants/pools.tsx
@@ -93,18 +93,6 @@ export const livePools: Pool.SerializedPoolConfig<SerializedWrappedToken>[] = [
     version: 3,
   },
   {
-    sousId: 335,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.sis,
-    contractAddress: {
-      56: '0xFBA59bA5485670ec243EFA8903564aa5C0AD2373',
-      97: '',
-    },
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.5704',
-    version: 3,
-  },
-  {
     sousId: 334,
     stakingToken: bscTokens.rdnt,
     earningToken: bscTokens.cake,
@@ -280,6 +268,18 @@ export const livePools: Pool.SerializedPoolConfig<SerializedWrappedToken>[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 335,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.sis,
+    contractAddress: {
+      56: '0xFBA59bA5485670ec243EFA8903564aa5C0AD2373',
+      97: '',
+    },
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.5704',
+    version: 3,
+  },
   {
     sousId: 331,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8126d75</samp>

### Summary
🏊🏁🔄

<!--
1.  🏊 - This emoji represents a pool, and is used here to indicate that this pull request is related to the pool data in some way.
2.  🏁 - This emoji represents a finish line, and is used here to indicate that this pull request is about moving a pool from the active to the finished state.
3.  🔄 - This emoji represents a refresh or update, and is used here to indicate that this pull request is updating the website with the latest pool data.
-->
Move a finished pool from `activePools` to `finishedPools` in `pools.tsx`. This change updates the website to show the correct pool status.

> _A pool with `sousId` three-three-five_
> _Was active, but now it's not alive_
> _So we moved it with care_
> _To the `finishedPools` lair_
> _And updated the website to thrive_

### Walkthrough
*  Move the pool with sousId 335 from active to finished pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/6607/files?diff=unified&w=0#diff-e908818b4901940f12fbf07467ab23f3a2ae9d6241c30818341cd8e72d47069aL96-L107), [link](https://github.com/pancakeswap/pancake-frontend/pull/6607/files?diff=unified&w=0#diff-e908818b4901940f12fbf07467ab23f3a2ae9d6241c30818341cd8e72d47069aR272-R283))


