### PR TITLE
perf: Minor improve for unstable network

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -9,8 +9,13 @@ export const SERVER_NODES = {
 } satisfies Record<ChainId, string>
 
 export const PUBLIC_NODES = {
-  [ChainId.BSC]: process.env.NEXT_PUBLIC_NODE_PRODUCTION,
+  [ChainId.BSC]: [
+    process.env.NEXT_PUBLIC_NODE_PRODUCTION,
+    getNodeRealUrlV2(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+    'https://bsc-dataseed1.defibit.io',
+    'https://bsc-dataseed1.binance.org',
+  ].filter(Boolean),
   [ChainId.BSC_TESTNET]: 'https://data-seed-prebsc-1-s1.binance.org:8545',
   [ChainId.ETHEREUM]: getNodeRealUrlV2(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
   [ChainId.GOERLI]: getNodeRealUrlV2(ChainId.GOERLI, process.env.NEXT_PUBLIC_NODE_REAL_API_GOERLI),
-} satisfies Record<ChainId, string>
+} satisfies Record<ChainId, string | string[]>

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -189,7 +189,9 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
     }
 
     // console.log('[BEST Trade] Offchain trade is used', tradeFromOffchain)
-    return bestTradeFromOffchain
+    return bestTradeFromQuoter_.trade.outputAmount.greaterThan(bestTradeFromOffchain.trade.outputAmount)
+      ? bestTradeFromQuoter_
+      : bestTradeFromOffchain
   }, [bestTradeFromOffchain, bestTradeFromQuoterApi, bestTradeFromQuoterWorker, isQuoterAPIEnabled])
 }
 

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -189,7 +189,7 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
     }
 
     // console.log('[BEST Trade] Offchain trade is used', tradeFromOffchain)
-    return bestTradeFromQuoter_.trade.outputAmount.greaterThan(bestTradeFromOffchain.trade.outputAmount)
+    return quoterTrade.outputAmount.greaterThan(tradeFromOffchain.outputAmount)
       ? bestTradeFromQuoter_
       : bestTradeFromOffchain
   }, [bestTradeFromOffchain, bestTradeFromQuoterApi, bestTradeFromQuoterWorker, isQuoterAPIEnabled])

--- a/apps/web/src/hooks/useV3Pools.ts
+++ b/apps/web/src/hooks/useV3Pools.ts
@@ -99,6 +99,7 @@ export function useV3CandidatePoolsWithoutTicks(
       return SmartRouter.getV3PoolsWithoutTicksOnChain(pairs, viemClients)
     },
     enabled: Boolean(error && key && options.enabled),
+    keepPreviousData: true,
   })
 
   const candidatePools = useMemo<V3Pool[] | null>(() => {
@@ -161,21 +162,23 @@ export function useV3PoolsWithTicks(
       }
     },
     {
+      errorRetryCount: 5,
       revalidateOnFocus: false,
     },
   )
 
-  const { mutate, data } = poolsWithTicks
+  const { mutate, data, error } = poolsWithTicks
   useEffect(() => {
     // Revalidate pools if block number increases
     if (
       blockNumber &&
+      !error &&
       fetchingBlock.current !== blockNumber.toString() &&
       (!data?.blockNumber || blockNumber - data.blockNumber > 5)
     ) {
       mutate()
     }
-  }, [blockNumber, mutate, data?.blockNumber])
+  }, [blockNumber, mutate, data?.blockNumber, error])
 
   return poolsWithTicks
 }
@@ -211,18 +214,19 @@ export function useV3PoolsFromSubgraph(pairs?: Pair[], { key, blockNumber, enabl
     },
   )
 
-  const { mutate, data } = result
+  const { mutate, data, error } = result
   useEffect(() => {
     // Revalidate pools if block number increases
     if (
       queryEnabled &&
       blockNumber &&
+      !error &&
       fetchingBlock.current !== blockNumber.toString() &&
       (!data?.blockNumber || blockNumber - data.blockNumber > 5)
     ) {
       mutate()
     }
-  }, [blockNumber, mutate, data?.blockNumber, queryEnabled])
+  }, [blockNumber, mutate, data?.blockNumber, queryEnabled, error])
   return result
 }
 

--- a/apps/web/src/utils/nodeReal.ts
+++ b/apps/web/src/utils/nodeReal.ts
@@ -41,6 +41,11 @@ export const getNodeRealUrlV2 = (chainId: number, key?: string) => {
         host = `eth-goerli.nodereal.io/v1/${key}`
       }
       break
