### PR TITLE
chore(TabMenu): Padding bottom adjustment

### DIFF
--- a/packages/ui-wallets/src/WalletModal.tsx
+++ b/packages/ui-wallets/src/WalletModal.tsx
@@ -80,7 +80,7 @@ const TabContainer = ({ children, docLink, docText }: PropsWithChildren<{ docLin
   return (
     <AtomBox position="relative" zIndex="modal" className={modalWrapperClass}>
       <AtomBox position="absolute" style={{ top: '-50px' }}>
-        <TabMenu activeIndex={index} onItemClick={setIndex} gap="0px" isColorInverse>
+        <TabMenu activeIndex={index} onItemClick={setIndex} gap="0px" isColorInverse isShowBorderBottom={false}>
           <Tab>{t('Connect Wallet')}</Tab>
           <Tab>{t('What’s a Web3 Wallet?')}</Tab>
         </TabMenu>

--- a/packages/uikit/src/components/TabMenu/TabMenu.tsx
+++ b/packages/uikit/src/components/TabMenu/TabMenu.tsx
@@ -3,10 +3,11 @@ import styled from "styled-components";
 import Flex from "../Box/Flex";
 import { TabMenuProps } from "./types";
 
-const Wrapper = styled(Flex)<{ fullWidth?: boolean }>`
-  border-bottom: 2px solid ${({ theme }) => theme.colors.input};
+const Wrapper = styled(Flex)<{ fullWidth?: boolean; isShowBorderBottom?: boolean }>`
+  border-bottom: ${({ isShowBorderBottom, theme }) =>
+    isShowBorderBottom ? `2px solid ${theme.colors.input}` : "none"};
   overflow-x: scroll;
-  padding: ${({ fullWidth }) => (fullWidth ? 0 : "16px")};
+  padding: ${({ fullWidth }) => (fullWidth ? 0 : "16px 16px 0 16px")};
 
   ::-webkit-scrollbar {
     display: none;
@@ -40,9 +41,10 @@ const TabMenu: React.FC<React.PropsWithChildren<TabMenuProps>> = ({
   fullWidth,
   gap,
   isColorInverse = false,
+  isShowBorderBottom = true,
 }) => {
   return (
-    <Wrapper p={["0 4px", "0 16px"]} fullWidth={fullWidth}>
+    <Wrapper p={["0 4px", "0 16px"]} fullWidth={fullWidth} isShowBorderBottom={isShowBorderBottom}>
       <Inner fullWidth={fullWidth} gap={gap}>
         {Children.map(children, (child: ReactElement, index) => {
           const isActive = activeIndex === index;

--- a/packages/uikit/src/components/TabMenu/types.ts
+++ b/packages/uikit/src/components/TabMenu/types.ts
@@ -7,6 +7,7 @@ export interface TabMenuProps {
   fullWidth?: boolean;
   gap?: string;
   isColorInverse?: boolean;
+  isShowBorderBottom?: boolean;
 }
 export interface TabProps extends ColorProps {
   isActive?: boolean;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a440aae</samp>

### Summary
🎨📝🛠️

<!--
1.  🎨 - This emoji represents a change that improves the style or appearance of the UI, such as removing the bottom border from the `TabMenu` component in the `WalletModal` component.
2.  📝 - This emoji represents a change that updates or adds documentation, such as the `TabMenuProps` interface and the new prop description.
3.  🛠️ - This emoji represents a change that fixes or improves the functionality of the code, such as adding the new prop `isShowBorderBottom` to the `TabMenu` component and applying the conditional border style.
-->
Added a new prop `isShowBorderBottom` to the `TabMenu` component to enable or disable the bottom border style. Modified the `WalletModal` component to use this prop and remove the bottom border from the `TabMenu` component.

> _No border for the wallet of doom_
> _`isShowBorderBottom` is the key_
> _We control the style of the `TabMenu`_
> _We are the masters of the UI_

### Walkthrough
*  Remove bottom border from `TabMenu` component in `WalletModal` component by passing a new prop `isShowBorderBottom` with a value of `false` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6855/files?diff=unified&w=0#diff-d4a85d21c19e0a0a9892411a3e5cb5c53a4a3fdb72b5afd8bd11cd0c00536903L83-R83))
*  Add new prop `isShowBorderBottom` to `TabMenu` component and use it to conditionally apply the `border-bottom` style to the `Wrapper` styled component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6855/files?diff=unified&w=0#diff-de0633966d0aebf4a06e70ecde7b8f4b86e37b6560c2373c9fc99534e24ea840L6-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/6855/files?diff=unified&w=0#diff-de0633966d0aebf4a06e70ecde7b8f4b86e37b6560c2373c9fc99534e24ea840L43-R47))
*  Update the type definition of `TabMenu` component props to include the new prop `isShowBorderBottom` as an optional boolean ([link](https://github.com/pancakeswap/pancake-frontend/pull/6855/files?diff=unified&w=0#diff-413d58540c882709e421b2aaed585f7c4a22ea68072f968f4be66fba616c9a41R10))



Before:
![image](https://user-images.githubusercontent.com/109973128/236837000-244d6a40-c272-4913-a891-6ae0dcf1ebdf.png)

After:
![image](https://user-images.githubusercontent.com/109973128/236837091-650fcbd4-a95f-475c-b13f-6ef93b40ce48.png)
![image](https://user-images.githubusercontent.com/109973128/236837129-34ed3d63-a3c4-4412-96db-c90617483688.png)
