### PR TITLE
feat: try fallback nodes

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -2,6 +2,8 @@ import { ChainId } from '@pancakeswap/sdk'
 import { getNodeRealUrlV2 } from 'utils/nodeReal'
 import { FallbackTransportConfig } from 'viem'
 
+const isTest = process.env.NODE_ENV === 'test'
+
 export const SERVER_NODES = {
   [ChainId.BSC]: [
     process.env.NEXT_PUBLIC_NODE_PRODUCTION,
@@ -25,8 +27,8 @@ export const PUBLIC_NODES = {
     urls: [
       process.env.NEXT_PUBLIC_NODE_PRODUCTION,
       // getNodeRealUrlV2(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
-      'https://bsc-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
-      'https://multi-necessary-choice.bsc.quiknode.pro/',
+      isTest ? null : 'https://bsc-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
+      isTest ? null : 'https://multi-necessary-choice.bsc.quiknode.pro/',
       'https://bsc-dataseed1.defibit.io',
       'https://bsc-dataseed1.binance.org',
     ].filter(Boolean),
@@ -42,8 +44,8 @@ export const PUBLIC_NODES = {
   [ChainId.ETHEREUM]: {
     urls: [
       getNodeRealUrlV2(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
-      'https://little-quick-brook.quiknode.pro/74f7f03cbdc91e54f2ed689df3fc500e6bc5b4e7/',
-      'https://eth-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
+      isTest ? null : 'https://little-quick-brook.quiknode.pro/74f7f03cbdc91e54f2ed689df3fc500e6bc5b4e7/',
+      isTest ? null : 'https://eth-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
       // 'https://eth.llamarpc.com',
     ].filter(Boolean),
     fallbackConfig: {

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -25,10 +25,8 @@ export const PUBLIC_NODES = {
     urls: [
       process.env.NEXT_PUBLIC_NODE_PRODUCTION,
       // getNodeRealUrlV2(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
-      process.env.NODE_ENV === 'production'
-        ? 'https://bsc-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7'
-        : null,
-      process.env.NODE_ENV === 'production' ? 'https://multi-necessary-choice.bsc.quiknode.pro/' : null,
+      'https://bsc-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
+      'https://multi-necessary-choice.bsc.quiknode.pro/',
       'https://bsc-dataseed1.defibit.io',
       'https://bsc-dataseed1.binance.org',
     ].filter(Boolean),

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -1,5 +1,6 @@
 import { ChainId } from '@pancakeswap/sdk'
 import { getNodeRealUrlV2 } from 'utils/nodeReal'
+import { FallbackTransportConfig } from 'viem'
 
 export const SERVER_NODES = {
   [ChainId.BSC]: [
@@ -20,20 +21,49 @@ export const SERVER_NODES = {
 } satisfies Record<ChainId, string[]>
 
 export const PUBLIC_NODES = {
-  [ChainId.BSC]: [
-    process.env.NEXT_PUBLIC_NODE_PRODUCTION,
-    getNodeRealUrlV2(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
-    'https://bsc-dataseed1.defibit.io',
-    'https://bsc-dataseed1.binance.org',
-  ].filter(Boolean),
-  [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
-  [ChainId.ETHEREUM]: [
-    getNodeRealUrlV2(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
-    'https://eth.llamarpc.com',
-    'https://cloudflare-eth.com',
-  ].filter(Boolean),
-  [ChainId.GOERLI]: [
-    getNodeRealUrlV2(ChainId.GOERLI, process.env.NEXT_PUBLIC_NODE_REAL_API_GOERLI),
-    'https://eth-goerli.public.blastapi.io',
-  ].filter(Boolean),
-} satisfies Record<ChainId, string[]>
+  [ChainId.BSC]: {
+    urls: [
+      process.env.NEXT_PUBLIC_NODE_PRODUCTION,
+      // getNodeRealUrlV2(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+      process.env.NODE_ENV === 'production'
+        ? 'https://bsc-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7'
+        : null,
+      process.env.NODE_ENV === 'production' ? 'https://multi-necessary-choice.bsc.quiknode.pro/' : null,
+      'https://bsc-dataseed1.defibit.io',
+      'https://bsc-dataseed1.binance.org',
+    ].filter(Boolean),
+    fallbackConfig: {
+      rank: {
+        interval: 10_000,
+      },
+    },
+  },
+  [ChainId.BSC_TESTNET]: {
+    urls: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
+  },
+  [ChainId.ETHEREUM]: {
+    urls: [
+      getNodeRealUrlV2(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+      'https://little-quick-brook.quiknode.pro/74f7f03cbdc91e54f2ed689df3fc500e6bc5b4e7/',
+      'https://eth-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
+      // 'https://eth.llamarpc.com',
+    ].filter(Boolean),
+    fallbackConfig: {
+      rank: {
+        interval: 10_000,
+      },
+    },
+  },
+  [ChainId.GOERLI]: {
+    urls: [
+      getNodeRealUrlV2(ChainId.GOERLI, process.env.NEXT_PUBLIC_NODE_REAL_API_GOERLI),
+      'https://eth-goerli.public.blastapi.io',
+    ].filter(Boolean),
+  },
+} satisfies Record<
+  ChainId,
+  {
+    urls: string[]
+    fallbackConfig?: FallbackTransportConfig
+  }
+>

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -46,6 +46,7 @@ export const PUBLIC_NODES = {
       getNodeRealUrlV2(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
       isTest ? null : 'https://little-quick-brook.quiknode.pro/74f7f03cbdc91e54f2ed689df3fc500e6bc5b4e7/',
       isTest ? null : 'https://eth-mainnet.gateway.pokt.network/v1/lb/0559a4d874bda0ee4ebef6c7',
+      'https://cloudflare-eth.com',
       // 'https://eth.llamarpc.com',
     ].filter(Boolean),
     fallbackConfig: {

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pancakeswap/sdk'
 import { CHAINS } from 'config/chains'
 import { PUBLIC_NODES } from 'config/nodes'
-import { createPublicClient, http, fallback, PublicClient } from 'viem'
+import { createPublicClient, http, fallback, PublicClient, FallbackTransportConfig } from 'viem'
 
 export const viemClients = CHAINS.reduce((prev, cur) => {
   return {
@@ -9,14 +9,14 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
     [cur.id]: createPublicClient({
       chain: cur,
       transport: fallback(
-        (PUBLIC_NODES[cur.id] as string[]).map((url) =>
+        PUBLIC_NODES[cur.id].urls.map((url) =>
           http(url, {
             timeout: 15_000,
           }),
         ),
-        {
-          rank: false,
-        },
+        process.env.NODE_ENV !== 'test' && 'fallbackConfig' in PUBLIC_NODES[cur.id]
+          ? (PUBLIC_NODES[cur.id] as { fallbackConfig: FallbackTransportConfig }).fallbackConfig
+          : { rank: false },
       ),
       batch: {
         multicall: {

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -15,7 +15,7 @@ import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 
 // get most configs chain nodes length
 const mostNodesConfig = Object.values(PUBLIC_NODES).reduce((prev, cur) => {
-  return cur.length > prev ? cur.length : prev
+  return cur.urls.length > prev ? cur.urls.length : prev
 }, 0)
 
 export const { publicClient, chains } = configureChains(
@@ -28,9 +28,9 @@ export const { publicClient, chains } = configureChains(
           if (process.env.NODE_ENV === 'test' && chain.id === mainnet.id && i === 0) {
             return { http: 'https://cloudflare-eth.com' }
           }
-          return PUBLIC_NODES[chain.id]?.[i]
+          return PUBLIC_NODES[chain.id as keyof typeof PUBLIC_NODES]?.urls?.[i]
             ? {
-                http: PUBLIC_NODES[chain.id][i],
+                http: PUBLIC_NODES[chain.id as keyof typeof PUBLIC_NODES].urls[i],
               }
             : null
         },

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -37,6 +37,7 @@ export const { publicClient, chains } = configureChains(
       })
     }),
   {
+    rank: false,
     batch: {
       multicall: {
         batchSize: 1024 * 200,

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -5,7 +5,6 @@ import { CHAINS } from 'config/chains'
 import { PUBLIC_NODES } from 'config/nodes'
 import memoize from 'lodash/memoize'
 import { configureChains, createConfig, createStorage } from 'wagmi'
-import { mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { LedgerConnector } from 'wagmi/connectors/ledger'
@@ -25,9 +24,6 @@ export const { publicClient, chains } = configureChains(
     .map((i) => {
       return jsonRpcProvider({
         rpc: (chain) => {
-          if (process.env.NODE_ENV === 'test' && chain.id === mainnet.id && i === 0) {
-            return { http: 'https://cloudflare-eth.com' }
-          }
           return PUBLIC_NODES[chain.id as keyof typeof PUBLIC_NODES]?.urls?.[i]
             ? {
                 http: PUBLIC_NODES[chain.id as keyof typeof PUBLIC_NODES].urls[i],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d2d5cb</samp>

### Summary
🔧🔄🎨

<!--
1.  🔧 - This emoji represents the refactoring and improvement of the node configuration and connection logic, which can be seen as a maintenance or fixing task.
2.  🔄 - This emoji represents the update of the `viemClients` function to support different fallback configurations, which can be seen as a change or enhancement of the existing functionality.
3.  🎨 - This emoji represents the update of the node selection logic in `wagmi.ts` to use the new `urls` property, which can be seen as a cosmetic or aesthetic improvement of the code.
-->
Refactored and improved the node configuration and selection logic for the `viem` and `wagmi` libraries. Added support for multiple node URLs and fallback options for each chain in `nodes.ts`. Simplified the code and enhanced the reliability and performance of the node connections.

> _Sing, O Muse, of the skillful refactorer_
> _Who reshaped the node configuration_
> _For the `viem` library, the swift connector_
> _Of many chains and transports in creation_

### Walkthrough
*  Refactor `PUBLIC_NODES` object to have `urls` and `fallbackConfig` properties for each chain and update some node URLs ([link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecR3), [link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL23-R67))
*  Update `viemClients` function in `viem.ts` to use the new `PUBLIC_NODES` structure and pass the `fallbackConfig` property to the `fallback` transport if it exists ([link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL4-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL12-R19))
*  Update `mostNodesConfig` and `getNodes` functions in `wagmi.ts` to use the `urls` property of the `PUBLIC_NODES` object and cast the `chain.id` to a key type ([link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-b746ecf7aeb22ba05a0775d1f2dfe06c2a8060b11a267f6052829f5ff4f87185L18-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/6993/files?diff=unified&w=0#diff-b746ecf7aeb22ba05a0775d1f2dfe06c2a8060b11a267f6052829f5ff4f87185L31-R33))


