### PR TITLE
fix: Prevent crash on unsupported network

### DIFF
--- a/apps/web/src/state/swap/hooks.test.ts
+++ b/apps/web/src/state/swap/hooks.test.ts
@@ -3,7 +3,6 @@
 import { useEffect } from 'react'
 import { renderHook } from '@testing-library/react-hooks'
 import { useAtom } from 'jotai'
-import { DEFAULT_OUTPUT_CURRENCY } from 'config/constants/exchange'
 import { parse } from 'querystring'
 import { Mock, vi } from 'vitest'
 import { swapReducerAtom } from 'state/swap/reducer'
@@ -32,9 +31,9 @@ describe('hooks', () => {
       })
     })
 
-    test('should return BNB CAKE pair by default', () => {
+    test('should return Native by default', () => {
       expect(queryParametersToSwapState(parse(''))).toEqual({
-        [Field.OUTPUT]: { currencyId: DEFAULT_OUTPUT_CURRENCY },
+        [Field.OUTPUT]: { currencyId: undefined },
         [Field.INPUT]: { currencyId: 'BNB' },
         typedValue: '',
         independentField: Field.INPUT,

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -4,7 +4,7 @@ import { CAKE, USDC } from '@pancakeswap/tokens'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 import { useUserSlippage } from '@pancakeswap/utils/user'
 import { SLOW_INTERVAL } from 'config/constants'
-import { DEFAULT_INPUT_CURRENCY, DEFAULT_OUTPUT_CURRENCY } from 'config/constants/exchange'
+import { DEFAULT_INPUT_CURRENCY } from 'config/constants/exchange'
 import { useTradeExactIn, useTradeExactOut } from 'hooks/Trades'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useBestAMMTrade } from 'hooks/useBestAMMTrade'
@@ -219,7 +219,7 @@ export function queryParametersToSwapState(
   let outputCurrency =
     typeof parsedQs.outputCurrency === 'string'
       ? isAddress(parsedQs.outputCurrency) || nativeSymbol
-      : defaultOutputCurrency ?? DEFAULT_OUTPUT_CURRENCY
+      : defaultOutputCurrency
   if (inputCurrency === outputCurrency) {
     if (typeof parsedQs.outputCurrency === 'string') {
       inputCurrency = ''

--- a/apps/web/src/utils/contractHelpers.ts
+++ b/apps/web/src/utils/contractHelpers.ts
@@ -129,7 +129,7 @@ export const getPointCenterIfoContract = (signer?: WalletClient) => {
 export const getCakeContract = (chainId?: number) => {
   return getContract({
     abi: erc20ABI,
-    address: chainId ? CAKE[chainId].address : CAKE[ChainId.BSC].address,
+    address: chainId ? CAKE[chainId]?.address : CAKE[ChainId.BSC].address,
     chainId,
   })
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d6330d5</samp>

### Summary
🛠️🗑️🌐

<!--
1.  🛠️ - This emoji represents a bug fix or a minor improvement, as the optional chaining operator prevents a possible crash or error.
2.  🗑️ - This emoji represents a code cleanup or a removal of unused or redundant code, as the import statement was not needed and the output currency was hardcoded.
3.  🌐 - This emoji represents a multi-chain or cross-chain feature or enhancement, as the swap function now supports different output currencies based on the chainId.
-->
Improved multi-chain compatibility of swap feature and added error handling for CAKE token contract. Removed unused import in `hooks.ts` and added optional chaining operator in `contractHelpers.ts`.

> _Sing, O Muse, of the skillful developers who strive_
> _To enhance the app of the Pancake, the sweet reward of DeFi_
> _They guard against errors with optional chaining, `CAKE[chainId]?.address`_
> _And make the output currency follow the chain, a dynamic success_

### Walkthrough
* Change the fallback value for output currency in swap state to use a dynamic parameter instead of a fixed constant, to support multi-chain feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/6990/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L222-R222))
* Add optional chaining operator to CAKE token address access, to prevent error when connected to a chain without CAKE contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/6990/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL132-R132))
* Remove unused import of `DEFAULT_OUTPUT_CURRENCY` from `swap/hooks.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6990/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L7-R7))


