### PR TITLE
feat: Apr breakdown

### DIFF
--- a/apps/web/src/hooks/usePoolAvgInfo.ts
+++ b/apps/web/src/hooks/usePoolAvgInfo.ts
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import { ChainId } from '@pancakeswap/sdk'
+import { gql } from 'graphql-request'
+import useSWR from 'swr'
+
+import { v3Clients } from 'utils/graphql'
+
+export interface UsePoolAvgInfoParams {
+  numberOfDays?: number
+  address?: string
+  chainId?: ChainId
+}
+
+export const averageArray = (dataToCalculate: number[]): number => {
+  let data = [...dataToCalculate]
+  // Remove the highest and lowest volume to be more accurate
+  if (data.length > 3) {
+    data = data.sort((a: number, b: number) => a - b).slice(1, data.length - 1)
+  }
+
+  return data.reduce((result, val) => result + val, 0) / data.length
+}
+
+interface Info {
+  volumeUSD: number
+  tvlUSD: number
+  feesUSD: number
+}
+
+const defaultInfo: Info = {
+  volumeUSD: 0,
+  tvlUSD: 0,
+  feesUSD: 0,
+}
+
+export function usePoolAvgInfo({ address = '', numberOfDays = 7, chainId }: UsePoolAvgInfoParams) {
+  const { data } = useSWR<{ volumeUSD: number; tvlUSD: number; feesUSD: number }>(
+    address && chainId && [address, chainId],
+    async () => {
+      const client = v3Clients[chainId]
+      if (!client) {
+        console.log('[Failed] Trading volume', address, chainId)
+        return defaultInfo
+      }
+
+      const query = gql`
+        query getVolume($days: Int!, $address: String!) {
+          poolDayDatas(first: $days, orderBy: date, orderDirection: desc, where: { pool: $address }) {
+            volumeUSD
+            tvlUSD
+            feesUSD
+          }
+        }
+      `
+      const { poolDayDatas } = await client.request(query, {
+        days: numberOfDays,
+        address: address.toLocaleLowerCase(),
+      })
+      const volumes = poolDayDatas.map((d: { volumeUSD: string }) => Number(d.volumeUSD))
+      const tvlUSDs = poolDayDatas.map((d: { tvlUSD: string }) => Number(d.tvlUSD))
+      const feesUSDs = poolDayDatas.map((d: { feesUSD: string }) => Number(d.feesUSD))
+      return {
+        volumeUSD: averageArray(volumes),
+        tvlUSD: averageArray(tvlUSDs),
+        feesUSD: averageArray(feesUSDs),
+      }
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  )
+
+  return data || defaultInfo
+}

--- a/apps/web/src/hooks/usePoolAvgInfo.ts
+++ b/apps/web/src/hooks/usePoolAvgInfo.ts
@@ -58,13 +58,12 @@ export function usePoolAvgInfo({ address = '', numberOfDays = 7, chainId }: UseP
         address: address.toLocaleLowerCase(),
       })
       const volumes = poolDayDatas.map((d: { volumeUSD: string }) => Number(d.volumeUSD))
-      const tvlUSDs = poolDayDatas.map((d: { tvlUSD: string }) => Number(d.tvlUSD))
       const feeUSDs = poolDayDatas.map(
         (d: { feesUSD: string; protocolFeesUSD: string }) => Number(d.feesUSD) - Number(d.protocolFeesUSD),
       )
       return {
         volumeUSD: averageArray(volumes),
-        tvlUSD: averageArray(tvlUSDs),
+        tvlUSD: parseFloat(poolDayDatas[0]?.tvlUSD) || 0,
         feeUSD: averageArray(feeUSDs),
       }
     },

