### PR TITLE
fix: Missing currency logo display

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
@@ -1,11 +1,20 @@
 import { Route, SmartRouter } from '@pancakeswap/smart-router/evm'
 import { useTranslation } from '@pancakeswap/localization'
-import { Modal, ModalV2, QuestionHelper, Text, Flex, useTooltip, AutoColumn, UseModalV2Props } from '@pancakeswap/uikit'
+import {
+  Modal,
+  ModalV2,
+  QuestionHelper,
+  Text,
+  Flex,
+  useTooltip,
+  AutoColumn,
+  UseModalV2Props,
+  CurrencyLogo,
+} from '@pancakeswap/uikit'
 import { Currency } from '@pancakeswap/sdk'
 import { AtomBox } from '@pancakeswap/ui'
 import { useMemo, memo } from 'react'
 
-import { CurrencyLogo } from 'components/Logo'
 import { RoutingSettingsButton } from 'components/Menu/GlobalSettings/SettingsModal'
 import { RouterBox, RouterPoolBox, RouterTypeText, CurrencyLogoWrapper } from 'views/Swap/components/RouterViewer'
 import { v3FeeToPercent } from '../utils/exchange'

--- a/packages/uikit/src/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/packages/uikit/src/components/CurrencyLogo/CurrencyLogo.tsx
@@ -6,7 +6,7 @@ import { useHttpLocations } from "@pancakeswap/hooks";
 
 import { TokenLogo } from "../TokenLogo";
 import { BinanceIcon } from "../Svg";
-import { getTokenLogoURL } from "./utils";
+import { getCurrencyLogoUrls } from "./utils";
 
 const StyledLogo = styled(TokenLogo)<{ size: string }>`
   width: ${({ size }) => size};
@@ -29,14 +29,12 @@ export function CurrencyLogo({
     if (currency?.isNative) return [];
 
     if (currency?.isToken) {
-      const tokenLogoURL = getTokenLogoURL(currency);
+      const logoUrls = getCurrencyLogoUrls(currency);
 
       if (currency instanceof WrappedTokenInfo) {
-        if (!tokenLogoURL) return [...uriLocations];
-        return [...uriLocations, tokenLogoURL];
+        return [...uriLocations, ...logoUrls];
       }
-      if (!tokenLogoURL) return [];
-      return [tokenLogoURL];
+      return [...logoUrls];
     }
     return [];
   }, [currency, uriLocations]);

--- a/packages/uikit/src/components/CurrencyLogo/utils.ts
+++ b/packages/uikit/src/components/CurrencyLogo/utils.ts
@@ -1,6 +1,6 @@
 import { getAddress } from "ethers/lib/utils";
 import memoize from "lodash/memoize";
-import { ChainId, Token } from "@pancakeswap/sdk";
+import { ChainId, Token, Currency } from "@pancakeswap/sdk";
 
 const mapping: { [key: number]: string } = {
   [ChainId.BSC]: "smartchain",
@@ -29,4 +29,22 @@ export const getTokenLogoURLByAddress = memoize(
     return null;
   },
   (address, chainId) => `${chainId}#${address}`
+);
+
+const chainName: { [key: number]: string } = {
+  [ChainId.BSC]: "",
+  [ChainId.ETHEREUM]: "eth",
+};
+
+export const getCurrencyLogoUrls = memoize(
+  (currency?: Currency): string[] => {
+    const chainId = currency?.chainId || ChainId.BSC;
+    const tokenAddress = getAddress(currency?.wrapped?.address || "");
+    const trustWalletLogo = getTokenLogoURL(currency?.wrapped);
+    const logoUrl = `https://tokens.pancakeswap.finance/images/${
+      chainId === ChainId.BSC ? "" : `${chainName[chainId]}/`
+    }${tokenAddress}.png`;
+    return [trustWalletLogo, logoUrl].filter((url) => Boolean(url)) as string[];
+  },
+  (currency?: Currency) => `logoUrls#${currency?.chainId}#${currency?.wrapped?.address}`
 );


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7228b81</samp>

### Summary
🔄🔧🚀

<!--
1.  🔄 - This emoji represents the change of importing the `CurrencyLogo` component from a different source and updating the usage accordingly.
2.  🔧 - This emoji represents the change of renaming and moving a function that fetches logo urls, and simplifying the component that renders the logos. This emoji implies a refactoring or improvement of the code.
3.  🚀 - This emoji represents the addition of a memoized function that returns the logo urls for any currency from various sources. This emoji implies a new feature or enhancement of the user interface.
-->
Updated the `CurrencyLogo` component and its usage to support multiple chains and logo sources. Refactored the logo fetching logic to a memoized function in `./utils`.

> _Oh, we're the savvy coders of the PancakeSwap crew_
> _We import the `CurrencyLogo` from the uikit new_
> _We fetch the logos from the sources that we choose_
> _With the memoized `getCurrencyLogoUrls` function that we use_

### Walkthrough
* Import `CurrencyLogo` component from `@pancakeswap/uikit` instead of `components/Logo` to use updated version with multiple chains and logo sources ([link](https://github.com/pancakeswap/pancake-frontend/pull/6909/files?diff=unified&w=0#diff-43a0f24a3f080dbb58cebbb2f34170a9b5a213998fa678068661ca2f0dad6a34L3-R17))
* Rename `getTokenLogoURL` function to `getCurrencyLogoUrls` and move it to `./utils` to return an array of logo urls for a given currency ([link](https://github.com/pancakeswap/pancake-frontend/pull/6909/files?diff=unified&w=0#diff-3ff99f20f9adb4ac1bd36560f39301a453f1cdfb14c25d7567e9634188194c7dL9-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/6909/files?diff=unified&w=0#diff-7deb472f34cafe26dd54d7936b6e694673570a38a9cc6694b511062b1e8b01d9L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/6909/files?diff=unified&w=0#diff-7deb472f34cafe26dd54d7936b6e694673570a38a9cc6694b511062b1e8b01d9R33-R50))
* Simplify `CurrencyLogo` component logic to use `getCurrencyLogoUrls` function and return the union of `uriLocations` and logo urls for the currency ([link](https://github.com/pancakeswap/pancake-frontend/pull/6909/files?diff=unified&w=0#diff-3ff99f20f9adb4ac1bd36560f39301a453f1cdfb14c25d7567e9634188194c7dL32-R37))


