### PR TITLE
fix: Migrate bugs

### DIFF
--- a/apps/web/src/hooks/useTokenBalance.ts
+++ b/apps/web/src/hooks/useTokenBalance.ts
@@ -2,6 +2,7 @@ import { ChainId } from '@pancakeswap/sdk'
 import { CAKE } from '@pancakeswap/tokens'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
 
 import { Address, erc20ABI, useAccount, useBalance, useContractRead } from 'wagmi'
 import { useActiveChainId } from './useActiveChainId'
@@ -23,7 +24,7 @@ const useTokenBalance = (tokenAddress: Address, forceBSC?: boolean) => {
   return {
     ...rest,
     fetchStatus: status,
-    balance: typeof data !== 'undefined' ? new BigNumber(data.toString()) : BIG_ZERO,
+    balance: useMemo(() => (typeof data !== 'undefined' ? new BigNumber(data.toString()) : BIG_ZERO), [data]),
   }
 }
 

--- a/apps/web/src/pages/v2/pair/[[...currency]].tsx
+++ b/apps/web/src/pages/v2/pair/[[...currency]].tsx
@@ -88,9 +88,14 @@ export default function PoolV2Page() {
                 <NextLinkFromReactRouter to={`/v2/add/${currencyIdA}/${currencyIdB}`}>
                   <Button width="100%">{t('Add')}</Button>
                 </NextLinkFromReactRouter>
-                <NextLinkFromReactRouter to={`/v2/remove/${currencyIdA}/${currencyIdB}`}>
-                  <Button ml="16px" variant="secondary" width="100%">
+                <NextLinkFromReactRouter to={`/v2/remove/${currencyIdA}/${currencyIdB}`} style={{ margin: '0px 8px' }}>
+                  <Button variant="secondary" width="100%">
                     {t('Remove')}
+                  </Button>
+                </NextLinkFromReactRouter>
+                <NextLinkFromReactRouter to={`/v2/migrate/${pair?.liquidityToken?.address}`}>
+                  <Button variant="secondary" width="100%">
+                    {t('Migrate')}
                   </Button>
                 </NextLinkFromReactRouter>
               </>
@@ -108,6 +113,11 @@ export default function PoolV2Page() {
               <NextLinkFromReactRouter to={`/v2/remove/${currencyIdA}/${currencyIdB}`}>
                 <Button variant="secondary" width="100%" mb="8px">
                   {t('Remove')}
+                </Button>
+              </NextLinkFromReactRouter>
+              <NextLinkFromReactRouter to={`/v2/migrate/${pair.liquidityToken.address}`}>
+                <Button variant="secondary" width="100%" mb="8px">
+                  {t('Migrate')}
                 </Button>
               </NextLinkFromReactRouter>
             </>

--- a/apps/web/src/views/AddLiquidityV3/Migrate.tsx
+++ b/apps/web/src/views/AddLiquidityV3/Migrate.tsx
@@ -45,6 +45,7 @@ import { isUserRejected } from 'utils/sentry'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ResponsiveTwoColumns } from 'views/AddLiquidityV3'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { useFeeTierDistribution } from 'hooks/v3/useFeeTierDistribution'
 import FeeSelector from './formViews/V3FormView/components/FeeSelector'
 import RangeSelector from './formViews/V3FormView/components/RangeSelector'
 import RateToggle from './formViews/V3FormView/components/RateToggle'
@@ -140,6 +141,8 @@ function V2PairMigrate({
     [token1, pairBalance, reserve1.quotient, v2LPTotalSupply.quotient],
   )
 
+  const { isLoading, isError, largestUsageFeeTier } = useFeeTierDistribution(token0, token1)
+
   const [feeAmount, setFeeAmount] = useState(FeeAmount.MEDIUM)
 
   const handleFeePoolSelect = useCallback<HandleFeePoolSelectFn>(({ feeAmount: newFeeAmount }) => {
@@ -172,13 +175,18 @@ function V2PairMigrate({
   )
   const v3SpotPrice = pool?.token0Price ?? undefined
 
-  let priceDifferenceFraction: Fraction | undefined =
-    v2SpotPrice && v3SpotPrice ? v3SpotPrice.divide(v2SpotPrice).subtract(1).multiply(100) : undefined
-  if (priceDifferenceFraction?.lessThan(ZERO)) {
-    priceDifferenceFraction = priceDifferenceFraction.multiply(-1)
-  }
+  const priceDifferenceFraction: Fraction | undefined = useMemo(() => {
+    const result = v2SpotPrice && v3SpotPrice ? v3SpotPrice.divide(v2SpotPrice).subtract(1).multiply(100) : undefined
+    if (result?.lessThan(ZERO)) {
+      return result.multiply(-1)
+    }
+    return result
+  }, [v2SpotPrice, v3SpotPrice])
 
-  const largePriceDifference = priceDifferenceFraction && !priceDifferenceFraction?.lessThan(2n)
+  const largePriceDifference = useMemo(
+    () => priceDifferenceFraction && !priceDifferenceFraction?.lessThan(2n),
+    [priceDifferenceFraction],
+  )
 
   // modal and loading
   // capital efficiency warning
@@ -190,8 +198,7 @@ function V2PairMigrate({
 
   useEffect(() => {
     if (feeAmount) {
-      onLeftRangeInput('')
-      onRightRangeInput('')
+      onBothRangeInput({ leftTypedValue: '', rightTypedValue: '' })
     }
     // NOTE: ignore exhaustive-deps to avoid infinite re-render
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -210,6 +217,13 @@ function V2PairMigrate({
       onRightRangeInput(maxPrice)
     }
   }, [minPrice, maxPrice, onRightRangeInput, onLeftRangeInput, leftRangeTypedValue, rightRangeTypedValue])
+
+  useEffect(() => {
+    if (!isError && !isLoading && largestUsageFeeTier) {
+      setFeeAmount(largestUsageFeeTier)
+    }
+  }, [isError, isLoading, largestUsageFeeTier])
+
   // txn values
   const deadline = useTransactionDeadline() // custom from users settings
 
@@ -219,20 +233,35 @@ function V2PairMigrate({
   const [allowedSlippage] = useUserSlippagePercent()
 
   // the v3 tick is either the pool's tickCurrent, or the tick closest to the v2 spot price
-  const tick = pool?.tickCurrent ?? priceToClosestTick(v2SpotPrice)
+  const tick = useMemo(() => pool?.tickCurrent ?? priceToClosestTick(v2SpotPrice), [pool?.tickCurrent, v2SpotPrice])
   // the price is either the current v3 price, or the price at the tick
-  const sqrtPrice = pool?.sqrtRatioX96 ?? TickMath.getSqrtRatioAtTick(tick)
-  const position =
-    typeof tickLower === 'number' && typeof tickUpper === 'number' && !invalidRange
-      ? Position.fromAmounts({
-          pool: pool ?? new Pool(token0, token1, feeAmount, sqrtPrice, 0, tick, []),
-          tickLower,
-          tickUpper,
-          amount0: token0Value.quotient,
-          amount1: token1Value.quotient,
-          useFullPrecision: true, // we want full precision for the theoretical position
-        })
-      : undefined
+  const sqrtPrice = useMemo(() => pool?.sqrtRatioX96 ?? TickMath.getSqrtRatioAtTick(tick), [pool?.sqrtRatioX96, tick])
+  const position = useMemo(
+    () =>
+      typeof tickLower === 'number' && typeof tickUpper === 'number' && !invalidRange
+        ? Position.fromAmounts({
+            pool: pool ?? new Pool(token0, token1, feeAmount, sqrtPrice, 0, tick, []),
+            tickLower,
+            tickUpper,
+            amount0: token0Value.quotient,
+            amount1: token1Value.quotient,
+            useFullPrecision: true, // we want full precision for the theoretical position
+          })
+        : undefined,
+    [
+      feeAmount,
+      invalidRange,
+      pool,
+      sqrtPrice,
+      tick,
+      tickLower,
+      tickUpper,
+      token0,
+      token0Value.quotient,
+      token1,
+      token1Value.quotient,
+    ],
+  )
 
   const { amount0: v3Amount0Min, amount1: v3Amount1Min } = useMemo(
     () => (position ? position.mintAmountsWithSlippage(allowedSlippage) : { amount0: undefined, amount1: undefined }),
@@ -353,8 +382,6 @@ function V2PairMigrate({
       !deadline ||
       typeof tickLower !== 'number' ||
       typeof tickUpper !== 'number' ||
-      !v3Amount0Min ||
-      !v3Amount1Min ||
       !chainId
     )
       return
@@ -466,7 +493,10 @@ function V2PairMigrate({
     currency1,
   ])
 
-  const isSuccessfullyMigrated = !!pendingMigrationHash && BigInt(pairBalance.toString()) === ZERO
+  const isSuccessfullyMigrated = useMemo(
+    () => !!pendingMigrationHash && BigInt(pairBalance.toString()) === ZERO,
+    [pendingMigrationHash, pairBalance],
+  )
 
   return (
     <CardBody>
@@ -482,7 +512,7 @@ function V2PairMigrate({
                     {token0?.symbol}
                   </Text>
                 </AutoRow>
-                <Text bold>{token0Value.toSignificant(6)}</Text>
+                <Text bold>{token0Value.toFixed(token0.decimals)}</Text>
               </AutoRow>
               <AutoRow>
                 <AutoRow gap="4px" flex={1}>
@@ -491,7 +521,7 @@ function V2PairMigrate({
                     {token1?.symbol}
                   </Text>
                 </AutoRow>
-                <Text bold>{token1Value.toSignificant(6)}</Text>
+                <Text bold>{token1Value.toFixed(token1.decimals)}</Text>
               </AutoRow>
             </AutoColumn>
           </GreyCard>
@@ -512,7 +542,7 @@ function V2PairMigrate({
                       {token0?.symbol}
                     </Text>
                   </AutoRow>
-                  {position && <Text bold>{position.amount0.toSignificant(6)}</Text>}
+                  {position && <Text bold>{position.amount0.toFixed(token0.decimals)}</Text>}
                 </AutoRow>
                 <AutoRow>
                   <AutoRow gap="4px" flex={1}>
@@ -521,7 +551,7 @@ function V2PairMigrate({
                       {token1?.symbol}
                     </Text>
                   </AutoRow>
-                  {position && <Text bold>{position.amount1.toSignificant(6)}</Text>}
+                  {position && <Text bold>{position.amount1.toFixed(token1.decimals)}</Text>}
                 </AutoRow>
                 {position && chainId && refund0 && refund1 ? (
                   <Text color="textSubtle">
@@ -542,9 +572,13 @@ function V2PairMigrate({
             <RateToggle
               currencyA={invertPrice ? currency1 : currency0}
               handleRateToggle={() => {
-                onLeftRangeInput('')
-                onRightRangeInput('')
                 setBaseToken((base) => (base.equals(token0) ? token1 : token0))
+                if (!ticksAtLimit[Bound.LOWER] && !ticksAtLimit[Bound.UPPER]) {
+                  onBothRangeInput({
+                    leftTypedValue: (invertPrice ? priceLower : priceUpper?.invert())?.toSignificant(6) ?? '',
+                    rightTypedValue: (invertPrice ? priceUpper : priceLower?.invert())?.toSignificant(6) ?? '',
+                  })
+                }
               }}
             />
           </RowBetween>
@@ -681,7 +715,7 @@ function V2PairMigrate({
               {t('Full Range')}
             </Button>
           )}
-          {outOfRange ? (
+          {outOfRange || !v3Amount0Min || !v3Amount1Min ? (
             <Message variant="warning">
               <RowBetween>
                 <Text ml="12px" fontSize="12px">
@@ -705,8 +739,6 @@ function V2PairMigrate({
                   disabled={
                     approval !== ApprovalState.NOT_APPROVED ||
                     signatureData !== null ||
-                    !v3Amount0Min ||
-                    !v3Amount1Min ||
                     invalidRange ||
                     confirmingMigration
                   }
@@ -728,8 +760,6 @@ function V2PairMigrate({
               <CommitButton
                 variant={isSuccessfullyMigrated ? 'success' : 'primary'}
                 disabled={
-                  !v3Amount0Min ||
-                  !v3Amount1Min ||
                   invalidRange ||
                   (approval !== ApprovalState.APPROVED && signatureData === null) ||
                   confirmingMigration ||


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6552d46</samp>

### Summary
🚀📊🎨

<!--
1.  🚀 for improving performance and user experience
2.  📊 for adding new data and logic to the feature
3.  🎨 for improving the UI and design of the feature
-->
Improve liquidity migration from v2 to v3 by adding fee tier distribution data and suggestions. Optimize some calculations in `Migrate.tsx` using memoization.

> _To migrate from v2 to v3_
> _We need to fetch the `feeTier` data_
> _We use a new hook_
> _To give a default look_
> _And memoize some calculations later_

### Walkthrough
*  Suggest a default fee tier for the user when migrating v2 liquidity to v3 based on the subgraph data ([link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L132-R136), [link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507R207-R213))
*  Memoize the calculations of price difference, tick, sqrtPrice, position, and isSuccessfullyMigrated to improve performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L164-R173), [link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L211-R251), [link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L441-R471))
*  Update the range input values when the user toggles the rate between the two tokens to preserve the price range ([link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L517-R553))
*  Remove the unused import of FeeAmount ([link](https://github.com/pancakeswap/pancake-frontend/pull/6946/files?diff=unified&w=0#diff-9d0699166de79d1a5a73897629d0ae029a8fca22f273d21a07c7646df6457507L34-R34))


