### PR TITLE
fix: Farmv3 tvl timeout

### DIFF
--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -80,7 +80,6 @@ export const useFarmsV3Public = () => {
 
         return data
       } catch (error) {
-        console.error(error, 'v3?')
         // return fallback for now since not all chains supported
         return fallback
       }
@@ -166,8 +165,6 @@ export const useFarmsV3 = ({ mockApr = false }: UseFarmsOptions = {}) => {
       keepPreviousData: true,
     },
   )
-
-  console.log(error, 'error', data, farmV3.data, farmV3.error)
 
   return {
     data: error ? farmV3.data : ((data ?? farmV3.data) as FarmsV3Response<FarmV3DataWithPriceTVL>),

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -80,6 +80,7 @@ export const useFarmsV3Public = () => {
 
         return data
       } catch (error) {
+        console.error(error)
         // return fallback for now since not all chains supported
         return fallback
       }

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -168,7 +168,7 @@ export const useFarmsV3 = ({ mockApr = false }: UseFarmsOptions = {}) => {
   )
 
   return {
-    data: ((data ?? farmV3.data) as FarmsV3Response<FarmV3DataWithPriceTVL>),
+    data: (data ?? farmV3.data) as FarmsV3Response<FarmV3DataWithPriceTVL>,
     isLoading: farmV3.isLoading,
     error: farmV3.error,
   }

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -104,7 +104,7 @@ export const useFarmsV3 = ({ mockApr = false }: UseFarmsOptions = {}) => {
 
   const cakePrice = useCakePriceAsBN()
 
-  const { data, error } = useSWR<FarmsV3Response<FarmV3DataWithPriceTVL>>(
+  const { data } = useSWR<FarmsV3Response<FarmV3DataWithPriceTVL>>(
     [chainId, 'cake-apr-tvl', farmV3.data],
     async () => {
       const tvls: TvlMap = {}
@@ -167,7 +167,7 @@ export const useFarmsV3 = ({ mockApr = false }: UseFarmsOptions = {}) => {
   )
 
   return {
-    data: error ? farmV3.data : ((data ?? farmV3.data) as FarmsV3Response<FarmV3DataWithPriceTVL>),
+    data: ((data ?? farmV3.data) as FarmsV3Response<FarmV3DataWithPriceTVL>),
     isLoading: farmV3.isLoading,
     error: farmV3.error,
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5ed283c</samp>

### Summary
🚀🐛📝

<!--
1.  🚀 for improving performance
2.  🐛 for fixing errors
3.  📝 for adding logs
-->
Improve v3 farms API error handling and performance with `fetchWithTimeout` and `useSWR`. Add debugging logs to `apps/web/src/state/farmsV3/hooks.ts`.

> _We're facing the doom of the v3 farms_
> _We need to fetch with timeout and handle the errors_
> _We use the `useSWR` hook to get the data we need_
> _We log the results to see what we have achieved_

### Walkthrough
* Import and use `fetchWithTimeout` utility function to set a timeout for fetch requests and reject them if they take too long ([link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dR27), [link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL113-R114))
* Destructure and handle `error` property from `useSWR` hook to deal with errors from SWR cache or revalidation logic ([link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL106-R107), [link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL168-R172))
* Modify and add console statements for debugging purposes to distinguish errors from v3 farms API and inspect data and error values ([link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL81-R82), [link](https://github.com/pancakeswap/pancake-frontend/pull/6950/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL168-R172))


