### PR TITLE
chore: Update wording

### DIFF
--- a/apps/web/src/views/V3Info/index.tsx
+++ b/apps/web/src/views/V3Info/index.tsx
@@ -184,7 +184,7 @@ export default function Home() {
             }
             topLeft={
               <AutoColumn gap="4px">
-                <Text fontSize="16px">{t('Volume 24H')}</Text>
+                <Text fontSize="16px">{t('Volume')}</Text>
                 <Text fontSize="32px">
                   <MonoSpace>
                     {volumeHover

--- a/packages/uikit/src/widgets/Farm/components/FarmTable/Liquidity.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmTable/Liquidity.tsx
@@ -43,7 +43,7 @@ export const StakedLiquidity: React.FunctionComponent<React.PropsWithChildren<Fa
   const tooltip = useTooltip(
     <>
       <Text>{t("Total active (in-range) liquidity staked in the farm.")}</Text>
-      {updatedAt && <Text>Update {distanceToNow(updatedAt)}</Text>}
+      {updatedAt && <Text>Updated {distanceToNow(updatedAt)}</Text>}
     </>,
     {
       placement: "top-end",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 07606ac</samp>

### Summary
📊🕒✏️

<!--
1.  📊 This emoji can be used to represent the change in the volume metric, as it is a chart or graph that shows data or statistics. Alternatively, 🔉 or 🔊 could also be used to indicate volume, but they might be more associated with sound than trading volume.
2. 🕒 This emoji can be used to represent the change in the update time, as it is a clock face that shows three o'clock, which could imply a recent or periodic update. Alternatively, 🔄 or 🗓 could also be used to indicate an update, but they might be more ambiguous or less specific.
3. ✏️ This emoji can be used to represent the general editing or improvement of the text labels, as it is a pencil that shows writing or correcting. Alternatively, 📝 or 🖊 could also be used to indicate writing or editing, but they might be less common or recognizable.
-->
Fixed some text labels for the V3 farms UI. Changed `Volume 24H` to `Volume` in `V3Info/index.tsx` and `Update` to `Updated` in `FarmTable/Liquidity.tsx`.

> _`Volume` label changed_
> _Data source is not daily_
> _Autumn harvest time_

### Walkthrough
* Change the text label for the volume metric to match the data source ([link](https://github.com/pancakeswap/pancake-frontend/pull/6784/files?diff=unified&w=0#diff-fce97b79832b871b02584f0299b2e8dd193ff70364a26e26ee6fcf8078b8acacL187-R187))
* Fix the grammar of the update time text for the liquidity data ([link](https://github.com/pancakeswap/pancake-frontend/pull/6784/files?diff=unified&w=0#diff-0989a33138702d01286551b3d587fe71426f955d6ec547410770aed2ee9ae4d5L46-R46))


