### PR TITLE
chore: Remove home page AffiliateModal

### DIFF
--- a/apps/web/src/views/Home/index.tsx
+++ b/apps/web/src/views/Home/index.tsx
@@ -6,7 +6,6 @@ import Container from 'components/Layout/Container'
 import { useTranslation } from '@pancakeswap/localization'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ChainId } from '@pancakeswap/sdk'
-import AffiliateModal from 'views/AffiliatesProgram/components/Dashboard/AffiliateModal'
 import Hero from './components/Hero'
 import { swapSectionData, earnSectionData, cakeSectionData } from './components/SalesSection/data'
 import MetricsSection from './components/MetricsSection'
@@ -82,7 +81,6 @@ const Home: React.FC<React.PropsWithChildren> = () => {
           }
         `}
       </style>
-      <AffiliateModal />
       <StyledHeroSection
         innerProps={{ style: { margin: '0', width: '100%' } }}
         containerProps={{


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1099e4c</samp>

### Summary
🗑️🔥🏠

<!--
1.  🗑️ - This emoji means "waste basket" or "trash can" and can be used to indicate that something has been removed or deleted. In this case, it shows that the `AffiliateModal` component and its import statement have been discarded from the `Home` view.
2.  🔥 - This emoji means "fire" or "flame" and can be used to indicate that something has been burned, destroyed, or eliminated. In this case, it shows that the affiliate program feature has been disabled or deactivated from the app.
3.  🏠 - This emoji means "house" or "home" and can be used to indicate that something relates to the `Home` view or the main page of the app. In this case, it shows that the changes affect the `Home` view component.
-->
Disabled affiliate program feature by removing `AffiliateModal` from `Home` view.

> _Sing, O Muse, of the swift and skillful coder_
> _Who, by his cunning, `AffiliateModal` removed_
> _From the `Home` view, where it once had lured_
> _Many a mortal with promises of gold._

### Walkthrough
*  Remove `AffiliateModal` component and its import from `Home` view ([link](https://github.com/pancakeswap/pancake-frontend/pull/6921/files?diff=unified&w=0#diff-a3036a0bb4c8967f7a13f579b01902e65cde700b6268c495ca2dc48a37e3ebc9L9), [link](https://github.com/pancakeswap/pancake-frontend/pull/6921/files?diff=unified&w=0#diff-a3036a0bb4c8967f7a13f579b01902e65cde700b6268c495ca2dc48a37e3ebc9L85))


