### PR TITLE
chore(aptos-Pools): Ends in cell don't show on mobile

### DIFF
--- a/apps/aptos/components/Pools/components/PoolTable/PoolRow.tsx
+++ b/apps/aptos/components/Pools/components/PoolTable/PoolRow.tsx
@@ -44,7 +44,7 @@ const PoolRow: React.FC<
         />
       )}
       <Pool.AprCell<Coin> pool={pool} aprComp={Apr} />
-      <Pool.EndsInCell<Coin> pool={pool} getNow={getNow} />
+      {isLargerScreen && <Pool.EndsInCell<Coin> pool={pool} getNow={getNow} />}
     </Pool.ExpandRow>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fb69d58</samp>

### Summary
📱⏰🙈

<!--
1.  📱 - This emoji represents the responsiveness of the pool table to different screen sizes, as well as the mobile device that the column is hidden on.
2.  ⏰ - This emoji represents the remaining time of the pool, which is the column that is conditionally rendered based on the screen width.
3.  🙈 - This emoji represents the hiding or showing of the column, depending on the value of the `isLargerScreen` variable.
-->
Improved responsiveness of pool table by hiding `Pool.EndsInCell` on smaller screens. Modified `PoolRow.tsx` to use a custom hook for screen width detection.

> _`Pool.EndsInCell` hides_
> _when `isLargerScreen` is false_
> _autumn leaves fall fast_

### Walkthrough
*  Hide `Pool.EndsInCell` component on smaller screens for better responsiveness ([link](https://github.com/pancakeswap/pancake-frontend/pull/6778/files?diff=unified&w=0#diff-260aa78f6a9bce733117e747c347f25436651557a84e3d8b1e1c430cd36b9057L47-R47))



Before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/109973128/235283539-07494865-48f4-4562-8c67-c484efafa868.png">

After:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/109973128/235283546-d509be2b-d6a6-4db5-9a6a-c4e6fe9a6d63.png">