+    case 56:
+      if (key) {
+        host = `bsc-mainnet.nodereal.io/v1/${key}`
+      }
+      break
     default:
       host = null
   }

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -20,7 +20,12 @@ export const { provider, chains } = configureChains(CHAINS, [
         return { http: 'https://cloudflare-eth.com' }
       }
       return PUBLIC_NODES[chain.id]
-        ? { http: typeof PUBLIC_NODES[chain.id] === 'string' ? PUBLIC_NODES[chain.id] as string : PUBLIC_NODES[chain.id][0] }
+        ? {
+            http:
+              typeof PUBLIC_NODES[chain.id] === 'string'
+                ? (PUBLIC_NODES[chain.id] as string)
+                : PUBLIC_NODES[chain.id][0],
+          }
         : { http: chain.rpcUrls.default.http[0] }
     },
   }),

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -19,7 +19,9 @@ export const { provider, chains } = configureChains(CHAINS, [
       if (process.env.NODE_ENV === 'test' && chain.id === mainnet.id) {
         return { http: 'https://cloudflare-eth.com' }
       }
-      return PUBLIC_NODES[chain.id] ? { http: PUBLIC_NODES[chain.id] } : { http: chain.rpcUrls.default.http[0] }
+      return PUBLIC_NODES[chain.id]
+        ? { http: typeof PUBLIC_NODES[chain.id] === 'string' ? PUBLIC_NODES[chain.id] as string : PUBLIC_NODES[chain.id][0] }
+        : { http: chain.rpcUrls.default.http[0] }
     },
   }),
 ])

--- a/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
+++ b/apps/web/src/views/Farms/components/UpdatePositionsReminder.tsx
@@ -93,7 +93,7 @@ export function UpdatePositionsReminder_() {
       tokenId: stakedTokenIds[i],
     }))
     ?.filter((userInfo) => {
-      const farm = farmsV3?.farmsWithPrice.find((f) => f.pid === (userInfo.pid as BigNumber).toNumber())
+      const farm = farmsV3?.farmsWithPrice.find((f) => f.pid === (userInfo.pid as BigNumber)?.toNumber())
       if (!farm) return false
       if (
         (userInfo.rewardGrowthInside as BigNumber).gt(
@@ -109,7 +109,7 @@ export function UpdatePositionsReminder_() {
   // getting it on client side to final confirm
   const { data: rewardGrowthGlobalX128s, isLoading } = useContractReads({
     contracts: isOverRewardGrowthGlobalUserInfos?.map((userInfo) => {
-      const farm = farmsV3?.farmsWithPrice.find((f) => f.pid === (userInfo.pid as BigNumber).toNumber())
+      const farm = farmsV3?.farmsWithPrice.find((f) => f.pid === (userInfo.pid as BigNumber)?.toNumber())
       return {
         abi: lmPoolAbi,
         address: farm?.lmPool as `0x${string}`,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc390a3</samp>

### Summary
🔄🌐🛠️

<!--
1.  🔄 This emoji represents the fallback mechanism that switches between different node URLs, and the changes to the `getNodeRealUrlV2` function that support the BSC chain.
2.  🌐 This emoji represents the use of the `viem` library and the `http` transport to improve the reliability and performance of the node requests, and the changes to the `getProvider` function that handle the array of node URLs.
3.  🛠️ This emoji represents the options and error handling added to various hooks that fetch V3 pools data, and the improvements to the `UpdatePositionsReminder_` component.
-->
Improved node requests and V3 pools data fetching for BSC chain. Added fallback transport mechanism to switch between different node URLs in case of failure or latency. Used optional chaining operator and error handling to avoid data inconsistencies and improve user experience. Modified `useV3Pools.ts`, `UpdatePositionsReminder.tsx`, `nodes.ts`, `nodeReal.ts`, `viem.ts`, and `wagmi.ts`.

> _We are the nodes of the BSC chain_
> _We switch and fall back in the storm of pain_
> _We fetch the pools with options and hooks_
> _We handle the errors and avoid the rooks_

### Walkthrough
*  Modify `PUBLIC_NODES` object to support an array of node URLs for the BSC chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL12-R21))
*  Use `fallback` transport from `viem` library to switch between node URLs in case of failure or latency ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL5-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-b746ecf7aeb22ba05a0775d1f2dfe06c2a8060b11a267f6052829f5ff4f87185L22-R24))
*  Add `keepPreviousData` option to `useV3CandidatePoolsWithoutTicks` hook to prevent data clearing while revalidating ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR102))
*  Add `errorRetryCount` option to `useV3PoolsWithTicks` hook to limit retries in case of error ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL164-R175))
*  Add `error` variable to `useV3PoolsWithTicks` and `useV3PoolsFromSubgraph` hooks and use it as a dependency or condition for revalidation ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL178-R181), [link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL214-R217), [link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bR223), [link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL225-R229))
*  Modify `getNodeRealUrlV2` function to support the BSC chain and use the `key` parameter for authentication ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94R44-R48))
*  Use optional chaining operator when accessing the `pid` property of the `userInfo` object in `UpdatePositionsReminder_` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-98c6c51dabb06f56a511c769cf2dc636d8d1475303124f43cb302a3f899e4391L96-R96), [link](https://github.com/pancakeswap/pancake-frontend/pull/6954/files?diff=unified&w=0#diff-98c6c51dabb06f56a511c769cf2dc636d8d1475303124f43cb302a3f899e4391L112-R112))


