### PR TITLE
chore: List GQ v3 farm

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -46,6 +46,14 @@ export const farmsV3 = [
   },
   // keep those farms on top
   {
+    pid: 22,
+    lpSymbol: 'GQ-USDT LP',
+    token: bscTokens.gq,
+    quoteToken: bscTokens.usdt,
+    lpAddress: '0x07003daEbc432ecec26309cCd1391BBBF06cC890',
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 20,
     lpSymbol: 'ETH-ankrETH LP',
     token: bscTokens.eth,
@@ -223,13 +231,6 @@ const farms: SerializedFarmConfig[] = [
     quoteToken: bscTokens.wbnb,
   },
   //    * V3 by order of release (some may be out of PID order due to multiplier boost)
-  {
-    pid: 164,
-    lpSymbol: 'GQ-USDT LP',
-    lpAddress: '0x06a2355fE6f2E93F3177be26Df5926211e9dd462',
-    token: bscTokens.gq,
-    quoteToken: bscTokens.usdt,
-  },
   {
     pid: 163,
     lpSymbol: 'HAY-USDT LP',

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -224,6 +224,13 @@ const farms: SerializedFarmConfig[] = [
   },
   //    * V3 by order of release (some may be out of PID order due to multiplier boost)
   {
+    pid: 164,
+    lpSymbol: 'GQ-USDT LP',
+    lpAddress: '0x06a2355fE6f2E93F3177be26Df5926211e9dd462',
+    token: bscTokens.gq,
+    quoteToken: bscTokens.usdt,
+  },
+  {
     pid: 163,
     lpSymbol: 'HAY-USDT LP',
     lpAddress: '0xB2Aa63f363196caba3154D4187949283F085a488',

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -48,8 +48,8 @@ export const farmsV3 = [
   {
     pid: 22,
     lpSymbol: 'GQ-USDT LP',
-    token: bscTokens.gq,
-    quoteToken: bscTokens.usdt,
+    token: bscTokens.usdt,
+    quoteToken: bscTokens.gq,
     lpAddress: '0x07003daEbc432ecec26309cCd1391BBBF06cC890',
     feeAmount: FeeAmount.MEDIUM,
   },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dc18651</samp>

### Summary
🌾🇺🇸🚀

<!--
1.  🌾 - This emoji represents a farm or agriculture, and can be used to indicate the addition of a new farm to the array.
2.  🇺🇸 - This emoji represents the United States flag, and can be used to indicate the USDT token that is part of the LP pair.
3.  🚀 - This emoji represents a rocket, and can be used to indicate the launch of a new version or feature, such as the V3 launch.
-->
Add a new farm for GQ-USDT on V3. Update `farmsV3` array in `packages/farms/constants/56.ts` with the new farm details.

> _New farm for `GQ-USDT`_
> _Medium fee, pid twenty-two_
> _V3 launch in spring_

### Walkthrough
* Add a new farm for the GQ-USDT LP pair with pid 22 and medium fee ([link](https://github.com/pancakeswap/pancake-frontend/pull/6633/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R49-R56)) in `packages/farms/constants/56.ts`




