### PR TITLE
fix: info token realted pool fees usd issue

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -18,7 +18,9 @@ export const GRAPH_API_POTTERY = 'https://api.thegraph.com/subgraphs/name/pancak
 export const GRAPH_API_PREDICTION_V1 = 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction'
 
 export const INFO_CLIENT = 'https://proxy-worker.pancake-swap.workers.dev/bsc-exchange'
-export const V3_BSC_INFO_CLIENT = `https://open-platform.nodereal.io/${process.env.NEXT_PUBLIC_NODE_REAL_API_INFO}/pancakeswap-v3/graphql`
+export const V3_BSC_INFO_CLIENT = `https://open-platform.nodereal.io/${
+  process.env.NEXT_PUBLIC_NODE_REAL_API_INFO || process.env.NEXT_PUBLIC_NODE_REAL_API_ETH
+}/pancakeswap-v3/graphql`
 
 export const INFO_CLIENT_ETH = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth'
 export const BLOCKS_CLIENT = 'https://api.thegraph.com/subgraphs/name/pancakeswap/blocks'

--- a/apps/web/src/views/V3Info/data/pool/poolData.ts
+++ b/apps/web/src/views/V3Info/data/pool/poolData.ts
@@ -177,10 +177,10 @@ export async function fetchPoolDatas(
           : 0
       const feeUSD =
         current && oneDay
-          ? new BigNumber(current.feesUSD)
-              .minus(current.protocolFeesUSD)
-              .minus(new BigNumber(oneDay.feesUSD).minus(oneDay.protocolFeesUSD))
-          : new BigNumber(current.feesUSD).minus(current.protocolFeesUSD)
+          ? new BigNumber(current?.feesUSD)
+              .minus(current?.protocolFeesUSD)
+              .minus(new BigNumber(oneDay?.feesUSD).minus(oneDay?.protocolFeesUSD))
+          : new BigNumber(current?.feesUSD).minus(current?.protocolFeesUSD)
       // Hotifx: Subtract fees from TVL to correct data while subgraph is fixed.
       /**
        * Note: see issue desribed here https://github.com/Uniswap/v3-subgraph/issues/74

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -28,6 +28,7 @@ import { getBlockExploreLink } from 'utils'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import BarChart from '../components/BarChart/alt'
+import LineChart from '../components/LineChart/alt'
 import { GreyBadge } from '../components/Card'
 import DensityChart from '../components/DensityChart'
 import { LocalLoader } from '../components/Loader'
@@ -340,7 +341,7 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
                     label={valueLabel}
                   />
                 ) : view === ChartView.TVL ? (
-                  <BarChart
+                  <LineChart
                     data={formattedTvlData}
                     color={backgroundColor}
                     minHeight={340}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9d9d8ec</samp>

### Summary
🔄🛡️📈

<!--
1.  🔄 - This emoji represents the change in the `V3_BSC_INFO_CLIENT` constant, which involves switching or rotating the fallback option for the NodeReal API endpoint.
2.  🛡️ - This emoji represents the change in the `fetchPoolDatas` function, which involves adding protection or safeguarding against potential errors or crashes.
3.  📈 - This emoji represents the change in the `PoolPage` component, which involves adding a line chart or graph for displaying the TVL of the pool.
-->
This pull request enhances the pool page UI with a line chart for TVL, adds a fallback option for the NodeReal API endpoint, and fixes possible null errors when fetching pool data from the subgraph.

> _Oh, we're the brave developers of the PancakeSwap app_
> _We fetch the pool data from the NodeReal API_
> _We use the `?.` operator to avoid a crash_
> _And we show the TVL with a `LineChart` so snappy_

### Walkthrough
*  Modify the `V3_BSC_INFO_CLIENT` constant to use the `NEXT_PUBLIC_NODE_REAL_API_ETH` environment variable as a fallback option for querying the NodeReal API on both BSC and ETH networks ([link](https://github.com/pancakeswap/pancake-frontend/pull/6843/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L21-R23))
*  Prevent potential errors or crashes when accessing the `feesUSD` and `protocolFeesUSD` properties of the `current` and `oneDay` objects by using optional chaining operators (`?.`) in the `fetchPoolDatas` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/6843/files?diff=unified&w=0#diff-cb5b05db991ca45b363ad45f207e349555dee69b52482d471db83df4f6035a80L180-R183))
*  Replace the `BarChart` component with the `LineChart` component from `../components/LineChart/alt` for rendering the TVL of the pool in a line chart format in the `PoolPage` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6843/files?diff=unified&w=0#diff-3064cf71a39aece557e7aebe4bfbbe0aa57e882e2b199bb8945b76792e519f59R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/6843/files?diff=unified&w=0#diff-3064cf71a39aece557e7aebe4bfbbe0aa57e882e2b199bb8945b76792e519f59L343-R344))


