### PR TITLE
fix: user gas undefined

### DIFF
--- a/apps/web/src/state/user/hooks/index.tsx
+++ b/apps/web/src/state/user/hooks/index.tsx
@@ -315,7 +315,7 @@ export function useGasPrice(chainIdOverride?: number): bigint | undefined {
     },
   )
   if (chainId === ChainId.BSC) {
-    return userGas === GAS_PRICE_GWEI.rpcDefault ? bscProviderGasPrice : BigInt(userGas)
+    return userGas === GAS_PRICE_GWEI.rpcDefault ? bscProviderGasPrice : BigInt(userGas ?? GAS_PRICE_GWEI.default)
   }
   if (chainId === ChainId.BSC_TESTNET) {
     return DEFAULT_BSC_TESTNET_GAS_BIGINT


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a653b7</samp>

### Summary
🛠️🌐⛽

<!--
1.  🛠️ - This emoji represents a bug fix or a minor improvement to existing functionality. The change adds a fallback value for the `userGas` variable, which prevents a possible error when converting it to a BigInt.
2.  🌐 - This emoji represents a network-specific change or a change that affects cross-chain compatibility. The change is relevant for the Binance Smart Chain network, where the gas price may vary depending on the provider.
3.  ⛽ - This emoji represents a change related to gas fees, gas price, or gas estimation. The change adds a default gas price in gwei as a fallback value for the `userGas` variable, which affects the calculation of the transaction fee.
-->
Fix a potential error when converting user gas price to BigInt on Binance Smart Chain. Use a default gas price as a fallback value in `userGas` hook.

> _`userGas` may fail_
> _use default gas price in gwei_
> _autumn wind is cold_

### Walkthrough
*  Add fallback value for userGas variable to prevent conversion error ([link](https://github.com/pancakeswap/pancake-frontend/pull/6988/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL318-R318))


