### PR TITLE
fix: line chart default color

### DIFF
--- a/apps/web/src/views/V3Info/components/BarChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/BarChart/index.tsx
@@ -40,7 +40,7 @@ export type LineChartProps = {
 
 const BarChart = ({
   data,
-  color = '#56B2A4',
+  color = '#1FC7D4',
   setValue,
   setLabel,
   topLeft,

--- a/apps/web/src/views/V3Info/components/CandleChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/CandleChart/index.tsx
@@ -44,7 +44,7 @@ export type LineChartProps = {
 
 const CandleChart = ({
   data,
-  color = '#56B2A4',
+  color = '#1FC7D4',
   setValue,
   setLabel,
   topLeft,

--- a/apps/web/src/views/V3Info/components/LineChart/alt.tsx
+++ b/apps/web/src/views/V3Info/components/LineChart/alt.tsx
@@ -42,7 +42,7 @@ export type LineChartProps = {
 
 const Chart = ({
   data,
-  color = '#56B2A4',
+  color = '#1FC7D4',
   value,
   label,
   setValue,

--- a/apps/web/src/views/V3Info/components/LineChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/LineChart/index.tsx
@@ -39,7 +39,7 @@ export type LineChartProps = {
 
 const LineChart = ({
   data,
-  color = '#56B2A4',
+  color = '#1FC7D4',
   setValue,
   setLabel,
   topLeft,

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -343,7 +343,6 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
                 ) : view === ChartView.TVL ? (
                   <LineChart
                     data={formattedTvlData}
-                    color={backgroundColor}
                     minHeight={340}
                     setValue={setLatestValue}
                     setLabel={setValueLabel}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ac0330c</samp>

### Summary
🎨🌈🔥

<!--
1.  🎨 This emoji represents the change of color for the chart components, as it is often used to indicate design or aesthetic changes.
2.  🌈 This emoji represents the removal of the color prop from the PoolCard component, as it is often used to indicate gradients or diversity.
3.  🔥 This emoji represents the overall improvement of the pool page design, as it is often used to indicate something awesome or exciting.
-->
Changed the color prop of various chart components from `#56B2A4` to `#1FC7D4` to match the new design of the pool page. Removed the color prop of the `PoolCard` component from the `PoolPage` component, as it was no longer needed.

> _`color` prop changed_
> _to match new pool design_
> _charts shine like water_

### Walkthrough
*  Changed the color of the charts on the pool page to match the new design ([link](https://github.com/pancakeswap/pancake-frontend/pull/6845/files?diff=unified&w=0#diff-134aab933b36d675998a308036b2a74561fea59b2d95cce7c5fc7cebdbf32554L43-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/6845/files?diff=unified&w=0#diff-119bfc75c5f58a9b7a52c5a946b90b48dd2fd0652affa48f8c2012cd17519180L47-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/6845/files?diff=unified&w=0#diff-b776535726e27e77344ae81eb7adae9338c38b162802a2e0e8d88574c9622242L45-R45), [link](https://github.com/pancakeswap/pancake-frontend/pull/6845/files?diff=unified&w=0#diff-0ab7db11a1a340d6d0167dc4bf8a63c0ad4ac8a576d8196405b1b6a4f0dce6f5L42-R42))
*  Removed the color prop from the `PoolCard` component on the `PoolPage` component, as it is no longer needed ([link](https://github.com/pancakeswap/pancake-frontend/pull/6845/files?diff=unified&w=0#diff-3064cf71a39aece557e7aebe4bfbbe0aa57e882e2b199bb8945b76792e519f59L346))