--- a/apps/web/src/hooks/usePoolAvgInfo.ts
+++ b/apps/web/src/hooks/usePoolAvgInfo.ts
@@ -24,17 +24,17 @@ export const averageArray = (dataToCalculate: number[]): number => {
 interface Info {
   volumeUSD: number
   tvlUSD: number
-  feesUSD: number
+  feeUSD: number
 }
 
 const defaultInfo: Info = {
   volumeUSD: 0,
   tvlUSD: 0,
-  feesUSD: 0,
+  feeUSD: 0,
 }
 
 export function usePoolAvgInfo({ address = '', numberOfDays = 7, chainId }: UsePoolAvgInfoParams) {
-  const { data } = useSWR<{ volumeUSD: number; tvlUSD: number; feesUSD: number }>(
+  const { data } = useSWR<Info>(
     address && chainId && [address, chainId],
     async () => {
       const client = v3Clients[chainId]
@@ -49,6 +49,7 @@ export function usePoolAvgInfo({ address = '', numberOfDays = 7, chainId }: UseP
             volumeUSD
             tvlUSD
             feesUSD
+            protocolFeesUSD
           }
         }
       `
@@ -58,11 +59,13 @@ export function usePoolAvgInfo({ address = '', numberOfDays = 7, chainId }: UseP
       })
       const volumes = poolDayDatas.map((d: { volumeUSD: string }) => Number(d.volumeUSD))
       const tvlUSDs = poolDayDatas.map((d: { tvlUSD: string }) => Number(d.tvlUSD))
-      const feesUSDs = poolDayDatas.map((d: { feesUSD: string }) => Number(d.feesUSD))
+      const feeUSDs = poolDayDatas.map(
+        (d: { feesUSD: string; protocolFeesUSD: string }) => Number(d.feesUSD) - Number(d.protocolFeesUSD),
+      )
       return {
         volumeUSD: averageArray(volumes),
         tvlUSD: averageArray(tvlUSDs),
-        feesUSD: averageArray(feesUSDs),
+        feeUSD: averageArray(feeUSDs),
       }
     },
     {

--- a/apps/web/src/hooks/usePoolTradingVolume.ts
+++ b/apps/web/src/hooks/usePoolTradingVolume.ts
@@ -1,52 +1,6 @@
-/* eslint-disable no-console */
-import { ChainId } from '@pancakeswap/sdk'
-import { gql } from 'graphql-request'
-import useSWR from 'swr'
+import { usePoolAvgInfo, UsePoolAvgInfoParams } from './usePoolAvgInfo'
 
-import { v3Clients } from 'utils/graphql'
-
-interface Params {
-  numberOfDays?: number
-  address?: string
-  chainId?: ChainId
-}
-
-export const averageArray = (data: number[]): number => {
-  return data.reduce((result, val) => result + val, 0) / data.length
-}
-
-export function usePoolAvgTradingVolume({ address, numberOfDays = 7, chainId }: Params) {
-  const { data } = useSWR(
-    address && chainId && [address, chainId],
-    async () => {
-      const client = v3Clients[chainId]
-      if (!client) {
-        console.log('[Failed] Trading volume', address, chainId)
-        return 0
-      }
-
-      const query = gql`
-        query getVolume($days: Int!, $address: String!) {
-          poolDayDatas(first: $days, orderBy: date, orderDirection: desc, where: { pool: $address }) {
-            volumeUSD
-          }
-        }
-      `
-      const { poolDayDatas } = await client.request(query, {
-        days: numberOfDays,
-        address: address.toLocaleLowerCase(),
-      })
-      const volumes = poolDayDatas.map((d: { volumeUSD: string }) => Number(d.volumeUSD))
-      // Remove the highest and lowest volume to be more accurate
-      if (volumes.length > 3) {
-        return averageArray(volumes.sort((a: number, b: number) => a - b).slice(1, volumes.length - 1))
-      }
-      return averageArray(volumes)
-    },
-    {
-      revalidateOnFocus: false,
-    },
-  )
-
-  return data
+export function usePoolAvgTradingVolume(params: UsePoolAvgInfoParams) {
+  const { volumeUSD } = usePoolAvgInfo(params)
+  return volumeUSD
 }

--- a/apps/web/src/views/Farms/components/FarmCard/ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/ApyButton.tsx
@@ -40,7 +40,7 @@ const ApyButton: React.FC<React.PropsWithChildren<ApyButtonProps>> = ({
   lpTokenPrice,
   lpSymbol,
   cakePrice,
-  apr,
+  apr = 0,
   multiplier,
   displayApr,
   lpRewardsApr,
@@ -79,7 +79,7 @@ const ApyButton: React.FC<React.PropsWithChildren<ApyButtonProps>> = ({
       stakingTokenDecimals={18}
       stakingTokenSymbol={lpSymbol}
       stakingTokenPrice={lpTokenPrice.toNumber()}
-      earningTokenPrice={cakePrice.toNumber()}
+      earningTokenPrice={cakePrice?.toNumber()}
       apr={bCakeMultiplier ? apr * bCakeMultiplier : apr}
       multiplier={multiplier}
       displayApr={bCakeMultiplier ? (_toNumber(displayApr) - apr + apr * bCakeMultiplier).toFixed(2) : displayApr}
@@ -89,7 +89,7 @@ const ApyButton: React.FC<React.PropsWithChildren<ApyButtonProps>> = ({
         boosted ? (
           <BCakeCalculator
             targetInputBalance={calculatorBalance}
-            earningTokenPrice={cakePrice.toNumber()}
+            earningTokenPrice={cakePrice?.toNumber()}
             lpTokenStakedAmount={lpTokenStakedAmount}
             setBCakeMultiplier={setBCakeMultiplier}
           />
@@ -111,22 +111,25 @@ const ApyButton: React.FC<React.PropsWithChildren<ApyButtonProps>> = ({
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     <>
       <Text>
-        {t('APR (incl. LP rewards)')}:{' '}
-        <Text style={{ display: 'inline-block' }} color={strikethrough && 'secondary'}>
+        {t('Combined APR')}:{' '}
+        <Text style={{ display: 'inline-block' }} color={strikethrough && 'secondary'} bold>
           {strikethrough ? `${(apr * boostMultiplier + lpRewardsApr).toFixed(2)}%` : `${displayApr}%`}
         </Text>
       </Text>
-      <Text ml="5px">
-        *{t('Base APR (CAKE yield only)')}:{' '}
-        {strikethrough ? (
-          <Text style={{ display: 'inline-block' }} color="secondary">{`${(apr * boostMultiplier).toFixed(2)}%`}</Text>
-        ) : (
-          `${apr.toFixed(2)}%`
-        )}
-      </Text>
-      <Text ml="5px">
-        *{t('LP Rewards APR')}: {lpRewardsApr === 0 ? '-' : lpRewardsApr}%
-      </Text>
+      <ul>
+        <li>
+          {t('Farm APR')}:{' '}
+          <Text style={{ display: 'inline-block' }} color={strikethrough ? 'secondary' : 'normal'} bold>
+            {strikethrough ? `${(apr * boostMultiplier).toFixed(2)}%` : `${apr.toFixed(2)}%`}
+          </Text>
+        </li>
+        <li>
+          {t('LP Fee APR')}:{' '}
+          <Text style={{ display: 'inline-block' }} color={strikethrough ? 'secondary' : 'normal'} bold>
+            {lpRewardsApr === 0 ? '-' : lpRewardsApr}%
+          </Text>
+        </li>
+      </ul>
       {strikethrough && (
         <Text>
           {t('Available Boosted')}:{' '}

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -89,7 +89,7 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
 
   const {
     volumeUSD: volume24H,
-    feesUSD,
+    feeUSD,
     tvlUSD,
   } = usePoolAvgInfo({
     address: farm.lpAddress,
@@ -99,7 +99,7 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
   const balanceA = existingPosition_?.amount0 ?? currencyBalances[Field.CURRENCY_A]
   const balanceB = existingPosition_?.amount1 ?? currencyBalances[Field.CURRENCY_B]
 
-  const globalLpApr = useMemo(() => (tvlUSD ? (100 * feesUSD * 365) / tvlUSD : 0), [feesUSD, tvlUSD])
+  const globalLpApr = useMemo(() => (tvlUSD ? (100 * feeUSD * 365) / tvlUSD : 0), [feeUSD, tvlUSD])
 
   const depositUsdAsBN = useMemo(
     () =>

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -8,10 +8,11 @@ import {
   RoiCalculatorModalV2,
   Skeleton,
   Text,
-  TooltipText,
   useModalV2,
   useRoi,
   Flex,
+  useTooltip,
+  TooltipText,
 } from '@pancakeswap/uikit'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { useCakePriceAsBN } from '@pancakeswap/utils/useCakePrice'
@@ -21,7 +22,7 @@ import { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { Bound } from 'config/constants/types'
-import { usePoolAvgTradingVolume } from 'hooks/usePoolTradingVolume'
+import { usePoolAvgInfo } from 'hooks/usePoolAvgInfo'
 import { useAllV3Ticks } from 'hooks/v3/usePoolTickData'
 import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
 import { usePairTokensPrice } from 'hooks/v3/usePairTokensPrice'
@@ -86,13 +87,19 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
   const currencyAUsdPrice = +farm.tokenPriceBusd
   const currencyBUsdPrice = +farm.quoteTokenPriceBusd
 
-  const volume24H = usePoolAvgTradingVolume({
+  const {
+    volumeUSD: volume24H,
+    feesUSD,
+    tvlUSD,
+  } = usePoolAvgInfo({
     address: farm.lpAddress,
     chainId: farm.token.chainId,
   })
 
   const balanceA = existingPosition_?.amount0 ?? currencyBalances[Field.CURRENCY_A]
   const balanceB = existingPosition_?.amount1 ?? currencyBalances[Field.CURRENCY_B]
+
+  const globalLpApr = useMemo(() => (tvlUSD ? (100 * feesUSD * 365) / tvlUSD : 0), [feesUSD, tvlUSD])
 
   const depositUsdAsBN = useMemo(
     () =>
@@ -116,7 +123,7 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
         .times(cakePrice.toFixed(3))
         .div(
           new BigNumber(farm.lmPoolLiquidity).plus(
-            isPositionStaked ? BIG_ZERO : existingPosition_?.liquidity.toString() ?? BIG_ZERO,
+            isPositionStaked ? BIG_ZERO : existingPosition_?.liquidity?.toString() ?? BIG_ZERO,
           ),
         )
         .times(100),
@@ -154,8 +161,33 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
     volume24H,
   })
 
-  const positionDisplayApr = getDisplayApr(+positionCakeApr, +apr.toFixed(2))
-  const displayApr = getDisplayApr(+farm.cakeApr, +apr.toFixed(2))
+  const lpApr = existingPosition_ ? +apr.toFixed(2) : globalLpApr
+  const cakeApr = +farm.cakeApr
+  const positionDisplayApr = getDisplayApr(+positionCakeApr, lpApr)
+  const displayApr = getDisplayApr(cakeApr, lpApr)
+  const cakeAprDisplay = cakeApr.toFixed(2)
+  const lpAprDisplay = lpApr.toFixed(2)
+
+  const aprTooltip = useTooltip(
+    <>
+      <Text>
+        {t('Combined APR')}: <b>{displayApr}%</b>
+      </Text>
+      <ul>
+        <li>
+          {t('Farm APR')}: <b>{cakeAprDisplay}%</b>
+        </li>
+        <li>
+          {t('LP Fee APR')}: <b>{lpAprDisplay}%</b>
+        </li>
+      </ul>
+      <br />
+      <Text>
+        {t('Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.')}
+      </Text>
+      <Text>{t('APRs for individual positions may vary depending on the configs.')}</Text>
+    </>,
+  )
 
   if (farm.multiplier === '0X') {
     return <Text fontSize="14px">0%</Text>
@@ -183,16 +215,21 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
           </ApyLabelContainer>
         </AutoRow>
       ) : (
-        <FarmUI.FarmApyButton
-          variant="text-and-button"
-          handleClickButton={(e) => {
-            e.stopPropagation()
-            e.preventDefault()
-            roiModal.onOpen()
-          }}
-        >
-          {displayApr}%
-        </FarmUI.FarmApyButton>
+        <>
+          <TooltipText ref={aprTooltip.targetRef} decorationColor="secondary">
+            <FarmUI.FarmApyButton
+              variant="text-and-button"
+              handleClickButton={(e) => {
+                e.stopPropagation()
+                e.preventDefault()
+                roiModal.onOpen()
+              }}
+            >
+              {displayApr}%
+            </FarmUI.FarmApyButton>
+          </TooltipText>
+          {aprTooltip.tooltipVisible && aprTooltip.tooltip}
+        </>
       )}
       {cakePrice && cakeAprFactor && (
         <RoiCalculatorModalV2

--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -12,9 +12,6 @@ import {
   MobileColumnSchema,
   useMatchBreakpoints,
   V3DesktopColumnSchema,
-  Text,
-  useTooltip,
-  TooltipText,
 } from '@pancakeswap/uikit'
 import { createElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
@@ -117,7 +114,7 @@ const FarmMobileCell = styled.td`
 const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>> = (props) => {
   const { initialActivity, userDataReady, farm } = props
   const hasSetInitialValue = useRef(false)
-  const hasStakedAmount = farm.isStaking
+  const hasStakedAmount = farm.isStaking || false
   const [actionPanelExpanded, setActionPanelExpanded] = useState(hasStakedAmount)
   const shouldRenderChild = useDelayedUnmount(actionPanelExpanded, 300)
   const { t } = useTranslation()
@@ -125,18 +122,6 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
   const toggleActionPanel = useCallback(() => {
     setActionPanelExpanded(!actionPanelExpanded)
   }, [actionPanelExpanded])
-
-  const aprTooltip = useTooltip(
-    <>
-      <Text>
-        {t(
-          'Global APR calculated using the total amount of active & staked liquidity with the pool CAKE reward emissions.',
-        )}
-      </Text>
-      <br />
-      <Text>{t('APRs for individual positions may vary depend on their price range settings.')}</Text>
-    </>,
-  )
 
   useEffect(() => {
     setActionPanelExpanded(hasStakedAmount)
@@ -205,10 +190,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                     <td key={key}>
                       <CellInner onClick={(e) => e.stopPropagation()}>
                         <CellLayout label={t('APR')}>
-                          <TooltipText ref={aprTooltip.targetRef} decorationColor="secondary">
-                            <FarmV3ApyButton farm={props.details} />
-                          </TooltipText>
-                          {aprTooltip.tooltipVisible && aprTooltip.tooltip}
+                          <FarmV3ApyButton farm={props.details} />
                         </CellLayout>
                       </CellInner>
                     </td>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2482,5 +2482,8 @@
   "ETH to WBETH conversion and earn ETH staking rewards!": "ETH to WBETH conversion and earn ETH staking rewards!",
   "Get Started": "Get Started",
   "V3 Farms": "V3 Farms",
-  "V2 Farms": "V2 Farms"
+  "V2 Farms": "V2 Farms",
+  "Combined APR": "Combined APR",
+  "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.": "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.",
+  "APRs for individual positions may vary depending on the configs.": "APRs for individual positions may vary depending on the configs."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5dfba42</samp>

### Summary
📊🌐🛠️

<!--
1.  📊 - This emoji represents the use of GraphQL and SWR to fetch and display the pool data for the V3 farms. It also signifies the calculation and display of the APR based on the pool data.
2. 🌐 - This emoji represents the addition of new translation keys and values for the tooltip text that explains the APR for the V3 farms. It also signifies the need to update the translation strings for other languages.
3. 🛠️ - This emoji represents the refactoring and improvement of the existing code for the APR tooltip for the V2 farms and the creation of a custom tooltip component for the V3 farms. It also signifies the fixing of potential errors and the enhancement of the code readability and maintainability.
-->
This pull request adds a custom tooltip component and logic to display the APR breakdown and explanation for the V3 farms in the `pancake-frontend` app. It also refactors and simplifies some existing components and hooks that are related to the V3 farms and adds some new translation strings for the tooltip text.

> _We're fetching and calculating the pool data with `usePoolAvgInfo`_
> _We're showing the APR and the volume with hooks and tooltips so_
> _Heave away, me hearties, heave away_
> _We're refactoring and translating the code for a better UI display_

### Walkthrough
*  Add a new hook `usePoolAvgInfo` to fetch and calculate the average volume, fee, and TVL of a pool using GraphQL and SWR ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-d222d0730fba2a5012ec5239b85d99e20b1e7c56e3120e0ae4623df49b57b127R1-R76))
*  Simplify the existing hook `usePoolTradingVolume` to use `usePoolAvgInfo` and only return the volumeUSD property ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-40fd11da097eccd64f117994d7a89af428eeb7504c9a7abc3404fea26af5b9dbL1-R6))
*  Add default values and optional chaining operators to prevent NaN and undefined errors in the `ApyButton` component for the V2 farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-02d07d878611b08c65ffbda68d21d02a392e25c9c83640035a308ea064d802d6L43-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-02d07d878611b08c65ffbda68d21d02a392e25c9c83640035a308ea064d802d6L82-R82), [link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-02d07d878611b08c65ffbda68d21d02a392e25c9c83640035a308ea064d802d6L92-R92), [link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-02d07d878611b08c65ffbda68d21d02a392e25c9c83640035a308ea064d802d6L114-R132))
*  Modify the text and layout of the tooltip that shows the breakdown of the APR for the V2 farms in the `ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-02d07d878611b08c65ffbda68d21d02a392e25c9c83640035a308ea064d802d6L114-R132))
*  Import and use the `useTooltip` hook to create a custom tooltip component for the `FarmV3ApyButton` component for the V3 farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L11-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L186-R232))
*  Modify the import and usage of the `usePoolAvgInfo` hook to access the volumeUSD, feeUSD, and tvlUSD properties from the pool data in the `FarmV3ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L24-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L89-R94))
*  Add and memoize a new variable `globalLpApr` to calculate the annualized percentage rate of the LP fees for the pool based on the TVL in the `FarmV3ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0R102-R103))
*  Add an optional chaining operator to prevent errors when the user's existing position or its liquidity property is undefined or null in the `FarmV3ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L119-R126))
*  Modify the variables `positionDisplayApr` and `displayApr` to use the `lpApr` variable instead of the `apr` variable as the second argument of the `getDisplayApr` function in the `FarmV3ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L157-R191))
*  Add two new variables `cakeAprDisplay` and `lpAprDisplay` to format the CAKE APR and the LP APR for the tooltip text in the `FarmV3ApyButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L157-R191))
*  Remove unused imports of the `Text`, `useTooltip`, and `TooltipText` components from the `Row` component for the table view ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L15-L17))
*  Add a default value of false to the `hasStakedAmount` variable in the `Row` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L120-R117))
*  Remove the variable `aprTooltip` and its assignment in the `Row` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L129-L140))
*  Remove the `TooltipText` component and the `aprTooltip` hook from the JSX element that renders the `FarmV3ApyButton` component in the `Row` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L208-R193))
*  Add new translation keys and values for the tooltip text that shows the breakdown and explanation of the APR for the V3 farms in the `translations.json` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/6844/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2485-R2488))




