### PR TITLE
Update web Menu component utils.ts  [Bug]

### DIFF
--- a/apps/web/src/components/Menu/utils.ts
+++ b/apps/web/src/components/Menu/utils.ts
@@ -1,11 +1,19 @@
 import orderBy from 'lodash/orderBy'
 import { ConfigMenuItemsType } from './config/config'
 
-export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) =>
-  menuConfig.find((menuItem) => pathname.startsWith(menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
+export const isSubpath = (path: string, path2: string,skiproot:boolean = true) => {
+  if (path === path2 || path === '/' || path2 === '/' && skiproot) {
+    return path === path2;
+  }
+  return path.startsWith(path2);
+};
+
+export const getActiveMenuItem = ({ pathname, menuConfig }: { pathname: string; menuConfig: ConfigMenuItemsType[] }) => {
+  return menuConfig.find((menuItem) => isSubpath(pathname,menuItem.href) || getActiveSubMenuItem({ menuItem, pathname }))
+};
 
 export const getActiveSubMenuItem = ({ pathname, menuItem }: { pathname: string; menuItem?: ConfigMenuItemsType }) => {
-  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => pathname.startsWith(subMenuItem.href)) ?? []
+  const activeSubMenuItems = menuItem?.items.filter((subMenuItem) => isSubpath(pathname,subMenuItem.href)) ?? []
 
   // Pathname doesn't include any submenu item href - return undefined
   if (!activeSubMenuItems || activeSubMenuItems.length === 0) {


### PR DESCRIPTION
If it is the root path, the `startsWith` function will cause all subpaths to match.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b2a2e1</samp>

### Summary
🐛🚧🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. The bug fix addresses the issue of highlighting the wrong menu item or subitem when the pathname has a common prefix with another menu item or subitem.
2.  🚧 - This emoji represents a work in progress, which is the status of this change. The change is not yet merged or deployed, and may require further testing or review before it is ready for production. The work in progress emoji indicates that the change is still under development and may be subject to change or feedback.
3.  🌐 - This emoji represents a web app, which is the context of this change. The change affects the menu component of the PancakeSwap web app, which is a decentralized exchange and yield farming platform on the Binance Smart Chain. The web app emoji indicates that the change is related to the user interface and navigation of the web app.
-->
Fixed a bug in the menu component that caused incorrect highlighting of menu items and subitems. Added a new `isSubpath` function in `utils.ts` to check subpath relationships between paths.

> _`isSubpath` checks_
> _menu items and subitems_
> _autumn bug is fixed_

### Walkthrough
*  Fix menu item and subitem highlighting based on pathname ([link](https://github.com/pancakeswap/pancake-frontend/pull/6685/files?diff=unified&w=0#diff-0b77e25afe037cdef98a60c39dac876869202b8ed2af99dd39ee25c601fd6e74L4-R16),  )


