### PR TITLE
chore: list FUSE farm on ETH

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -49,9 +49,9 @@ export const farmsV3 = defineFarmV3Configs([
   // Keep those farms on top
   {
     pid: 30,
-    lpAddress: Pool.getAddress(ethereumTokens.fuse, ethereumTokens.eth, FeeAmount.MEDIUM),
+    lpAddress: Pool.getAddress(ethereumTokens.fuse, ethereumTokens.weth, FeeAmount.MEDIUM),
     token0: ethereumTokens.fuse,
-    token1: ethereumTokens.eth,
+    token1: ethereumTokens.weth,
     feeAmount: FeeAmount.MEDIUM,
   },
   {

--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 30,
+    lpAddress: Pool.getAddress(ethereumTokens.fuse, ethereumTokens.eth, FeeAmount.MEDIUM),
+    token0: ethereumTokens.fuse,
+    token1: ethereumTokens.eth,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 29,
     lpAddress: '0x392d0F0B7Fe5161Db89f2DB87d33a20682C12A2B',
     token0: ethereumTokens.weth,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3be950d</samp>

### Summary
🌾🦄🔄

<!--
1.  🌾 - This emoji represents farming or staking, which is the main feature of the change. Users can farm FUSE rewards by staking their FUSE-ETH LP tokens in the new farm.
2. 🦄 - This emoji represents Uniswap, which is the protocol that the new farm uses. Uniswap is a popular decentralized exchange that allows users to swap and provide liquidity for various tokens. The unicorn is the logo and mascot of Uniswap.
3. 🔄 - This emoji represents swapping or exchanging, which is the underlying mechanism of the FUSE-ETH pair. Users can swap FUSE for ETH or vice versa on Uniswap, and also provide liquidity for the pair to earn fees and LP tokens. The emoji shows two arrows forming a circle, indicating a trade or exchange.
-->
Add a new farm for FUSE-ETH LP tokens on Uniswap V3. The farm allows users to earn rewards by staking LP tokens from the `FUSE-ETH` pool with a `0.3%` fee tier in `packages/farms/constants/1.ts`.

> _`farmsV3` expands_
> _stake `FUSE-ETH` LP tokens_
> _autumn harvest awaits_

### Walkthrough
*  Add a new farm for FUSE-ETH LP tokens on Uniswap V3 ([link](https://github.com/pancakeswap/pancake-frontend/pull/6916/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R51-R57))


