### PR TITLE
chore(RangeTag): Tooltip placement adjustment

### DIFF
--- a/apps/web/src/components/RangeTag.tsx
+++ b/apps/web/src/components/RangeTag.tsx
@@ -28,6 +28,7 @@ export function RangeTag({
             )}
             size="20px"
             color="white"
+            placement="bottom"
           />
         </Flex>
       )}

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3StakeAndUnStake.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3StakeAndUnStake.tsx
@@ -183,6 +183,7 @@ const FarmV3StakeAndUnStake: React.FunctionComponent<React.PropsWithChildren<Far
             text={t('Inactive positions will NOT earn CAKE rewards from farm.')}
             size="20px"
             color="white"
+            placement="bottom"
           />
         </RangeTag>
       )}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e5773fd</samp>

### Summary
🎯🏷️🌾

<!--
1.  🎯 - This emoji represents the placement prop, which is used to specify the position of the tooltip relative to the target element. The emoji suggests the idea of aiming or aligning the tooltip correctly.
2.  🏷️ - This emoji represents the range tag, which is a custom component that displays the price range of a token pair. The emoji suggests the idea of a label or a tag that provides some information.
3.  🌾 - This emoji represents the farm, which is a feature that allows users to earn rewards by staking their LP tokens. The emoji suggests the idea of farming or harvesting crops, which is a common metaphor for yield farming in DeFi.
-->
Added the `placement` prop to the `Tooltip` components in `RangeTag.tsx` and `FarmV3StakeAndUnStake.tsx` to position the tooltips below the elements they are attached to, for better user experience and consistency. This change addresses issue #2419.

> _`Tooltip` placement_
> _Below the buttons and tags_
> _Autumn leaves falling_

### Walkthrough
*  Position tooltips below range tags and buttons for better visibility ([link](https://github.com/pancakeswap/pancake-frontend/pull/6837/files?diff=unified&w=0#diff-517a7bdbee7eed5989395c0d4816d87c888fb38329ee552f5d8ba36e4fa8bab1R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/6837/files?diff=unified&w=0#diff-8a582a55c28fd93909c966467f9e5085ddc4c08b0128a15e9f1168ab8a9c1cf5R186))



Before:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/109973128/236657539-af143434-3eec-46f3-9475-7856c00679b1.png">
<img width="315" alt="image" src="https://user-images.githubusercontent.com/109973128/236657546-43fe1c76-6bd2-4712-bb2b-378e5e80639c.png">

After:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/109973128/236657788-875caa4b-883b-4d43-922d-62d81668a7d5.png">
