### PR TITLE
fix: Quick input stays same after amount change

### DIFF
--- a/apps/aptos/components/CurrencyInputPanel/index.tsx
+++ b/apps/aptos/components/CurrencyInputPanel/index.tsx
@@ -182,8 +182,8 @@ export const CurrencyInputPanel = ({
                   onPercentInput &&
                   [25, 50, 75].map((percent) => {
                     const isAtCurrentPercent =
-                      (maxAmount && value === percentAmount[percent]) || (lpPercent && lpPercent === percent.toString())
-
+                      (maxAmount && value !== '0' && value === percentAmount[percent]) ||
+                      (lpPercent && lpPercent === percent.toString())
                     return (
                       <Button
                         key={`btn_quickCurrency${percent}`}

--- a/apps/web/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, memo, useCallback } from 'react'
+import { useMemo, memo, useCallback } from 'react'
 import { Currency, Pair, Token, Percent, CurrencyAmount } from '@pancakeswap/sdk'
 import {
   Button,
@@ -24,7 +24,7 @@ import { StablePair } from 'views/AddLiquidity/AddStableLiquidity/hooks/useStabl
 
 import { FiatLogo } from 'components/Logo/CurrencyLogo'
 import { useAccount } from 'wagmi'
-import { useCurrencyBalance } from '../../state/wallet/hooks'
+import { useCurrencyBalance } from 'state/wallet/hooks'
 import CurrencySearchModal from '../SearchModal/CurrencySearchModal'
 import { CurrencyLogo, DoubleCurrencyLogo } from '../Logo'
 
@@ -160,7 +160,6 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
   const handleUserInput = useCallback(
     (val: string) => {
       onUserInput(val)
-      setCurrentClickedPercent('')
     },
     [onUserInput],
   )
@@ -170,8 +169,6 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
       onPresentCurrencyModal()
     }
   }, [onPresentCurrencyModal, disableCurrencySelect])
-
-  const [currentClickedPercent, setCurrentClickedPercent] = useState('')
 
   const isAtPercentMax = (maxAmount && value === maxAmount.toExact()) || (lpPercent && lpPercent === '100')
 
@@ -289,7 +286,6 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
                   showQuickInputButton &&
                   onPercentInput &&
                   [25, 50, 75].map((percent) => {
-                    const isAtClickedPercent = currentClickedPercent === percent.toString()
                     const isAtCurrentPercent =
                       (maxAmount && value !== '0' && value === percentAmount[percent]) ||
                       (lpPercent && lpPercent === percent.toString())
@@ -299,11 +295,10 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
                         key={`btn_quickCurrency${percent}`}
                         onClick={() => {
                           onPercentInput(percent)
-                          setCurrentClickedPercent(percent.toString())
                         }}
                         scale="xs"
                         mr="5px"
-                        variant={isAtClickedPercent || isAtCurrentPercent ? 'primary' : 'secondary'}
+                        variant={isAtCurrentPercent ? 'primary' : 'secondary'}
                         style={{ textTransform: 'uppercase' }}
                       >
                         {percent}%
@@ -316,7 +311,6 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
                       e.stopPropagation()
                       e.preventDefault()
                       onMax?.()
-                      setCurrentClickedPercent('MAX')
                     }}
                     scale="xs"
                     variant={isAtPercentMax ? 'primary' : 'secondary'}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc942b1</samp>

### Summary
🐛🔥♻️

<!--
1.  🐛 - This emoji represents a bug fix, and is commonly used to indicate that a change fixes an issue or error in the code.
2.  🔥 - This emoji represents removing code or files, and is commonly used to indicate that a change deletes or cleans up unused or unnecessary code.
3.  ♻️ - This emoji represents refactoring or improving code, and is commonly used to indicate that a change enhances the code quality, structure, or performance.
-->
This pull request improves the `CurrencyInputPanel` component in two ways: it removes unused and redundant code in `apps/web/src/components/CurrencyInputPanel/index.tsx`, and it fixes a percentage button bug in `apps/aptos/components/CurrencyInputPanel/index.tsx`.

> _Oh, we're the coders of the sea, and we fix the bugs with glee_
> _We heave and ho, and make it so, the input and percent agree_
> _We don't need no `currentClickedPercent`, it's just a waste of space_
> _We simplify the logic and we make the code a better place_

### Walkthrough
*  Fix input value and percentage button mismatch when input value is zero ([link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-d68130d4a406d32394548987c21ffa580a7a85b1c6d6b6d30376461d4937aabcL185-R186))
*  Remove unused `currentClickedPercent` state and related logic from `CurrencyInputPanel` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L155), [link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L166-L167), [link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L280), [link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L290-R289), [link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L307))
*  Simplify `onClick` and `variant` props of percentage buttons by using `isAtCurrentPercent` condition ([link](https://github.com/pancakeswap/pancake-frontend/pull/6852/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L290-R289))


