### PR TITLE
fix(liquidity): Correct adddress weth and eth comparison

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -95,7 +95,10 @@ export function AprCalculator({
   const { [Bound.LOWER]: priceLower, [Bound.UPPER]: priceUpper } = pricesAtTicks
   const { [Field.CURRENCY_A]: amountA, [Field.CURRENCY_B]: amountB } = parsedAmounts
 
-  const inverted = Boolean(baseCurrency && quoteCurrency && quoteCurrency.wrapped.sortsBefore(baseCurrency.wrapped))
+  const tokenA = (baseCurrency ?? undefined)?.wrapped
+  const tokenB = (quoteCurrency ?? undefined)?.wrapped
+
+  const inverted = Boolean(tokenA && tokenB && tokenA?.address !== tokenB?.address && tokenB.sortsBefore(tokenA))
 
   const baseUSDPrice = useStablecoinPrice(baseCurrency)
   const quoteUSDPrice = useStablecoinPrice(quoteCurrency)

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -22,6 +22,7 @@ import useStableConfig, { StableConfigContext } from 'views/Swap/hooks/useStable
 import AddStableLiquidity from 'views/AddLiquidity/AddStableLiquidity'
 import AddLiquidity from 'views/AddLiquidity'
 import { usePreviousValue } from '@pancakeswap/hooks'
+import { getAddress } from 'utils/addressHelpers'
 
 import FeeSelector from './formViews/V3FormView/components/FeeSelector'
 
@@ -111,7 +112,7 @@ export function UniversalAddLiquidity({
       const isETHOrWETHOther =
         currencyIdOther !== undefined &&
         (currencyIdOther === NATIVE[chainId]?.symbol ||
-          (chainId !== undefined && currencyIdOther === WNATIVE[chainId]?.address))
+          (chainId !== undefined && getAddress(currencyIdOther) === WNATIVE[chainId]?.address))
 
       if (isETHOrWETHNew && isETHOrWETHOther) {
         return [currencyIdNew, undefined]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 68cdcb0</samp>

### Summary
🔧🌐🚀

<!--
1.  🔧 - This emoji represents a refactoring or a bug fix, as the change improves the existing functionality of the `AprCalculator` component and fixes a potential issue with the token address comparison.
2.  🌐 - This emoji represents a cross-chain or multi-chain feature, as the change enhances the compatibility of the app with different chains and tokens, such as WETH and ETH.
3.  🚀 - This emoji represents a performance or usability improvement, as the change reduces unnecessary swaps and errors when adding liquidity to V3 pools.
-->
This pull request improves the logic and UI of the `AddLiquidityV3` view for adding liquidity to V3 pools. It fixes some issues with token address comparison and sorting, and uses a utility function to handle different address formats.

> _To calculate APR with precision_
> _We need to refactor our decision_
> _Instead of `sortsBefore`_
> _We use `wrapped` and more_
> _To handle tokens with different chain IDs and vision_

### Walkthrough
*  Refactor `AprCalculator` component to use `wrapped` property of currencies instead of `sortsBefore` method ([link](https://github.com/pancakeswap/pancake-frontend/pull/6674/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L98-R102))
* Use `getAddress` utility function to normalize and compare token addresses ([link](https://github.com/pancakeswap/pancake-frontend/pull/6674/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefR25), [link](https://github.com/pancakeswap/pancake-frontend/pull/6674/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefL114-R115))


