### PR TITLE
chore: list PEEL and BNBX farm

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -55,8 +55,8 @@ export const getStaticProps: GetStaticProps = async () => {
       throw new Error('No block found for 30 days ago')
     }
 
-    const totalTx = await infoServerClient.request(totalTxQuery)
-    const totalTx30DaysAgo = await infoServerClient.request(totalTxQuery, {
+    const totalTx = await infoServerClient.request<any>(totalTxQuery)
+    const totalTx30DaysAgo = await infoServerClient.request<any>(totalTxQuery, {
       block: {
         number: days30AgoBlock.number,
       },
@@ -88,7 +88,7 @@ export const getStaticProps: GetStaticProps = async () => {
 
   if (process.env.BIT_QUERY_HEADER) {
     try {
-      const result = await bitQueryServerClient.request(usersQuery, {
+      const result = await bitQueryServerClient.request<any>(usersQuery, {
         since: days30Ago.toISOString(),
         till: new Date().toISOString(),
       })
@@ -103,7 +103,7 @@ export const getStaticProps: GetStaticProps = async () => {
   }
 
   try {
-    const result = await infoServerClient.request(gql`
+    const result = await infoServerClient.request<any>(gql`
       query tvl {
         pancakeFactories(first: 1) {
           totalLiquidityUSD

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -46,6 +46,22 @@ export const farmsV3 = [
   },
   // keep those farms on top
   {
+    pid: 37,
+    lpSymbol: 'BNBX-BNB LP',
+    token: bscTokens.bnbx,
+    quoteToken: bscTokens.bnb,
+    lpAddress: '0x77B27c351B13Dc6a8A16Cc1d2E9D5e7F9873702E',
+    feeAmount: FeeAmount.LOW,
+  },
+  {
+    pid: 36,
+    lpSymbol: 'PEEL-BUSD LP',
+    token: bscTokens.peel,
+    quoteToken: bscTokens.busd,
+    lpAddress: '0x08eAbc3d13Fb4bdFFD1F42a5644C1c826aCF62c0',
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 35,
     lpSymbol: 'REVV-EDU LP',
     token: bscTokens.revv,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f9681c</samp>

### Summary
🛠️🔄🚀

<!--
1.  🛠️ - This emoji conveys the idea of fixing or improving something, which is what the use of generic type `<any>` does for the GraphQL client requests. It avoids TypeScript errors and makes the code more adaptable to different data types.
2.  🔄 - This emoji suggests the notion of changing or updating something, which is what the update of the GraphQL client requests entails. It also implies a sense of compatibility or interoperability, which is what the generic type `<any>` enables for the GraphQL data.
3.  🚀 - This emoji implies a sense of speed, efficiency, or performance, which is what the use of generic type `<any>` can potentially enhance for the GraphQL client requests. It also conveys a sense of innovation or progress, which is what the update of the GraphQL client requests reflects.
-->
Improved GraphQL client requests in `index.tsx` by using generic type `<any>` for better TypeScript compatibility and flexibility.

> _To avoid TypeScript errors and fuss_
> _The client requests now use `<any>`_
> _This makes them more flexible_
> _But also less legible_
> _For `infoServerClient` and `bitQueryServerClient`_

### Walkthrough
*  Use generic type parameter `<any>` for `infoServerClient.request` and `bitQueryServerClient.request` methods to avoid TypeScript errors when accessing response data ([link](https://github.com/pancakeswap/pancake-frontend/pull/6807/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL58-R59), [link](https://github.com/pancakeswap/pancake-frontend/pull/6807/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL91-R91), [link](https://github.com/pancakeswap/pancake-frontend/pull/6807/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL106-R106)) in `index.tsx`


