### PR TITLE
fix: Roi crash when full range selected

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -346,6 +346,7 @@ export function AprCalculator({
         volume24H={volume24H}
         priceUpper={priceUpper}
         priceLower={priceLower}
+        fullRangeSelected={formState.rightRangeTypedValue === true && formState.leftRangeTypedValue === true}
         priceSpan={priceSpan}
         onPriceSpanChange={setPriceSpan}
         onApply={onApply}

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -612,7 +612,7 @@ export default function V3FormView({
                     .map(([quickAction, zoomLevel]) => {
                       return (
                         <Button
-                          width="100%"
+                          style={{ flexBasis: '20%', padding: 0 }}
                           key={`quickActions${quickAction}`}
                           onClick={() => {
                             if (+quickAction === activeQuickAction) {
@@ -632,7 +632,7 @@ export default function V3FormView({
                       )
                     })}
                 <Button
-                  width="200%"
+                  style={{ flexBasis: '40%', padding: 0 }}
                   onClick={() => {
                     if (activeQuickAction === 100) {
                       handleRefresh()

--- a/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
@@ -61,6 +61,7 @@ export type RoiCalculatorProps = {
   price?: Price<Token, Token>;
   priceLower?: Price<Token, Token>;
   priceUpper?: Price<Token, Token>;
+  fullRangeSelected?: boolean;
   currencyAUsdPrice?: number;
   currencyBUsdPrice?: number;
   depositAmountInUsd?: number | string;
@@ -103,6 +104,7 @@ export function RoiCalculator({
   price,
   priceLower,
   priceUpper,
+  fullRangeSelected,
   volume24H,
   maxLabel,
   max,
@@ -186,6 +188,7 @@ export function RoiCalculator({
     quoteCurrency: currencyB,
     priceLower,
     priceUpper,
+    fullRangeSelected,
   });
   const { getDecrementLower, getIncrementLower, getDecrementUpper, getIncrementUpper } = useRangeHopCallbacks(
     currencyA,

--- a/packages/uikit/src/widgets/RoiCalculator/hooks/usePriceRange.ts
+++ b/packages/uikit/src/widgets/RoiCalculator/hooks/usePriceRange.ts
@@ -19,6 +19,7 @@ interface Params {
   quoteCurrency?: Currency;
   priceLower?: Price<Currency, Currency>;
   priceUpper?: Price<Currency, Currency>;
+  fullRangeSelected?: boolean;
 }
 
 interface PriceRangeInfo {
@@ -39,8 +40,9 @@ export function usePriceRange({
   feeAmount,
   priceLower: initialPriceLower,
   priceUpper: initialPriceUpper,
+  fullRangeSelected,
 }: Params): PriceRangeInfo | null {
-  const [fullRange, setFullRange] = useState(false);
+  const [fullRange, setFullRange] = useState(!!fullRangeSelected);
   const [priceLower, setPriceLower] = useState<Price<Currency, Currency> | undefined>(initialPriceLower);
   const [priceUpper, setPriceUpper] = useState<Price<Currency, Currency> | undefined>(initialPriceUpper);
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 75c4cb4</samp>

### Summary
🆕🎨📈

<!--
1.  🆕 - This emoji indicates that a new prop or feature is added to the component or the hook.
2.  🎨 - This emoji indicates that the styles or layout of the component are improved or adjusted.
3.  📈 - This emoji indicates that the calculation or rendering of the return on investment is enhanced or modified.
-->
This pull request adds a new feature to the Add Liquidity V3 form that allows the user to select the full price range for the liquidity pool and see the corresponding return on investment. It modifies the `RoiCalculator`, `usePriceRange`, and `Button` components, as well as the `V3FormView` and `AprCalculator` views.

> _Sing, O Muse, of the cunning `AprCalculator`,_
> _Who with skill and wisdom guides the liquidity seeker,_
> _And of the valiant `RoiCalculator`, its faithful ally,_
> _Who reveals the hidden profits of the full price range._

### Walkthrough
*  Add `fullRangeSelected` prop to `AprCalculator` and `RoiCalculator` components to indicate full price range selection for liquidity pool ([link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R228), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR55), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR98), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR180))
*  Pass `fullRangeSelected` prop from `AprCalculator` to `RoiCalculator` and from `RoiCalculator` to `usePriceRange` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R228), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR98), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-a4a72dfaf8b6243fbd15605ac0d87d9df449304d8f20d6ad93eda90b5db48d75R22))
*  Use `fullRangeSelected` prop to set initial state of `fullRange` variable in `usePriceRange` hook and update `priceRangeInfo` object in `RoiCalculator` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-a4a72dfaf8b6243fbd15605ac0d87d9df449304d8f20d6ad93eda90b5db48d75L42-R45), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR180))
*  Modify styles of `Button` components for quick and custom price range actions in `V3FormView` component to improve alignment and spacing ([link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L605-R605), [link](https://github.com/pancakeswap/pancake-frontend/pull/6682/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L624-R624))


