### PR TITLE
chore(Liqiuidty): Display accurate Token amount

### DIFF
--- a/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
+++ b/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
@@ -17,7 +17,7 @@ export function formattedCurrencyAmount({
     ? '0'
     : currencyAmount.greaterThan(CURRENCY_AMOUNT_MIN)
     ? isShowExactAmount
-      ? currencyAmount.toExact({ groupSeparator: ',' })
+      ? currencyAmount.toFixed(6, { groupSeparator: ',' })
       : currencyAmount.toSignificant(significantDigits, { groupSeparator: ',' })
     : `<${CURRENCY_AMOUNT_MIN.toSignificant(1)}`
 }

--- a/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
+++ b/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
@@ -5,13 +5,20 @@ const CURRENCY_AMOUNT_MIN = new Fraction(1n, 1000000n)
 interface FormatterCurrencyAmountProps {
   currencyAmount?: CurrencyAmount<Currency>
   significantDigits?: number
+  isShowExactAmount?: boolean
 }
 
-export function formattedCurrencyAmount({ currencyAmount, significantDigits = 4 }: FormatterCurrencyAmountProps) {
+export function formattedCurrencyAmount({
+  currencyAmount,
+  significantDigits = 4,
+  isShowExactAmount = false,
+}: FormatterCurrencyAmountProps) {
   return !currencyAmount || currencyAmount.equalTo(0n)
     ? '0'
     : currencyAmount.greaterThan(CURRENCY_AMOUNT_MIN)
-    ? currencyAmount.toSignificant(significantDigits, { groupSeparator: ',' })
+    ? isShowExactAmount
+      ? currencyAmount.toExact()
+      : currencyAmount.toSignificant(significantDigits, { groupSeparator: ',' })
     : `<${CURRENCY_AMOUNT_MIN.toSignificant(1)}`
 }
 

--- a/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
+++ b/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
@@ -17,7 +17,7 @@ export function formattedCurrencyAmount({
     ? '0'
     : currencyAmount.greaterThan(CURRENCY_AMOUNT_MIN)
     ? isShowExactAmount
-      ? currencyAmount.toExact()
+      ? currencyAmount.toExact({ groupSeparator: ',' })
       : currencyAmount.toSignificant(significantDigits, { groupSeparator: ',' })
     : `<${CURRENCY_AMOUNT_MIN.toSignificant(1)}`
 }

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -290,6 +290,7 @@ export default function PoolPage() {
       value,
     }
 
+    if (!signer) return
     signer
       .estimateGas(txn)
       .then((estimate) => {
@@ -562,7 +563,7 @@ export default function PoolPage() {
                         </Flex>
                         <Flex justifyContent="center">
                           <Text small mr="4px">
-                            <FormattedCurrencyAmount currencyAmount={positionValueUpper} />
+                            <FormattedCurrencyAmount currencyAmount={positionValueUpper} isShowExactAmount />
                           </Text>
                         </Flex>
                         <RowBetween justifyContent="flex-end">
@@ -584,7 +585,7 @@ export default function PoolPage() {
                         </Flex>
                         <Flex justifyContent="center">
                           <Text small mr="4px">
-                            <FormattedCurrencyAmount currencyAmount={positionValueLower} />
+                            <FormattedCurrencyAmount currencyAmount={positionValueLower} isShowExactAmount />
                           </Text>
                         </Flex>
                         <RowBetween justifyContent="flex-end">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f065a9c</samp>

### Summary
🎨🐛🔢

<!--
1.  🎨 - This emoji is often used for changes related to UI or design, and it could represent the modification of the `FormattedCurrencyAmount` component to accept a new prop and the improved display of liquidity position data.
2.  🐛 - This emoji is commonly used for bug fixes or error handling, and it could represent the added guard clause to prevent errors when the signer is not available.
3.  🔢 - This emoji is sometimes used for changes related to numbers or calculations, and it could represent the use of `FormattedCurrencyAmount` with `isShowExactAmount` to show the exact upper and lower ticks of the position.
-->
Improved the web app UI for liquidity positions and added a new prop to `FormattedCurrencyAmount` component. This allows users to see more accurate and detailed information about their liquidity pools and the price ranges they are providing liquidity for.

> _Oh we're the savvy sailors of the web app sea_
> _We tweak the `FormattedCurrencyAmount` with glee_
> _We show the exact amount or the digits as we please_
> _And we guard the liquidity from the signer's freeze_

### Walkthrough
*  Add optional prop `isShowExactAmount` to `FormattedCurrencyAmount` component to control the precision of the displayed currency amount ([link](https://github.com/pancakeswap/pancake-frontend/pull/6838/files?diff=unified&w=0#diff-c3561a5a03d74c3f116dd6ec8ad7f89c98a291ad458c699e6aa93e7e597cbdddL8-R21))
*  Prevent `useEffect` hook from running if signer is not available in liquidity position page ([link](https://github.com/pancakeswap/pancake-frontend/pull/6838/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR293))
*  Display exact values of upper and lower ticks of liquidity position using `FormattedCurrencyAmount` component with `isShowExactAmount` prop set to `true` in `apps/web/src/pages/liquidity/[tokenId].tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6838/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL565-R566), [link](https://github.com/pancakeswap/pancake-frontend/pull/6838/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL587-R588))


Before:
![image](https://user-images.githubusercontent.com/109973128/236668674-b2a99a27-f6bb-409f-b24c-bb92ca315c4f.png)

After:
![image](https://user-images.githubusercontent.com/109973128/236668655-7eaa289f-c4de-4c30-8795-53dbbea8cc56.png)

When there are many digits in the amount, it may become distorted, so it is important to display the precise number.

