### PR TITLE
chore: Remove frame csp due to third party usage

### DIFF
--- a/packages/next-config/withWebSecurityHeaders.ts
+++ b/packages/next-config/withWebSecurityHeaders.ts
@@ -2,16 +2,16 @@ import type { NextConfig } from 'next'
 
 type Headers = Awaited<ReturnType<NonNullable<NextConfig['headers']>>>
 
-function createCSP() {
-  const IFRAME_WHITE_LIST = ['https://*.safe.global']
-
-  const rules = [`frame-ancestors 'self' ${IFRAME_WHITE_LIST.join(' ')}`, 'report-uri /api/_report/csp']
-
-  return {
-    key: 'Content-Security-Policy',
-    value: rules.join('; '),
-  }
-}
+// function createCSP() {
+//   const IFRAME_WHITE_LIST = ['https://*.safe.global']
+//
+//   const rules = [`frame-ancestors 'self' ${IFRAME_WHITE_LIST.join(' ')}`, 'report-uri /api/_report/csp']
+//
+//   return {
+//     key: 'Content-Security-Policy',
+//     value: rules.join('; '),
+//   }
+// }
 
 export function withWebSecurityHeaders(config: NextConfig): NextConfig {
   const originalHeaders = config.headers || []
@@ -33,7 +33,7 @@ export function withWebSecurityHeaders(config: NextConfig): NextConfig {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
           },
-          createCSP(),
+          // createCSP(),
         ],
       },
     ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6d8a1ea</samp>

### Summary
🚫🎰🧪

<!--
1.  🚫 This emoji means "no" or "prohibited" and can be used to indicate that the code is commenting out something that was previously allowed or enforced, such as the Content-Security-Policy header.
2.  🎰 This emoji means "slot machine" or "gambling" and can be used to indicate that the code is related to a new lottery feature that involves embedding an iframe from a different domain.
3.  🧪 This emoji means "test tube" or "experiment" and can be used to indicate that the code is a temporary change for testing purposes and not intended for production.
-->
Temporarily disabled Content-Security-Policy header in `withWebSecurityHeaders.ts` to enable iframe embedding for lottery feature.

> _`Content-Security-Policy` is broken_
> _For a lottery of doom and despair_
> _An iframe of temptation is open_
> _But the prize is a nightmare_

### Walkthrough
*  Disable Content-Security-Policy header to allow iframe embedding ([link](https://github.com/pancakeswap/pancake-frontend/pull/6917/files?diff=unified&w=0#diff-6aa78b1c0e55dbfe59ebe097a8976bcc007627796cc9e1cb854531e0de043047L5-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/6917/files?diff=unified&w=0#diff-6aa78b1c0e55dbfe59ebe097a8976bcc007627796cc9e1cb854531e0de043047L36-R36))


