### PR TITLE
chore(V3Info): Use translation

### DIFF
--- a/apps/web/src/views/V3Info/components/PoolTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/PoolTable/index.tsx
@@ -1,5 +1,6 @@
 import { ArrowBackIcon, ArrowForwardIcon, Box, SortArrowIcon, Text } from '@pancakeswap/uikit'
 import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useTranslation } from '@pancakeswap/localization'
 import useTheme from 'hooks/useTheme'
 import NextLink from 'next/link'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
@@ -94,6 +95,8 @@ const MAX_ITEMS = 10
 export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDatas: PoolData[]; maxItems?: number }) {
   const { chainId } = useActiveChainId()
 
+  const { t } = useTranslation()
+
   // theming
   const { theme } = useTheme()
 
@@ -151,7 +154,7 @@ export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDat
           <ResponsiveGrid>
             <Text color={theme.colors.textSubtle}>#</Text>
             <ClickableColumnHeader color={theme.colors.textSubtle}>
-              Pool
+              {t('Pair')}
               <SortButton
                 scale="sm"
                 variant="subtle"
@@ -162,7 +165,7 @@ export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDat
               </SortButton>
             </ClickableColumnHeader>
             <ClickableColumnHeader color={theme.colors.textSubtle}>
-              TVL
+              {t('TVL')}
               <SortButton
                 scale="sm"
                 variant="subtle"
@@ -173,7 +176,7 @@ export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDat
               </SortButton>
             </ClickableColumnHeader>
             <ClickableColumnHeader color={theme.colors.textSubtle}>
-              Volume 24H
+              {t('Volume 24H')}
               <SortButton
                 scale="sm"
                 variant="subtle"
@@ -184,7 +187,7 @@ export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDat
               </SortButton>
             </ClickableColumnHeader>
             <ClickableColumnHeader color={theme.colors.textSubtle}>
-              Volume 7D
+              {t('Volume 7D')}
               <SortButton
                 scale="sm"
                 variant="subtle"

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -334,9 +334,9 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                 </Box>
               </Card>
             </ContentLayout>
-            <Heading>Pools</Heading>
+            <Heading>{t('Pairs')}</Heading>
             <PoolTable poolDatas={formatPoolData} />
-            <Heading>Transactions</Heading>
+            <Heading>{t('Transactions')}</Heading>
             {transactions ? <TransactionTable transactions={transactions} /> : <LocalLoader fill={false} />}
           </AutoColumn>
         )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0538204</samp>

### Summary
🔄🌐🗣️

<!--
1.  🔄 This emoji conveys the idea of swapping or changing something, which is what the text label did. It also matches the Uniswap logo and the name of the app, which is about exchanging tokens.
2.  🌐 This emoji represents the globe or the world, which is a common symbol for internationalization or localization. It also suggests the diversity and inclusiveness of the app, which supports multiple languages and regions.
3.  🗣️ This emoji depicts a person speaking, which is related to the concept of translation or communication. It also implies that the app is user-friendly and responsive to the needs and preferences of different audiences.
-->
This pull request improves the internationalization and consistency of the V3Info views by using the `useTranslation` hook and the `t` function for text labels. It affects the `PoolTable` and `TokenPage` components and the files `index.tsx` and `TokenPage.tsx`.

> _To make the app more coherent_
> _The label "Pools" was not expedient_
> _So they used `t` to render_
> _The key "Pairs" in the header_
> _And `useTranslation` for the columns' content_

### Walkthrough
*  Import and use `useTranslation` hook to enable localization of text labels in `PoolTable` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8R98-R99), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L154-R157), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L165-R168), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L176-R179), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L187-R190))
* Replace "Pool" with "Pair" to match Uniswap V3 terminology in `PoolTable` and `TokenPage` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-767fb8ce989f5f5f174b4f1123d5f94e7bd099865ff61ce704d3be530e0646a8L154-R157), [link](https://github.com/pancakeswap/pancake-frontend/pull/6656/files?diff=unified&w=0#diff-fd3d3e8de440a3e78e6c72bb15a4f3571e879dacc7b420529fcce1757e1c4a55L337-R339))



