### PR TITLE
feat: Add Trading reward nav status

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItemsStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItemsStatus.ts
@@ -8,6 +8,7 @@ import { getStatus } from 'views/Ifos/hooks/helpers'
 import { useCompetitionStatus } from './useCompetitionStatus'
 import { usePotteryStatus } from './usePotteryStatus'
 import { useVotingStatus } from './useVotingStatus'
+import { useTradingRewardStatus } from './useTradingRewardStatus'
 
 export const useMenuItemsStatus = (): Record<string, string> => {
   const currentBlock = useChainCurrentBlock(ChainId.BSC)
@@ -16,6 +17,7 @@ export const useMenuItemsStatus = (): Record<string, string> => {
   const potteryStatus = usePotteryStatus()
   const votingStatus = useVotingStatus()
   const isUserLocked = useUserCakeLockStatus()
+  const tradingRewardStatus = useTradingRewardStatus()
 
   const ifoStatus =
     currentBlock && activeIfo && activeIfo.endBlock > currentBlock
@@ -35,6 +37,9 @@ export const useMenuItemsStatus = (): Record<string, string> => {
       ...(isUserLocked && {
         '/pools': 'lock_end',
       }),
+      ...(tradingRewardStatus && {
+        '/trading-reward': tradingRewardStatus,
+      }),
     }
-  }, [competitionStatus, ifoStatus, potteryStatus, votingStatus, isUserLocked])
+  }, [competitionStatus, ifoStatus, potteryStatus, votingStatus, isUserLocked, tradingRewardStatus])
 }

--- a/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
@@ -9,7 +9,7 @@ export const useTradingRewardStatus = () => {
     const currentTime = new Date().getTime() / 1000
     if (latestCampaignId) {
       const incentive = allTradingRewardPairData.campaignIdsIncentive.find(
-        (i) => i.campaignId.toLowerCase() === latestCampaignId.toLowerCase(),
+        (i) => i.campaignId.toLowerCase() === latestCampaignId?.toLowerCase(),
       )
 
       if (currentTime >= incentive?.campaignStart && currentTime <= incentive?.campaignClaimTime) {

--- a/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
@@ -3,16 +3,18 @@ import useAllTradingRewardPair from 'views/TradingReward/hooks/useAllTradingRewa
 
 export const useTradingRewardStatus = () => {
   const { data: allTradingRewardPairData } = useAllTradingRewardPair()
-  const latestCampaignId = allTradingRewardPairData.campaignIds[allTradingRewardPairData.campaignIds.length - 1]
+  const latestCampaignId = allTradingRewardPairData.campaignIds?.[allTradingRewardPairData.campaignIds.length - 1]
 
   return useMemo(() => {
     const currentTime = new Date().getTime() / 1000
-    const incentive = allTradingRewardPairData.campaignIdsIncentive.find(
-      (i) => i.campaignId.toLowerCase() === latestCampaignId.toLowerCase(),
-    )
+    if (latestCampaignId) {
+      const incentive = allTradingRewardPairData.campaignIdsIncentive.find(
+        (i) => i.campaignId.toLowerCase() === latestCampaignId.toLowerCase(),
+      )
 
-    if (currentTime >= incentive?.campaignStart && currentTime <= incentive?.campaignClaimTime) {
-      return 'live'
+      if (currentTime >= incentive?.campaignStart && currentTime <= incentive?.campaignClaimTime) {
+        return 'live'
+      }
     }
 
     return ''

--- a/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import useAllTradingRewardPair from 'views/TradingReward/hooks/useAllTradingRewardPair'
+
+export const useTradingRewardStatus = () => {
+  const { data: allTradingRewardPairData } = useAllTradingRewardPair()
+  const latestCampaignId = allTradingRewardPairData.campaignIds[allTradingRewardPairData.campaignIds.length - 1]
+
+  return useMemo(() => {
+    const currentTime = new Date().getTime() / 1000
+    const incentive = allTradingRewardPairData.campaignIdsIncentive.find(
+      (i) => i.campaignId.toLowerCase() === latestCampaignId.toLowerCase(),
+    )
+
+    if (currentTime >= incentive?.campaignStart && currentTime <= incentive?.campaignClaimTime) {
+      return 'live'
+    }
+
+    return ''
+  }, [latestCampaignId, allTradingRewardPairData])
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 328cb25</samp>

### Summary
🆕🎁🕒

<!--
1.  🆕 - This emoji represents the creation of a new file and a new hook.
2.  🎁 - This emoji represents the trading reward feature, which rewards users for trading on the platform.
3.  🕒 - This emoji represents the time-based logic of the hook, which checks the current time against the campaign start and claim time.
-->
Added a new menu item for the trading reward page, which shows the status of the latest trading reward campaign using a custom hook. Created a new hook `useTradingRewardStatus` to fetch and compare the campaign data and return the status.

> _`useTradingRewardStatus` to find the latest campaign_
> _Claim your prize before the time runs out_
> _Don't let the others take your share of the fame_
> _Show them your skills on the trading reward page_

### Walkthrough
*  Add `useTradingRewardStatus` hook to fetch and return the status of the latest trading reward campaign ([link](https://github.com/pancakeswap/pancake-frontend/pull/6929/files?diff=unified&w=0#diff-188a4fc41bafbe3196976f16f7309d2152bb8ed76ba789dcb87f289057eeff14R1-R20))
*  Import and use `useTradingRewardStatus` hook in `useMenuItemsStatus` hook to conditionally render the menu item for the trading reward page ([link](https://github.com/pancakeswap/pancake-frontend/pull/6929/files?diff=unified&w=0#diff-1d536c4bc0524077f09b5d0d684e6c295708103892cebb53cf5f07bc22f6f95cR11), [link](https://github.com/pancakeswap/pancake-frontend/pull/6929/files?diff=unified&w=0#diff-1d536c4bc0524077f09b5d0d684e6c295708103892cebb53cf5f07bc22f6f95cR20))
*  Add `/trading-reward` property to `menuItemsStatus` object with the value of `tradingRewardStatus` variable ([link](https://github.com/pancakeswap/pancake-frontend/pull/6929/files?diff=unified&w=0#diff-1d536c4bc0524077f09b5d0d684e6c295708103892cebb53cf5f07bc22f6f95cL38-R44))


![Screenshot 2023-05-19 at 3 30 33 PM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/f7edb41a-421a-418a-be23-0c4c5505ec63)
