### PR TITLE
chore: Remove vc analytics

### DIFF
--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -19,7 +19,6 @@
     "@pancakeswap/farms": "*",
     "@pancakeswap/uikit": "*",
     "@pancakeswap/ui-wallets": "*",
-    "@vercel/analytics": "^0.1.2",
     "aptos": "^1.3.16",
     "bignumber.js": "^9.0.0",
     "date-fns": "^2.29.3",

--- a/apps/aptos/pages/_app.tsx
+++ b/apps/aptos/pages/_app.tsx
@@ -3,7 +3,6 @@ import '../css/theme.css'
 
 import BigNumber from 'bignumber.js'
 import { PancakeTheme, ResetCSS, ToastListener } from '@pancakeswap/uikit'
-import { Analytics } from '@vercel/analytics/react'
 import { Menu } from 'components/Menu'
 import Providers from 'components/Providers'
 import { NextPage } from 'next'
@@ -61,7 +60,6 @@ function MyApp(props: AppProps) {
         <App {...props} />
         <ToastListener />
       </Providers>
-      <Analytics />
       {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
         <Script
           strategy="afterInteractive"

--- a/apps/blog/pages/_app.tsx
+++ b/apps/blog/pages/_app.tsx
@@ -2,7 +2,6 @@ import '@pancakeswap/ui/css/reset.css'
 import { PancakeTheme, ResetCSS, dark, light, ModalProvider, UIKitProvider } from '@pancakeswap/uikit'
 import { AppProps } from 'next/app'
 import Script from 'next/script'
-import { Analytics } from '@vercel/analytics/react'
 import { Provider as WrapBalancerProvider } from 'react-wrap-balancer'
 import { LanguageProvider } from '@pancakeswap/localization'
 import { createGlobalStyle } from 'styled-components'
@@ -75,7 +74,6 @@ function MyApp({ Component, pageProps }: AppProps) {
           </LanguageProvider>
         </StyledThemeProvider>
       </NextThemeProvider>
-      <Analytics />
       <Script
         strategy="afterInteractive"
         id="google-tag"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72cbf34</samp>

### Summary
🗑️🚀🔒

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, such as a dependency or a component. It can be used to indicate that some code or functionality was discarded or cleaned up.
2.  🚀 - This emoji represents the improvement or enhancement of something, such as performance or speed. It can be used to indicate that some code or functionality was optimized or made faster.
3.  🔒 - This emoji represents the security or privacy of something, such as data or information. It can be used to indicate that some code or functionality was made more secure or respectful of user privacy.
-->
Removed `Analytics` component and `@vercel/analytics` package from aptos and blog apps. This improves the website performance and privacy by avoiding unnecessary analytics scripts.

> _Oh we're the coders of the sea, and we work with skill and speed_
> _We don't need no `Analytics` to track our every deed_
> _So haul away the package, and remove the component too_
> _We'll make our website faster, and respect our users' privacy_

### Walkthrough
* Remove `@vercel/analytics` dependency and usage from aptos and blog apps ([link](https://github.com/pancakeswap/pancake-frontend/pull/6744/files?diff=unified&w=0#diff-2e0a28c02ce581e54b6b6f5803ee5d4b292c79f235eeeaed29cfc4666fa7cad0L22), [link](https://github.com/pancakeswap/pancake-frontend/pull/6744/files?diff=unified&w=0#diff-17d59c4dfd457c10672222cb737947ec12293d9aa0f4e85f42bcb36c801f0bc5L6), [link](https://github.com/pancakeswap/pancake-frontend/pull/6744/files?diff=unified&w=0#diff-17d59c4dfd457c10672222cb737947ec12293d9aa0f4e85f42bcb36c801f0bc5L64), [link](https://github.com/pancakeswap/pancake-frontend/pull/6744/files?diff=unified&w=0#diff-57987834d6cc63fdef4401b3d012aef6b9a5a41a260faf4ddb1365873785997bL5), [link](https://github.com/pancakeswap/pancake-frontend/pull/6744/files?diff=unified&w=0#diff-57987834d6cc63fdef4401b3d012aef6b9a5a41a260faf4ddb1365873785997bL78))


