### PR TITLE
fix: tsc handle error

### DIFF
--- a/packages/smart-router/evm/v3-router/providers/hybridPoolProvider.ts
+++ b/packages/smart-router/evm/v3-router/providers/hybridPoolProvider.ts
@@ -27,7 +27,7 @@ export function createHybridPoolProvider({ onChainProvider }: HybridProviderConf
 
 interface Options {
   provider: OnChainProvider
-  blockNumber: BigintIsh
+  blockNumber?: BigintIsh
   protocols?: PoolType[]
 }
 

--- a/packages/smart-router/tsup.config.ts
+++ b/packages/smart-router/tsup.config.ts
@@ -13,6 +13,11 @@ export default defineConfig((options) => ({
   splitting: true,
   clean: !options.watch,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration')
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+      if (err) {
+        console.error(stdout)
+        process.exit(1)
+      }
+    })
   },
 }))

--- a/packages/swap-sdk-core/tsup.config.ts
+++ b/packages/swap-sdk-core/tsup.config.ts
@@ -11,6 +11,11 @@ export default defineConfig((options) => ({
   splitting: true,
   clean: !options.watch,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration')
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+      if (err) {
+        console.error(stdout)
+        process.exit(1)
+      }
+    })
   },
 }))

--- a/packages/swap-sdk/tsup.config.ts
+++ b/packages/swap-sdk/tsup.config.ts
@@ -11,6 +11,11 @@ export default defineConfig((options) => ({
   treeshake: true,
   splitting: true,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration')
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+      if (err) {
+        console.error(stdout)
+        process.exit(1)
+      }
+    })
   },
 }))

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -12,7 +12,12 @@ export default defineConfig((options) => {
     treeshake: true,
     splitting: true,
     onSuccess: async () => {
-      exec('tsc --emitDeclarationOnly --declaration')
+      exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+        if (err) {
+          console.error(stdout)
+          process.exit(1)
+        }
+      })
     },
   }
 })

--- a/packages/v3-sdk/tsup.config.ts
+++ b/packages/v3-sdk/tsup.config.ts
@@ -11,6 +11,11 @@ export default defineConfig((options) => ({
   treeshake: true,
   splitting: true,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration')
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+      if (err) {
+        console.error(stdout)
+        process.exit(1)
+      }
+    })
   },
 }))


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d5e8ad5</samp>

### Summary
🛠️📦🚀

<!--
1.  🛠️ - This emoji can be used to indicate a fix or improvement to the code, such as making the `blockNumber` property optional or handling errors from the `exec` function.
2.  📦 - This emoji can be used to indicate a change related to the packaging or bundling of the code, such as using the `tsup` tool or generating type declarations.
3.  🚀 - This emoji can be used to indicate a change that enhances the performance or functionality of the code, such as using the latest block number by default or providing more accurate pool data.
-->
Made `blockNumber` optional in `HybridPoolProvider` to use latest block by default. Added error handling to `onSuccess` callbacks in `tsup.config.ts` files for various packages to catch and report compilation issues.

> _`blockNumber` now_
> _optional for pool data_
> _autumn leaves falling_

### Walkthrough
*  Make `blockNumber` optional in `Options` interface to use latest block by default when fetching pool data ([link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-55474eb92781b2d8c217119979b8174b8458ac36f9973a0bf65f8f60283fdfa9L30-R30))
*  Handle errors from `exec` function in `onSuccess` callback and exit with non-zero code if any ([link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-4e4ec7ede28a42687cfc6d7e9eecca9af029374e2b99c5b8032d2984c11e6d43L16-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-62bd18f32e2ec0b5a7277f9d977e7bc9abfb260ff7b80d4a308c3260274fb6efL14-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-24710ccfa763b4572357fec6eb436b9bf64c7be09efaf367f2695b484cb7b48aL14-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-894ba18cb369d579fe478c18d8d150c1e929449266d7a7a38716d8febdd22c49L15-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/6643/files?diff=unified&w=0#diff-2a7ead6c2f71fb04919684ef6909599d89df52ddbb16f882a93ce8e4c07e93cfL14-R19))


