### PR TITLE
fix: Remove cache on block on update reminder

### DIFF
--- a/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
+++ b/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
@@ -84,7 +84,7 @@ export function UpdatePositionsReminder_() {
         })),
       [chainId, masterchefV3.address, masterchefV3.interface, stakedTokenIds],
     ),
-    cacheOnBlock: true,
+    cacheTime: 0,
     enabled: !loading && stakedTokenIds.length > 0,
   })
 
@@ -119,7 +119,7 @@ export function UpdatePositionsReminder_() {
         chainId,
       }
     }),
-    cacheOnBlock: true,
+    cacheTime: 0,
     enabled: isOverRewardGrowthGlobalUserInfos?.length > 0,
   })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b3a8a0</samp>

### Summary
🚫🎣🔄

<!--
1.  🚫 - This emoji can be used to indicate that caching was disabled or turned off, as it is a common symbol for prohibition or denial.
2.  🎣 - This emoji can be used to represent hooks, which are a common metaphor for functions that fetch or retrieve data, as well as farms, which are the source of the data in this case. Alternatively, one could use 🪝, which is a more literal hook emoji, but it may not be as widely supported or recognized.
3.  🔄 - This emoji can be used to signify that the data is updated or refreshed frequently, as it is a common symbol for reloading or syncing. Alternatively, one could use ⏱️, which is a stopwatch emoji, to imply that the data is time-sensitive or changes often.
-->
Improved data freshness for farms view by disabling cache for `useFarmUser` and `useUserUnclaimedRewards` hooks.

> _No more lies from the cache of doom_
> _We need the truth about our farms_
> _`fetchUserPositions` and `fetchUserRewards`_
> _We'll break the chains of stale data_

### Walkthrough
*  Disable caching for data hooks to ensure fresh fetch of staked positions and rewards ([link](https://github.com/pancakeswap/pancake-frontend/pull/6890/files?diff=unified&w=0#diff-98c6c51dabb06f56a511c769cf2dc636d8d1475303124f43cb302a3f899e4391L87-R87), [link](https://github.com/pancakeswap/pancake-frontend/pull/6890/files?diff=unified&w=0#diff-98c6c51dabb06f56a511c769cf2dc636d8d1475303124f43cb302a3f899e4391L122-R122))


