### PR TITLE
chore: update pancake Protector Banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
@@ -135,13 +135,11 @@ const PancakeProtectorBanner = () => {
           <LogoBox>
             <Image src={pancakeSwapLogo} alt="pancakeSwapLogo" width={119} height={18} unoptimized />
           </LogoBox>
-          <Header>{isMobile ? t('Pancake Protectors Beta Week') : t('Join Pancake Protectors Beta Week')}</Header>
-          <StyledSubheading>
-            {isDesktop && t('Empower your characters with Pancake Squad and Bunnies NFTs')}
-          </StyledSubheading>
+          <Header>{t('Join Pancake Protectors')}</Header>
+          <StyledSubheading>{isDesktop && t('Exclusive Perks for PancakeSwap Bunnies and Squads')}</StyledSubheading>
           <Flex alignItems="center" style={{ gap: isMobile ? 4 : 16 }}>
             <Link
-              href="https://blog.pancakeswap.finance/articles/introducing-pancake-protectors-join-the-ultimate-beta-week"
+              href="https://blog.pancakeswap.finance/articles/pancake-protectors-is-here-discover-the-power-of-cake-and-perks-for-pancake-squads-and-bunnies"
               style={{ textDecoration: 'none' }}
               external
             >
@@ -152,7 +150,7 @@ const PancakeProtectorBanner = () => {
             <Devider />
             <Link href="https://protectors.pancakeswap.finance" external style={{ textDecoration: 'none' }}>
               <StyledButton variant="text" style={{ color: 'white' }} scale={isMobile ? 'sm' : 'md'}>
-                {isMobile ? t('Beta') : t('Explore Beta')}
+                {t('Play Now')}
                 <ArrowForwardIcon color="white" />
               </StyledButton>
             </Link>

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -29,6 +29,7 @@ interface IBannerConfig {
  *  },
  * ```
  */
+
 export const useMultipleBannerConfig = () => {
   const isRenderIFOBanner = useIsRenderIfoBanner()
   const isRenderCompetitionBanner = useIsRenderCompetitionBanner()

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -35,8 +35,8 @@ export const useMultipleBannerConfig = () => {
 
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
-      { shouldRender: true, banner: <TradingRewardBanner /> },
       { shouldRender: true, banner: <PancakeProtectorBanner /> },
+      { shouldRender: true, banner: <TradingRewardBanner /> },
       { shouldRender: true, banner: <LiquidStakingBanner /> },
       { shouldRender: true, banner: <V3LaunchBanner /> },
       { shouldRender: true, banner: <FarmV3MigrationBanner /> },

--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -47,7 +47,7 @@ function useChainlinkRoundDataSet() {
           abi: chainlinkOracleABI,
           address: chainlinkOracleAddress,
           functionName: 'getRoundData',
-          args: [(lastRound.data ?? 0n) - BigInt(i)],
+          args: [(lastRound.data ?? 0n) - BigInt(i)] as const,
         } as const),
     ),
     enabled: !!lastRound.data,

--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -47,7 +47,7 @@ function useChainlinkRoundDataSet() {
           abi: chainlinkOracleABI,
           address: chainlinkOracleAddress,
           functionName: 'getRoundData',
-          args: [(lastRound.data ?? 0n) - BigInt(i)] as const,
+          args: [(lastRound.data ?? 0n) - BigInt(i)],
         } as const),
     ),
     enabled: !!lastRound.data,

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2525,5 +2525,6 @@
   "This position must be staking in farm to apply the combined APR with farming rewards.": "This position must be staking in farm to apply the combined APR with farming rewards.",
   "APR (with farming)": "APR (with farming)",
   "Include farming rewards": "Include farming rewards",
-  "Join Pancake Protectors": "Join Pancake Protectors"
+  "Join Pancake Protectors": "Join Pancake Protectors",
+  "Exclusive Perks for PancakeSwap Bunnies and Squads": "Exclusive Perks for PancakeSwap Bunnies and Squads"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2518,16 +2518,12 @@
   "Before trading any token, please DYOR, and pay attention to the risk scanner.": "Before trading any token, please DYOR, and pay attention to the risk scanner.",
   "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored.": "Subgraph is currently experiencing issues. Performance may suffer until subgraph is restored.",
   "Affiliate program registration is paused at the moment. Please check back after subgraph status is restored": "Affiliate program registration is paused at the moment. Please check back after subgraph status is restored",
-  "Pancake Protectors Beta Week": "Pancake Protectors Beta Week",
-  "Join Pancake Protectors Beta Week": "Join Pancake Protectors Beta Week",
-  "Empower your characters with Pancake Squad and Bunnies NFTs": "Empower your characters with Pancake Squad and Bunnies NFTs",
-  "Beta": "Beta",
-  "Explore Beta": "Explore Beta",
   "Pancake Protectors": "Pancake Protectors",
   "Please be extra careful during this period as altcoin trading volumes are on the surge recently.": "Please be extra careful during this period as altcoin trading volumes are on the surge recently.",
   "Go to Farms": "Go to Farms",
   "has an active PancakeSwap farm. Stake your position in the farm to start earning with the indicated APR with CAKE farming.": "has an active PancakeSwap farm. Stake your position in the farm to start earning with the indicated APR with CAKE farming.",
   "This position must be staking in farm to apply the combined APR with farming rewards.": "This position must be staking in farm to apply the combined APR with farming rewards.",
   "APR (with farming)": "APR (with farming)",
-  "Include farming rewards": "Include farming rewards"
+  "Include farming rewards": "Include farming rewards",
+  "Join Pancake Protectors": "Join Pancake Protectors"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da326d3</samp>

### Summary
🎮🚀🔝

<!--
1.  🎮 - This emoji represents the launch of the new game, and the fact that the banner is inviting users to play it. It also conveys a sense of fun and excitement, which matches the tone of the banner text.
2. 🚀 - This emoji represents the idea of launching something new, and also implies speed and momentum. It suggests that the new game is a big and important feature, and that users should not miss it. It also matches the rocket icon used in the banner button.
3. 🔝 - This emoji represents the change in the order of the banners, and the fact that the `PancakeProtectorBanner` is now the first one to be shown. It implies that the new game is the top priority and the most attractive offer for users. It also matches the arrow icon used in the banner text.
-->
Updated and reordered the home page banners to highlight the new Pancake Protectors game. Changed the `PancakeProtectorBanner` component and the `useMultipleBannerConfig` hook to showcase the game and encourage users to play it.

> _`PancakeProtectorBanner`_
> _First in the hook, new game calls_
> _Autumn of pancakes_

### Walkthrough
*  Update banner text, link, and button to promote Pancake Protectors game launch ([link](https://github.com/pancakeswap/pancake-frontend/pull/6999/files?diff=unified&w=0#diff-462e5918a9f05347786f8973e69f0b1c68999afeb91f6858a174b80fa3f7a4fbL138-R142), [link](https://github.com/pancakeswap/pancake-frontend/pull/6999/files?diff=unified&w=0#diff-462e5918a9f05347786f8973e69f0b1c68999afeb91f6858a174b80fa3f7a4fbL155-R153))
*  Change banner order to display Pancake Protectors banner first in `useMultipleBannerConfig` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/6999/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L38-R39))


