### PR TITLE
fix: info token img path

### DIFF
--- a/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
@@ -28,7 +28,10 @@ export const CurrencyLogo: React.FC<
   }, [address, chainName])
 
   const imagePath = chainName === 'BSC' ? '' : `${chainName?.toLowerCase()}/`
-  const srcFromPCS = `https://tokens.pancakeswap.finance/images/${imagePath}${isAddress(address)}.png`
+  const checkedSumAddress = isAddress(address)
+  const srcFromPCS = checkedSumAddress
+    ? `https://tokens.pancakeswap.finance/images/${imagePath}${checkedSumAddress}.png`
+    : ''
   return <StyledLogo size={size} srcs={[srcFromPCS, src]} alt="token logo" useFilledIcon {...rest} />
 }
 

--- a/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
+++ b/apps/web/src/views/Info/components/CurrencyLogo/index.tsx
@@ -27,10 +27,8 @@ export const CurrencyLogo: React.FC<
     return getTokenLogoURL(new Token(multiChainId[chainName], address, 18, ''))
   }, [address, chainName])
 
-  const imagePath = chainName === 'BSC' ? '' : `${multiChainId[chainName]}/tokens/`
-  const srcFromPCS = `https://${chainName === 'BSC' ? 'tokens.' : ''}pancakeswap.finance/images/${imagePath}${isAddress(
-    address,
-  )}.png`
+  const imagePath = chainName === 'BSC' ? '' : `${chainName?.toLowerCase()}/`
+  const srcFromPCS = `https://tokens.pancakeswap.finance/images/${imagePath}${isAddress(address)}.png`
   return <StyledLogo size={size} srcs={[srcFromPCS, src]} alt="token logo" useFilledIcon {...rest} />
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e8ed08d</samp>

### Summary
🐛🔄🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of this change. It indicates that the previous code had a flaw or error that caused some token logos to not load properly, and that the new code resolves this issue.
2.  🔄 - This emoji represents a refactor, which is a secondary effect of this change. It indicates that the previous code was simplified and improved to make it more readable, consistent, and maintainable, without changing its functionality or behavior. Refactoring is a common practice in software development to enhance the quality and structure of the code.
3.  🌐 - This emoji represents a network or web-related change, which is a relevant aspect of this change. It indicates that the new code affects how the token logos are fetched from a CDN on the web, and that it supports different chains or networks that PancakeSwap operates on. This emoji can also imply cross-chain compatibility or interoperability, which are important features for decentralized applications.
-->
Fixed token logo loading bug on info page for non-BSC chains. Simplified `imagePath` and `srcFromPCS` logic in `CurrencyLogo` component.

> _`imagePath` changed_
> _Simpler logic for logos_
> _Autumn bug hunting_

### Walkthrough
*  Simplify and fix the logic for fetching token logos from the CDN on the info page (`apps/web/src/views/Info/components/CurrencyLogo/index.tsx`, [link](https://github.com/pancakeswap/pancake-frontend/pull/6768/files?diff=unified&w=0#diff-301957623fd94925e69acb3cb09ec99f42e60a87dc559eb1ba4464f3ad632cc0L30-R31))


