### PR TITLE
chore: Remove duplicate padding property in farm card

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/SingleFarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/SingleFarmV3Card.tsx
@@ -37,7 +37,6 @@ const { FarmV3HarvestAction } = FarmUI.FarmV3Table
 
 const ActionContainer = styled(Flex)`
   width: 100%;
-  padding: 0 16px;
   border: 2px solid ${({ theme }) => theme.colors.input};
   border-radius: 16px;
   flex-grow: 1;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9cd75b3</samp>

### Summary
🎨🗑️📐

<!--
1.  🎨 - This emoji represents a change in the appearance or style of the UI, which is what removing the padding does.
2.  🗑️ - This emoji represents a change that deletes or removes something, which is what removing the padding style does.
3.  📐 - This emoji represents a change that adjusts the layout or alignment of the UI, which is what removing the padding does.
-->
Removed padding from `ActionContainer` component in farm card. This improves the layout and appearance of the staking and harvesting buttons.

> _`ActionContainer`_
> _No padding for alignment_
> _Autumn harvest time_

### Walkthrough
* Remove padding from the action buttons in the farm card to align them with the card content and the design spec ([link](https://github.com/pancakeswap/pancake-frontend/pull/6692/files?diff=unified&w=0#diff-a0e14b675dc91766985e0c839ed91ba3d2a3b84ec6d3f0e3ec8a971bab841095L40))


