### PR TITLE
fix: v3 info search limit issue

### DIFF
--- a/apps/web/src/views/V3Info/constants.ts
+++ b/apps/web/src/views/V3Info/constants.ts
@@ -60,6 +60,8 @@ export const SUBGRAPH_START_BLOCK = {
   [ChainId.ETHEREUM]: 16950686,
 }
 
+export const NODE_REAL_ADDRESS_LIMIT = 50
+
 export const DURATION_INTERVAL = {
   day: ONE_HOUR_SECONDS,
   week: ONE_DAY_SECONDS,

--- a/apps/web/src/views/V3Info/data/search/index.ts
+++ b/apps/web/src/views/V3Info/data/search/index.ts
@@ -140,17 +140,17 @@ export async function fetchSearchResults(
       ...tokens.asAddress.map((d) => d.id),
       ...tokens.asName.map((d) => d.id),
       ...tokens.asSymbol.map((d) => d.id),
-    ]
+    ].slice(0, 50)
 
     const poolAddress = [
       ...pools.as0.map((d) => d.id),
       ...pools.as1.map((d) => d.id),
       ...pools.asAddress.map((d) => d.id),
-    ]
+    ].slice(0, 50)
 
     const tokensData = await fetchedTokenDatas(client, tokenAddress, blocks)
     const poolsData = await fetchPoolDatas(client, poolAddress, blocks)
-    const filteredSortedTokens = Object.values(tokensData.data)
+    const filteredSortedTokens = Object.values(tokensData?.data ?? {})
       .filter(notEmpty)
       .filter((t) => {
         const regexMatches = Object.keys(t).map((tokenEntryKey) => {
@@ -169,7 +169,7 @@ export async function fetchSearchResults(
         return regexMatches.some((m) => m)
       })
 
-    const filteredSortedPools = Object.values(poolsData.data)
+    const filteredSortedPools = Object.values(poolsData?.data ?? {})
       .filter(notEmpty)
       .filter((t) => {
         const regexMatches = Object.keys(t).map((key) => {

--- a/apps/web/src/views/V3Info/data/search/index.ts
+++ b/apps/web/src/views/V3Info/data/search/index.ts
@@ -5,6 +5,7 @@ import { PoolData, TokenData } from '../../types'
 import { escapeRegExp, notEmpty } from '../../utils'
 import { fetchPoolDatas } from '../pool/poolData'
 import { fetchedTokenDatas } from '../token/tokenData'
+import { NODE_REAL_ADDRESS_LIMIT } from '../../constants'
 
 export const TOKEN_SEARCH = gql`
   query tokens($value: String, $id: ID) {
@@ -132,7 +133,7 @@ export async function fetchSearchResults(
       id: value,
     })
     const pools = await client.request<PoolRes>(POOL_SEARCH, {
-      tokens: tokens.asSymbol?.map((t) => t.id),
+      tokens: tokens.asSymbol?.map((t) => t.id).slice(0, NODE_REAL_ADDRESS_LIMIT),
       id: value,
     })
 
@@ -140,13 +141,13 @@ export async function fetchSearchResults(
       ...tokens.asAddress.map((d) => d.id),
       ...tokens.asName.map((d) => d.id),
       ...tokens.asSymbol.map((d) => d.id),
-    ].slice(0, 50)
+    ].slice(0, NODE_REAL_ADDRESS_LIMIT)
 
     const poolAddress = [
       ...pools.as0.map((d) => d.id),
       ...pools.as1.map((d) => d.id),
       ...pools.asAddress.map((d) => d.id),
-    ].slice(0, 50)
+    ].slice(0, NODE_REAL_ADDRESS_LIMIT)
 
     const tokensData = await fetchedTokenDatas(client, tokenAddress, blocks)
     const poolsData = await fetchPoolDatas(client, poolAddress, blocks)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 64f5353</samp>

### Summary
🔍🚀🐛

<!--
1.  🔍 for improving the search feature
2.  🚀 for improving the performance
3.  🐛 for fixing the error handling
-->
Improved search feature for tokens and pools on V3 info page by reducing API calls and adding error handling. Modified `apps/web/src/views/V3Info/data/search/index.ts`.

> _Search feature improved_
> _`token` and `pool` limited_
> _Winter of errors_

### Walkthrough
*  Limit the number of token and pool addresses to 50 when fetching search results to improve performance and avoid query limit errors ([link](https://github.com/pancakeswap/pancake-frontend/pull/6952/files?diff=unified&w=0#diff-2cf6b3ab9915e76d8c2e51af63fc60ffc075c12b76051895c5724593892d52faL143-R143), [link](https://github.com/pancakeswap/pancake-frontend/pull/6952/files?diff=unified&w=0#diff-2cf6b3ab9915e76d8c2e51af63fc60ffc075c12b76051895c5724593892d52faL149-R153))
*  Add optional chaining and nullish coalescing operators to handle undefined or null values for `tokensData` and `poolsData` in `apps/web/src/views/V3Info/data/search/index.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6952/files?diff=unified&w=0#diff-2cf6b3ab9915e76d8c2e51af63fc60ffc075c12b76051895c5724593892d52faL149-R153), [link](https://github.com/pancakeswap/pancake-frontend/pull/6952/files?diff=unified&w=0#diff-2cf6b3ab9915e76d8c2e51af63fc60ffc075c12b76051895c5724593892d52faL172-R172))


