### PR TITLE
chore: add warning text for v2 info

### DIFF
--- a/apps/web/src/views/Info/components/InfoNav/index.tsx
+++ b/apps/web/src/views/Info/components/InfoNav/index.tsx
@@ -8,6 +8,8 @@ import {
   UserMenuItem,
   Text,
   NextLinkFromReactRouter,
+  Message,
+  MessageText,
 } from '@pancakeswap/uikit'
 import { useCallback, useMemo } from 'react'
 import {} from 'hooks/useSwitchNetwork'
@@ -16,7 +18,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { useRouter } from 'next/router'
 import styled from 'styled-components'
 import Search from 'views/Info/components/InfoSearch'
-import { useMultiChainPath, useChainNameByQuery } from 'state/info/hooks'
+import { useMultiChainPath, useChainNameByQuery, useChainIdByQuery } from 'state/info/hooks'
 import { multiChainId, multiChainPaths } from 'state/info/constant'
 import { chains } from 'utils/wagmi'
 import { ChainLogo } from 'components/Logo/ChainLogo'
@@ -39,6 +41,7 @@ const InfoNav: React.FC<{ isStableSwap: boolean }> = ({ isStableSwap }) => {
   const { t } = useTranslation()
   const router = useRouter()
   const chainPath = useMultiChainPath()
+  const chainId = useChainIdByQuery()
   const stableSwapQuery = isStableSwap ? '?type=stableSwap' : ''
   const activeIndex = useMemo(() => {
     if (router?.pathname?.includes('/pairs')) {
@@ -50,27 +53,38 @@ const InfoNav: React.FC<{ isStableSwap: boolean }> = ({ isStableSwap }) => {
     return 0
   }, [router.pathname])
   return (
-    <NavWrapper>
-      <Flex>
-        <Box>
-          <ButtonMenu activeIndex={activeIndex} scale="sm" variant="subtle">
-            <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}${stableSwapQuery}`}>
-              {t('Overview')}
-            </ButtonMenuItem>
-            <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}/pairs${stableSwapQuery}`}>
-              {t('Pairs')}
-            </ButtonMenuItem>
-            <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}/tokens${stableSwapQuery}`}>
-              {t('Tokens')}
-            </ButtonMenuItem>
-          </ButtonMenu>
+    <>
+      <NavWrapper>
+        <Flex>
+          <Box>
+            <ButtonMenu activeIndex={activeIndex} scale="sm" variant="subtle">
+              <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}${stableSwapQuery}`}>
+                {t('Overview')}
+              </ButtonMenuItem>
+              <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}/pairs${stableSwapQuery}`}>
+                {t('Pairs')}
+              </ButtonMenuItem>
+              <ButtonMenuItem as={NextLinkFromReactRouter} to={`/info${chainPath}/tokens${stableSwapQuery}`}>
+                {t('Tokens')}
+              </ButtonMenuItem>
+            </ButtonMenu>
+          </Box>
+          <NetworkSwitcher activeIndex={activeIndex} />
+        </Flex>
+        <Box width={['100%', '100%', '250px']}>
+          <Search />
         </Box>
-        <NetworkSwitcher activeIndex={activeIndex} />
-      </Flex>
-      <Box width={['100%', '100%', '250px']}>
-        <Search />
-      </Box>
-    </NavWrapper>
+      </NavWrapper>
+      {chainId === ChainId.BSC && !isStableSwap && (
+        <Message my="24px" mx="24px" variant="warning">
+          <MessageText fontSize="17px">
+            {t(
+              'Data and ranking may not be accurate due to heavy spamming. Please pay attention to the risk scanner always DYOR before trading',
+            )}
+          </MessageText>
+        </Message>
+      )}
+    </>
   )
 }
 

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2486,5 +2486,6 @@
   "Combined APR": "Combined APR",
   "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.": "Calculated using the total active liquidity staked versus the CAKE reward emissions for the farm.",
   "APRs for individual positions may vary depending on the configs.": "APRs for individual positions may vary depending on the configs.",
-  "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.": "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range."
+  "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.": "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.",
+  "Data and ranking may not be accurate due to heavy spamming. Please pay attention to the risk scanner always DYOR before trading": "Data and ranking may not be accurate due to heavy spamming. Please pay attention to the risk scanner always DYOR before trading"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a783f34</samp>

### Summary
:globe_with_meridians::warning::wrench:

<!--
1.  :globe_with_meridians: - This emoji represents the addition of the translation key and value for the warning message, which is related to localization and internationalization.
2.  :warning: - This emoji represents the warning message component itself, which is meant to alert the users about potential issues and dangers.
3.  :wrench: - This emoji represents the conditional logic that determines when to show the warning message, which is related to configuration and settings.
-->
Added a warning message for BSC users on the info page when stable swap is disabled. The message is localized using the `translations.json` file.

> _`BSC` users warned_
> _Stable swap may be wrong_
> _Autumn of distrust_

### Walkthrough
*  Add a warning message for BSC users on the info page ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aR11-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL19-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aR44), [link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL53-R87), [link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2488-R2489))
  - Import `Message` and `MessageText` components from `uikit` to display the message ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aR11-R12))
  - Import `useChainIdByQuery` hook from `state/info/hooks` to get the current chain ID from the URL ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL19-R21))
  - Declare `chainId` variable and assign it the value returned by the hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aR44))
  - Wrap `InfoNav` component in a fragment and conditionally render the message if the chain ID is BSC and the stable swap query parameter is false ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL53-R87))
  - Add the translation key and value for the message to the `translations.json` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/6906/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2488-R2489))


