### PR TITLE
chore(TabMenu): Padding bottom adjustment

### DIFF
--- a/packages/uikit/src/components/TabMenu/TabMenu.tsx
+++ b/packages/uikit/src/components/TabMenu/TabMenu.tsx
@@ -6,7 +6,7 @@ import { TabMenuProps } from "./types";
 const Wrapper = styled(Flex)<{ fullWidth?: boolean }>`
   border-bottom: 2px solid ${({ theme }) => theme.colors.input};
   overflow-x: scroll;
-  padding: ${({ fullWidth }) => (fullWidth ? 0 : "16px")};
+  padding: ${({ fullWidth }) => (fullWidth ? 0 : "0 16px")};
 
   ::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1d32406</samp>

### Summary
🐛📱🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the padding adjustment for the `Wrapper` component. It indicates that the change was made to resolve an existing issue or error in the code or UI.
2. 📱 - This emoji represents responsiveness, which is one of the goals of the pull request and the padding adjustment for the `Wrapper` component. It indicates that the change was made to improve how the component adapts to different screen sizes and devices.
3. 🎨 - This emoji represents UI design, which is another aspect of the pull request and the padding adjustment for the `Wrapper` component. It indicates that the change was made to enhance the appearance and style of the component.
-->
Adjusted the padding of the `Wrapper` component in `TabMenu.tsx` to fix a visual bug. This improved the responsiveness and layout of the tab menu component.

> _`Wrapper` padding_
> _Adjusted for tab menu_
> _A winter bug fixed_

### Walkthrough
*  Adjust `Wrapper` component's padding to fix vertical space bug in tab menu ([link](https://github.com/pancakeswap/pancake-frontend/pull/6828/files?diff=unified&w=0#diff-de0633966d0aebf4a06e70ecde7b8f4b86e37b6560c2373c9fc99534e24ea840L9-R9))



Before:
![image](https://user-images.githubusercontent.com/109973128/236480931-70355c97-3ea4-4bb1-8e75-044a93012d31.png)
![image](https://user-images.githubusercontent.com/109973128/236481005-d614a059-e3c2-4b9b-bce1-5318b183bbb1.png)

After:
![image](https://user-images.githubusercontent.com/109973128/236481081-abeaf452-06c4-4cb2-bd03-02bd0f569a42.png)
![image](https://user-images.githubusercontent.com/109973128/236481170-1661d2f1-2350-4343-82a2-37e203fc6c64.png)

