### PR TITLE
fix: logger log itself

### DIFF
--- a/apps/web/src/quote-worker.ts
+++ b/apps/web/src/quote-worker.ts
@@ -26,12 +26,14 @@ const fetchWithLogging = async (url: RequestInfo | URL, init?: RequestInit) => {
   const response = await fetch_(url, init)
   const end = Date.now()
   if (urlString && size) {
-    log.info('QuoteRPC', {
-      url: urlString,
-      size,
-      time: end - start,
-      status: response.status,
-    })
+    if (!urlString.includes('vercel-vitals.axiom.co')) {
+      log.info('QuoteRPC', {
+        url: urlString,
+        size,
+        time: end - start,
+        status: response.status,
+      })
+    }
   }
 
   return response


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7340125</samp>

### Summary
🚫📉📖

<!--
1.  🚫 This emoji can be used to indicate that something was excluded, blocked, or removed. In this case, it shows that the logging of requests to `vercel-vitals.axiom.co` was disabled.
2.  📉 This emoji can be used to represent a decrease, a decline, or a performance improvement. In this case, it shows that the change was intended to reduce noise and improve the quote worker performance.
3.  📖 This emoji can be used to represent a book, a document, or a readability enhancement. In this case, it shows that the change was meant to improve the readability of the logs.
-->
Improved quote worker performance and reliability by reducing logging noise. Modified `fetchWithLogging` in `quote-worker.ts` to skip logging requests to `vercel-vitals.axiom.co`.

> _`fetchWithLogging`_
> _skips Vercel vitals now_
> _less noise in winter_

### Walkthrough
*  Exclude logging requests to `vercel-vitals.axiom.co` to reduce noise and improve readability ([link](https://github.com/pancakeswap/pancake-frontend/pull/6976/files?diff=unified&w=0#diff-cb95365019f7ba2030863c54e03dafdfde7363d4004781eab13cf7e887fa31deL29-R36))


