### PR TITLE
chore: v3 liquidity chart initial position

### DIFF
--- a/apps/web/src/views/V3Info/components/DensityChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/DensityChart/index.tsx
@@ -66,7 +66,7 @@ const ZOOM_INTERVAL = 20
 
 const initialState = {
   left: 0,
-  right: INITIAL_TICKS_TO_FETCH * 2 + 1,
+  right: INITIAL_TICKS_TO_FETCH * 3 - 1,
   refAreaLeft: '',
   refAreaRight: '',
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2dc4858</samp>

### Summary
🐛📊🔄

<!--
1.  🐛 - This emoji represents a bug or a bug fix, and can be used to indicate that the change was made to resolve an issue or error in the code.
2.  📊 - This emoji represents a chart or a graph, and can be used to indicate that the change was related to the data visualization or the density chart component.
3.  🔄 - This emoji represents a refresh or an update, and can be used to indicate that the change was made to synchronize or align the data or the state with the expected values or behavior.
-->
Fixed a bug in the density chart component that caused incorrect data range. Adjusted the `right` property of the `initialState` object in `DensityChart/index.tsx` to match the number of ticks fetched.

> _`right` property changed_
> _to match fetched tick count_
> _bug fix for winter_

### Walkthrough
* Fix density chart range by aligning `right` property with number of ticks fetched ([link](https://github.com/pancakeswap/pancake-frontend/pull/6635/files?diff=unified&w=0#diff-3c04b5aecd4a88911f07a50262f6341e3f242e52158c3321b071317cb4a86c2fL69-R69))


