### PR TITLE
fix: Vcake in cake benefits

### DIFF
--- a/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
+++ b/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
@@ -7,15 +7,15 @@ import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import { useTranslation } from '@pancakeswap/localization'
 import { useChainCurrentBlock } from 'state/block/hooks'
 import { getVaultPosition, VaultPosition } from 'utils/cakePool'
-import { getCakeVaultAddress, getAddress } from 'utils/addressHelpers'
+import { getCakeVaultAddress } from 'utils/addressHelpers'
 import { multicallv2 } from 'utils/multicall'
 import { getActivePools } from 'utils/calls'
 import cakeVaultAbi from 'config/abi/cakeVaultV2.json'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { convertSharesToCake } from '../../../../views/Pools/helpers'
-import { getScores } from '../../../../views/Voting/getScores'
-import { PANCAKE_SPACE } from '../../../../views/Voting/config'
-import * as strategies from '../../../../views/Voting/strategies'
+import { convertSharesToCake } from 'views/Pools/helpers'
+import { getScores } from 'views/Voting/getScores'
+import { PANCAKE_SPACE } from 'views/Voting/config'
+import { cakePoolBalanceStrategy, createTotalStrategy } from 'views/Voting/strategies'
 
 const useCakeBenefits = () => {
   const { address: account } = useAccount()
@@ -71,11 +71,11 @@ const useCakeBenefits = () => {
       iCake = getBalanceNumber(new BigNumber(credit.toString())).toLocaleString('en', { maximumFractionDigits: 3 })
 
       const eligiblePools = await getActivePools(ChainId.BSC, currentBscBlock)
-      const poolAddresses = eligiblePools.map(({ contractAddress }) => getAddress(contractAddress, ChainId.BSC))
+      const poolAddresses = eligiblePools.map(({ contractAddress }) => contractAddress)
 
       const [cakeVaultBalance, total] = await getScores(
         PANCAKE_SPACE,
-        [strategies.cakePoolBalanceStrategy('v1'), strategies.createTotalStrategy(poolAddresses, 'v1')],
+        [cakePoolBalanceStrategy('v1'), createTotalStrategy(poolAddresses, 'v1')],
         ChainId.BSC.toString(),
         [account],
         currentBscBlock,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6d0adf0</samp>

### Summary
🧹📖🛡️

<!--
1.  🧹 - This emoji represents cleaning or simplifying code, which is what the import statements and pool addresses were made more concise and consistent.
2.  📖 - This emoji represents readability or documentation, which is what the code quality and clarity improved by using named imports and constants for the pool addresses.
3.  🛡️ - This emoji represents reliability or security, which is what the code gained by avoiding hard-coded or repeated values for the pool addresses, which could be prone to errors or inconsistencies.
-->
Refactored `useCakeBenefits` hook to use cleaner and more reliable code. This hook calculates the user's benefits from staking CAKE tokens in different pools.

> _We're sailing on the Cake Benefits ship_
> _We're heaving on the code with every pull and push_
> _We've simplified the imports and the pool addresses_
> _We've made our hook more readable and consistent_

### Walkthrough
*  Simplify imports and remove `getAddress` function from `useCakeBenefits.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6758/files?diff=unified&w=0#diff-615c30d6c6f61b444636d64d6a14f50985cc9c40098057c21eaa564896f85851L10-R18))
*  Use original contract addresses and rename strategies for clarity in `useCakeBenefits.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6758/files?diff=unified&w=0#diff-615c30d6c6f61b444636d64d6a14f50985cc9c40098057c21eaa564896f85851L74-R78))


