### PR TITLE
chore: Remove csp

### DIFF
--- a/packages/next-config/withWebSecurityHeaders.ts
+++ b/packages/next-config/withWebSecurityHeaders.ts
@@ -2,14 +2,14 @@ import type { NextConfig } from 'next'
 
 type Headers = Awaited<ReturnType<NonNullable<NextConfig['headers']>>>
 
-function createCSP() {
-  const IFRAME_WHITE_LIST = ['https://*.safe.global']
-
-  return {
-    key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' ${IFRAME_WHITE_LIST.join(' ')}`,
-  }
-}
+// function createCSP() {
+//   const IFRAME_WHITE_LIST = ['https://*.safe.global']
+//
+//   return {
+//     key: 'Content-Security-Policy',
+//     value: `frame-ancestors 'self' ${IFRAME_WHITE_LIST.join(' ')}`,
+//   }
+// }
 
 export function withWebSecurityHeaders(config: NextConfig): NextConfig {
   const originalHeaders = config.headers || []
@@ -31,7 +31,7 @@ export function withWebSecurityHeaders(config: NextConfig): NextConfig {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
           },
-          createCSP(),
+          // createCSP(),
         ],
       },
     ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 80d8767</samp>

### Summary
🛡️🪟🛠️

<!--
1.  🛡️ - This emoji represents the security aspect of the change, as the Content-Security-Policy header is a mechanism to protect web pages from malicious injections and cross-site scripting attacks. Removing it may expose the web page to some risks, so this emoji conveys the importance of the change and the need for careful review and testing.
2.  🪟 - This emoji represents the iframe element, which is the source of the compatibility issue that motivated the change. Iframes are used to embed other web pages or content within a web page, and they have some restrictions and challenges when it comes to security and communication. This emoji conveys the nature of the problem and the solution that the change is trying to achieve.
3.  🛠️ - This emoji represents the fix or workaround aspect of the change, as the removal of the Content-Security-Policy header is not a permanent or ideal solution, but rather a temporary measure to make the web page work with WalletConnect and other integrations. This emoji conveys the intention of the change and the need for further improvement or refinement in the future.
-->
Removed Content-Security-Policy header from web page to allow WalletConnect and other iframe integrations. Modified `withWebSecurityHeaders.ts` file.

> _No more security, no more rules_
> _They commented out the `createCSP` tool_
> _Now the frames can connect and interact_
> _But they opened the door for the evil to attack_

### Walkthrough
*  Remove the Content-Security-Policy header that restricted the sources of frames ([link](https://github.com/pancakeswap/pancake-frontend/pull/6902/files?diff=unified&w=0#diff-6aa78b1c0e55dbfe59ebe097a8976bcc007627796cc9e1cb854531e0de043047L5-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/6902/files?diff=unified&w=0#diff-6aa78b1c0e55dbfe59ebe097a8976bcc007627796cc9e1cb854531e0de043047L34-R34)) in `withWebSecurityHeaders.ts`. This fixes the WalletConnect issue and improves the user experience with third-party integrations that use iframes.


