### PR TITLE
chore: Move to finished pools

### DIFF
--- a/apps/web/src/config/constants/pools.tsx
+++ b/apps/web/src/config/constants/pools.tsx
@@ -117,30 +117,6 @@ export const livePools: Pool.SerializedPoolConfig<SerializedWrappedToken>[] = [
     version: 3,
   },
   {
-    sousId: 333,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.gq,
-    contractAddress: {
-      56: '0x2f50d0010d408e0c299be8e1a8d553b8eb3e96ed',
-      97: '',
-    },
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '7.093',
-    version: 3,
-  },
-  {
-    sousId: 332,
-    stakingToken: bscTokens.csix,
-    earningToken: bscTokens.cake,
-    contractAddress: {
-      56: '0x6fBD8a65c844a3565cA4e71Eb577a2a8F821ABB4',
-      97: '',
-    },
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.0124',
-    version: 3,
-  },
-  {
     sousId: 329,
     stakingToken: bscTokens.hay,
     earningToken: bscTokens.cake,
@@ -268,6 +244,30 @@ export const livePools: Pool.SerializedPoolConfig<SerializedWrappedToken>[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 333,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.gq,
+    contractAddress: {
+      56: '0x2f50d0010d408e0c299be8e1a8d553b8eb3e96ed',
+      97: '',
+    },
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '7.093',
+    version: 3,
+  },
+  {
+    sousId: 332,
+    stakingToken: bscTokens.csix,
+    earningToken: bscTokens.cake,
+    contractAddress: {
+      56: '0x6fBD8a65c844a3565cA4e71Eb577a2a8F821ABB4',
+      97: '',
+    },
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.0124',
+    version: 3,
+  },
   {
     sousId: 334,
     stakingToken: bscTokens.rdnt,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 61725d0</samp>

### Summary
🍰🏁📝

<!--
1.  🍰 - This emoji represents CAKE, the token that was being staked in the pools that have ended.
2.  🏁 - This emoji represents the end of a race or competition, which is fitting for the end of the staking pools.
3.  📝 - This emoji represents writing or updating something, which is what this pull request does by changing the pool configuration.
-->
This pull request removes two expired CAKE staking pools from the active pools section of the web app. It edits the `pools.tsx` file to move the pools with `sousId` 333 and 332 to the finished pools list.

> _Two CAKE staking pools have expired_
> _So their config had to be rewired_
> _They moved from active to finished_
> _With `sousId` diminished_
> _And the pull request was soon admired_

### Walkthrough
* Remove CAKE-GQ and CAKE-CSIX pools from active pools list ([link](https://github.com/pancakeswap/pancake-frontend/pull/6660/files?diff=unified&w=0#diff-e908818b4901940f12fbf07467ab23f3a2ae9d6241c30818341cd8e72d47069aL120-L143)) in `pools.tsx`


