### PR TITLE
chore: Add warning if exit price is out of range

### DIFF
--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2485,5 +2485,6 @@
   "V2 Farms": "V2 Farms",
   "Combined APR": "Combined APR",
   "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.": "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.",
-  "APRs for individual positions may vary depending on the configs.": "APRs for individual positions may vary depending on the configs."
+  "APRs for individual positions may vary depending on the configs.": "APRs for individual positions may vary depending on the configs.",
+  "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.": "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range."
 }

--- a/packages/uikit/src/widgets/RoiCalculator/ImpermanentLossCalculator.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/ImpermanentLossCalculator.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { CAKE } from "@pancakeswap/tokens";
 
 import { Section } from "./Section";
-import { Box, Row, AutoColumn, Toggle, RowBetween, DoubleCurrencyLogo } from "../../components";
+import { Box, Row, AutoColumn, Toggle, RowBetween, DoubleCurrencyLogo, Message } from "../../components";
 import {
   AssetCard,
   Asset,
@@ -166,6 +166,11 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
     [exitRate, hodlRate]
   );
 
+  const isExitPriceOutOfRange = useMemo(
+    () => principal && exit && exit.length >= 2 && exit.slice(0, 2).some((asset) => Number(asset.amount) === 0),
+    [exit, principal]
+  );
+
   const getPriceAdjustedAssets = useCallback(
     (newAssets?: Asset[]) => {
       if (
@@ -271,6 +276,14 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
     return null;
   }
 
+  const outofRangeWarning = isExitPriceOutOfRange ? (
+    <Message variant="warning">
+      {t(
+        "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range."
+      )}
+    </Message>
+  ) : null;
+
   const calculator = on ? (
     <>
       <TwoColumns>
@@ -324,6 +337,7 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
           </AutoColumn>
         </TwoColumns>
       </CardSection>
+      {outofRangeWarning}
     </>
   ) : null;
 

--- a/packages/uikit/src/widgets/RoiCalculator/ImpermanentLossCalculator.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/ImpermanentLossCalculator.tsx
@@ -42,13 +42,12 @@ interface Props {
   setEditCakePrice: (cakePrice: number) => void;
 }
 
-const getCakeAssetsByReward = (chainId: number, cakePrice_: string, cakeReward = 0, modifiedCakePrice?: string) => {
-  const cakePrice = modifiedCakePrice || cakePrice_;
+const getCakeAssetsByReward = (chainId: number, cakeRewardAmount = 0, cakePrice: string) => {
   return {
     currency: CAKE[chainId as keyof typeof CAKE],
-    amount: Number.isFinite(cakeReward) ? +cakeReward / +cakePrice_ : Infinity,
+    amount: cakeRewardAmount,
     price: cakePrice,
-    value: Number.isFinite(cakeReward) ? +cakeReward * (+cakePrice / +cakePrice_) : Infinity,
+    value: Number.isFinite(cakeRewardAmount) ? +cakeRewardAmount * +cakePrice : Infinity,
     key: "CAKE_ASSET_BY_APY",
   };
 };
@@ -93,6 +92,10 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
         : undefined,
     [valueA, currencyA, valueB, currencyB, currencyAUsdPrice, currencyBUsdPrice]
   );
+  const cakeRewardAmount = useMemo(
+    () => (Number.isFinite(cakeReward) ? +cakeReward / +cakePrice : Infinity),
+    [cakeReward, cakePrice]
+  );
   const liquidity = useMemo(
     () =>
       amountA &&
@@ -105,13 +108,14 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
     [amountA, amountB, tickUpper, tickLower, sqrtRatioX96]
   );
 
-  const exitAssets = useMemo<Asset[] | undefined>(
-    () =>
-      assets && isFarm && currencyA && currencyA.chainId in CAKE && cakePrice
-        ? [...assets, getCakeAssetsByReward(currencyA.chainId, cakePrice, cakeReward)]
-        : assets,
-    [assets, cakeReward, cakePrice, currencyA, isFarm]
-  );
+  const exitAssets = useMemo<Asset[] | undefined>(() => {
+    if (assets && isFarm && currencyA && currencyA.chainId in CAKE && cakePrice) {
+      const cakePriceToUse =
+        assets.find((a) => a.currency.equals(CAKE[currencyA.chainId as keyof typeof CAKE]))?.price ?? cakePrice;
+      return [...assets, getCakeAssetsByReward(currencyA.chainId, cakeRewardAmount, cakePriceToUse)];
+    }
+    return assets;
+  }, [assets, cakeRewardAmount, cakePrice, currencyA, isFarm]);
 
   const [entry, setEntry] = useState<Asset[] | undefined>(assets);
   const [exit, setExit] = useState<Asset[] | undefined>(exitAssets);
@@ -221,7 +225,7 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
           ...adjusted,
           {
             ...maybeAssetCake,
-            ...getCakeAssetsByReward(assetCurrencyA.chainId, cakePrice, cakeReward, String(maybeAssetCake.price)),
+            ...getCakeAssetsByReward(assetCurrencyA.chainId, cakeRewardAmount, String(maybeAssetCake.price)),
           },
         ];
 
@@ -232,7 +236,7 @@ export const ImpermanentLossCalculator = memo(function ImpermanentLossCalculator
     },
     // setEditCakePrice is not a dependency because it's setState
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [amountA, amountB, tickLower, tickUpper, sqrtRatioX96, cakeReward, cakePrice, liquidity]
+    [amountA, amountB, tickLower, tickUpper, sqrtRatioX96, cakeRewardAmount, liquidity]
   );
 
   const updateEntry = useCallback(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4cfc8c2</samp>

### Summary
🌐⚠️🧮

<!--
1.  🌐 - This emoji represents the addition of a new translation key and value to the `translations.json` file for the English language. The globe emoji is often used to indicate internationalization or localization of a web application or service, and in this case it signifies that a new language resource was added to support the user interface.
2.  ⚠️ - This emoji represents the addition of a new warning message component to the impermanent loss calculator widget, to inform the user when their exit price is out of the price range of their liquidity position. The warning emoji is commonly used to indicate a potential hazard, risk, or issue that the user should be aware of or pay attention to, and in this case it signifies that the user might incur a loss from their position being out-of-range.
3.  🧮 - This emoji represents the impermanent loss calculator widget, which is a tool that allows the user to estimate their potential profit or loss from providing liquidity to a Uniswap pool. The abacus emoji is often used to represent calculation, mathematics, or accounting, and in this case it signifies that the widget is related to the numerical analysis of the user's liquidity position.
-->
Added a warning message to the `ImpermanentLossCalculator` widget to alert the user of potential losses from out-of-range exit prices. Updated the English translation file with the new message text.

> _`Exit price` warning_
> _Shows in calculator widget_
> _Autumn leaves falling_

### Walkthrough
*  Add a new translation key and value for a warning message in the impermanent loss calculator widget ([link](https://github.com/pancakeswap/pancake-frontend/pull/6905/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2488-R2489))
*  Import the `Message` component to render the warning message with a styled text box ([link](https://github.com/pancakeswap/pancake-frontend/pull/6905/files?diff=unified&w=0#diff-95e40c98abf44fff73a68d2b738b3c800f9ba2f7495e184acd13e86276da695fL9-R9))
*  Declare a variable `isExitPriceOutOfRange` to check if the user's exit price is outside of the position price range ([link](https://github.com/pancakeswap/pancake-frontend/pull/6905/files?diff=unified&w=0#diff-95e40c98abf44fff73a68d2b738b3c800f9ba2f7495e184acd13e86276da695fR169-R173))
*  Declare a variable `outofRangeWarning` to conditionally render the `Message` component with the translation key as its children ([link](https://github.com/pancakeswap/pancake-frontend/pull/6905/files?diff=unified&w=0#diff-95e40c98abf44fff73a68d2b738b3c800f9ba2f7495e184acd13e86276da695fR279-R286))
*  Add the `outofRangeWarning` variable as a child element of the `AutoColumn` component in `ImpermanentLossCalculator.tsx` to display the warning message below the input fields and above the output fields of the widget ([link](https://github.com/pancakeswap/pancake-frontend/pull/6905/files?diff=unified&w=0#diff-95e40c98abf44fff73a68d2b738b3c800f9ba2f7495e184acd13e86276da695fR340))


