### PR TITLE
feat: Rename noperps to perps

### DIFF
--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateLinks.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateLinks.tsx
@@ -70,7 +70,7 @@ const AffiliateLinks: React.FC<React.PropsWithChildren<AffiliateLinksProps>> = (
     const name = affiliate.nickName ? affiliate.nickName : affiliate.name
     const displayName = name.replaceAll(' ', '_')
     const discount = new BigNumber(percentage).gt(0) ? new BigNumber(percentage).times(3).div(100).toFixed(2) : 0
-    return `${hostname}/affiliates-program?ref=${linkId}&user=${displayName}&discount=${discount}&noperps=${affiliate.ablePerps}`
+    return `${hostname}/affiliates-program?ref=${linkId}&user=${displayName}&discount=${discount}&perps=${affiliate.ablePerps}`
   }
 
   const handleCopyText = ({ linkId, percentage }: { linkId: string; percentage: number }) => {

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateModal/index.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateModal/index.tsx
@@ -21,17 +21,10 @@ const AffiliateModal = () => {
   const [showModal, setShowModal] = useAtom(showAffiliateModalAtom)
 
   useEffect(() => {
-    const { ref, user, discount, noperps } = router.query
+    const { ref, user, discount, perps } = router.query
     // Close when switch address
     setIsOpen(
-      (isAffiliateExist || isUserExist) &&
-        !isFetching &&
-        address &&
-        showModal &&
-        !ref &&
-        !user &&
-        !discount &&
-        !noperps,
+      (isAffiliateExist || isUserExist) && !isFetching && address && showModal && !ref && !user && !discount && !perps,
     )
   }, [address, isAffiliateExist, isUserExist, isFetching, showModal, router])
 

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/WelcomePage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/WelcomePage.tsx
@@ -18,14 +18,14 @@ const WelcomePage: React.FC<React.PropsWithChildren<WelcomePageProps>> = ({ isLo
   const router = useRouter()
   const { address } = useAccount()
   const { isUserExist } = useUserExist()
-  const { user, discount, noperps } = router.query
+  const { user, discount, perps } = router.query
   const [isChecked, setIsChecked] = useState(false)
 
   const handleCheckbox = () => setIsChecked(!isChecked)
 
   const isDiscountZero = useMemo(() => new BigNumber((discount as string) ?? '0').eq(0), [discount])
 
-  const noPerps = useMemo(() => (noperps as string) === 'true', [noperps])
+  const noPerps = useMemo(() => (perps as string) === 'true', [perps])
 
   const isReady = useMemo(() => !isLoading && isChecked, [isLoading, isChecked])
 

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/WelcomePage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/WelcomePage.tsx
@@ -25,7 +25,7 @@ const WelcomePage: React.FC<React.PropsWithChildren<WelcomePageProps>> = ({ isLo
 
   const isDiscountZero = useMemo(() => new BigNumber((discount as string) ?? '0').eq(0), [discount])
 
-  const noPerps = useMemo(() => (perps as string) === 'true', [perps])
+  const noPerps = useMemo(() => (perps as string) === 'false', [perps])
 
   const isReady = useMemo(() => !isLoading && isChecked, [isLoading, isChecked])
 

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/index.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/index.tsx
@@ -30,8 +30,8 @@ const OnBoardingModal = () => {
   const [currentView, setCurrentView] = useState(Views.STEP1)
 
   useEffect(() => {
-    const { ref, user, discount, noperps } = router.query
-    if (ref && user && discount && noperps) {
+    const { ref, user, discount, perps } = router.query
+    if (ref && user && discount && perps) {
       setIsOpen(true)
     }
   }, [router])
@@ -61,7 +61,7 @@ const OnBoardingModal = () => {
         setCurrentView(Views.STEP2)
         toastSuccess(t('Congratulations! You’re all set!'))
       } else {
-        toastError(result.error)
+        toastError(result?.error || '')
       }
     } catch (error) {
       console.error(`Submit Start Now Error: ${error}`)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a5f6567</samp>

### Summary
🔧🔄🚀

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate a bug fix or an improvement in the code logic or functionality.
2.  🔄 - This emoji represents a refresh or a sync icon, and can be used to indicate a change or an update in the naming or the parameters of the code.
3.  🚀 - This emoji represents a rocket or a launch, and can be used to indicate a new feature or a enhancement in the user experience or the performance of the code.
-->
Fixed bugs and improved logic for the affiliates program onboarding modal and dashboard. Renamed the query parameter `noperps` to `perps` to match the backend and the affiliate object.

> _To match the backend and the prop_
> _The query param `noperps` was dropped_
> _The `useEffect` hook_
> _And the `WelcomePage` look_
> _Were updated with `perps` as swapped_

### Walkthrough
*  Rename `noperps` query parameter to `perps` and update logic accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-92ad6d59216367a922777f8135af1616e96c770822263c139bf78ec4f33c38e8L73-R73), [link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-d340cf8e318234cfd4c708464d493e17f407da97df10d86c97f80f2951a4de7fL24-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-a372d30a34fe7a4cc479c67d24becf486f458cba59431245c32fd6c591247febL33-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-2818427fba1ed6a5850f954915676609b500747386955dccef050a5ce10616e0L21-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-2818427fba1ed6a5850f954915676609b500747386955dccef050a5ce10616e0L28-R28))
*  Handle undefined or null `result` object in `toastError` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/6932/files?diff=unified&w=0#diff-a372d30a34fe7a4cc479c67d24becf486f458cba59431245c32fd6c591247febL64-R64))


