### PR TITLE
chore: list C98 farm on BSC

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -42,6 +42,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
+    pid: 41,
+    token0: bscTokens.c98,
+    token1: bscTokens.bnb,
+    lpAddress: Pool.getAddress(bscTokens.c98, bscTokens.bnb, FeeAmount.MEDIUM),
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 40,
     token0: bscTokens.ush,
     token1: bscTokens.bnb,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0400953</samp>

### Summary
🆕🌾💸

<!--
1.  🆕 - This emoji signifies that a new farm was added, which is a notable feature for users who want to stake their C98/BNB tokens and earn rewards.
2.  🌾 - This emoji represents farming or yield farming, which is the activity of staking tokens in a pool and earning rewards. It is a common emoji used by many DeFi projects and platforms to indicate their farming features.
3.  💸 - This emoji denotes money or fees, which is relevant for this change since the farm has a medium fee amount. This means that users who stake or unstake their tokens will have to pay a certain percentage of their tokens as a fee to the platform. This emoji can also imply that the farm has a high reward potential, depending on the market conditions and the token price.
-->
Add a new farm for C98/BNB pair on V3 pools. Update `packages/farms/constants/56.ts` with the new farm data and fee amount.

> _New farm for `C98`_
> _Medium fee for the pair_
> _Autumn harvest time_

### Walkthrough
* Add a new farm for C98/BNB pair with medium fee ([link](https://github.com/pancakeswap/pancake-frontend/pull/6922/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R45-R51))


