### PR TITLE
chore: ensName as recipient improvement

### DIFF
--- a/apps/web/src/hooks/useGetENSAddressByName.ts
+++ b/apps/web/src/hooks/useGetENSAddressByName.ts
@@ -1,0 +1,20 @@
+import { ChainId } from '@pancakeswap/sdk'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useEnsAddress } from 'wagmi'
+
+const ENS_NAME_REGEX = /^[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)?$/
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/
+
+export const useGetENSAddressByName = (ensNameOrAddress: string) => {
+  const { chainId } = useActiveChainId()
+  const { data: recipientENSAddress } = useEnsAddress({
+    name: ensNameOrAddress,
+    chainId,
+    enabled:
+      (ENS_NAME_REGEX.test(ensNameOrAddress) || ADDRESS_REGEX.test(ensNameOrAddress)) &&
+      chainId !== ChainId.BSC &&
+      chainId !== ChainId.BSC_TESTNET,
+  })
+  return recipientENSAddress
+}

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -1,28 +1,29 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId, Currency, CurrencyAmount, Price, Trade, TradeType } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, Price, Trade, TradeType } from '@pancakeswap/sdk'
 import { CAKE, USDC } from '@pancakeswap/tokens'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 import { useUserSlippage } from '@pancakeswap/utils/user'
+import { SLOW_INTERVAL } from 'config/constants'
 import { DEFAULT_INPUT_CURRENCY, DEFAULT_OUTPUT_CURRENCY } from 'config/constants/exchange'
 import { useTradeExactIn, useTradeExactOut } from 'hooks/Trades'
 import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useBestAMMTrade } from 'hooks/useBestAMMTrade'
+import { useGetENSAddressByName } from 'hooks/useGetENSAddressByName'
 import useNativeCurrency from 'hooks/useNativeCurrency'
+import { useAtom, useAtomValue } from 'jotai'
 import { useRouter } from 'next/router'
 import { ParsedUrlQuery } from 'querystring'
 import { useEffect, useMemo, useState } from 'react'
+import useSWRImmutable from 'swr/immutable'
 import { isAddress } from 'utils'
 import { computeSlippageAdjustedAmounts } from 'utils/exchange'
 import { getTokenAddress } from 'views/Swap/components/Chart/utils'
-import { useAccount, useEnsAddress } from 'wagmi'
-import { useBestAMMTrade } from 'hooks/useBestAMMTrade'
-import useSWRImmutable from 'swr/immutable'
-import { SLOW_INTERVAL } from 'config/constants'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAccount } from 'wagmi'
 import { useCurrencyBalances } from '../wallet/hooks'
 import { Field, replaceSwapState } from './actions'
 import fetchDerivedPriceData, { getTokenBestTvlProtocol } from './fetch/fetchDerivedPriceData'
 import { normalizeDerivedChartData, normalizeDerivedPairDataByActiveToken } from './normalizers'
