### PR TITLE
fix: Scam v3 Lp

### DIFF
--- a/apps/web/src/components/LiquidityCardRow/index.tsx
+++ b/apps/web/src/components/LiquidityCardRow/index.tsx
@@ -76,6 +76,11 @@ export const LiquidityCardRow = ({
     </Flex>
   )
 
+  // Avoid scam LP
+  if (currency0.symbol.length > 7 || currency1.symbol.length > 7) {
+    return null
+  }
+
   if (link) {
     return (
       <Card mb="8px">

--- a/apps/web/src/components/LiquidityCardRow/index.tsx
+++ b/apps/web/src/components/LiquidityCardRow/index.tsx
@@ -76,11 +76,6 @@ export const LiquidityCardRow = ({
     </Flex>
   )
 
-  // Avoid scam LP
-  if (currency0?.symbol?.length > 7 || currency1?.symbol?.length > 7) {
-    return null
-  }
-
   if (link) {
     return (
       <Card mb="8px">

--- a/apps/web/src/components/LiquidityCardRow/index.tsx
+++ b/apps/web/src/components/LiquidityCardRow/index.tsx
@@ -77,7 +77,7 @@ export const LiquidityCardRow = ({
   )
 
   // Avoid scam LP
-  if (currency0.symbol.length > 7 || currency1.symbol.length > 7) {
+  if (currency0?.symbol?.length > 7 || currency1?.symbol?.length > 7) {
     return null
   }
 

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -131,10 +131,14 @@ export default function PoolListPage() {
             subtitle,
             setInverted,
           }) => {
-            const token0Symbol =
-              currencyQuote.symbol.length > 7 ? currencyQuote.symbol.slice(0, 7).concat('...') : currencyQuote.symbol
-            const token1Symbol =
-              currencyBase.symbol.length > 7 ? currencyBase.symbol.slice(0, 7).concat('...') : currencyBase.symbol
+            let token0Symbol = ''
+            let token1Symbol = ''
+            if (currencyQuote && currencyBase) {
+              token0Symbol =
+                currencyQuote.symbol.length > 7 ? currencyQuote.symbol.slice(0, 7).concat('...') : currencyQuote.symbol
+              token1Symbol =
+                currencyBase.symbol.length > 7 ? currencyBase.symbol.slice(0, 7).concat('...') : currencyBase.symbol
+            }
 
             return (
               <LiquidityCardRow
@@ -144,7 +148,7 @@ export default function PoolListPage() {
                 currency1={currencyBase}
                 tokenId={p.tokenId}
                 pairText={
-                  !currencyQuote || !currencyBase ? <Dots>{t('Loading')}</Dots> : `${token0Symbol}-${token1Symbol} LP`
+                  !token0Symbol || !token1Symbol ? <Dots>{t('Loading')}</Dots> : `${token0Symbol}-${token1Symbol} LP`
                 }
                 tags={
                   <>

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -130,34 +130,37 @@ export default function PoolListPage() {
             positionSummaryLink,
             subtitle,
             setInverted,
-          }) => (
-            <LiquidityCardRow
-              feeAmount={feeAmount}
-              link={positionSummaryLink}
-              currency0={currencyQuote}
-              currency1={currencyBase}
-              tokenId={p.tokenId}
-              pairText={
-                !currencyQuote || !currencyBase ? (
-                  <Dots>{t('Loading')}</Dots>
-                ) : (
-                  `${currencyQuote.symbol}-${currencyBase.symbol} LP`
-                )
-              }
-              tags={
-                <>
-                  {p.isStaked && (
-                    <Tag outline variant="warning" mr="8px">
-                      Farming
-                    </Tag>
-                  )}
-                  <RangeTag removed={removed} outOfRange={outOfRange} />
-                </>
-              }
-              subtitle={subtitle}
-              onSwitch={() => setInverted((prev) => !prev)}
-            />
-          )}
+          }) => {
+            const token0Symbol =
+              currencyQuote.symbol.length > 7 ? currencyQuote.symbol.slice(0, 7).concat('...') : currencyQuote.symbol
+            const token1Symbol =
+              currencyBase.symbol.length > 7 ? currencyBase.symbol.slice(0, 7).concat('...') : currencyBase.symbol
+
+            return (
+              <LiquidityCardRow
+                feeAmount={feeAmount}
+                link={positionSummaryLink}
+                currency0={currencyQuote}
+                currency1={currencyBase}
+                tokenId={p.tokenId}
+                pairText={
+                  !currencyQuote || !currencyBase ? <Dots>{t('Loading')}</Dots> : `${token0Symbol}-${token1Symbol} LP`
+                }
+                tags={
+                  <>
+                    {p.isStaked && (
+                      <Tag outline variant="warning" mr="8px">
+                        Farming
+                      </Tag>
+                    )}
+                    <RangeTag removed={removed} outOfRange={outOfRange} />
+                  </>
+                }
+                subtitle={subtitle}
+                onSwitch={() => setInverted((prev) => !prev)}
+              />
+            )
+          }}
         </PositionListItem>
       )
     })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e16386</samp>

### Summary
🛡️🚫🧑‍💻

<!--
1.  🛡️ - This emoji represents security, protection, or defense, and can be used to indicate that the change is a security measure that prevents users from being scammed by fake tokens.
2.  🚫 - This emoji represents prohibition, denial, or rejection, and can be used to indicate that the change filters out or excludes some liquidity pools based on a condition.
3.  🧑‍💻 - This emoji represents a person working on a computer, coding, or programming, and can be used to indicate that the change is part of a pull request that involves technical or development work.
-->
Prevent displaying scam liquidity pools with long token names on the liquidity page. Add a check to the `LiquidityCardRow` component in `apps/web/src/components/LiquidityCardRow/index.tsx` to filter out such pools.

> _`LiquidityCardRow`_
> _Hides scam pools with long names_
> _Autumn leaves fall fast_

### Walkthrough
*  Prevent displaying scam liquidity pools with fake tokens by returning null from `LiquidityCardRow` if either currency symbol is longer than 7 characters ([link](https://github.com/pancakeswap/pancake-frontend/pull/6969/files?diff=unified&w=0#diff-bdc04a42c688d80292bbdecdbb6c0576149f85c5809009c2a7cc49b95e9c0ab4R79-R83))


