### PR TITLE
chore: Add Discord Icon

### DIFF
--- a/apps/blog/components/Article/SingleArticle/SocialIcon.tsx
+++ b/apps/blog/components/Article/SingleArticle/SocialIcon.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Flex, TwitterIcon, TelegramIcon, RedditIcon, Link } from '@pancakeswap/uikit'
+import { Flex, TwitterIcon, TelegramIcon, RedditIcon, Link, DiscordIcon } from '@pancakeswap/uikit'
 import { useRouter } from 'next/router'
 
 const StyledLink = styled(Link)`
@@ -47,6 +47,9 @@ const SocialIcon = () => {
       </StyledLink>
       <StyledLink external href={`https://reddit.com/submit?url=${BLOG_URL}${router.asPath}`}>
         <RedditIcon width={40} />
+      </StyledLink>
+      <StyledLink external href="https://discord.com/invite/pancakeswap">
+        <DiscordIcon width={40} />
       </StyledLink>
     </StyledSocialIcon>
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cef8e18</samp>

### Summary
🆕💬🍰

<!--
1.  🆕 - This emoji can be used to indicate that something new was added, such as a feature, a component, or a link.
2.  💬 - This emoji can be used to represent communication, chat, or social media, which are relevant to the Discord icon and the purpose of the link.
3.  🍰 - This emoji can be used to show the association with PancakeSwap, the project that the blog articles belong to and the Discord server that the icon links to.
-->
Added a Discord icon to the blog articles to promote the PancakeSwap community. Used the existing `DiscordIcon` component and `apps/blog/components/Article/SingleArticle/SocialIcon.tsx` file.

> _Join the Discord of the PancakeSwap_
> _`DiscordIcon` shines in the dark_
> _We are the rebels of the crypto space_
> _We defy the fate of the market crash_

### Walkthrough
*  Add a Discord icon and link to the social media options in the `SingleArticle` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87R51-R53))
*  Import the `DiscordIcon` component from the `@pancakeswap/uikit` package and use it in the `StyledLink` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87R51-R53))
*  Set the `external` prop of the `StyledLink` component to `true` to open the link in a new tab ([link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87R51-R53))
*  Set the `href` prop of the `StyledLink` component to the PancakeSwap Discord server URL ([link](https://github.com/pancakeswap/pancake-frontend/pull/6628/files?diff=unified&w=0#diff-829e47cb3606be37afa5e5e286e276b791de058a776934b29c95e65e6e547b87R51-R53))


