### PR TITLE
feat(FarmsV3): Add farmTypes filter

### DIFF
--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -320,34 +320,23 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
       chosenFs = stakedOnly ? farmsList(stakedArchivedFarms) : farmsList(archivedFarms)
     }
 
-    if (v3FarmOnly || v2FarmOnly) {
-      const v3OrV2Farms = chosenFs.filter(
-        (farm) => (v3FarmOnly && farm.version === 3) || (v2FarmOnly && farm.version === 2),
+    if (v3FarmOnly || v2FarmOnly || boostedOnly || stableSwapOnly) {
+      const filterFarms = chosenFs.filter(
+        (farm) =>
+          (v3FarmOnly && farm.version === 3) ||
+          (v2FarmOnly && farm.version === 2) ||
+          (boostedOnly && farm.boosted) ||
+          (stableSwapOnly && farm.isStable),
       )
 
-      const stakedV3OrV2Farms = chosenFs.filter(
+      const stakedFilterFarms = chosenFs.filter(
         (farm) =>
           farm.userData &&
           (new BigNumber(farm.userData.stakedBalance).isGreaterThan(0) ||
             new BigNumber(farm.userData.proxy?.stakedBalance).isGreaterThan(0)),
       )
 
-      chosenFs = stakedOnly ? farmsList(stakedV3OrV2Farms) : farmsList(v3OrV2Farms)
-    }
-
-    if (boostedOnly || stableSwapOnly) {
-      const boostedOrStableSwapFarms = chosenFs.filter(
-        (farm) => (boostedOnly && farm.boosted) || (stableSwapOnly && farm.isStable),
-      )
-
-      const stakedBoostedOrStableSwapFarms = chosenFs.filter(
-        (farm) =>
-          farm.userData &&
-          (new BigNumber(farm.userData.stakedBalance).isGreaterThan(0) ||
-            new BigNumber(farm.userData.proxy?.stakedBalance).isGreaterThan(0)),
-      )
-
-      chosenFs = stakedOnly ? farmsList(stakedBoostedOrStableSwapFarms) : farmsList(boostedOrStableSwapFarms)
+      chosenFs = stakedOnly ? farmsList(stakedFilterFarms) : farmsList(filterFarms)
     }
 
     return chosenFs

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -222,6 +222,8 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
   const userDataReady = !account || (!!account && v2UserDataLoaded && v3UserDataLoaded)
 
   const [stakedOnly, setStakedOnly] = useUserFarmStakedOnly(isActive)
+  const [v3FarmOnly, setV3FarmOnly] = useState(false)
+  const [v2FarmOnly, setV2FarmOnly] = useState(false)
   const [boostedOnly, setBoostedOnly] = useState(false)
   const [stableSwapOnly, setStableSwapOnly] = useState(false)
   const [farmTypesEnableCount, setFarmTypesEnableCount] = useState(0)
@@ -316,6 +318,22 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
     }
     if (isArchived) {
       chosenFs = stakedOnly ? farmsList(stakedArchivedFarms) : farmsList(archivedFarms)
+    }
+
+    if (v3FarmOnly || v2FarmOnly) {
+      console.log(chosenFs)
+      const v3OrV2Farms = chosenFs.filter(
+        (farm) => (v3FarmOnly && farm.version === 3) || (v2FarmOnly && farm.version === 2),
+      )
+
+      const stakedV3OrV2Farms = chosenFs.filter(
+        (farm) =>
+          farm.userData &&
+          (new BigNumber(farm.userData.stakedBalance).isGreaterThan(0) ||
+            new BigNumber(farm.userData.proxy?.stakedBalance).isGreaterThan(0)),
+      )
+
+      chosenFs = stakedOnly ? farmsList(stakedV3OrV2Farms) : farmsList(v3OrV2Farms)
     }
 
     if (boostedOnly || stableSwapOnly) {
@@ -453,6 +471,10 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
             <FarmUI.FarmTabButtons hasStakeInFinishedFarms={stakedInactiveFarms.length > 0} />
             <Flex mt="20px" ml="16px">
               <FarmTypesFilter
+                v3FarmOnly={v3FarmOnly}
+                handleSetV3FarmOnly={setV3FarmOnly}
+                v2FarmOnly={v2FarmOnly}
+                handleSetV2FarmOnly={setV2FarmOnly}
                 boostedOnly={boostedOnly}
                 handleSetBoostedOnly={setBoostedOnly}
                 stableSwapOnly={stableSwapOnly}

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -321,7 +321,6 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
     }
 
     if (v3FarmOnly || v2FarmOnly) {
-      console.log(chosenFs)
       const v3OrV2Farms = chosenFs.filter(
         (farm) => (v3FarmOnly && farm.version === 3) || (v2FarmOnly && farm.version === 2),
       )
@@ -366,6 +365,8 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
     archivedFarms,
     boostedOnly,
     stableSwapOnly,
+    v3FarmOnly,
+    v2FarmOnly,
   ])
 
   const chosenFarmsMemoized = useMemo(() => {

--- a/apps/web/src/views/Farms/components/FarmTypesFilter.tsx
+++ b/apps/web/src/views/Farms/components/FarmTypesFilter.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useState, useRef } from 'react'
-import { Box, Button, RocketIcon, CurrencyIcon, Flex, Text, InlineMenu, Toggle } from '@pancakeswap/uikit'
+import {
+  Box,
+  Button,
+  RocketIcon,
+  CurrencyIcon,
+  Flex,
+  Text,
+  InlineMenu,
+  Toggle,
+  FarmIcon,
+  TradeIcon,
+} from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 
@@ -8,6 +19,10 @@ interface FarmTypesFilterProps {
   handleSetBoostedOnly: (value: boolean) => void
   stableSwapOnly: boolean
   handleSetStableSwapOnly: (value: boolean) => void
+  v3FarmOnly?: boolean
+  handleSetV3FarmOnly?: (value: boolean) => void
+  v2FarmOnly?: boolean
+  handleSetV2FarmOnly?: (value: boolean) => void
   farmTypesEnableCount: number
   handleSetFarmTypesEnableCount: (value: number) => void
 }
@@ -37,6 +52,10 @@ export const FarmTypesFilter: React.FC<FarmTypesFilterProps> = ({
   handleSetBoostedOnly,
   stableSwapOnly,
   handleSetStableSwapOnly,
+  v3FarmOnly,
+  handleSetV3FarmOnly,
+  v2FarmOnly,
+  handleSetV2FarmOnly,
   farmTypesEnableCount,
   handleSetFarmTypesEnableCount,
 }) => {
@@ -87,6 +106,44 @@ export const FarmTypesFilter: React.FC<FarmTypesFilterProps> = ({
                 </Text>
               </FarmTypesWrapper>
               <Box height="240px" overflowY="auto">
+                <StyledItemRow alignItems="center" px="16px" py="8px" ml="8px" mt="8px">
+                  <TradeIcon />
+                  <Text fontSize={16} ml="10px" style={{ flex: 1 }} bold>
+                    {t('V3 Farms')}
+                  </Text>
+                  <ToggleWrapper>
+                    <Toggle
+                      id="v3-only-farms"
+                      checked={v3FarmOnly}
+                      onChange={() => {
+                        const totalFarmsEnableCount = farmTypesEnableCount + (!v3FarmOnly ? 1 : -1)
+                        handleSetFarmTypesEnableCount(totalFarmsEnableCount)
+
+                        handleSetV3FarmOnly(!v3FarmOnly)
+                      }}
+                      scale="sm"
+                    />
+                  </ToggleWrapper>
+                </StyledItemRow>
+                <StyledItemRow alignItems="center" px="16px" py="8px" ml="8px" mt="8px">
+                  <FarmIcon />
+                  <Text fontSize={16} ml="10px" style={{ flex: 1 }} bold>
+                    {t('V2 Farms')}
+                  </Text>
+                  <ToggleWrapper>
+                    <Toggle
+                      id="v2-only-farms"
+                      checked={v2FarmOnly}
+                      onChange={() => {
+                        const totalFarmsEnableCount = farmTypesEnableCount + (!v2FarmOnly ? 1 : -1)
+                        handleSetFarmTypesEnableCount(totalFarmsEnableCount)
+
+                        handleSetV2FarmOnly(!v2FarmOnly)
+                      }}
+                      scale="sm"
+                    />
+                  </ToggleWrapper>
+                </StyledItemRow>
                 <StyledItemRow alignItems="center" px="16px" py="8px" ml="8px" mt="8px">
                   <RocketIcon />
                   <Text fontSize={16} ml="10px" style={{ flex: 1 }} bold>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2462,5 +2462,7 @@
   "Liquid Staking Integration for WBETH:": "Liquid Staking Integration for WBETH:",
   "Stake ETH Receive WBETH": "Stake ETH Receive WBETH",
   "ETH to WBETH conversion and earn ETH staking rewards!": "ETH to WBETH conversion and earn ETH staking rewards!",
-  "Get Started": "Get Started"
+  "Get Started": "Get Started",
+  "V3 Farms": "V3 Farms",
+  "V2 Farms": "V2 Farms"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a2867fe</samp>

### Summary
🌾🔍🚀

<!--
1.  🌾 - This emoji represents farms, agriculture, and harvesting, and can be used to indicate the main theme of the feature.
2.  🔍 - This emoji represents searching, filtering, and finding, and can be used to indicate the functionality of the feature.
3.  🚀 - This emoji represents launching, boosting, and accelerating, and can be used to indicate the performance or benefit of the feature.
-->
Add a farm type filter to the FarmsV3 view. This lets the user select which kinds of farms to display in the `apps/web/src/views/Farms/FarmsV3.tsx` file.

> _To filter farms by their types_
> _This pull request adds some pipes_
> _It renders `FarmTypesFilter`_
> _And updates `chosenFs` with er_
> _To show boosted or stable swap stripes_

### Walkthrough
*  Add a filter for selecting different types of farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/6780/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR46), [link](https://github.com/pancakeswap/pancake-frontend/pull/6780/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR225-R227), [link](https://github.com/pancakeswap/pancake-frontend/pull/6780/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR455-R462))
* Filter the farms list based on the farm types and staked balance ([link](https://github.com/pancakeswap/pancake-frontend/pull/6780/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR321-R335), [link](https://github.com/pancakeswap/pancake-frontend/pull/6780/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR349-R350))


![image](https://user-images.githubusercontent.com/109973128/235286957-9ac1fcc7-6a2a-4b06-93c4-b9e568c2ac5a.png)
