### PR TITLE
fix: ROI calculator min max price issue

### DIFF
--- a/apps/web/src/views/V3Info/data/token/priceData.ts
+++ b/apps/web/src/views/V3Info/data/token/priceData.ts
@@ -136,11 +136,11 @@ const HOUR_PRICE_CHART = gql`
     }
   }
 `
-const HOUR_PRICE_MIN = gql`
-  query poolHourDatas($startTime: Int!, $address: String!) {
-    tokenHourDatas(
+const HOUR_PRICE_MIN = (timestamp: number | string) => gql`
+  query minPrice( $address: String!) {
+    poolHourDatas(
       first: 1
-      where: { token: $address, periodStartUnix_gt: $startTime, low_gt: 0 }
+      where: { pool: $address, periodStartUnix: ${timestamp}, low_gt: 0 }
       orderBy: low
       orderDirection: asc
     ) {
@@ -149,11 +149,11 @@ const HOUR_PRICE_MIN = gql`
   }
 `
 
-const HOUR_PRICE_MAX = gql`
-  query poolHourDatas($startTime: Int!, $address: String!) {
-    tokenHourDatas(
+const HOUR_PRICE_MAX = (timestamp: number | string) => gql`
+  query maxPrice( $address: String!) {
+    poolHourDatas(
       first: 1
-      where: { token: $address, periodStartUnix_gt: $startTime }
+      where: { pool: $address, periodStartUnix: ${timestamp} }
       orderBy: high
       orderDirection: desc
     ) {
@@ -364,9 +364,8 @@ export async function fetchPairPriceChartTokenData(
           })
         )?.poolDayDatas?.[0]?.high
       : (
-          await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MAX, {
+          await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MAX(blocks?.[0].timestamp), {
             address,
-            startTime: +blocks?.[0].timestamp,
           })
         )?.poolHourDatas?.[0]?.high
     const minQueryPrice = isDay
@@ -376,9 +375,8 @@ export async function fetchPairPriceChartTokenData(
           })
         )?.poolDayDatas?.[0]?.low
       : (
-          await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MIN, {
+          await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MIN(blocks?.[0].timestamp), {
             address,
-            startTime: +blocks?.[0].timestamp,
           })
         )?.poolHourDatas?.[0]?.low
 

--- a/apps/web/src/views/V3Info/data/token/priceData.ts
+++ b/apps/web/src/views/V3Info/data/token/priceData.ts
@@ -366,7 +366,7 @@ export async function fetchPairPriceChartTokenData(
       : (
           await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MAX, {
             address,
-            startTime: blocks?.[0].timestamp,
+            startTime: +blocks?.[0].timestamp,
           })
         )?.poolHourDatas?.[0]?.high
     const minQueryPrice = isDay
@@ -378,7 +378,7 @@ export async function fetchPairPriceChartTokenData(
       : (
           await dataClient.request<PairPriceMinMAxResults>(HOUR_PRICE_MIN, {
             address,
-            startTime: blocks?.[0].timestamp,
+            startTime: +blocks?.[0].timestamp,
           })
         )?.poolHourDatas?.[0]?.low
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at de2ee7d</samp>

### Summary
📈🕒🛠️

<!--
1.  📈 - This emoji represents the addition of a new feature that shows the hourly price range of a token in the chart, which can help users analyze the price movements and volatility of the token more accurately.
2.  🕒 - This emoji represents the use of the `isDay` parameter to switch between the daily and hourly price range queries, which can help users choose the time frame that suits their needs and preferences.
3.  🛠️ - This emoji represents the modification of the existing function to accommodate the new queries and logic, which can help users see the consistency and compatibility of the code.
-->
Add hourly price range feature to token chart. Use new GraphQL queries to fetch data from `priceData.ts`.

> _Oh we are the coders of the high seas_
> _We fetch and display the token price range_
> _We use GraphQL queries to get the data we need_
> _And we heave away on the `isDay` parameter_

### Walkthrough
*  Add GraphQL queries to fetch hourly minimum and maximum prices of a token ([link](https://github.com/pancakeswap/pancake-frontend/pull/6977/files?diff=unified&w=0#diff-d07346acfe2667d74769a98af04f9c5b92df4442fd5fe7beae637f1c1ef8b727L139-R164))
*  Modify function to use hourly queries when fetching pair price chart token data for hourly chart ([link](https://github.com/pancakeswap/pancake-frontend/pull/6977/files?diff=unified&w=0#diff-d07346acfe2667d74769a98af04f9c5b92df4442fd5fe7beae637f1c1ef8b727L335-R383))


