### PR TITLE
fix: Migrate text incorrectly displayed

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/Migrate.tsx
+++ b/apps/web/src/views/AddLiquidityV3/Migrate.tsx
@@ -28,7 +28,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { splitSignature } from 'ethers/lib/utils'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Trans, useTranslation } from '@pancakeswap/localization'
-import { CurrencyAmount, ERC20Token, Fraction, Pair, Price, WNATIVE, ZERO } from '@pancakeswap/sdk'
+import { CurrencyAmount, ERC20Token, Fraction, NATIVE, Pair, Price, WNATIVE, ZERO } from '@pancakeswap/sdk'
 import { AtomBox } from '@pancakeswap/ui'
 import { useUserSlippagePercent } from '@pancakeswap/utils/user'
 import { FeeAmount, Pool, Position, priceToClosestTick, TickMath } from '@pancakeswap/v3-sdk'
@@ -132,7 +132,7 @@ function V2PairMigrate({
   const [feeAmount, setFeeAmount] = useState(FeeAmount.MEDIUM)
 
   const handleFeePoolSelect = useCallback<HandleFeePoolSelectFn>(({ feeAmount: newFeeAmount }) => {
-    setFeeAmount(newFeeAmount)
+    if (newFeeAmount) setFeeAmount(newFeeAmount)
   }, [])
 
   const { position: existingPosition } = useDerivedPositionInfo(undefined)
@@ -498,10 +498,10 @@ function V2PairMigrate({
                 {position && chainId && refund0 && refund1 ? (
                   <Text color="textSubtle">
                     At least {formatCurrencyAmount(refund0, 4, locale)}{' '}
-                    {chainId && WNATIVE[chainId]?.equals(token0) ? 'ETH' : token0.symbol} and{' '}
+                    {chainId && WNATIVE[chainId]?.equals(token0) ? NATIVE?.[chainId].symbol : token0.symbol} and{' '}
                     {formatCurrencyAmount(refund1, 4, locale)}{' '}
-                    {chainId && WNATIVE[chainId]?.equals(token1) ? 'ETH' : token1.symbol} will be refunded to your
-                    wallet due to selected price range.
+                    {chainId && WNATIVE[chainId]?.equals(token1) ? NATIVE?.[chainId].symbol : token1.symbol} will be
+                    refunded to your wallet due to selected price range.
                   </Text>
                 ) : null}
               </AutoColumn>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dc739a8</samp>

### Summary
🐛🖌️🔄

<!--
1.  🐛 - for fixing a bug
2.  🖌️ - for improving the UI
3.  🔄 - for adding the migration feature
-->
Fix bug and enhance UI for `Migrate.tsx` in Add Liquidity V3 view. Use `NATIVE` constant to show native currency symbol.

> _The Add Liquidity V3 view_
> _Had a bug that needed to be slew_
> _So they fixed it with skill_
> _And improved the UI_
> _Using `NATIVE` to show the right cue_

### Walkthrough
*  Add `NATIVE` constant to display correct native currency symbol for each chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/6879/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L31-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/6879/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L501-R504))
*  Fix bug that sets `feeAmount` to `undefined` when selecting "Auto" fee tier option ([link](https://github.com/pancakeswap/pancake-frontend/pull/6879/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L135-R135))


