### PR TITLE
chore: update pancake protector banner link

### DIFF
--- a/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
@@ -150,7 +150,7 @@ const PancakeProtectorBanner = () => {
               </StyledButton>
             </Link>
             <Devider />
-            <Link href="protectors.pancakeswap.finance" external style={{ textDecoration: 'none' }}>
+            <Link href="https://protectors.pancakeswap.finance" external style={{ textDecoration: 'none' }}>
               <StyledButton variant="text" style={{ color: 'white' }} scale={isMobile ? 'sm' : 'md'}>
                 {isMobile ? t('Beta') : t('Explore Beta')}
                 <ArrowForwardIcon color="white" />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5bdd8be</samp>

### Summary
🐛🔗🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It also conveys a sense of humor, since the PancakeSwap platform is themed around pancakes and syrup, and bugs are often associated with syrup.
2.  🔗 - This emoji represents a link, which is the element that was modified by the change. It also conveys a sense of connection and communication, which are relevant to the feature that the banner is promoting.
3.  🚀 - This emoji represents a launch, which is the context of the change. The banner is announcing a new feature that is being released to the users, and the emoji conveys a sense of excitement and innovation.
-->
Fixed a broken link in the `PancakeProtectorBanner` component. The link now correctly leads to the external website of the Pancake Protector feature.

> _`Link` href fixed_
> _Pancake Protector Banner_
> _Autumn harvest time_

### Walkthrough
*  Fix external link bug in Pancake Protector Banner component by adding `https://` protocol prefix to `href` attribute ([link](https://github.com/pancakeswap/pancake-frontend/pull/6935/files?diff=unified&w=0#diff-462e5918a9f05347786f8973e69f0b1c68999afeb91f6858a174b80fa3f7a4fbL153-R153))


