### PR TITLE
fix: modal overflow style

### DIFF
--- a/packages/uikit/src/__tests__/widgets/modal.test.tsx
+++ b/packages/uikit/src/__tests__/widgets/modal.test.tsx
@@ -93,6 +93,8 @@ it("renders correctly", () => {
     }
 
     .c1 {
+      border-radius: var(--radii-32px);
+      overflow: hidden;
       min-width: 320px;
     }
 
@@ -210,6 +212,7 @@ it("renders correctly", () => {
       >
         <div
           class="c1"
+          overflow="hidden"
         >
           <div
             class="c2"

--- a/packages/uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/uikit/src/widgets/Modal/Modal.tsx
@@ -35,7 +35,9 @@ export const ModalWrapper = ({
       }}
       ref={wrapperRef}
     >
-      <Box {...props}>{children}</Box>
+      <Box overflow="hidden" borderRadius="32px 32px 0x 0x" {...props}>
+        {children}
+      </Box>
     </ModalContainer>
   );
 };

--- a/packages/uikit/src/widgets/Modal/Modal.tsx
+++ b/packages/uikit/src/widgets/Modal/Modal.tsx
@@ -35,7 +35,7 @@ export const ModalWrapper = ({
       }}
       ref={wrapperRef}
     >
-      <Box overflow="hidden" borderRadius="32px 32px 0x 0x" {...props}>
+      <Box overflow="hidden" borderRadius="32px" {...props}>
         {children}
       </Box>
     </ModalContainer>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7475abc</samp>

### Summary
🎨🛠️🚧

<!--
1.  🎨 - This emoji is often used to indicate changes related to improving the UI or the style of a component. In this case, the `overflow` and `borderRadius` properties are both related to the visual appearance of the modal, so this emoji is appropriate.
2.  🛠️ - This emoji is often used to indicate changes related to fixing bugs or issues with a component. In this case, the change was part of a pull request that aimed to fix some UI issues with the modal component, so this emoji is also appropriate.
3.  🚧 - This emoji is often used to indicate changes related to work in progress or incomplete features. In this case, the change was part of a pull request that may not have been merged or deployed yet, so this emoji is also appropriate. Alternatively, this emoji could be replaced by 🚀 if the change was ready to be deployed or released.
-->
Fixed UI issues with the modal component by adding `overflow="hidden"` and `borderRadius="32px"` to the `ModalWrapper` component in `Modal.tsx`.

> _`ModalWrapper` changed_
> _Overflow hidden, corners round_
> _A cozy winter_

### Walkthrough
* Add overflow and border radius to modal container to prevent content from spilling over the corners ([link](https://github.com/pancakeswap/pancake-frontend/pull/6617/files?diff=unified&w=0#diff-f4822f1319c351ac2e93d2d277e619764383f699c607416843215ac5647f953fL38-R40))


