### PR TITLE
refactor: Use intl numberformat instead of numbro to reduce bundle size

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -90,7 +90,6 @@
     "next-axiom": "^0.13.0",
     "next-seo": "^5.15.0",
     "next-themes": "^0.2.0",
-    "numbro": "^2.3.6",
     "qs": "^6.0.0",
     "react": "^18.2.0",
     "react-countup": "^6.4.0",

--- a/apps/web/src/views/V3Info/utils/numbers.ts
+++ b/apps/web/src/views/V3Info/utils/numbers.ts
@@ -1,5 +1,3 @@
-import numbro from 'numbro'
-
 // using a currency library here in case we want to add more in future
 export const formatDollarAmount = (num: number | undefined, digits = 2, round = true) => {
   if (num <= 0) return '$0.00'
@@ -8,18 +6,11 @@ export const formatDollarAmount = (num: number | undefined, digits = 2, round = 
     return '<$0.001'
   }
 
-  return numbro(num)
-    .formatCurrency({
-      average: round,
-      mantissa: num > 1000 ? 2 : digits,
-      abbreviations: {
-        million: 'M',
-        billion: 'B',
-        thousand: 'K',
-        trillion: 'T',
-      },
-    })
-    .toUpperCase()
+  return Intl.NumberFormat('en-US', {
+    notation: round ? 'compact' : 'standard',
+    minimumFractionDigits: num > 1000 ? 2 : digits,
+    maximumFractionDigits: num > 1000 ? 2 : digits,
+  }).format(num)
 }
 
 // using a currency library here in case we want to add more in future
@@ -29,15 +20,10 @@ export const formatAmount = (num: number | undefined, digits = 2) => {
   if (num < 0.001) {
     return '<0.001'
   }
-  return numbro(num)
-    .format({
-      average: true,
-      mantissa: num > 1000 ? 2 : digits,
-      abbreviations: {
-        million: 'M',
-        billion: 'B',
-        trillion: 'T',
-      },
-    })
-    .toUpperCase()
+
+  return Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    minimumFractionDigits: num > 1000 ? 2 : digits,
+    maximumFractionDigits: num > 1000 ? 2 : digits,
+  }).format(num)
 }

--- a/packages/utils/formatInfoNumbers.ts
+++ b/packages/utils/formatInfoNumbers.ts
@@ -1,5 +1,3 @@
-import numbro from 'numbro'
-
 // Returns first 2 digits after first non-zero decimal
 // i.e. 0.001286 -> 0.0012, 0.9845 -> 0.98, 0.0102 -> 0.010, etc
 // Intended to be used for tokens whose value is less than $1
@@ -11,6 +9,8 @@ export const getFirstThreeNonZeroDecimals = (value: number) => {
 export type formatAmountNotation = 'compact' | 'standard'
 
 export type tokenPrecisionStyle = 'normal' | 'enhanced'
+
+const GROUPING_FALSE_LARGER_THAN_THIS = 1_000_000_000_000_000_000
 
 /**
  * This function is used to format token prices, liquidity, amount of tokens in TX, and in general any numbers on info section
@@ -56,19 +56,12 @@ export const formatAmount = (
     precision = amount < 1 || tokenPrecision === 'enhanced' ? 3 : 2
   }
 
-  let format = `0.${'0'.repeat(precision)}a`
-
-  if (notation === 'standard') {
-    format = `0,0.${'0'.repeat(precision)}`
-  }
-
-  if (isInteger && amount < 1000) {
-    format = '0'
-  }
-
   const amountWithPrecision = parseFloat(amount?.toFixed(precision))
 
-  // toUpperCase is needed cause numeral doesn't have support for capital K M B out of the box
-  // TODO: numbro support though, need to convert the format string to new format
-  return numbro(amountWithPrecision).format(format).toUpperCase()
+  return Intl.NumberFormat('en-US', {
+    notation,
+    minimumFractionDigits: isInteger && amount < 1000 ? 0 : precision,
+    maximumFractionDigits: isInteger && amount < 1000 ? 0 : precision,
+    useGrouping: amountWithPrecision < GROUPING_FALSE_LARGER_THAN_THIS,
+  }).format(amountWithPrecision)
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,6 @@
     "bignumber.js": "^9.0.0",
     "vitest": "^0.30.1",
     "swr": "^2.1.3",
-    "numbro": "^2.3.6",
     "jotai": "^2.0.3"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,9 +708,6 @@ importers:
       next-themes:
         specifier: ^0.2.0
         version: 0.2.0(next@13.3.4)(react-dom@18.2.0)(react@18.2.0)
-      numbro:
-        specifier: ^2.3.6
-        version: 2.3.6
       polished:
         specifier: ^4.2.2
         version: 4.2.2
@@ -1812,9 +1809,6 @@ importers:
       jotai:
         specifier: ^2.0.3
         version: 2.0.3(react@18.2.0)
-      numbro:
-        specifier: ^2.3.6
-        version: 2.3.6
       styled-components:
         specifier: ^5.3.3
         version: 5.3.3(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
@@ -12769,9 +12763,6 @@ packages:
     dependencies:
       bindings: 1.5.0
 
-  /bignumber.js@8.1.1:
-    resolution: {integrity: sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==}
-
   /bignumber.js@9.0.2:
     resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==}
 
@@ -20976,11 +20967,6 @@ packages:
       semver: 7.5.0
       validate-npm-package-name: 4.0.0
     dev: true
-
-  /numbro@2.3.6:
-    resolution: {integrity: sha512-pxpoTT3hVxQGaOA2RTzXR/muonQNd1K1HPJbWo7QOmxPwiPmoFCFfsG9XXgW3uqjyzezJ0P9IvCPDXUtJexjwg==}
-    dependencies:
-      bignumber.js: 8.1.1
 
   /nwsapi@2.2.2:
     resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0476b75</samp>

### Summary
🗑️🌐🔧

<!--
1.  🗑️ - This emoji represents removing something, such as a dependency, file, or code. It can be used for the first and fourth bullet points, which involve deleting `numbro` from the project and the lock file.
2.  🌐 - This emoji represents the web, globalization, or internationalization. It can be used for the second and third bullet points, which involve migrating to use `Intl.NumberFormat`, a native web API that supports different locales and formats for numbers.
3.  🔧 - This emoji represents fixing, improving, or refactoring something. It can be used for the third bullet point, which involves refactoring the `formatAmount` function to use a different approach and add new features.
-->
Removed `numbro` dependency and replaced it with native `Intl.NumberFormat` for formatting numbers in `packages/utils/formatInfoNumbers.ts`. Updated `pnpm-lock.yaml` and `package.json` files accordingly.

> _No more `numbro`, no more lies_
> _We format numbers with our own eyes_
> _We rebel against the bloated code_
> _We use the native `Intl.NumberFormat` mode_

### Walkthrough
*  Remove `numbro` dependency from the project and use `Intl.NumberFormat` instead for formatting numbers ([link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L93), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-3c9d506718b89c55d251d5485665fa4162171d6de183d6bc5acfef42effbddeaL1-L2), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L28), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL711-L713), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1815-L1817), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12772-L12774), [link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL20980-L20984))
*  Refactor `formatAmount` function in `packages/utils/formatInfoNumbers.ts` to accept `notation` and `precision` parameters and handle integer cases ([link](https://github.com/pancakeswap/pancake-frontend/pull/6936/files?diff=unified&w=0#diff-3c9d506718b89c55d251d5485665fa4162171d6de183d6bc5acfef42effbddeaL59-R62))


