### PR TITLE
fix: prevent subgraph error blocking quote

### DIFF
--- a/apps/web/src/hooks/useCommonPools.ts
+++ b/apps/web/src/hooks/useCommonPools.ts
@@ -70,9 +70,10 @@ function commonPoolsHookCreator({ useV3Pools }: FactoryOptions) {
     // FIXME: allow inconsistent block not working as expected
     const pools = useMemo(
       () =>
-        v2Pools && v3Pools && stablePools && (allowInconsistentBlock || !!consistentBlockNumber)
-          ? [...v2Pools, ...v3Pools, ...stablePools]
-          : undefined,
+        // v2Pools && v3Pools && stablePools && (allowInconsistentBlock || !!consistentBlockNumber)
+        //   ? [...v2Pools, ...v3Pools, ...stablePools]
+        //   : undefined,
+        [...(v2Pools || []), ...(v3Pools || []), ...(stablePools || [])],
       [v2Pools, v3Pools, stablePools, allowInconsistentBlock, consistentBlockNumber],
     )
     const refresh = useCallback(() => {

--- a/apps/web/src/hooks/useV3Pools.ts
+++ b/apps/web/src/hooks/useV3Pools.ts
@@ -23,6 +23,7 @@ export interface V3PoolsResult {
   loading: boolean
   syncing: boolean
   blockNumber?: number
+  error?: Error
 }
 
 export function useV3CandidatePools(
@@ -37,6 +38,7 @@ export function useV3CandidatePools(
     key,
     blockNumber,
     refresh,
+    error,
   } = useV3CandidatePoolsWithoutTicks(currencyA, currencyB, options)
 
   const {
@@ -53,6 +55,7 @@ export function useV3CandidatePools(
 
   return {
     refresh,
+    error,
     pools: candidatePools,
     loading: isLoading || ticksLoading,
     syncing: isValidating || ticksValidating,
@@ -85,6 +88,7 @@ export function useV3CandidatePoolsWithoutTicks(
     isLoading,
     isValidating,
     mutate,
+    error,
   } = useV3PoolsFromSubgraph(pairs, { ...options, key })
 
   const candidatePools = useMemo<V3Pool[] | null>(() => {
@@ -101,6 +105,7 @@ export function useV3CandidatePoolsWithoutTicks(
     syncing: isValidating,
     blockNumber: poolsFromSubgraphState?.blockNumber,
     key: poolsFromSubgraphState?.key,
+    error,
   }
 }
 
@@ -186,6 +191,7 @@ export function useV3PoolsFromSubgraph(pairs?: Pair[], { key, blockNumber, enabl
     },
     {
       revalidateOnFocus: false,
+      errorRetryCount: 10,
     },
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3315fd3</samp>

### Summary
🐛🚨🔄

<!--
1.  🐛 - This emoji represents the bug fix that was done to prevent the pool list from disappearing.
2.  🚨 - This emoji represents the error handling that was added to the v3 pools data fetching logic, to alert the user of any problems and retry the query if possible.
3.  🔄 - This emoji represents the improved resilience of the data fetching by using the `errorRetryCount` option, which allows the query to retry a certain number of times before giving up.
-->
Improved error handling and data fetching for v3 pools hooks. Fixed a bug that caused the pool list to disappear in some cases.

> _`commonPoolsHook` changed_
> _Returns all pools, not undefined_
> _Fixes list bug_

### Walkthrough
*  Modify `commonPoolsHookCreator` to return all pools regardless of consistency status ([link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-15ed992def68801de075c1f54a3654cdda25fb6f9bb5bc1975579cdd61995ba4L73-R76))
*  Extend `V3PoolsResult` interface to include optional `error` property ([link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR26))
*  Modify `useV3CandidatePools` hook to return and pass `error` property to `useV3PoolsWithTicks` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR41), [link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR58))
*  Modify `useV3CandidatePoolsWithoutTicks` hook to return and pass `error` property to `useV3PoolsWithTicks` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR91), [link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR108))
*  Add `errorRetryCount` option to `useQuery` hook in `useV3PoolsFromSubgraph` hook to improve data fetching resilience ([link](https://github.com/pancakeswap/pancake-frontend/pull/6785/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR194))


