### PR TITLE
chore(LockPool): AfterBurning alert UI adjustment

### DIFF
--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -403,7 +403,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
           </ActionContent>
         </ActionContainer>
         {isMobile && vaultPosition >= VaultPosition.LockedEnd && (
-          <Flex mb="24px" justifyContent="space-between">
+          <Flex mb="24px" mr="4px" ml="4px" justifyContent="space-between">
             <Text fontSize="14px" color="failure" as="span">
               {vaultPosition === VaultPosition.AfterBurning ? t('After Burning') : t('After Burning In')}
             </Text>

--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -317,19 +317,21 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
                 <Text fontSize="12px" bold color="textSubtle" as="span" textTransform="uppercase">
                   {t('Unlocks In')}
                 </Text>
-                <Text
-                  lineHeight="1"
-                  mt="5px"
-                  bold
-                  fontSize="20px"
-                  color={vaultPosition >= VaultPosition.LockedEnd ? '#D67E0A' : 'text'}
-                >
-                  {vaultPosition >= VaultPosition.LockedEnd ? t('Unlocked') : remainingTime}
+                <Flex>
+                  <Text
+                    lineHeight="1"
+                    mt="5px"
+                    bold
+                    fontSize="20px"
+                    color={vaultPosition >= VaultPosition.LockedEnd ? '#D67E0A' : 'text'}
+                  >
+                    {vaultPosition >= VaultPosition.LockedEnd ? t('Unlocked') : remainingTime}
+                  </Text>
                   {tagTooltipVisibleOfBurn && tagTooltipOfBurn}
                   <span ref={tagTargetRefOfBurn}>
-                    <HelpIcon ml="4px" width="20px" height="20px" color="textSubtle" />
+                    <HelpIcon ml="4px" mt="4px" width="20px" height="20px" color="textSubtle" />
                   </span>
-                </Text>
+                </Flex>
                 <Text
                   height="20px"
                   fontSize="12px"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c1ed206</samp>

### Summary
🖌️📐🆙

<!--
1.  🖌️ - This emoji can be used to indicate that the changes involve some UI adjustments or refinements, such as colors, fonts, margins, etc.
2.  📐 - This emoji can be used to indicate that the changes involve some layout or alignment improvements, such as flexbox, grid, positioning, etc.
3.  🆙 - This emoji can be used to indicate that the changes involve some enhancement or upgrade to the existing functionality or design, such as adding new features, improving performance, etc.
-->
Improved the UI of the stake action panel in the pools table. Aligned the text and the help icon, and added some margin to the `Stake.tsx` component.

> _Sing, O Muse, of the skillful coder who refined_
> _the stake action panel, where the pools of wealth are shown,_
> _and made it more aligned and pleasing to the eye,_
> _like Hephaestus crafting his divine works of art._

### Walkthrough
*  Align text and help icon vertically and add margin to flex container in stake action panel (`Stake.tsx`, [link](https://github.com/pancakeswap/pancake-frontend/pull/6782/files?diff=unified&w=0#diff-4372234a7cdd7a2362382e5a55cecf8b68971bcce4c7c08419cdf20ff16c1300L320-R334), [link](https://github.com/pancakeswap/pancake-frontend/pull/6782/files?diff=unified&w=0#diff-4372234a7cdd7a2362382e5a55cecf8b68971bcce4c7c08419cdf20ff16c1300L406-R408))



Before:
![image](https://user-images.githubusercontent.com/109973128/235300311-04f97942-b21c-45d7-a482-0b9d0c378216.png)

After:
![image](https://user-images.githubusercontent.com/109973128/235300859-300669b6-6ae5-4cb2-b547-0340abce33ef.png)
