### PR TITLE
chore: Move to finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -13,15 +13,6 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
-    sousId: 344,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.peel,
-    contractAddress: '0xeBc4E95DF515a34c173530b231EDa53E6a786944',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.9186',
-    version: 3,
-  },
-  {
     sousId: 343,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.edu,
@@ -182,6 +173,51 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 344,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.peel,
+    contractAddress: '0xeBc4E95DF515a34c173530b231EDa53E6a786944',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.9186',
+    version: 3,
+  },
+  {
+    sousId: 322,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.pstake,
+    contractAddress: '0x98AC153577d65f2eEF2256f3AeF8ba9D7E4B756B',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.1186',
+    version: 3,
+  },
+  {
+    sousId: 340,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.champ,
+    contractAddress: '0x731Aa0b17143A3095430bf322D6aB132cA32b99F',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.432',
+    version: 3,
+  },
+  {
+    sousId: 336,
+    stakingToken: bscTokens.xcad,
+    earningToken: bscTokens.cake,
+    contractAddress: '0x548e422031E9063c21c84C7478EBa0f7ae9641B7',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.009548',
+    version: 3,
+  },
+  {
+    sousId: 338,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.sfund,
+    contractAddress: '0x4809d86700E1f6be32992172Bd57fD3d954993e7',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.06145',
+    version: 3,
+  },
   {
     sousId: 337,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 30476b2</samp>

### Summary
🔄🚫📉

<!--
1.  🔄 - This emoji signifies that some pools have been moved or swapped from one array to another, indicating a change in their status or availability.
2.  🚫 - This emoji signifies that one pool has been removed entirely from the constants file, indicating that it is no longer supported or active on the platform.
3.  📉 - This emoji signifies that the `tokenPerBlock` values have been reduced for some pools, indicating a lower reward rate or emission for those pools.
-->
Move six pools from active to finished and update rewards in `packages/pools/src/constants/pools/56.ts`. This change reflects the end of some farming campaigns and the start of new ones on PancakeSwap.

> _`pools` constants change_
> _one pool gone, five pools finished_
> _autumn of Pancake_

### Walkthrough
* Remove pool with sousId 344 from activePools array in `packages/pools/src/constants/pools/56.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6886/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL16-L24))
* Add five pools with sousIds 322, 340, 336, 338, and 342 to finishedPools array in `packages/pools/src/constants/pools/56.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6886/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR177-R221))
* Update tokenPerBlock values for the added pools in `packages/pools/src/constants/pools/56.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6886/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR177-R221))


