### PR TITLE
fix: ens name as Recipient

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -76,7 +76,7 @@ export function useSingleTokenSwapInfo(
     return null
   }
 
-  let inputTokenPrice: number
+  let inputTokenPrice = 0
   try {
     inputTokenPrice = parseFloat(
       new Price({
@@ -115,7 +115,7 @@ export function useDerivedSwapInfo(
   const { chainId } = useActiveChainId()
   const { address: account } = useAccount()
   const { t } = useTranslation()
-  const recipientENSAddress = useEnsAddress({
+  const { data: recipientENSAddress } = useEnsAddress({
     name: recipient,
     chainId,
     enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
@@ -320,7 +320,14 @@ export const useFetchPairPricesV3 = ({
       chainId &&
       token1Address && ['derivedPrice', { token0Address, token1Address, chainId, protocol0, protocol1, timeWindow }],
     async () => {
-      const data = await fetchDerivedPriceData(token0Address, token1Address, timeWindow, protocol0, protocol1, chainId)
+      const data = await fetchDerivedPriceData(
+        token0Address,
+        token1Address,
+        timeWindow,
+        protocol0 ?? 'v3',
+        protocol1 ?? 'v3',
+        chainId,
+      )
       return normalizeDerivedPairDataByActiveToken({
         activeToken: token0Address,
         pairData: normalizeDerivedChartData(data),

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallArguments.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallArguments.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { BigNumber } from 'ethers'
-import { SwapRouter, SmartRouterTrade, SWAP_ROUTER_ADDRESSES } from '@pancakeswap/smart-router/evm'
-import { Percent, TradeType } from '@pancakeswap/sdk'
+import { ChainId, Percent, TradeType } from '@pancakeswap/sdk'
+import { SWAP_ROUTER_ADDRESSES, SmartRouterTrade, SwapRouter } from '@pancakeswap/smart-router/evm'
 import { FeeOptions } from '@pancakeswap/v3-sdk'
+import { BigNumber } from 'ethers'
 import { useMemo } from 'react'
+import { isAddress } from 'utils'
+import { useEnsAddress } from 'wagmi'
 
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useProviderOrSigner } from 'hooks/useProviderOrSigner'
@@ -32,7 +34,19 @@ export function useSwapCallArguments(
   const { account, chainId } = useActiveWeb3React()
   const provider = useProviderOrSigner()
 
-  const recipient = recipientAddress === null ? account : recipientAddress
+  const { data: recipientENSAddress } = useEnsAddress({
+    name: recipientAddress,
+    chainId,
+    enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
+  })
+  const recipient =
+    recipientAddress === null
+      ? account
+      : isAddress(recipientAddress)
+      ? recipientAddress
+      : isAddress(recipientENSAddress)
+      ? recipientENSAddress
+      : null
 
   return useMemo(() => {
     if (!trade || !recipient || !provider || !account || !chainId) return []

--- a/apps/web/src/views/Swap/components/AddressInputPanel.tsx
+++ b/apps/web/src/views/Swap/components/AddressInputPanel.tsx
@@ -81,7 +81,7 @@ export default function AddressInputPanel({
   const { chainId } = useActiveChainId()
 
   const { t } = useTranslation()
-  const recipientENSAddress = useEnsAddress({
+  const { data: recipientENSAddress } = useEnsAddress({
     name: value,
     chainId,
     enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9cda00b</samp>

### Summary
🎣📜🔄

<!--
1.  🎣 - This emoji represents the use of hooks, a common pattern in React for managing state and effects. The `useEnsAddress` hook is an example of a custom hook that encapsulates some logic and returns a value.
2. 📜 - This emoji represents the use of ENS, the Ethereum Name Service, which allows users to register human-readable names for their Ethereum addresses. The `useEnsAddress` hook takes an address as an input and returns the corresponding ENS name, if any. The emoji could also symbolize the concept of a name or a label.
3. 🔄 - This emoji represents the use of `useSWR`, a library that provides a way to fetch and cache data in React applications. The `useSWR` hook takes a key and a fetcher function as arguments and returns a data object and an error object. The hook also handles revalidation, deduplication, and suspense. The emoji could also symbolize the concept of updating or refreshing data.
-->
Refactor `useEnsAddress` hook to use `useSWR` and update `AddressInputPanel` component accordingly. This improves data fetching and caching for ENS addresses.

> _`useEnsAddress` changed_
> _Returns an object with data_
> _Refactor for spring_

### Walkthrough
*  Refactor the `useEnsAddress` hook to use `useSWR` for data fetching and caching ([link](https://github.com/pancakeswap/pancake-frontend/pull/6848/files?diff=unified&w=0#diff-0716a7a1702a8f7ec9209bf141a59d0c5c2791ab35698f19a4b430d0e04eb430L84-R84),          0,          0,        F0


