### PR TITLE
chore: list v3 id farm

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -42,6 +42,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
+    pid: 39,
+    token0: bscTokens.id,
+    token1: bscTokens.usdt,
+    lpAddress: Pool.getAddress(bscTokens.id, bscTokens.usdt, FeeAmount.MEDIUM),
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 38,
     token0: bscTokens.bnb,
     token1: bscTokens.gal,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7cd83d</samp>

### Summary
🆔🌊💸

<!--
1.  🆔 - This emoji can be used to represent the ID token, which is the native token of the Everest project and the reward token for the farm.
2.  🌊 - This emoji can be used to represent the liquidity provider tokens, which are tokens that represent a share of a liquidity pool on Uniswap V3. The farm allows users to stake these tokens and earn ID rewards.
3.  💸 - This emoji can be used to represent the medium fee amount, which is the percentage of the trading fees that the liquidity providers receive from the pool. The fee amount affects the risk and return of the pool, and the farm uses a medium fee amount of 0.3%.
-->
Added a new farm for ID/USDT liquidity providers on Uniswap V3. The farm uses the `Pool` contract and has a medium fee.

> _New farm in `farmsV3`_
> _Stake ID/USDT for rewards_
> _Medium fee, pool contract_

### Walkthrough
* Add a new farm for ID/USDT pair ([link](https://github.com/pancakeswap/pancake-frontend/pull/6891/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R45-R51))


