### PR TITLE
feat: Check price impact on usd price

### DIFF
--- a/apps/web/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanel/index.tsx
@@ -122,6 +122,9 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
   const amountInDollar = useStablecoinPriceAmount(
     showUSDPrice ? currency : undefined,
     Number.isFinite(+value) ? +value : undefined,
+    {
+      hideIfPriceImpactTooHigh: true,
+    },
   )
 
   const [onPresentCurrencyModal] = useModal(

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -22,8 +22,10 @@ import getLpAddress from 'utils/getLpAddress'
 import { multiplyPriceByAmount } from 'utils/prices'
 import { useCakePriceAsBN } from '@pancakeswap/utils/useCakePrice'
 import { getFullDecimalMultiplier } from '@pancakeswap/utils/getFullDecimalMultiplier'
+import { computeTradePriceBreakdown } from 'views/Swap/V3Swap/utils/exchange'
 import { isChainTestnet } from 'utils/wagmi'
 import { useProvider } from 'wagmi'
+import { warningSeverity } from 'utils/exchange'
 import { usePairContract } from './useContract'
 import { PairState, useV2Pairs } from './usePairs'
 import { useActiveChainId } from './useActiveChainId'
@@ -114,6 +116,13 @@ export function useStablecoinPrice(currency?: Currency, enabled = true): Price<C
 
     if (trade) {
       const { inputAmount, outputAmount } = trade
+
+      const { priceImpactWithoutFee } = computeTradePriceBreakdown(trade)
+
+      // if price impact is too high, don't show price
+      if (!priceImpactWithoutFee || warningSeverity(priceImpactWithoutFee) > 2) {
+        return undefined
+      }
 
       return new Price(currency, stableCoin, inputAmount.quotient, outputAmount.quotient)
     }

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -223,8 +223,8 @@ export default function PoolPage() {
   const isCollectPending = useIsTransactionPending(collectMigrationHash ?? undefined)
 
   // usdc prices always in terms of tokens
-  const price0 = useStablecoinPrice(token0 ?? undefined, !!feeValue0)
-  const price1 = useStablecoinPrice(token1 ?? undefined, !!feeValue1)
+  const price0 = useStablecoinPrice(token0 ?? undefined, { enabled: !!feeValue0 })
+  const price1 = useStablecoinPrice(token1 ?? undefined, { enabled: !!feeValue1 })
 
   const fiatValueOfFees: CurrencyAmount<Currency> | null = useMemo(() => {
     if (!price0 || !price1 || !feeValue0 || !feeValue1) return null

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
@@ -59,8 +59,8 @@ export const PositionPreview = ({
   const priceLower = sorted ? position.token0PriceLower : position.token0PriceUpper.invert()
   const priceUpper = sorted ? position.token0PriceUpper : position.token0PriceLower.invert()
 
-  const price0 = useStablecoinPrice(position.pool.token0 ?? undefined, !!position.amount0)
-  const price1 = useStablecoinPrice(position.pool.token1 ?? undefined, !!position.amount1)
+  const price0 = useStablecoinPrice(position.pool.token0 ?? undefined, { enabled: !!position.amount0 })
+  const price1 = useStablecoinPrice(position.pool.token1 ?? undefined, { enabled: !!position.amount1 })
 
   const handleRateChange = useCallback(() => {
     setBaseCurrency(quoteCurrency)

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -218,8 +218,8 @@ function Remove({ tokenId }: { tokenId: BigNumber }) {
 
   const removed = position?.liquidity?.eq(0)
 
-  const price0 = useStablecoinPrice(liquidityValue0?.currency?.wrapped ?? undefined, !!feeValue0)
-  const price1 = useStablecoinPrice(liquidityValue1?.currency?.wrapped ?? undefined, !!feeValue1)
+  const price0 = useStablecoinPrice(liquidityValue0?.currency?.wrapped ?? undefined, { enabled: !!feeValue0 })
+  const price1 = useStablecoinPrice(liquidityValue1?.currency?.wrapped ?? undefined, { enabled: !!feeValue1 })
 
   function modalHeader() {
     return (


### PR DESCRIPTION
Hide the usd price when price impact too high

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8519d8</samp>

### Summary
🚫💰🔎

<!--
1.  🚫 - This emoji conveys the idea of blocking or preventing something, which is what the price impact checks do. They prevent the user from seeing a price that might be misleading or unfavorable due to high slippage or low liquidity.
2.  💰 - This emoji represents money or currency, which is the main subject of the `useStablecoinPrice` hook. The hook is used to show the user how much of a stablecoin they can get for their input token, or vice versa.
3.  🔎 - This emoji signifies searching or inspecting something, which is what the price impact checks do. They compare the input and output amounts of the trade with the market prices and calculate the percentage difference, or the price impact.
-->
Improved accuracy of stablecoin prices by adding price impact checks to `useStablecoinPrice` hook. This hook is used in `useBUSDPrice.ts` to get the price of BUSD in other tokens.

> _Don't trust the stablecoin price_
> _It may deceive you with its lies_
> _When the impact is too high_
> _The hook returns the void inside_

### Walkthrough
* Import and use `computeTradePriceBreakdown` and `warningSeverity` functions to calculate and check the price impact of a trade ([link](https://github.com/pancakeswap/pancake-frontend/pull/6707/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaL25-R28), [link](https://github.com/pancakeswap/pancake-frontend/pull/6707/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaR120-R126))
* Return undefined instead of the price from `useStablecoinPrice` hook if the price impact is too high ([link](https://github.com/pancakeswap/pancake-frontend/pull/6707/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaR120-R126))


