### PR TITLE
chore: Fix closed tag color

### DIFF
--- a/packages/uikit/src/widgets/Farm/components/Tags/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/Tags/index.tsx
@@ -162,7 +162,7 @@ const SoonTag: React.FC<React.PropsWithChildren<TagProps>> = (props) => {
 const ClosedTag: React.FC<React.PropsWithChildren<TagProps>> = (props) => {
   const { t } = useTranslation();
   return (
-    <Tag variant="textDisabled" startIcon={<BlockIcon width="18px" color="textDisabled" mr="4px" />} {...props}>
+    <Tag variant="textDisabled" startIcon={<BlockIcon width="18px" color="text" mr="4px" />} {...props}>
       {t("Closed")}
     </Tag>
   );


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e7b1fc8</samp>

### Summary
🎨🚫♿

<!--
1.  🎨 - This emoji can be used to indicate a change in the color or appearance of a component or element, such as the BlockIcon.
2.  🚫 - This emoji can be used to indicate a change related to something that is closed, disabled, or unavailable, such as the inactive farms.
3.  ♿ - This emoji can be used to indicate a change related to accessibility, usability, or inclusion, such as improving the contrast and visibility of the text.
-->
Improved the visibility of the "Closed" tag for inactive farms by changing the color of the `BlockIcon` component. This was part of a larger pull request to enhance the accessibility and user experience of the farm cards.

> _`BlockIcon` changes_
> _Contrast for closed farms enhanced_
> _A winter project_

### Walkthrough
* Improve the contrast and visibility of the "Closed" tag for inactive farms by changing the color of the BlockIcon component from "textDisabled" to "text" ([link](https://github.com/pancakeswap/pancake-frontend/pull/6694/files?diff=unified&w=0#diff-d10ba872d561ab4ac00ac17ef0b15f894c386d1896687698cd47cfc9113944e5L165-R165))

Before:
<img width="273" alt="image" src="https://user-images.githubusercontent.com/109973128/233784496-f9ef5549-80a6-49c4-9d02-3d3b64465f7e.png">

After:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/109973128/233784506-e70a5f6b-9522-43ce-af13-4697ece0ad1e.png">

