### PR TITLE
fix: Subgraph health indicator crash

### DIFF
--- a/apps/web/src/hooks/useSubgraphHealth.ts
+++ b/apps/web/src/hooks/useSubgraphHealth.ts
@@ -58,9 +58,9 @@ const useSubgraphHealth = (subgraphName: string) => {
             currentBlockNumber ? Promise.resolve(currentBlockNumber) : bscRpcProvider.getBlockNumber(),
           ])
 
-          const isHealthy = indexingStatusForCurrentVersion.health === 'healthy'
-          const chainHeadBlock = parseInt(indexingStatusForCurrentVersion.chains[0].chainHeadBlock.number)
-          const latestBlock = parseInt(indexingStatusForCurrentVersion.chains[0].latestBlock.number)
+          const isHealthy = indexingStatusForCurrentVersion?.health === 'healthy'
+          const chainHeadBlock = parseInt(indexingStatusForCurrentVersion?.chains[0]?.chainHeadBlock.number)
+          const latestBlock = parseInt(indexingStatusForCurrentVersion?.chains[0]?.latestBlock.number)
           const blockDifference = currentBlock - latestBlock
           // Sometimes subgraph might report old block as chainHeadBlock, so its important to compare
           // it with block retrieved from simpleRpcProvider.getBlockNumber()


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa1e0e8</samp>

### Summary
🛠️🚧🙈

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it can be used to indicate that the code has been modified to handle errors or edge cases better. The optional chaining operators are a way of fixing potential bugs or crashes that could occur if the subgraph response is not as expected.
2.  🚧 - This emoji represents a construction or a work in progress, and it can be used to indicate that the code has been modified to improve the functionality or performance of a feature. The optional chaining operators are a way of improving the subgraph health check feature, which is important for the app's usability and reliability.
3.  🙈 - This emoji represents an animal covering its eyes, and it can be used to indicate that the code has been modified to avoid or ignore some problems or limitations. The optional chaining operators are a way of avoiding errors or crashes that could be caused by the subgraph response, which might be out of the app's control or responsibility.
-->
Improved error handling in `useSubgraphHealth` hook by using optional chaining operators. This prevents the app from crashing or showing wrong data if the subgraph response is invalid or outdated.

> _`useSubgraphHealth`_
> _Optional chaining for safety_
> _Winter of bad data_

### Walkthrough
*  Use optional chaining operators to access subgraph response properties ([link](https://github.com/pancakeswap/pancake-frontend/pull/6979/files?diff=unified&w=0#diff-c950c572e508d931e24da2597549ce92eb8b4e3d8504934baa9b2362da769c87L61-R63))


