### PR TITLE
fix: get pool chainid

### DIFF
--- a/apps/web/src/utils/calls/pools.ts
+++ b/apps/web/src/utils/calls/pools.ts
@@ -22,12 +22,12 @@ export const getActivePools = async (chainId: ChainId, block?: number) => {
     .filter((pool) => pool.isFinished === false || pool.isFinished === undefined)
   const startBlockCalls = eligiblePools.map(({ contractAddress }) => ({
     abi: sousChefV2,
-    address: getAddress(contractAddress, 56),
+    address: contractAddress,
     name: 'startBlock',
   }))
   const endBlockCalls = eligiblePools.map(({ contractAddress }) => ({
     abi: sousChefV2,
-    address: getAddress(contractAddress, 56),
+    address: contractAddress,
     name: 'bonusEndBlock',
   }))
   const blockCall = !block

--- a/apps/web/src/utils/calls/pools.ts
+++ b/apps/web/src/utils/calls/pools.ts
@@ -7,7 +7,7 @@ import sousChefV2 from 'config/abi/sousChefV2.json'
 import chunk from 'lodash/chunk'
 
 import { multicallv3 } from '../multicall'
-import { getAddress, getMulticallAddress } from '../addressHelpers'
+import { getMulticallAddress } from '../addressHelpers'
 import multiCallAbi from '../../config/abi/Multicall.json'
 
 const multicallAddress = getMulticallAddress()

--- a/apps/web/src/utils/calls/pools.ts
+++ b/apps/web/src/utils/calls/pools.ts
@@ -39,7 +39,7 @@ export const getActivePools = async (chainId: ChainId, block?: number) => {
     : null
 
   const calls = !block ? [...startBlockCalls, ...endBlockCalls, blockCall] : [...startBlockCalls, ...endBlockCalls]
-  const resultsRaw = await multicallv3({ calls })
+  const resultsRaw = await multicallv3({ calls, chainId })
   const blockNumber = block || resultsRaw.pop()[0].toNumber()
   const blockCallsRaw = chunk(resultsRaw, resultsRaw.length / 2)
   const startBlocks: any[] = blockCallsRaw[0]

--- a/apps/web/src/views/Voting/hooks/useGetVotingPower.tsx
+++ b/apps/web/src/views/Voting/hooks/useGetVotingPower.tsx
@@ -2,7 +2,6 @@ import { ChainId } from '@pancakeswap/sdk'
 import { useAccount } from 'wagmi'
 import { FetchStatus } from 'config/constants/types'
 import useSWRImmutable from 'swr/immutable'
-import { getAddress } from 'utils/addressHelpers'
 import { getActivePools } from 'utils/calls'
 import { bscRpcProvider } from 'utils/providers'
 import { getVotingPower } from '../helpers'
@@ -24,7 +23,7 @@ const useGetVotingPower = (block?: number): State & { isLoading: boolean; isErro
   const { data, status, error } = useSWRImmutable(account ? [account, block, 'votingPower'] : null, async () => {
     const blockNumber = block || (await bscRpcProvider.getBlockNumber())
     const eligiblePools = await getActivePools(ChainId.BSC, blockNumber)
-    const poolAddresses = eligiblePools.map(({ contractAddress }) => getAddress(contractAddress, ChainId.BSC))
+    const poolAddresses = eligiblePools.map(({ contractAddress }) => contractAddress)
     const {
       cakeBalance,
       cakeBnbLpBalance,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2327411</samp>

### Summary
🚀🔗🧹

<!--
1.  🚀 - This emoji conveys the idea of improved performance and speed, as well as launching new features or updates.
2.  🔗 - This emoji represents the concept of chain or network compatibility, as well as connecting different parts or systems together.
3.  🧹 - This emoji suggests the idea of cleaning up or simplifying the code, as well as removing unnecessary or redundant functions.
-->
Refactored pool calls to use `chainId` instead of `getAddress` and updated `multicallv3` function. This enhances the network support and efficiency of fetching active pools.

> _`getActivePools` now_
> _Faster and more adaptable_
> _With `chainId` - fall_

### Walkthrough
*  Simplify contract address arguments for start and end block calls by removing `getAddress` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/6669/files?diff=unified&w=0#diff-f41110f1288856879d832b573331e57fec7d20039423abc3bb6c2917d08ca639L25-R30))
*  Add `chainId` variable as a parameter to `multicallv3` function call to enable cross-chain compatibility ([link](https://github.com/pancakeswap/pancake-frontend/pull/6669/files?diff=unified&w=0#diff-f41110f1288856879d832b573331e57fec7d20039423abc3bb6c2917d08ca639L42-R42))