-import { swapReducerAtom, SwapState } from './reducer'
+import { SwapState, swapReducerAtom } from './reducer'
 import { PairDataTimeWindowEnum } from './types'
 
 export function useSwapState() {
@@ -112,14 +113,9 @@ export function useDerivedSwapInfo(
   v2Trade: Trade<Currency, Currency, TradeType> | undefined
   inputError?: string
 } {
-  const { chainId } = useActiveChainId()
   const { address: account } = useAccount()
   const { t } = useTranslation()
-  const { data: recipientENSAddress } = useEnsAddress({
-    name: recipient,
-    chainId,
-    enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
-  })
+  const recipientENSAddress = useGetENSAddressByName(recipient)
 
   const to: string | null =
     (recipient === null ? account : isAddress(recipient) || isAddress(recipientENSAddress) || null) ?? null

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallArguments.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallArguments.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { ChainId, Percent, TradeType } from '@pancakeswap/sdk'
+import { Percent, TradeType } from '@pancakeswap/sdk'
 import { SWAP_ROUTER_ADDRESSES, SmartRouterTrade, SwapRouter } from '@pancakeswap/smart-router/evm'
 import { FeeOptions } from '@pancakeswap/v3-sdk'
 import { BigNumber } from 'ethers'
 import { useMemo } from 'react'
 import { isAddress } from 'utils'
-import { useEnsAddress } from 'wagmi'
+
+import { useGetENSAddressByName } from 'hooks/useGetENSAddressByName'
 
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useProviderOrSigner } from 'hooks/useProviderOrSigner'
@@ -33,12 +34,7 @@ export function useSwapCallArguments(
 ): SwapCall[] {
   const { account, chainId } = useActiveWeb3React()
   const provider = useProviderOrSigner()
-
-  const { data: recipientENSAddress } = useEnsAddress({
-    name: recipientAddress,
-    chainId,
-    enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
-  })
+  const recipientENSAddress = useGetENSAddressByName(recipientAddress)
   const recipient =
     recipientAddress === null
       ? account

--- a/apps/web/src/views/Swap/components/AddressInputPanel.tsx
+++ b/apps/web/src/views/Swap/components/AddressInputPanel.tsx
@@ -1,11 +1,12 @@
+import { useDebounce } from '@pancakeswap/hooks'
+import { useTranslation } from '@pancakeswap/localization'
+import { ChainId } from '@pancakeswap/sdk'
+import { AutoColumn, BscScanIcon, Link, Text } from '@pancakeswap/uikit'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useGetENSAddressByName } from 'hooks/useGetENSAddressByName'
 import { useCallback } from 'react'
 import styled from 'styled-components'
-import { ChainId } from '@pancakeswap/sdk'
-import { Text, Link, BscScanIcon, AutoColumn } from '@pancakeswap/uikit'
 import { isAddress } from 'utils'
-import { useEnsAddress } from 'wagmi'
-import { useTranslation } from '@pancakeswap/localization'
-import { useActiveChainId } from 'hooks/useActiveChainId'
 import { RowBetween } from '../../../components/Layout/Row'
 import { getBlockExploreLink, getBlockExploreName } from '../../../utils'
 
@@ -81,11 +82,8 @@ export default function AddressInputPanel({
   const { chainId } = useActiveChainId()
 
   const { t } = useTranslation()
-  const { data: recipientENSAddress } = useEnsAddress({
-    name: value,
-    chainId,
-    enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
-  })
+  const debounceEnsName = useDebounce(value, 500)
+  const recipientENSAddress = useGetENSAddressByName(debounceEnsName)
 
   const address = isAddress(value) ? value : isAddress(recipientENSAddress) || undefined
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e72430a</samp>

### Summary
🪝🔍📝

<!--
1.  🪝 - This emoji represents the new custom hook `useGetENSAddressByName` that is added in this pull request. It is a fishing hook that symbolizes the idea of fetching or retrieving data from a source, in this case, the ENS resolver. It also suggests the reusability and modularity of the hook.
2.  🔍 - This emoji represents the update to the swap state logic to use the new hook for resolving ENS names or addresses. It is a magnifying glass that symbolizes the idea of searching or finding something, in this case, the ENS address that corresponds to the user input. It also suggests the improvement in code readability and clarity.
3.  📝 - This emoji represents the update to the `AddressInputPanel` and the `useSwapCallArguments` hook to use the new hook for resolving ENS names from user input. It is a memo or a note that symbolizes the idea of writing or inputting something, in this case, the ENS name or address that the user wants to swap with. It also suggests the improvement in code readability and handling of different input formats.
-->
This pull request adds a new custom hook `useGetENSAddressByName` that resolves ENS names or addresses and uses it in the swap state and components. This improves the code readability and the user experience of entering ENS names in the swap interface.

> _Sing, O Muse, of the clever developers who devised_
> _A new custom hook, `useGetENSAddressByName`, to resolve_
> _The names and addresses of the ENS, the decentralized_
> _Domain system that links the mortal and the divine._

### Walkthrough
*  Add a new custom hook `useGetENSAddressByName` that resolves ENS names or addresses to ENS addresses ([link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-d1a2e571d5640505cbddad0deccf898d7c9befa2e68a67a17c0e6da49bba866fR1-R20))
*  Use the new hook `useGetENSAddressByName` instead of the `useEnsAddress` hook from the `wagmi` library in the `useDerivedSwapInfo` hook, the `AddressInputPanel` component, and the `useSwapCallArguments` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L115-R118), [link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-0716a7a1702a8f7ec9209bf141a59d0c5c2791ab35698f19a4b430d0e04eb430L84-R86), [link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-77157a86e87d5ceb7fb217f4d7adcedb558954f2133bd0e502299641aba9b7c5L36-R37))
*  Add a `useDebounce` hook to delay the ENS resolution in the `AddressInputPanel` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-0716a7a1702a8f7ec9209bf141a59d0c5c2791ab35698f19a4b430d0e04eb430L84-R86))
*  Remove unused imports of `ChainId` from the `@pancakeswap/sdk` package in the `apps/web/src/state/swap/hooks.ts` and `apps/web/src/views/Swap/V3Swap/hooks/useSwapCallArguments.ts` files ([link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L2-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/6876/files?diff=unified&w=0#diff-77157a86e87d5ceb7fb217f4d7adcedb558954f2133bd0e502299641aba9b7c5L2-R2))


