### PR TITLE
feat: Improve address type

### DIFF
--- a/apps/web/src/config/constants/contracts.ts
+++ b/apps/web/src/config/constants/contracts.ts
@@ -36,7 +36,7 @@ export default {
   },
   claimRefund: {
     56: '0xE7e53A7e9E3Cf6b840f167eF69519175c497e149',
-    97: '',
+    97: '0x',
   },
   pointCenterIfo: {
     56: '0x3C6919b132462C1FEc572c6300E83191f4F0012a',
@@ -52,15 +52,15 @@ export default {
   },
   tradingCompetitionFanToken: {
     56: '0xA8FECf847e28aa1Df39E995a45b7FCfb91b676d4',
-    97: '',
+    97: '0x',
   },
   tradingCompetitionMobox: {
     56: '0x1C5161CdB145dE35a8961F82b065fd1F75C3BaDf',
-    97: '',
+    97: '0x',
   },
   tradingCompetitionMoD: {
     56: '0xbDd9a61c67ee16c10f5E37b1D0c907a9EC959f33',
-    97: '',
+    97: '0x',
   },
   easterNft: {
     56: '0x23c41D28A239dDCAABd1bb1deF8d057189510066',
@@ -72,35 +72,35 @@ export default {
   },
   cakeFlexibleSideVault: {
     56: '0x615e896A8C2CA8470A2e9dc2E9552998f8658Ea0',
-    97: '',
+    97: '0x',
   },
   predictionsBNB: {
     56: '0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA',
-    97: '',
+    97: '0x',
   },
   predictionsCAKE: {
     56: '0x0E3A8078EDD2021dadcdE733C6b4a86E51EE8f07',
-    97: '',
+    97: '0x',
   },
   chainlinkOracleBNB: {
     56: '0x0567F2323251f0Aab15c8dFb1967E4e8A7D42aeE',
-    97: '',
+    97: '0x',
   },
   chainlinkOracleCAKE: {
     56: '0xB6064eD41d4f67e353768aA239cA86f4F73665a1',
-    97: '',
+    97: '0x',
   },
   predictionsV1: {
     56: '0x516ffd7d1e0ca40b1879935b2de87cb20fc1124b',
-    97: '',
+    97: '0x',
   },
   bunnySpecialCakeVault: {
     56: '0x5B4a770Abe7Eafb2601CA4dF9d73EA99363E60a4',
-    97: '',
+    97: '0x',
   },
   bunnySpecialPrediction: {
     56: '0x342c99e9aC24157657095eC69CB04b73257e7A9C',
-    97: '',
+    97: '0x',
   },
   bunnySpecialLottery: {
     56: '0x24ED31d31C5868e5a96aA77fdcB890f3511fa0b2',
@@ -108,7 +108,7 @@ export default {
   },
   bunnySpecialXmas: {
     56: '0x59EdDF3c21509dA3b0aCCd7c5ccc596d930f4783',
-    97: '',
+    97: '0x',
   },
   farmAuction: {
     56: '0xb92Ab7c1edcb273AbA24b0656cEb3681654805D2',
@@ -144,15 +144,15 @@ export default {
   },
   iCake: {
     56: '0x3C458828D1622F5f4d526eb0d24Da8C4Eb8F07b1',
-    97: '',
+    97: '0x',
   },
   bCakeFarmBooster: {
     56: '0xE4FAa3Ef5A9708C894435B0F39c2B440936A3A52',
-    97: '',
+    97: '0x',
   },
   bCakeFarmBoosterProxyFactory: {
     56: '0x2C36221bF724c60E9FEE3dd44e2da8017a8EF3BA',
-    97: '',
+    97: '0x',
   },
   nonBscVault: {
     56: '0xE6c904424417D03451fADd6E3f5b6c26BcC43841', // Only for pass contracts test
@@ -187,4 +187,4 @@ export default {
     97: '0x46A15B0b27311cedF172AB29E4f4766fbE7F4364',
   },
   quoter: V3_QUOTER_ADDRESSES,
-}
+} as const satisfies Record<string, Record<number, `0x${string}`>>

--- a/apps/web/src/utils/addressHelpers.ts
+++ b/apps/web/src/utils/addressHelpers.ts
@@ -1,9 +1,12 @@
 import { ChainId } from '@pancakeswap/sdk'
-import { Pool } from '@pancakeswap/uikit'
 import addresses from 'config/constants/contracts'
 import { VaultKey } from 'state/types'
 
-export const getAddress = (address: Pool.Address, chainId?: number): string => {
+export interface Addresses {
+  [chainId: number]: `0x${string}`
+}
+
+export const getAddress = (address: Addresses, chainId?: number): `0x${string}` => {
   return address[chainId] ? address[chainId] : address[ChainId.BSC]
 }
 

--- a/apps/web/src/utils/contractHelpers.ts
+++ b/apps/web/src/utils/contractHelpers.ts
@@ -2,7 +2,6 @@ import type { Signer } from '@ethersproject/abstract-signer'
 import type { Provider } from '@ethersproject/providers'
 import { provider } from 'utils/wagmi'
 import { Contract } from '@ethersproject/contracts'
-import { getPoolsConfig } from '@pancakeswap/pools'
 import { CAKE } from '@pancakeswap/tokens'
 
 // Addresses
@@ -120,8 +119,6 @@ import type {
   LotteryV2,
   Masterchef,
   MasterchefV1,
-  SousChef,
-  SousChefV2,
   BunnySpecial,
   LpToken,
   ClaimRefund,
@@ -160,8 +157,6 @@ import type {
   V3Migrator,
 } from 'config/abi/types'
 import { ChainId } from '@pancakeswap/sdk'
-
-const poolsConfig = getPoolsConfig(ChainId.BSC)
 
 export const getContract = ({
   abi,

--- a/apps/web/src/utils/contractHelpers.ts
+++ b/apps/web/src/utils/contractHelpers.ts
@@ -3,12 +3,10 @@ import type { Provider } from '@ethersproject/providers'
 import { provider } from 'utils/wagmi'
 import { Contract } from '@ethersproject/contracts'
 import { getPoolsConfig } from '@pancakeswap/pools'
-import { PoolCategory } from 'config/constants/types'
 import { CAKE } from '@pancakeswap/tokens'
 
 // Addresses
 import {
-  getAddress,
   getPancakeProfileAddress,
   getPancakeBunniesAddress,
   getBunnyFactoryAddress,
@@ -64,9 +62,6 @@ import pointCenterIfo from 'config/abi/pointCenterIfo.json'
 import lotteryV2Abi from 'config/abi/lotteryV2.json'
 import masterChef from 'config/abi/masterchef.json'
 import masterChefV1 from 'config/abi/masterchefV1.json'
-import sousChef from 'config/abi/sousChef.json'
-import sousChefV2 from 'config/abi/sousChefV2.json'
-import sousChefBnb from 'config/abi/sousChefBnb.json'
 import claimRefundAbi from 'config/abi/claimRefund.json'
 import tradingCompetitionEasterAbi from 'config/abi/tradingCompetitionEaster.json'
 import tradingCompetitionFanTokenAbi from 'config/abi/tradingCompetitionFanToken.json'
@@ -203,15 +198,6 @@ export const getIfoV3Contract = (address: string, signer?: Signer | Provider) =>
 }
 export const getMMLinkedPoolContract = (signer?: Signer | Provider, chainId?: number) => {
   return getContract({ abi: mmLinkedPoolAbi, address: getMMLinkedPoolAddress(chainId), signer }) as MmLinkedPool
-}
-export const getSouschefContract = (id: number, signer?: Signer | Provider) => {
-  const config = poolsConfig.find((pool) => pool.sousId === id)
-  const abi = config.poolCategory === PoolCategory.BINANCE ? sousChefBnb : sousChef
-  return getContract({ abi, address: getAddress(config.contractAddress), signer }) as SousChef
-}
-export const getSouschefV2Contract = (id: number, signer?: Signer | Provider) => {
-  const config = poolsConfig.find((pool) => pool.sousId === id)
-  return getContract({ abi: sousChefV2, address: getAddress(config.contractAddress), signer }) as SousChefV2
 }
 
 export const getPointCenterIfoContract = (signer?: Signer | Provider) => {

--- a/packages/multicall/index.ts
+++ b/packages/multicall/index.ts
@@ -11,11 +11,11 @@ export const multicallAddresses = {
   5: '0xcA11bde05977b3631167028862bE2a173976CA11',
   56: '0xcA11bde05977b3631167028862bE2a173976CA11',
   97: '0xcA11bde05977b3631167028862bE2a173976CA11',
-}
+} as const
 
 export const getMulticallContract = (chainId: ChainId, provider: Provider) => {
-  if (multicallAddresses[chainId]) {
-    return new Contract(multicallAddresses[chainId], multicallAbi, provider)
+  if (multicallAddresses[chainId as keyof typeof multicallAddresses]) {
+    return new Contract(multicallAddresses[chainId as keyof typeof multicallAddresses], multicallAbi, provider)
   }
   return null
 }

--- a/packages/uikit/src/widgets/Pool/types.ts
+++ b/packages/uikit/src/widgets/Pool/types.ts
@@ -16,10 +16,6 @@ import type {
 } from "@pancakeswap/pools";
 import { VaultKey } from "@pancakeswap/pools";
 
-export interface Address {
-  [chainId: number]: string;
-}
-
 export {
   PoolCategory,
   PoolConfigBaseProps,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1ba7cd7</samp>

### Summary
🔄🔒🚚

<!--
1.  🔄 - This emoji represents the refactoring of the `Pool.Address` type and the `getAddress` function to use a more generic and reusable interface for contract address mapping.
2. 🔒 - This emoji represents the improvement of type safety and narrowing of the `multicallAddresses` object and the `getMulticallContract` function by using `const` and casting the `chainId` parameter.
3. 🚚 - This emoji represents the relocation of some functions and ABIs related to sous chef contracts and addresses to separate files to avoid circular dependencies and improve code structure.
-->
Refactored some utility functions and types related to contract addresses and multicall. Moved sous chef logic to separate files and improved type safety and readability.

> _We are the masters of the contract address_
> _We use the `Addresses` interface to access_
> _We cast the `chainId` and narrow the type_
> _We avoid the circular dependency trap_

### Walkthrough
*  Replace `Pool.Address` type with generic `Addresses` interface and update `getAddress` function to use template literal type ([link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-05729caa7bf80ee8f359513f222175a79f3cd3e8aa704d68f0d5c67f8b010a23L2-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-888119257f0b1b96823b6104f5b2d884dd6a90d2fa91a1fc4355f43e15098570L19-L22))
* Move `getAddress` function from `contractHelpers.ts` to `addressHelpers.ts` and remove unused import ([link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL6-R9))
* Move sous chef contract ABIs and functions from `contractHelpers.ts` to `sousChefHelpers.ts` and rename them ([link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL67-L69), [link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL207-L215))
* Mark `multicallAddresses` object as `const` and narrow its key type to avoid using `any` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6766/files?diff=unified&w=0#diff-27f71073b93e54699fdbf5e8a4ca9ae1d49398c0f0971a598f6557336d27bcbcL14-R18))


