### PR TITLE
fix(aptos-Farms): Fix multiplier tooltip

### DIFF
--- a/apps/aptos/components/Farms/components/FarmCard/FarmCard.tsx
+++ b/apps/aptos/components/Farms/components/FarmCard/FarmCard.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback } from 'react'
 import BigNumber from 'bignumber.js'
 import { useFarms } from 'state/farms/hook'
-import { ethersToBigNumber } from '@pancakeswap/utils/bigNumber'
 import styled from 'styled-components'
 import { Card, Flex, Text, Skeleton, ExpandableSectionButton, Farm as FarmUI } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
@@ -55,9 +54,7 @@ const FarmCard: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
   const { t } = useTranslation()
   const { totalRegularAllocPoint, cakePerBlock } = useFarms()
 
-  const totalMultipliers = totalRegularAllocPoint
-    ? (ethersToBigNumber(totalRegularAllocPoint).toNumber() / 100).toString()
-    : '0'
+  const totalMultipliers = totalRegularAllocPoint ? (Number(totalRegularAllocPoint) / 100).toString() : '0'
 
   const farmCakePerSecond = getDisplayFarmCakePerSecond(farm.poolWeight?.toNumber(), cakePerBlock)
 

--- a/apps/aptos/components/Farms/components/FarmTable/FarmTable.tsx
+++ b/apps/aptos/components/Farms/components/FarmTable/FarmTable.tsx
@@ -2,8 +2,6 @@ import { useRef, useMemo } from 'react'
 import styled from 'styled-components'
 import { RowType, DesktopColumnSchema } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
-import { BigNumber as EthersBigNumber } from '@ethersproject/bignumber'
-import { ethersToBigNumber } from '@pancakeswap/utils/bigNumber'
 import { useRouter } from 'next/router'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import latinise from '@pancakeswap/utils/latinise'
@@ -17,8 +15,8 @@ export interface ITableProps {
   userDataReady: boolean
   cakePrice: BigNumber
   sortColumn?: string
-  totalRegularAllocPoint?: EthersBigNumber
-  cakePerBlock?: EthersBigNumber
+  totalRegularAllocPoint?: string
+  cakePerBlock?: string
 }
 
 const Container = styled.div`
@@ -103,9 +101,7 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({
     [],
   )
 
-  const totalMultipliers = totalRegularAllocPoint
-    ? (ethersToBigNumber(totalRegularAllocPoint).toNumber() / 100).toString()
-    : '-'
+  const totalMultipliers = totalRegularAllocPoint ? (Number(totalRegularAllocPoint) / 100).toString() : '-'
 
   const getFarmEarnings = (farm) => {
     const earnings = new BigNumber(farm?.userData?.earnings)
@@ -121,9 +117,7 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({
     const initialActivity = latinise(lpLabel?.toLowerCase()) === lowercaseQuery
 
     const farmCakePerSecond =
-      farm.poolWeight && cakePerBlock
-        ? (Number(farm.poolWeight) * ethersToBigNumber(cakePerBlock).toNumber()) / 1e8
-        : 10
+      farm.poolWeight && cakePerBlock ? (Number(farm.poolWeight) * Number(cakePerBlock)) / 1e8 : 10
 
     const row: RowProps = {
       apr: {

--- a/apps/aptos/components/Farms/components/getDisplayFarmCakePerSecond.ts
+++ b/apps/aptos/components/Farms/components/getDisplayFarmCakePerSecond.ts
@@ -1,10 +1,7 @@
-import { ethersToBigNumber } from '@pancakeswap/utils/bigNumber'
-import { BigNumber as EthersBigNumber } from '@ethersproject/bignumber'
-
-export const getDisplayFarmCakePerSecond = (poolWeight?: number, cakePerBlock?: EthersBigNumber) => {
+export const getDisplayFarmCakePerSecond = (poolWeight?: number, cakePerBlock?: string) => {
   if (!poolWeight || !cakePerBlock) return '0'
 
-  const farmCakePerSecond = (poolWeight * ethersToBigNumber(cakePerBlock).toNumber()) / 1e8
+  const farmCakePerSecond = (poolWeight * Number(cakePerBlock)) / 1e8
 
   return farmCakePerSecond < 0.000001 ? '<0.000001' : `~${farmCakePerSecond.toFixed(6)}`
 }

--- a/packages/farms/src/types.ts
+++ b/packages/farms/src/types.ts
@@ -216,6 +216,7 @@ export interface DeserializedFarmsState {
   poolLength: number
   regularCakePerBlock: number
   totalRegularAllocPoint: string
+  cakePerBlock: string
 }
 
 export interface FarmWithStakedValue extends DeserializedFarm {

--- a/packages/farms/src/types.ts
+++ b/packages/farms/src/types.ts
@@ -216,7 +216,7 @@ export interface DeserializedFarmsState {
   poolLength: number
   regularCakePerBlock: number
   totalRegularAllocPoint: string
-  cakePerBlock: string
+  cakePerBlock?: string
 }
 
 export interface FarmWithStakedValue extends DeserializedFarm {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3086cd8</samp>

### Summary
🚚➕🧹

<!--
1.  🚚 - This emoji can be used to indicate that something was moved from one place to another, such as the `getDisplayFarmCakePerSecond` function.
2.  ➕ - This emoji can be used to indicate that something was added, such as the `cakePerBlock` property to the interface.
3.  🧹 - This emoji can be used to indicate that something was cleaned up or simplified, such as the unused dependency and the number conversions.
-->
Simplified the logic and conversions of farm-related numbers in the `FarmCard` and `FarmTable` components. Added the `cakePerBlock` property to the `DeserializedFarmsState` interface to store the contract value as a string.

> _Sing, O Muse, of the clever coder who refined the farm display_
> _And moved the `getDisplayFarmCakePerSecond` function to its rightful place_
> _He shunned the cumbersome `EthersBigNumber` and the `ethersToBigNumber` tool_
> _And used the simple `Number` type to make his calculations cool_

### Walkthrough
*  Simplify the calculation of `totalMultipliers` and `farmCakePerSecond` by using `Number` instead of `ethersToBigNumber` in `FarmCard` and `FarmTable` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-8b765322f2ea8353d33299240988ee1b012663574645d61810dbc0af633ff97fL58-R57), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-8b765322f2ea8353d33299240988ee1b012663574645d61810dbc0af633ff97fL4), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-afeee2ff7a2b0a1bd1222f363b04453dfdee7562ebcf294448bced5331718e7eL106-R104), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-afeee2ff7a2b0a1bd1222f363b04453dfdee7562ebcf294448bced5331718e7eL124-R120), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-afeee2ff7a2b0a1bd1222f363b04453dfdee7562ebcf294448bced5331718e7eL5-L6), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-afeee2ff7a2b0a1bd1222f363b04453dfdee7562ebcf294448bced5331718e7eL20-R19))
*  Add `cakePerBlock` property to `DeserializedFarmsState` interface to store the contract value as a string and avoid unnecessary conversions ([link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-7ec74fd4450da8b95597a4d6ac4b0ac66cccf285c6ee516daa57e428b7e06a16R219))
*  Move and simplify `getDisplayFarmCakePerSecond` function from a separate file to `FarmCard` component and use `Number` instead of `ethersToBigNumber` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-c5bf286fa3180894057db5a16db2ff9a1514945392acd6850d84d3c921f6a2a1L1-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/6961/files?diff=unified&w=0#diff-8b765322f2ea8353d33299240988ee1b012663574645d61810dbc0af633ff97fL4))


