### PR TITLE
fix: Apr mismatch on liquidity page and farm

### DIFF
--- a/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
+++ b/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
@@ -1,4 +1,5 @@
 import { Currency, CurrencyAmount, Fraction } from '@pancakeswap/sdk'
+import { formatAmount } from '@pancakeswap/utils/formatFractions'
 
 const CURRENCY_AMOUNT_MIN = new Fraction(1n, 1000000n)
 
@@ -8,10 +9,11 @@ interface FormatterCurrencyAmountProps {
 }
 
 export function formattedCurrencyAmount({ currencyAmount, significantDigits = 4 }: FormatterCurrencyAmountProps) {
-  return !currencyAmount || currencyAmount.equalTo(0n)
+  const formattedAmount = formatAmount(currencyAmount, significantDigits)
+  return !formattedAmount || !currencyAmount || currencyAmount.equalTo(0n)
     ? '0'
     : currencyAmount.greaterThan(CURRENCY_AMOUNT_MIN)
-    ? currencyAmount.toSignificant(significantDigits, { groupSeparator: ',' })
+    ? new Intl.NumberFormat().format(formattedAmount)
     : `<${CURRENCY_AMOUNT_MIN.toSignificant(1)}`
 }
 

--- a/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
+++ b/apps/web/src/components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount.tsx
@@ -13,7 +13,7 @@ export function formattedCurrencyAmount({ currencyAmount, significantDigits = 4 
   return !formattedAmount || !currencyAmount || currencyAmount.equalTo(0n)
     ? '0'
     : currencyAmount.greaterThan(CURRENCY_AMOUNT_MIN)
-    ? new Intl.NumberFormat().format(formattedAmount)
+    ? new Intl.NumberFormat().format(Number(formattedAmount))
     : `<${CURRENCY_AMOUNT_MIN.toSignificant(1)}`
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7313586</samp>

### Summary
💰📊🐛

<!--
1.  💰 for improving the formatting of currency amounts
2. 📊 for modifying the chart component
3. 🐛 for fixing the logic of the `FarmV3ApyButton_` function
-->
This pull request enhances the display and calculation of currency amounts in the web app. It improves the formatting of chart values with a custom function in `FormattedCurrencyAmount.tsx`. It also simplifies and fixes the logic of the farm APY button in `FarmV3ApyButton.tsx`.

> _We are the masters of the chart_
> _We format amounts with skill and art_
> _We simplify the logic of the farm_
> _We fix the bugs and do no harm_

### Walkthrough
*  Use `formatAmount` function to format currency amounts with commas and significant digits ([link](https://github.com/pancakeswap/pancake-frontend/pull/6978/files?diff=unified&w=0#diff-c3561a5a03d74c3f116dd6ec8ad7f89c98a291ad458c699e6aa93e7e597cbdddR2), [link](https://github.com/pancakeswap/pancake-frontend/pull/6978/files?diff=unified&w=0#diff-c3561a5a03d74c3f116dd6ec8ad7f89c98a291ad458c699e6aa93e7e597cbdddL11-R16))


