### PR TITLE
fix: Ifo page crash

### DIFF
--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -21,7 +21,7 @@ const StyledCardBody = styled(CardBody)<{ isLoading: boolean }>`
 `
 
 interface CakeVaultProps extends CardProps {
-  pool: Pool.DeserializedPool<Token>
+  pool?: Pool.DeserializedPool<Token>
   showStakedOnly: boolean
   defaultFooterExpanded?: boolean
   showICake?: boolean
@@ -52,6 +52,10 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
   const { t } = useTranslation()
 
   const isLocked = (vaultPool as DeserializedLockedCakeVault).userData.locked
+
+  if (!pool) {
+    return null
+  }
 
   return (
     <>
@@ -114,8 +118,8 @@ const CakeVaultCard: React.FC<React.PropsWithChildren<CakeVaultProps>> = ({
 }) => {
   const { address: account } = useAccount()
 
-  const vaultPool = useVaultPoolByKey(pool.vaultKey)
-  const { totalStaked } = pool
+  const vaultPool = useVaultPoolByKey(pool?.vaultKey)
+  const totalStaked = pool?.totalStaked
 
   const {
     userData: { userShares, isLoading: isVaultUserDataLoading },
@@ -123,9 +127,9 @@ const CakeVaultCard: React.FC<React.PropsWithChildren<CakeVaultProps>> = ({
   } = vaultPool
 
   const accountHasSharesStaked = userShares && userShares.gt(0)
-  const isLoading = !pool.userData || isVaultUserDataLoading
+  const isLoading = !pool?.userData || isVaultUserDataLoading
 
-  if (showStakedOnly && !accountHasSharesStaked) {
+  if (!pool || (showStakedOnly && !accountHasSharesStaked)) {
     return null
   }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb2e144</samp>

### Summary
🐛🚧🧼

<!--
1.  🐛 - This emoji represents a bug fix, since the previous code could cause errors or unexpected behavior when the pool prop was null or undefined.
2.  🚧 - This emoji represents a work in progress or improvement, since the changes make the code more robust and resilient to different scenarios and edge cases.
3.  🧼 - This emoji represents a code cleanup or refactoring, since the changes simplify the logic and remove unnecessary or redundant code.
-->
Improved error handling for `CakeVaultCard` component. Made `pool` prop optional and added null checks to avoid rendering with invalid data.

> _There once was a component called `CakeVaultCard`_
> _That rendered a pool with some data and reward_
> _But sometimes the `pool` prop was null_
> _And the card looked quite dull_
> _So they made it optional and added some safeguard_

### Walkthrough
*  Make `pool` prop optional and handle undefined cases ([link](https://github.com/pancakeswap/pancake-frontend/pull/6676/files?diff=unified&w=0#diff-c0be0208c3bd6390761e83e72b23c947499f6e3e907daded57da595cdc8c7ff5L24-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/6676/files?diff=unified&w=0#diff-c0be0208c3bd6390761e83e72b23c947499f6e3e907daded57da595cdc8c7ff5R56-R59), [link](https://github.com/pancakeswap/pancake-frontend/pull/6676/files?diff=unified&w=0#diff-c0be0208c3bd6390761e83e72b23c947499f6e3e907daded57da595cdc8c7ff5L117-R122), [link](https://github.com/pancakeswap/pancake-frontend/pull/6676/files?diff=unified&w=0#diff-c0be0208c3bd6390761e83e72b23c947499f6e3e907daded57da595cdc8c7ff5L126-R132))


