### PR TITLE
chore: list blur&ens farm

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 28,
+    lpAddress: '0x392d0F0B7Fe5161Db89f2DB87d33a20682C12A2B',
+    token0: ethereumTokens.weth,
+    token1: ethereumTokens.ens,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 27,
     lpAddress: Pool.getAddress(ethereumTokens.pepe, ethereumTokens.weth, FeeAmount.HIGH),
     token0: ethereumTokens.pepe,

--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -48,11 +48,18 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
-    pid: 28,
+    pid: 29,
     lpAddress: '0x392d0F0B7Fe5161Db89f2DB87d33a20682C12A2B',
     token0: ethereumTokens.weth,
     token1: ethereumTokens.ens,
     feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 28,
+    lpAddress: '0xC7F25e2FcC474816efFd9be316F2E51cCef90Ceb',
+    token0: ethereumTokens.blur,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.HIGH,
   },
   {
     pid: 27,

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -208,4 +208,12 @@ export const ethereumTokens = {
     'Pepe',
     'https://www.pepe.vip/',
   ),
+  ens: new ERC20Token(
+    ChainId.ETHEREUM,
+    '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72',
+    18,
+    'ENS',
+    'Ethereum Name Service',
+    'https://ens.domains/',
+  ),
 }

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -208,6 +208,14 @@ export const ethereumTokens = {
     'Pepe',
     'https://www.pepe.vip/',
   ),
+  blur: new ERC20Token(
+    ChainId.ETHEREUM,
+    '0x5283D291DBCF85356A21bA090E6db59121208b44',
+    18,
+    'BLUR',
+    'Blur',
+    'https://blur.io/',
+  ),
   ens: new ERC20Token(
     ChainId.ETHEREUM,
     '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1bd2164</samp>

### Summary
🌊🏷️🍰

<!--
1.  🌊 - This emoji represents the liquidity pool of WETH and ENS tokens on Uniswap V3, as well as the concept of providing liquidity in general. The emoji can also suggest the volatility and depth of the pool, as well as the potential rewards for staking LP tokens.
2.  🏷️ - This emoji represents the ENS token, which is used for registering and managing domain names on the Ethereum Name Service. The emoji can also suggest the utility and value of the token, as well as the identity and reputation of the holders.
3.  🍰 - This emoji represents the CAKE token, which is the native token of PancakeSwap and the reward for staking LP tokens in the farms. The emoji can also suggest the sweetness and appeal of the token, as well as the fun and playful nature of the platform.
-->
This pull request adds new farms and tokens for Uniswap V3 pools. It introduces a new farm for the `WETH-ENS` pool with medium fees and a new token definition for the `ENS` token.

> _New farms for `CAKE`_
> _Stake `WETH` and `ENS` pairs_
> _Autumn harvest time_

### Walkthrough
*  Add new farms for Uniswap V3 pools of WETH and various tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/6877/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R51-R57),                                      F


