### PR TITLE
feat: Add apr breakdown on each position

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -170,6 +170,7 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
   const positionDisplayApr = getDisplayApr(+positionCakeApr, lpApr)
   const displayApr = getDisplayApr(cakeApr, lpApr)
   const cakeAprDisplay = cakeApr.toFixed(2)
+  const positionCakeAprDisplay = positionCakeApr.toFixed(2)
   const lpAprDisplay = lpApr.toFixed(2)
 
   const aprTooltip = useTooltip(
@@ -192,6 +193,21 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
       <Text>{t('APRs for individual positions may vary depending on the configs.')}</Text>
     </>,
   )
+  const existingPositionAprTooltip = useTooltip(
+    <>
+      <Text>
+        {t('Combined APR')}: <b>{positionDisplayApr}%</b>
+      </Text>
+      <ul>
+        <li>
+          {t('Farm APR')}: <b>{positionCakeAprDisplay}%</b>
+        </li>
+        <li>
+          {t('LP Fee APR')}: <b>{lpAprDisplay}%</b>
+        </li>
+      </ul>
+    </>,
+  )
 
   if (farm.multiplier === '0X') {
     return <Text fontSize="14px">0%</Text>
@@ -211,7 +227,12 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
                 {positionCakeApr.toLocaleString('en-US', { maximumFractionDigits: 2 })}%
               </TooltipText>
             ) : (
-              <Text fontSize="14px">{positionDisplayApr}%</Text>
+              <>
+                <TooltipText ref={existingPositionAprTooltip.targetRef} decorationColor="secondary">
+                  <Text fontSize="14px">{positionDisplayApr}%</Text>
+                </TooltipText>
+                {existingPositionAprTooltip.tooltipVisible && existingPositionAprTooltip.tooltip}
+              </>
             )}
             <IconButton variant="text" style={{ height: 18, width: 18 }} scale="sm">
               <CalculateIcon width="18px" color="textSubtle" />

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -160,8 +160,8 @@ function FarmV3ApyButton_({ farm, existingPosition: existingPosition_, isPositio
     amountA: existingPosition?.amount0,
     amountB: existingPosition?.amount1,
     compoundOn: false,
-    currencyAUsdPrice,
-    currencyBUsdPrice,
+    currencyAUsdPrice: isSorted ? currencyAUsdPrice : currencyBUsdPrice,
+    currencyBUsdPrice: isSorted ? currencyBUsdPrice : currencyAUsdPrice,
     volume24H,
   })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9914eb9</samp>

### Summary
🧑‍🌾📈💡

<!--
1.  🧑‍🌾 - This emoji represents the farming or yield-generating aspect of the feature, as well as the user's position on the farm card.
2.  📈 - This emoji represents the APR or the annual percentage rate of return that the user can expect from their position, as well as the increase or improvement that the tooltip provides.
3.  💡 - This emoji represents the tooltip or the informative pop-up that shows the user more details about their position APR, as well as the idea or insight that the feature offers.
-->
Add a tooltip feature to show the user's existing position APR on the farm card. Update `FarmV3ApyButton.tsx` to use new variables and components for the tooltip.

> _To show the user's position APR_
> _This change adds a tooltip to the farm card_
> _It uses `positionCakeAprDisplay`_
> _And `existingPositionAprTooltip` to convey_
> _The farm APR with a color and a guard_

### Walkthrough
*  Add a tooltip to show the user's existing position APR in the farm card ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0R173), [link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0R196-R210), [link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L214-R235))
  - Declare a variable `positionCakeAprDisplay` to format the farm APR for the user's position ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0R173))
  - Declare a variable `existingPositionAprTooltip` to hold the tooltip component with the `useTooltip` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0R196-R210))
  - Render the tooltip component inside a `TooltipText` component with a `decorationColor` of `secondary` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L214-R235))
  - Conditionally show the tooltip based on the `tooltipVisible` property of `existingPositionAprTooltip` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L214-R235))
  - Trigger the tooltip by passing the `targetRef` property of `TooltipText` to the `ref` of the `Text` component that shows the user's position APR ([link](https://github.com/pancakeswap/pancake-frontend/pull/6885/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L214-R235))


