### PR TITLE
perf: Use on mouse move for v3 bar chart

### DIFF
--- a/apps/web/src/views/V3Info/components/BarChart/alt.tsx
+++ b/apps/web/src/views/V3Info/components/BarChart/alt.tsx
@@ -109,6 +109,38 @@ const Chart = ({
               if (setLabel) setLabel(undefined)
               if (setValue) setValue(undefined)
             }}
+            onMouseMove={(state) => {
+              if (state.isTooltipActive) {
+                if (setValue && parsedValue !== state?.activePayload?.[0]?.payload?.value) {
+                  setValue(state?.activePayload?.[0]?.payload?.value)
+                }
+                const dayNow = dayjs(state?.activePayload?.[0]?.payload?.value)
+                const formattedTime = dayNow.format('MMM D')
+
+                if (setLabel && label !== formattedTime) {
+                  if (activeWindow === VolumeWindow.weekly) {
+                    const formattedTimePlusWeek = dayNow.add(1, 'week')
+                    const isCurrent = formattedTimePlusWeek.isAfter(now)
+                    setLabel(
+                      `${formattedTime}-${
+                        isCurrent ? now.format('MMM D, YYYY') : formattedTimePlusWeek.format('MMM D, YYYY')
+                      }`,
+                    )
+                  } else if (activeWindow === VolumeWindow.monthly) {
+                    const formattedTimePlusMonth = dayNow.add(1, 'month')
+                    const isCurrent = formattedTimePlusMonth.isAfter(now)
+                    setLabel(
+                      `${formattedTime}-${
+                        isCurrent ? now.format('MMM D, YYYY') : formattedTimePlusMonth.format('MMM D, YYYY')
+                      }`,
+                    )
+                  } else {
+                    const formattedTimeDaily = dayNow.format('MMM D, YYYY')
+                    setLabel(formattedTimeDaily)
+                  }
+                }
+              }
+            }}
           >
             <XAxis
               dataKey="time"
@@ -117,40 +149,7 @@ const Chart = ({
               tickFormatter={(time) => dayjs(time).format(activeWindow === VolumeWindow.monthly ? 'MMM' : 'DD')}
               minTickGap={10}
             />
-            <Tooltip
-              cursor={{ fill: theme.colors.backgroundAlt }}
-              contentStyle={{ display: 'none' }}
-              formatter={(toolTipValue: number, name: string, props) => {
-                if (setValue && parsedValue !== props.payload.value) {
-                  setValue(props.payload.value)
-                }
-                const formattedTime = dayjs(props.payload.time).format('MMM D')
-                const formattedTimeDaily = dayjs(props.payload.time).format('MMM D, YYYY')
-                const formattedTimePlusWeek = dayjs(props.payload.time).add(1, 'week')
-                const formattedTimePlusMonth = dayjs(props.payload.time).add(1, 'month')
-
-                if (setLabel && label !== formattedTime) {
-                  if (activeWindow === VolumeWindow.weekly) {
-                    const isCurrent = formattedTimePlusWeek.isAfter(now)
-                    setLabel(
-                      `${formattedTime}-${
-                        isCurrent ? now.format('MMM D, YYYY') : formattedTimePlusWeek.format('MMM D, YYYY')
-                      }`,
-                    )
-                  } else if (activeWindow === VolumeWindow.monthly) {
-                    const isCurrent = formattedTimePlusMonth.isAfter(now)
-                    setLabel(
-                      `${formattedTime}-${
-                        isCurrent ? now.format('MMM D, YYYY') : formattedTimePlusMonth.format('MMM D, YYYY')
-                      }`,
-                    )
-                  } else {
-                    setLabel(formattedTimeDaily)
-                  }
-                }
-                return null
-              }}
-            />
+            <Tooltip cursor={{ fill: theme.colors.backgroundAlt }} contentStyle={{ display: 'none' }} />
             <Bar
               dataKey="value"
               fill={color}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cab4f83</samp>

### Summary
🐛↩️🔣

<!--
1.  🐛 for the bug fix
2.  ↩️ for the restored line of code
3.  🔣 for the reordered components
-->
Fix tooltip bug and improve code quality in `BarChart` component. The bug fix ensures the tooltip shows the correct data for each bar based on the mouse position. The code quality improvements include restoring a missing line and reordering some elements.

> _The tooltip of doom, it haunts the bar chart_
> _We fix the bug with `onMouseMove` art_
> _We restore the code that was lost in the fray_
> _We reorder the components, make them obey_

### Walkthrough
* Fix tooltip value and label update bug in bar chart ([link](https://github.com/pancakeswap/pancake-frontend/pull/6702/files?diff=unified&w=0#diff-001efd11be94b5d0625bbd974af74b3ca1cadc89c584bd57d0c59994ce0a3c57L112-R122), alt.tsx)


