### PR TITLE
feat(Affiliate): Add subgraph health indicators

### DIFF
--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/DesktopView.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/DesktopView.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
-import { Flex, Card } from '@pancakeswap/uikit'
+import { Flex, Card, Message, MessageText } from '@pancakeswap/uikit'
+import { useTranslation } from '@pancakeswap/localization'
 import { Views } from 'views/AffiliatesProgram/components/OnBoardingModal/index'
+import useShowWarningMessage from 'views/AffiliatesProgram/hooks/useShowWarningMessage'
 import WelcomePage from './WelcomePage'
 import Congratulations from './Congratulations'
 import StepIntro from './StepIntro'
@@ -26,8 +28,19 @@ const DesktopView: React.FC<React.PropsWithChildren<DesktopViewProps>> = ({
   onDismiss,
   handleStartNow,
 }) => {
+  const { t } = useTranslation()
+  const showWarningMessage = useShowWarningMessage()
   return (
-    <Container>
+    <Container flexDirection="column">
+      {showWarningMessage && (
+        <Message variant="warning" mb="16px">
+          <MessageText>
+            {t(
+              'Affiliate program registration is paused at the moment. Please check back after subgraph status is restored',
+            )}
+          </MessageText>
+        </Message>
+      )}
       <Flex width="100%">
         <Flex width="50%" pr="12px">
           <Card style={{ width: '100%' }}>

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/MobileView.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/MobileView.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
-import { Flex } from '@pancakeswap/uikit'
+import { useTranslation } from '@pancakeswap/localization'
+import { Flex, Message, MessageText } from '@pancakeswap/uikit'
 import { Views } from 'views/AffiliatesProgram/components/OnBoardingModal/index'
+import useShowWarningMessage from 'views/AffiliatesProgram/hooks/useShowWarningMessage'
 import WelcomePage from './WelcomePage'
 import Congratulations from './Congratulations'
 import StepIntro from './StepIntro'
@@ -34,9 +36,20 @@ const MobileView: React.FC<React.PropsWithChildren<MobileViewProps>> = ({
   onDismiss,
   handleStartNow,
 }) => {
+  const { t } = useTranslation()
+  const showWarningMessage = useShowWarningMessage()
   return (
     <Container>
       <WhiteBackground>
+        {showWarningMessage && (
+          <Message variant="warning" m="16px 16px 0 16px">
+            <MessageText>
+              {t(
+                'Affiliate program registration is paused at the moment. Please check back after subgraph status is restored',
+              )}
+            </MessageText>
+          </Message>
+        )}
         {currentView === Views.STEP1 ? (
           <WelcomePage isLoading={isLoading} handleStartNow={handleStartNow} onDismiss={onDismiss} />
         ) : (

--- a/apps/web/src/views/AffiliatesProgram/components/Overview/index.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Overview/index.tsx
@@ -6,6 +6,7 @@ import RewardCalculate from 'views/AffiliatesProgram/components/Overview/RewardC
 import Question from 'views/AffiliatesProgram/components/Overview/Question'
 import OnBoardingModal from 'views/AffiliatesProgram/components/OnBoardingModal'
 import AffiliateModal from 'views/AffiliatesProgram/components/Dashboard/AffiliateModal'
+import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 
 const AffiliatesProgram = () => {
   return (
@@ -17,6 +18,7 @@ const AffiliatesProgram = () => {
       <RewardCalculate />
       <Benefits />
       <Question />
+      <V3SubgraphHealthIndicator />
     </AffiliatesProgramLayout>
   )
 }

--- a/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+import { ChainId } from '@pancakeswap/sdk'
+import { V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
+import useSubgraphHealth, { SubgraphStatus } from 'hooks/useSubgraphHealth'
+
+const useShowWarningMessage = () => {
+  const subgraphName = V3_SUBGRAPH_URLS[ChainId.BSC]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
+  const { status } = useSubgraphHealth(subgraphName)
+
+  return useMemo(() => {
+    if (status === SubgraphStatus.DOWN) {
+      return true
+    }
+    return false
+  }, [status])
+}
+
+export default useShowWarningMessage

--- a/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { ChainId } from '@pancakeswap/sdk'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
 import useSubgraphHealth, { SubgraphStatus } from 'hooks/useSubgraphHealth'
 
 const useShowWarningMessage = () => {
-  const subgraphName = V3_SUBGRAPH_URLS[ChainId.BSC]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
+  const { chainId } = useActiveChainId()
+  const subgraphName = V3_SUBGRAPH_URLS[chainId]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
   const { status } = useSubgraphHealth(subgraphName)
 
   return useMemo(() => {

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2517,5 +2517,6 @@
   "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.": "Exit price is out of the position price range. The number of estimated rewards will not account for the loss from the position being out-of-range.",
   "The markets for some of the newer and low-cap tokens displayed on the v2 info page are highly volatile, and as a result, token information may not be accurate.": "The markets for some of the newer and low-cap tokens displayed on the v2 info page are highly volatile, and as a result, token information may not be accurate.",
   "Before trading any token, please DYOR, and pay attention to the risk scanner.": "Before trading any token, please DYOR, and pay attention to the risk scanner.",
-  "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored.": "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored."
+  "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored.": "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored.",
+  "Affiliate program registration is paused at the moment. Please check back after subgraph status is restored": "Affiliate program registration is paused at the moment. Please check back after subgraph status is restored"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3ff003d</samp>

### Summary
📊🌐🩺

<!--
1.  📊 This emoji represents the component that shows the subgraph health, which is a type of data visualization or chart.
2.  🌐 This emoji represents the subgraph itself, which is a network of data sources and queries that power the affiliates program.
3.  🩺 This emoji represents the health or reliability of the subgraph, which is important for users to trust the data they see.
-->
Added a subgraph health component to the affiliates program page. This component displays the status and lag of the V3 subgraph that powers the affiliates data.

> _The subgraph is the source of truth_
> _But sometimes it may fail or lag_
> _We need to see its vital signs_
> _To trust the data on the `AffiliatesOverview` component_

### Walkthrough
* Add a component to display the V3 subgraph health status on the affiliates program overview page ([link](https://github.com/pancakeswap/pancake-frontend/pull/6930/files?diff=unified&w=0#diff-120f396118292bb7fce8bb857aaf99e8daacfc4982d40a7537255a55cb9b8b54R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/6930/files?diff=unified&w=0#diff-120f396118292bb7fce8bb857aaf99e8daacfc4982d40a7537255a55cb9b8b54R21))
* Import the `V3SubgraphHealthIndicator` component from `components/SubgraphHealthIndicator` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6930/files?diff=unified&w=0#diff-120f396118292bb7fce8bb857aaf99e8daacfc4982d40a7537255a55cb9b8b54R9))
* Render the `V3SubgraphHealthIndicator` component inside the `AffiliatesProgram` component in `apps/web/src/views/AffiliatesProgram/components/Overview/index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6930/files?diff=unified&w=0#diff-120f396118292bb7fce8bb857aaf99e8daacfc4982d40a7537255a55cb9b8b54R21))


