### PR TITLE
fix: Ens avatar hook gives error on bsc network

### DIFF
--- a/apps/web/src/hooks/useDomain.ts
+++ b/apps/web/src/hooks/useDomain.ts
@@ -17,6 +17,7 @@ export const useDomainNameForAddress = (address: `0x${string}` | string, fetchDa
   })
   const { data: ensAvatar, isLoading: isEnsAvatarLoading } = useEnsAvatar({
     address: address as `0x${string}`,
+    enabled: chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET,
   })
 
   return useMemo(() => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f6cc15</samp>

### Summary
🚫🦊🍰

<!--
1.  🚫 - This emoji conveys the idea of disabling or blocking something, which is what the condition does for the BSC networks.
2.  🦊 - This emoji represents MetaMask, the most popular browser extension for interacting with Ethereum and BSC networks. The change affects how MetaMask users see their addresses on PancakeSwap.
3.  🍰 - This emoji is the logo of PancakeSwap, the platform where the change is implemented. It also suggests the idea of swapping or exchanging tokens, which is one of the main features of PancakeSwap.
-->
Disable `useDomainNameForAddress` hook for BSC and its testnet. This prevents showing ENS domains for BSC addresses, which are not compatible with the ENS resolver.

> _`useDomainNameForAddress`_
> _No ENS for BSC_
> _A hook with a condition_

### Walkthrough
* Disable ENS domain lookup for BSC addresses in `useDomainNameForAddress` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6959/files?diff=unified&w=0#diff-eaf278af1e252c50795b1e1288593d10523d442f05f28a79dbfb499314889bd1R20))


