### PR TITLE
fix: Eth token highlight list

### DIFF
--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -133,10 +133,11 @@ export const usePoolTransactionsSWR = (address: string): Transaction[] | undefin
 
 // Tokens hooks
 
-export const useAllTokenHighLight = (): TokenData[] => {
-  const chainName = useChainNameByQuery()
+export const useAllTokenHighLight = (targetChainName?: MultiChainName): TokenData[] => {
+  const chainNameByQuery = useChainNameByQuery()
+  const chainName = targetChainName ?? chainNameByQuery
   const [t24h, t48h, t7d, t14d] = getDeltaTimestamps()
-  const { blocks } = useBlockFromTimeStampSWR([t24h, t48h, t7d, t14d])
+  const { blocks } = useBlockFromTimeStampSWR([t24h, t48h, t7d, t14d], undefined, undefined, chainName)
   const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
   const { data, isLoading } = useSWRImmutable(
     blocks && chainName && [`info/token/data/${type}`, chainName],

--- a/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
@@ -26,6 +26,7 @@ export const CurrencyLogo: React.FC<
   const src = useMemo(() => {
     return getTokenLogoURL(new Token(multiChainId[chainName], address, 18, ''))
   }, [address, chainName])
+
   const imagePath = chainName === 'BSC' ? '' : `${multiChainId[chainName]}/tokens/`
   const srcFromPCS = `https://${chainName === 'BSC' ? 'tokens.' : ''}pancakeswap.finance/images/${imagePath}${isAddress(
     address,

--- a/apps/web/src/views/Info/hooks/useBlocksFromTimestamps.ts
+++ b/apps/web/src/views/Info/hooks/useBlocksFromTimestamps.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { multiChainId, multiChainName } from 'state/info/constant'
+import { multiChainId, multiChainName, MultiChainName } from 'state/info/constant'
 import { useChainNameByQuery } from 'state/info/hooks'
 import { Block } from 'state/info/types'
 import useSWRImmutable from 'swr/immutable'
@@ -52,8 +52,10 @@ export const useBlockFromTimeStampSWR = (
   timestamps: number[],
   sortDirection: 'asc' | 'desc' | undefined = 'desc',
   skipCount: number | undefined = 1000,
+  targetChainName?: MultiChainName,
 ) => {
-  const chainName = useChainNameByQuery()
+  const chainNameByQuery = useChainNameByQuery()
+  const chainName = targetChainName ?? chainNameByQuery
   const chainId = multiChainId[chainName]
   const timestampsString = JSON.stringify(timestamps)
   const timestampsArray = JSON.parse(timestampsString)

--- a/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
+++ b/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
@@ -2,6 +2,7 @@ import { PANCAKE_EXTENDED } from 'config/constants/lists'
 import { useAtomValue } from 'jotai'
 import { useMemo } from 'react'
 import { selectorByUrlsAtom } from 'state/lists/hooks'
+import { multiChainName } from 'state/info/constant'
 import { useTokenDatasSWR, useAllTokenHighLight } from 'state/info/hooks'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ChainId } from '@pancakeswap/sdk'
@@ -19,7 +20,7 @@ export const useTokenHighLightList = () => {
   const { chainId } = useActiveChainId()
   const bscWhiteList = useBSCWhiteList()
   const allTokensFromBSC = useTokenDatasSWR(chainId === ChainId.BSC ? bscWhiteList : [], false)
-  const allTokensFromETH = useAllTokenHighLight()
+  const allTokensFromETH = useAllTokenHighLight(multiChainName[chainId])
 
   return chainId === ChainId.BSC ? allTokensFromBSC : allTokensFromETH
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 39d8628</samp>

### Summary
🔄🚀📦

<!--
1.  🔄 - This emoji represents the change to the `useAllTokenHighLight` hook, which now accepts an optional parameter to override the chain name. This could be seen as a refactoring or an enhancement of the existing functionality.
2.  🚀 - This emoji represents the improvement of the hook for fetching blocks from timestamps, which now supports different views and chains. This could be seen as a new feature or a performance boost for the app.
3.  📦 - This emoji represents the move of the hook to a separate file, which could be seen as a code organization or a modularization of the logic.
-->
Improved and reused hooks for fetching blocks and tokens from different chains. Moved `useBlocksFromTimestamps` hook to a shared file and added a `targetChainName` parameter to `useAllTokenHighLight` hook.

> _`useAllTokenHighLight`_
> _now takes `targetChainName` -_
> _flexible hook_

### Walkthrough
* Move and modify `useBlockFromTimeStampSWR` hook to accept optional `targetChainName` parameter ([link](https://github.com/pancakeswap/pancake-frontend/pull/6670/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292L136-R140), [link](https://github.com/pancakeswap/pancake-frontend/pull/6670/files?diff=unified&w=0#diff-7c6ccf63679baba87f48a89831377910c7a82cd9f2b2fe8d1e2ee192792dc37eL2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/6670/files?diff=unified&w=0#diff-7c6ccf63679baba87f48a89831377910c7a82cd9f2b2fe8d1e2ee192792dc37eL55-R58))
* Modify `useAllTokenHighLight` hook to accept optional `targetChainName` parameter ([link](https://github.com/pancakeswap/pancake-frontend/pull/6670/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292L136-R140))


