### PR TITLE
chore: try build bCake v3

### DIFF
--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/multiplierAPI.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/multiplierAPI.ts
@@ -1,10 +1,9 @@
+import BN from 'bignumber.js'
 import { bCakeFarmBoosterV3ABI } from 'config/abi/bCakeFarmBoosterV3'
-import { FixedNumber } from 'ethers'
+import _toNumber from 'lodash/toNumber'
 import { publicClient } from 'utils/wagmi'
 
-import _toNumber from 'lodash/toNumber'
-
-const PRECISION_FACTOR = FixedNumber.from('1000000000000') // 1e12
+export const PRECISION_FACTOR = new BN('1000000000000') // 1e12
 
 export async function getPublicMultiplier({ farmBoosterContract, chainId }): Promise<number> {
   const [cAResult, caPercisionResult, boostPercisionResult] = await publicClient({ chainId }).multicall({
@@ -31,14 +30,14 @@ export async function getPublicMultiplier({ farmBoosterContract, chainId }): Pro
 
   const [cA, CA_PRECISION, BOOST_PRECISION] = [cAResult.result, caPercisionResult.result, boostPercisionResult.result]
 
-  const MAX_BOOST_PRECISION = FixedNumber.from(CA_PRECISION)
-    .divUnsafe(FixedNumber.from(cA))
-    .mulUnsafe(PRECISION_FACTOR)
-    .subUnsafe(FixedNumber.from(BOOST_PRECISION))
+  const MAX_BOOST_PRECISION = new BN(CA_PRECISION.toString())
+    .div(new BN(cA.toString()))
+    .times(PRECISION_FACTOR)
+    .minus(new BN(BOOST_PRECISION.toString()))
 
-  const boostPercent = PRECISION_FACTOR.addUnsafe(MAX_BOOST_PRECISION).divUnsafe(PRECISION_FACTOR)
+  const boostPercent = PRECISION_FACTOR.plus(MAX_BOOST_PRECISION).div(PRECISION_FACTOR)
 
-  return _toNumber(boostPercent.round(3).toString())
+  return _toNumber(boostPercent.toFixed(3).toString())
 }
 
 export async function getUserMultiplier({ address, tokenId, chainId }): Promise<number> {
@@ -63,10 +62,10 @@ export async function getUserMultiplier({ address, tokenId, chainId }): Promise<
   const [multiplier, BOOST_PRECISION] = [multiplierResult.result, boostPrecisionResult.result]
 
   return _toNumber(
-    PRECISION_FACTOR.addUnsafe(FixedNumber.from(multiplier))
-      .subUnsafe(FixedNumber.from(BOOST_PRECISION))
-      .divUnsafe(PRECISION_FACTOR)
-      .round(3)
+    PRECISION_FACTOR.plus(new BN(multiplier.toString()))
+      .minus(new BN(BOOST_PRECISION.toString()))
+      .div(PRECISION_FACTOR)
+      .toFixed(3)
       .toString(),
   )
 }

--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info.ts
@@ -1,9 +1,11 @@
+import BN from 'bignumber.js'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useBCakeFarmBoosterV3Contract, useMasterchefV3 } from 'hooks/useContract'
+import _toNumber from 'lodash/toNumber'
 import useSWRImmutable from 'swr/immutable'
 import { useContractRead } from 'wagmi'
-import { getUserMultiplier } from './useBoostMultiplierV3'
+import { PRECISION_FACTOR, getUserMultiplier } from './multiplierAPI'
 
 export const USER_ESTIMATED_MULTIPLIER = 2
 
@@ -56,7 +58,7 @@ export const useUserPositionInfo = (tokenId: string) => {
       reward: data?.[5],
       user: data?.[6],
       pid: data?.[7],
-      boostMultiplier: Number(data?.[8] ?? 0),
+      boostMultiplier: _toNumber(new BN(data?.[8].toString()).div(PRECISION_FACTOR).toFixed(3).toString()),
     },
     updateUserPositionInfo: mutate,
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e2b8fd0</samp>

### Summary
🔧🚚🧮

<!--
1.  🔧 - This emoji can be used to indicate a refactoring or improvement of existing code, as well as fixing bugs or issues. It suggests that the code is more robust, efficient, or readable after the change.
2.  🚚 - This emoji can be used to indicate a file or code relocation, such as moving functions to a different file or module. It suggests that the code is more organized, modular, or coherent after the change.
3.  🧮 - This emoji can be used to indicate a change related to calculations, numbers, or precision, such as replacing a data type or improving a formula. It suggests that the code is more accurate, reliable, or consistent after the change.
-->
Refactored and improved code for interacting with the boost multiplier contract for bCakeV3 farms. Moved contract functions to `multiplierAPI.ts` and fixed number formatting issues.

> _We're heaving on the ropes, me hearties, one, two, three_
> _We're making our code better, as you can plainly see_
> _We've renamed and refactored the `multiplier` file_
> _And improved the boost formatting with a `BN` style_

### Walkthrough
*  Rename and move `useBoostMultiplierV3.ts` to `multiplierAPI.ts` to provide functions for interacting with the multiplier contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/6992/files?diff=unified&w=0#diff-4732b5858e28345bf4fba011a22f65fedf809211fcadef2dbffad02152affb26L1-R7))
*  Replace `FixedNumber` with `BN` and update methods for calculations and formatting in `getPublicMultiplier` and `getUserMultiplier` functions to avoid precision errors ([link](https://github.com/pancakeswap/pancake-frontend/pull/6992/files?diff=unified&w=0#diff-4732b5858e28345bf4fba011a22f65fedf809211fcadef2dbffad02152affb26L34-R40), [link](https://github.com/pancakeswap/pancake-frontend/pull/6992/files?diff=unified&w=0#diff-4732b5858e28345bf4fba011a22f65fedf809211fcadef2dbffad02152affb26L66-R68))
*  Import `BN`, `PRECISION_FACTOR`, and `getUserMultiplier` from `multiplierAPI.ts` in `useBCakeV3Info.ts` and update `useUserPositionInfo` hook to use them for formatting `boostMultiplier` ([link](https://github.com/pancakeswap/pancake-frontend/pull/6992/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/6992/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL59-R61))


