### PR TITLE
chore: v3 info transaction table improvement

### DIFF
--- a/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
@@ -170,12 +170,8 @@ export default function TransactionTable({
       ) + extraPages
     setMaxPage(maxPageResult)
     if (maxPageResult === 0) setPage(0)
+    else setPage(1)
   }, [maxItems, transactions, txFilter])
-
-  const onFilterChange = useCallback((filter: TransactionType | undefined) => {
-    setPage(1)
-    setTxFilter(filter)
-  }, [])
 
   const sortedTransactions = useMemo(() => {
     return transactions
@@ -215,7 +211,7 @@ export default function TransactionTable({
           <RowFixed>
             <SortText
               onClick={() => {
-                onFilterChange(undefined)
+                setTxFilter(undefined)
               }}
               active={txFilter === undefined}
             >
@@ -223,7 +219,7 @@ export default function TransactionTable({
             </SortText>
             <SortText
               onClick={() => {
-                onFilterChange(TransactionType.SWAP)
+                setTxFilter(TransactionType.SWAP)
               }}
               active={txFilter === TransactionType.SWAP}
             >
@@ -231,7 +227,7 @@ export default function TransactionTable({
             </SortText>
             <SortText
               onClick={() => {
-                onFilterChange(TransactionType.MINT)
+                setTxFilter(TransactionType.MINT)
               }}
               active={txFilter === TransactionType.MINT}
             >
@@ -239,7 +235,7 @@ export default function TransactionTable({
             </SortText>
             <SortText
               onClick={() => {
-                onFilterChange(TransactionType.BURN)
+                setTxFilter(TransactionType.BURN)
               }}
               active={txFilter === TransactionType.BURN}
             >


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2172a72</samp>

### Summary
🔧🔄🧹

<!--
1.  🔧 - This emoji can be used to indicate that the pull request fixes or improves some functionality or logic, as in this case.
2.  🔄 - This emoji can be used to indicate that the pull request updates or refreshes some data or state, as in this case when the page number is reset and the transactions are filtered.
3.  🧹 - This emoji can be used to indicate that the pull request cleans up or simplifies some code, as in this case when the unnecessary functions are removed.
-->
Improve transactions table UI and logic in `V3Info` view. Refactor pagination and filtering code in `TransactionsTable` component.

> _The transactions table was a mess_
> _With pagination and filter stress_
> _But this pull request_
> _Made it much more digest_
> _By simplifying `setTransactionFilter` and `resetPage`_

### Walkthrough
* Reset the page number to 1 or 0 when transactions are updated ([link](https://github.com/pancakeswap/pancake-frontend/pull/6621/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL173-R175))
* Simplify the onFilterChange function by directly calling setTxFilter with the filter option ([link](https://github.com/pancakeswap/pancake-frontend/pull/6621/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL218-R214), [link](https://github.com/pancakeswap/pancake-frontend/pull/6621/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL226-R222), [link](https://github.com/pancakeswap/pancake-frontend/pull/6621/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL234-R230), [link](https://github.com/pancakeswap/pancake-frontend/pull/6621/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL242-R238))


