### PR TITLE
fix(farms): crash on wrong network

### DIFF
--- a/apps/web/src/hooks/v3/useV3Positions.ts
+++ b/apps/web/src/hooks/v3/useV3Positions.ts
@@ -22,16 +22,16 @@ export function useV3PositionsFromTokenIds(tokenIds: BigNumber[] | undefined): U
 
   const inputs = useMemo(
     () =>
-      tokenIds
+      tokenIds && positionManager
         ? tokenIds.map((tokenId) => ({
-            abi: positionManager.interface.format(FormatTypes.json) as any,
-            address: positionManager.address as `0x${string}`,
+            abi: positionManager?.interface?.format(FormatTypes.json) as any,
+            address: positionManager?.address as `0x${string}`,
             functionName: 'positions',
             args: [tokenId],
             chainId,
           }))
         : [],
-    [chainId, positionManager.address, positionManager.interface, tokenIds],
+    [chainId, positionManager, tokenIds],
   )
   const { isLoading, data: positions = [] } = useContractReads<any, any, any>({
     contracts: inputs,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ea0d3fa</samp>

### Summary
🐛🚀🧹

<!--
1.  🐛 for fixing the error handling of the `positionManager` contract instance
2.  🚀 for improving the performance of the `useV3Positions` hook by simplifying the `useMemo` dependency array
3.  🧹 for cleaning up the code and removing unnecessary comments
-->
Improved `useV3Positions` hook for Uniswap V3 integration. Added error handling and performance optimization to the hook and the `positionManager` contract.

> _`useV3Positions` hook_
> _Better error handling now_
> _Performance improved_

### Walkthrough
*  Add optional chaining to `positionManager` contract instance to prevent errors on unsupported chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/6871/files?diff=unified&w=0#diff-b5e93c41677a51d7040aca1e7bce6d826105c3619c3c6a2985d494235a440801L25-R28))
*  Simplify dependency array of `useMemo` hook by passing whole `positionManager` object instead of individual properties ([link](https://github.com/pancakeswap/pancake-frontend/pull/6871/files?diff=unified&w=0#diff-b5e93c41677a51d7040aca1e7bce6d826105c3619c3c6a2985d494235a440801L34-R34))


