### PR TITLE
fix: Use Exact out for more precise usd price

### DIFF
--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -67,7 +67,7 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
   )
 
   const amountOut = useMemo(
-    () => (stableCoin ? CurrencyAmount.fromRawAmount(stableCoin, 10 * 10 ** stableCoin.decimals) : undefined),
+    () => (stableCoin ? CurrencyAmount.fromRawAmount(stableCoin, 5 * 10 ** stableCoin.decimals) : undefined),
     [stableCoin],
   )
 
@@ -114,7 +114,6 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
 
     if (trade) {
       const { inputAmount, outputAmount } = trade
-      console.log(inputAmount, outputAmount)
 
       return new Price(currency, stableCoin, inputAmount.quotient, outputAmount.quotient)
     }

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -75,7 +75,7 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
     amount: amountIn,
     currency: stableCoin,
     baseCurrency: currency,
-    tradeType: TradeType.EXACT_INPUT,
+    tradeType: TradeType.EXACT_OUTPUT,
     maxSplits: 0,
     maxHops: baseTradeAgainst ? 2 : 3,
     enabled: enableLlama ? !isLoading && !priceFromLlama : shouldEnabled,
@@ -115,7 +115,7 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
     if (trade) {
       const { inputAmount, outputAmount } = trade
 
-      return new Price(currency, stableCoin, inputAmount.quotient, outputAmount.quotient)
+      return new Price(currency, stableCoin, outputAmount.quotient, inputAmount.quotient)
     }
 
     return undefined

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -67,14 +67,14 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
   )
 
   const amountOut = useMemo(
-    () => (currency ? CurrencyAmount.fromRawAmount(currency, 1 * 10 ** currency.decimals) : undefined),
-    [currency],
+    () => (stableCoin ? CurrencyAmount.fromRawAmount(stableCoin, 10 * 10 ** stableCoin.decimals) : undefined),
+    [stableCoin],
   )
 
   const { trade } = useBestAMMTrade({
     amount: amountOut,
-    currency: stableCoin,
-    baseCurrency: currency,
+    currency,
+    baseCurrency: stableCoin,
     tradeType: TradeType.EXACT_OUTPUT,
     maxSplits: 0,
     maxHops: baseTradeAgainst ? 2 : 3,
@@ -114,8 +114,9 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
 
     if (trade) {
       const { inputAmount, outputAmount } = trade
+      console.log(inputAmount, outputAmount)
 
-      return new Price(currency, stableCoin, outputAmount.quotient, inputAmount.quotient)
+      return new Price(currency, stableCoin, inputAmount.quotient, outputAmount.quotient)
     }
 
     return undefined

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -66,13 +66,13 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
     },
   )
 
-  const amountIn = useMemo(
+  const amountOut = useMemo(
     () => (currency ? CurrencyAmount.fromRawAmount(currency, 1 * 10 ** currency.decimals) : undefined),
     [currency],
   )
 
   const { trade } = useBestAMMTrade({
-    amount: amountIn,
+    amount: amountOut,
     currency: stableCoin,
     baseCurrency: currency,
     tradeType: TradeType.EXACT_OUTPUT,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 38c81a7</samp>

### Summary
🐛🔄💵

<!--
1.  🐛 - This emoji represents a bug fix, and is appropriate for the first part of the change log that describes fixing the bug in the hook.
2.  🔄 - This emoji represents a change or an update, and is suitable for the second part of the change log that mentions changing the arguments for the `tradeType` and the `Price` constructor.
3.  💵 - This emoji represents money or currency, and is relevant for the last part of the change log that refers to the stablecoin price and the input and output amounts.
-->
Fixed a stablecoin price inversion bug in the `useBUSDPrice` hook. Updated the logic to handle different trade types and price calculations.

> _In the dark abyss of the market_
> _The stablecoin price was twisted and wrong_
> _But we fixed the bug in the `useBUSDPrice` hook_
> _Now we trade with the correct input and output_

### Walkthrough
* Fix stablecoin price inversion bug by changing trade type and price constructor arguments ([link](https://github.com/pancakeswap/pancake-frontend/pull/6618/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaL78-R78), [link](https://github.com/pancakeswap/pancake-frontend/pull/6618/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaL118-R118))


