### PR TITLE
chore: set volume as default sorting

### DIFF
--- a/apps/web/src/views/V3Info/components/TokenTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TokenTable/index.tsx
@@ -134,7 +134,7 @@ export default function TokenTable({
   const { theme } = useTheme()
 
   // for sorting
-  const [sortField, setSortField] = useState(SORT_FIELD.tvlUSD)
+  const [sortField, setSortField] = useState(SORT_FIELD.volumeUSD)
   const [sortDirection, setSortDirection] = useState<boolean>(true)
 
   // pagination


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 705c9c9</samp>

### Summary
🔀📈🪙

<!--
1.  🔀 - This emoji represents the change of the sort field from tvlUSD to volumeUSD, as it implies switching or swapping the order of something.
2.  📈 - This emoji represents the volume metric, as it implies growth or movement in a numerical value over time.
3.  🪙 - This emoji represents the token table, as it implies a collection of coins or tokens. Alternatively, one could use 🏦 to represent the token table, as it implies a place where tokens are stored or exchanged.
-->
Changed the default sort field for the token table component to volume. This improves the user experience and matches the design mockup.

> _`sort` field updated_
> _`volumeUSD` more relevant_
> _autumn of tokens_

### Walkthrough
* Change the default sort field for the token table from total value locked to volume ([link](https://github.com/pancakeswap/pancake-frontend/pull/6883/files?diff=unified&w=0#diff-9f3e1db896201b7ecebd9b554c438c5dced210b06a2fcd74098ea31c855b010aL137-R137))


