### PR TITLE
fix: Ifo page crash on mobile

### DIFF
--- a/apps/web/src/views/Ifos/components/IfoPoolVaultCardMobile.tsx
+++ b/apps/web/src/views/Ifos/components/IfoPoolVaultCardMobile.tsx
@@ -33,7 +33,7 @@ const StyledTokenContent = styled(Flex)`
 `
 
 interface IfoPoolVaultCardMobileProps {
-  pool: Pool.DeserializedPool<Token>
+  pool?: Pool.DeserializedPool<Token>
 }
 
 const IfoPoolVaultCardMobile: React.FC<React.PropsWithChildren<IfoPoolVaultCardMobileProps>> = ({ pool }) => {
@@ -43,7 +43,7 @@ const IfoPoolVaultCardMobile: React.FC<React.PropsWithChildren<IfoPoolVaultCardM
   const { isExpanded, setIsExpanded } = useConfig()
   const cakeAsNumberBalance = getBalanceNumber(credit)
 
-  const vaultPool = useVaultPoolByKey(pool.vaultKey)
+  const vaultPool = useVaultPoolByKey(pool?.vaultKey || VaultKey.CakeVault)
 
   const {
     userData: { userShares, isLoading: isVaultUserDataLoading },
@@ -51,7 +51,11 @@ const IfoPoolVaultCardMobile: React.FC<React.PropsWithChildren<IfoPoolVaultCardM
   } = vaultPool
 
   const accountHasSharesStaked = userShares && userShares.gt(0)
-  const isLoading = !pool.userData || isVaultUserDataLoading
+  const isLoading = !pool?.userData || isVaultUserDataLoading
+
+  if (!pool) {
+    return null
+  }
 
   return (
     <StyledCardMobile isActive>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 613d7c4</samp>

### Summary
🛠️📱🚫

<!--
1.  🛠️ - This emoji represents a fix or improvement to existing code, which is what making the component more resilient to missing or incomplete data is.
2.  📱 - This emoji represents a mobile-specific change, which is what the `IfoPoolVaultCardMobile` component is.
3.  🚫 - This emoji represents a removal or omission of something, which is what rendering `null` if the `pool` prop is falsy does.
-->
Improved error handling and rendering of `IfoPoolVaultCardMobile` component for mobile IFO pool views. Added fallback values and checks for `pool` prop and `vaultPool` variable.

> _Oh we're the coders of the `IfoPoolVaultCardMobile`_
> _We make it work with any data that we can pull_
> _And if the `pool` prop is falsy or unstable_
> _We render `null` and save ourselves some trouble_

### Walkthrough
*  Make `pool` prop optional and handle missing data in `IfoPoolVaultCardMobile` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6680/files?diff=unified&w=0#diff-cd5bdecef30cabcbb22e4e9b611a9b44db41f812793cdf88c3d90f2d01c5ca48L36-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/6680/files?diff=unified&w=0#diff-cd5bdecef30cabcbb22e4e9b611a9b44db41f812793cdf88c3d90f2d01c5ca48L46-R46), [link](https://github.com/pancakeswap/pancake-frontend/pull/6680/files?diff=unified&w=0#diff-cd5bdecef30cabcbb22e4e9b611a9b44db41f812793cdf88c3d90f2d01c5ca48L54-R59))


