### PR TITLE
fix: Cannot open roi calculator via apy button on mobile

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -216,18 +216,18 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
         </AutoRow>
       ) : (
         <>
-          <TooltipText ref={aprTooltip.targetRef} decorationColor="secondary">
-            <FarmUI.FarmApyButton
-              variant="text-and-button"
-              handleClickButton={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-                roiModal.onOpen()
-              }}
-            >
+          <FarmUI.FarmApyButton
+            variant="text-and-button"
+            handleClickButton={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              roiModal.onOpen()
+            }}
+          >
+            <TooltipText ref={aprTooltip.targetRef} decorationColor="secondary">
               {displayApr}%
-            </FarmUI.FarmApyButton>
-          </TooltipText>
+            </TooltipText>
+          </FarmUI.FarmApyButton>
           {aprTooltip.tooltipVisible && aprTooltip.tooltip}
         </>
       )}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

copilot:all
