### PR TITLE
chore: switch TVL warning component

### DIFF
--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -11,11 +11,11 @@ import {
   ETH_TOKEN_WHITELIST,
 } from 'config/constants/info'
 
-export type MultiChainName = 'BSC' | 'ETH'
+export type MultiChainName = 'BSC' | 'ETH' | 'BSC_TESTNET'
 
 export type MultiChainNameExtend = MultiChainName | 'BSC_TESTNET'
 
-export const multiChainName = {
+export const multiChainName: Record<string | number, MultiChainNameExtend> = {
   [ChainId.BSC]: 'BSC',
   [ChainId.ETHEREUM]: 'ETH',
   [ChainId.BSC_TESTNET]: 'BSC_TESTNET',

--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -11,11 +11,11 @@ import {
   ETH_TOKEN_WHITELIST,
 } from 'config/constants/info'
 
-export type MultiChainName = 'BSC' | 'ETH' | 'BSC_TESTNET'
+export type MultiChainName = 'BSC' | 'ETH'
 
 export type MultiChainNameExtend = MultiChainName | 'BSC_TESTNET'
 
-export const multiChainName: Record<string | number, MultiChainNameExtend> = {
+export const multiChainName = {
   [ChainId.BSC]: 'BSC',
   [ChainId.ETHEREUM]: 'ETH',
   [ChainId.BSC_TESTNET]: 'BSC_TESTNET',

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { ChainId } from '@pancakeswap/sdk'
 import {
-  Alert,
   AutoColumn,
   Box,
   Breadcrumbs,

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -15,6 +15,8 @@ import {
   Spinner,
   Text,
   useMatchBreakpoints,
+  Message,
+  MessageText,
 } from '@pancakeswap/uikit'
 import Page from 'components/Layout/Page'
 import { TabToggle, TabToggleGroup } from 'components/TabToggle'
@@ -243,7 +245,11 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
               </Flex>
             </AutoColumn>
             {tokenData.tvlUSD <= 0 && (
-              <Alert title={t('TVL is currently too low to represent the data correctly')} variant="info" />
+              <Message variant="warning">
+                <MessageText fontSize="16px">
+                  {t('TVL is currently too low to represent the data correctly')}
+                </MessageText>
+              </Message>
             )}
             <ContentLayout>
               <Card>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81e05c4</samp>

### Summary
🔄⚠️🎨

<!--
1.  🔄 - This emoji indicates that something has been changed or replaced, such as switching from one UI kit to another.
2.  ⚠️ - This emoji represents a warning or caution, which is the purpose of the message when the token's TVL is low.
3.  🎨 - This emoji suggests a visual or aesthetic improvement, such as using a new style or design for the message.
-->
Replace deprecated UI components and improve warning message appearance on token page. Use new `Message` component from `@pancakeswap/uikit` to show a more prominent and consistent alert when a token has low TVL.

> _To make the UI look more slick_
> _We swapped `Alert` for `Message`_
> _And updated the style_
> _Of the warning so vile_
> _When the token's TVL is a tick_

### Walkthrough
* Migrate to new UI kit for warning message component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6684/files?diff=unified&w=0#diff-fd3d3e8de440a3e78e6c72bb15a4f3571e879dacc7b420529fcce1757e1c4a55R18-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/6684/files?diff=unified&w=0#diff-fd3d3e8de440a3e78e6c72bb15a4f3571e879dacc7b420529fcce1757e1c4a55L246-R252))


