### PR TITLE
chore: split locales file

### DIFF
--- a/.github/workflows/deployLocales.yml
+++ b/.github/workflows/deployLocales.yml
@@ -1,14 +1,11 @@
-name: Farm Config
+name: Deploy Locales
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop
     paths:
-      - 'packages/farms/constants/**'
-      - 'packages/tokens/**'
-      - '!packages/tokens/src/common.ts'
-      - '!packages/tokens/src/helpers.ts'
-      - '!packages/tokens/src/index.ts'
+      - 'locales/**'
 
 jobs:
   publish:
@@ -18,21 +15,12 @@ jobs:
       deployments: write
     env:
       HAVE_CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
-    name: Publish Farm Config to Cloudflare Pages
+    name: Publish Locales to Cloudflare Pages
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Test
-        run: yarn test:config
-
-      - name: Build list
-        run: yarn turbo run build --filter=@pancakeswap/farms
 
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@1
@@ -40,7 +28,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b82548875bdb333ff5edcca4d076f88d
-          projectName: farms-config
-          directory: ./packages/farms/lists
+          projectName: pcs-locales
+          directory: ./locales
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref_name == 'develop' && 'master' ||  null  }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
 files:
   - source: /packages/localization/src/config/translations.json
-    translation: /apps/web/public/locales/%locale%.json
+    translation: /locales/%locale%.json
 pull_request_title: 'chore: New Crowdin updates'
 commit_message: '[ci skip]'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 44071e7</samp>

### Summary
🌐🗂️🐛

<!--
1.  🌐 for the locales deployment action
2.  🗂️ for the translation file path update
3.  🐛 for the farm config deployment bug fix
-->
This pull request adds GitHub workflows to deploy farm config and locales files to Cloudflare Pages, and adjusts the translation file path in `crowdin.yml`.

> _Oh we are the coders of the sea, and we work on GitHub_
> _We push and pull and merge and deploy, and we never give up_
> _We've added a new workflow file, `deployLocales.yml`_
> _To send our translations to the cloud, on the count of three, HEAVE-HO!_

### Walkthrough
*  Add a new GitHub action to deploy the locales files to Cloudflare Pages ([link](https://github.com/pancakeswap/pancake-frontend/pull/6762/files?diff=unified&w=0#diff-463f3de2891efca2a0c2396e71e9e957a4c97a643df3e3880525dddfd3896e8bR1-R34))
*  Change the trigger for the existing GitHub action to deploy the farm config files to Cloudflare Pages from pull request events to push events to the develop branch ([link](https://github.com/pancakeswap/pancake-frontend/pull/6762/files?diff=unified&w=0#diff-0b4d7bd7148b51842880739adde7bf8cb6ef7f170295d34fb03eeb036e589563L3-R5))
*  Remove the redundant push trigger from the `farmConfig.yml` workflow file ([link](https://github.com/pancakeswap/pancake-frontend/pull/6762/files?diff=unified&w=0#diff-0b4d7bd7148b51842880739adde7bf8cb6ef7f170295d34fb03eeb036e589563L10-L12))
*  Update the branch name for the Cloudflare Pages deployment in the `farmConfig.yml` workflow file from `main` to `master` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6762/files?diff=unified&w=0#diff-0b4d7bd7148b51842880739adde7bf8cb6ef7f170295d34fb03eeb036e589563L47-R46))
*  Update the translation file path in the `crowdin.yml` configuration file to match the new directory structure for the locales files ([link](https://github.com/pancakeswap/pancake-frontend/pull/6762/files?diff=unified&w=0#diff-256aa18d225b85dd7da40aba5091225c2b6c93e8e40f8955fc92be6c5a674afcL3-R3))


