### PR TITLE
chore: add menu item for pancakeProtector

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -199,6 +199,11 @@ const config: (
           type: DropdownMenuItemType.DIVIDER,
         },
         {
+          label: t('Pancake Protectors'),
+          href: 'https://protectors.pancakeswap.finance',
+          type: DropdownMenuItemType.EXTERNAL_LINK,
+        },
+        {
           label: t('Blog'),
           href: 'https://blog.pancakeswap.finance',
           type: DropdownMenuItemType.EXTERNAL_LINK,

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -25,12 +25,13 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
   return useMemo(() => {
     if (menuItemsStatus && Object.keys(menuItemsStatus).length) {
       return menuItems.map((item) => {
-        const innerItems = item.items.map((innerItem) => {
+        const innerItems = item?.items?.map((innerItem) => {
           const itemStatus = menuItemsStatus[innerItem.href]
           const modalId = innerItem.confirmModalId
           const isInfo = innerItem.href === '/info/v3'
+          const isProtector = innerItem.href === 'https://protectors.pancakeswap.finance'
           if (itemStatus) {
-            let itemMenuStatus
+            let itemMenuStatus = null
             if (itemStatus === 'soon') {
               itemMenuStatus = <LinkStatus>{ text: t('Soon'), color: 'warning' }
             } else if (itemStatus === 'live') {
@@ -47,7 +48,7 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
             return { ...innerItem, status: itemMenuStatus }
           }
           if (modalId) {
-            let onClickEvent
+            let onClickEvent = null
             if (modalId === 'usCitizenConfirmModal') {
               onClickEvent = (e: React.MouseEvent<HTMLElement>) => {
                 if (!userNotUsCitizenAcknowledgement && onUsCitizenModalPresent) {
@@ -60,11 +61,13 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
             return { ...innerItem, onClick: onClickEvent }
           }
           if (isInfo) {
-            const itemMenuStatus = <LinkStatus>{ text: t('New'), color: 'success' }
             const href = `${innerItem.href}${multiChainPaths[chainId] ?? ''}`
-            return { ...innerItem, status: itemMenuStatus, href }
+            return { ...innerItem, href }
           }
-
+          if (isProtector) {
+            const itemMenuStatus = <LinkStatus>{ text: t('Beta'), color: 'success' }
+            return { ...innerItem, status: itemMenuStatus }
+          }
           return innerItem
         })
         return { ...item, items: innerItems }

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -29,7 +29,6 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
           const itemStatus = menuItemsStatus[innerItem.href]
           const modalId = innerItem.confirmModalId
           const isInfo = innerItem.href === '/info/v3'
-          const isProtector = innerItem.href === 'https://protectors.pancakeswap.finance'
           if (itemStatus) {
             let itemMenuStatus = null
             if (itemStatus === 'soon') {
@@ -63,10 +62,6 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
           if (isInfo) {
             const href = `${innerItem.href}${multiChainPaths[chainId] ?? ''}`
             return { ...innerItem, href }
-          }
-          if (isProtector) {
-            const itemMenuStatus = <LinkStatus>{ text: t('Beta'), color: 'success' }
-            return { ...innerItem, status: itemMenuStatus }
           }
           return innerItem
         })

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2523,5 +2523,6 @@
   "Join Pancake Protectors Beta Week": "Join Pancake Protectors Beta Week",
   "Empower your characters with Pancake Squad and Bunnies NFTs": "Empower your characters with Pancake Squad and Bunnies NFTs",
   "Beta": "Beta",
-  "Explore Beta": "Explore Beta"
+  "Explore Beta": "Explore Beta",
+  "Pancake Protectors": "Pancake Protectors"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9ed572d</samp>

### Summary
🥞🛡️🐛

<!--
1.  🥞 - This emoji represents the Pancake theme of the project and the new feature of Pancake Protectors.
2.  🛡️ - This emoji represents the idea of staking NFTs and earning rewards, as well as the protection aspect of the feature.
3.  🐛 - This emoji represents the bug fixes and improvements made to the error handling and the visual indicators of the menu items.
-->
This pull request adds a new menu item for `Pancake Protectors`, a feature that lets users stake NFTs and earn rewards. It also improves the error handling and the visual indicators of the menu items in `useMenuItems.ts` and adds a translation key for the new label in `translations.json`.

> _`Pancake Protectors`, a new way to stake_
> _Open a new tab and enter the gate_
> _Of rewards and risks, of beta and fate_
> _`translations.json`, the key to translate_

### Walkthrough
*  Add a new menu item for Pancake Protectors, a feature that allows staking NFTs and earning rewards ([link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-e0daeed87867fc4fc6b0b1a9c2d52c9bfbd175cd1822e100f43300c4046484adR202-R206), [link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL28-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2526-R2527))
  - Add a green "Beta" badge to indicate the experimental status of the feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL63-R70))
*  Improve error handling and code readability in the `useMenuItems` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL28-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL50-R51))
  - Remove the `status` property from the `isInfo` condition, which was showing a redundant "New" badge ([link](https://github.com/pancakeswap/pancake-frontend/pull/6938/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL63-R70))


