### PR TITLE
fix: Block number compare

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -123,7 +123,12 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
       // )
       return tradeFromOffchain ? bestTradeFromOffchain : bestTradeFromQuoter_
     }
-    if (JSBI.greaterThan(JSBI.BigInt(quoterTrade.blockNumber), JSBI.BigInt(tradeFromOffchain.blockNumber))) {
+
+    if (
+      quoterTrade.blockNumber &&
+      tradeFromOffchain.blockNumber &&
+      JSBI.greaterThan(JSBI.BigInt(quoterTrade.blockNumber), JSBI.BigInt(tradeFromOffchain.blockNumber))
+    ) {
       // console.log('[BEST Trade] Quoter trade is used', tradeFromQuoter)
       return bestTradeFromQuoter_
     }
@@ -233,7 +238,10 @@ function bestTradeHookFactory({
           )
         }
         SmartRouter.log(label, res)
-        return res
+        return {
+          ...res,
+          blockNumber,
+        }
       },
       enabled: !!(amount && currency && candidatePools && !loading && deferQuotient && enabled),
       refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 66e679a</samp>

### Summary
🐛🚀📈

<!--
1.  🐛 - This emoji represents a bug fix, since the safety check for undefined block numbers prevents errors from occurring when the block number is not available.
2.  🚀 - This emoji represents a performance improvement, since passing the block number from the smart router service to the custom trade hooks reduces the number of requests and network latency involved in fetching the block number separately.
3.  📈 - This emoji represents an enhancement, since increasing the accuracy of the best trade selection can lead to better outcomes for users who are swapping tokens.
-->
Improve best trade hook logic and reliability. Add block number check and parameter to `useBestAMMTrade` and custom trade hooks.

> _To improve the `useBestAMMTrade` hook_
> _We added a check that avoids a fluke_
> _If the block number is undefined_
> _We don't want the trade to be declined_
> _So we pass it from the smart router nook_

### Walkthrough
*  Add `blockNumber` property to custom trade hooks ([link](https://github.com/pancakeswap/pancake-frontend/pull/6631/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL236-R244))
*  Check for the existence of `blockNumber` before comparing trades ([link](https://github.com/pancakeswap/pancake-frontend/pull/6631/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL126-R131))


