### PR TITLE
refactor: refactor Chainlink oracle contract imports and typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ debug.log*
 
 # store for local dev scripts
 scripts/dev/**
+
+# typescript
+*.tsbuildinfo

--- a/apis/farms/package.json
+++ b/apis/farms/package.json
@@ -2,7 +2,7 @@
   "name": "farms-api",
   "version": "0.0.0",
   "dependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "bignumber.js": "^9.0.0",
     "@pancakeswap/farms": "workspace:*",
     "@pancakeswap/tokens": "workspace:*",

--- a/apps/bridge/components/stargate/config.ts
+++ b/apps/bridge/components/stargate/config.ts
@@ -1,4 +1,4 @@
-import { arbitrum, mainnet, optimism, polygon, avalanche, fantom } from 'wagmi/chains'
+import { arbitrum, mainnet, optimism, polygon, avalanche, fantom } from 'viem/chains'
 
 const VERSION = '0.0.25-mainnet.20'
 const SHA384 = 'RDYGBMTG+YS5OF8Kavau0Xdyq6j7e/5bFMF55lYu3Oz3gthIOqQSSJkcz96n6knF'

--- a/apps/bridge/components/stargate/network.ts
+++ b/apps/bridge/components/stargate/network.ts
@@ -1,4 +1,4 @@
-import { mainnet, arbitrum, optimism, polygon, fantom, avalanche, bsc } from 'wagmi/chains'
+import { mainnet, arbitrum, optimism, polygon, fantom, avalanche, bsc } from 'viem/chains'
 
 // Chain Id is defined by Stargate
 const stargateNetowrk = [

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -27,7 +27,7 @@
     "styled-components": "^5.3.3",
     "styled-jsx": "^5.1.2",
     "typescript": "^5.0.4",
-    "viem": "^0.3.30"
+    "viem": "^0.3.39"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "13.4.2",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -17,6 +17,7 @@
     "@pancakeswap/uikit": "workspace:*",
     "@pancakeswap/utils": "workspace:*",
     "@vanilla-extract/next-plugin": "^2.1.1",
+    "@wagmi/core": "^0.10.11",
     "ethers": "^5.0.0",
     "next": "13.4.2",
     "next-axiom": "^0.16.0",
@@ -26,8 +27,7 @@
     "styled-components": "^5.3.3",
     "styled-jsx": "^5.1.2",
     "typescript": "^5.0.4",
-    "wagmi": "^0.12.8",
-    "@wagmi/core": "^0.10.11"
+    "viem": "^0.3.30"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "13.4.2",

--- a/apps/bridge/tsconfig.json
+++ b/apps/bridge/tsconfig.json
@@ -5,8 +5,7 @@
     "target": "ES2015",
     "baseUrl": "./",
     "paths": {
-      "*": ["./*"],
-      "@pancakeswap/wagmi": ["../../packages/wagmi/src/index.ts"]
+      "*": ["./*"]
     }
   },
   "exclude": ["node_modules"]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -99,12 +99,12 @@
     "swiper": "^8.4.2",
     "swr": "^2.1.5",
     "typescript": "^5.0.4",
-    "wagmi": "1.0.5",
+    "wagmi": "1.0.9",
     "zod": "^3.21.4",
     "polished": "^4.2.2",
     "tiny-invariant": "^1.1.0",
     "uuid": "^8.0.0",
-    "viem": "^0.3.30"
+    "viem": "^0.3.39"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "13.4.2",

--- a/apps/web/src/utils/calls/estimateGas.ts
+++ b/apps/web/src/utils/calls/estimateGas.ts
@@ -30,8 +30,6 @@ export const estimateGas = async <
   if (!contract.estimateGas[methodName]) {
     throw new Error(`Method ${methodName} doesn't exist on ${contract.address}`)
   }
-  // TODO: wagmi
-  // @ts-ignore
   const rawGasEstimation = await contract.estimateGas[methodName](methodArgs, {
     value: 0n,
     account: contract.account,

--- a/apps/web/src/utils/contractHelpers.ts
+++ b/apps/web/src/utils/contractHelpers.ts
@@ -54,7 +54,7 @@ import { getContract as viemGetContract, WalletClient, PublicClient } from 'viem
 import { pancakeProfileABI } from 'config/abi/pancakeProfile'
 import { v3AirdropABI } from 'config/abi/v3Airdrop'
 import { bunnyFactoryABI } from 'config/abi/bunnyFactory'
-import { Abi } from 'abitype'
+import { Abi, Narrow } from 'abitype'
 import { lpTokenABI } from 'config/abi/lpTokenAbi'
 import { potteryVaultABI } from 'config/abi/potteryVaultAbi'
 import { potteryDrawABI } from 'config/abi/potteryDrawAbi'
@@ -87,7 +87,7 @@ export const getContract = <TAbi extends Abi | unknown[], TWalletClient extends 
   publicClient,
   signer,
 }: {
-  abi: TAbi
+  abi: Narrow<TAbi>
   address: Address
   chainId?: ChainId
   signer?: TWalletClient

--- a/apps/web/src/views/AddLiquidityV3/Migrate.tsx
+++ b/apps/web/src/views/AddLiquidityV3/Migrate.tsx
@@ -420,7 +420,7 @@ function V2PairMigrate({
     setConfirmingMigration(true)
 
     migrator.estimateGas
-      .multicall([data])
+      .multicall([data], { account: migrator.account, value: 0n })
       .then((gasEstimate) => {
         return migrator.write
           .multicall([data], { gas: calculateGasMargin(gasEstimate), account, chain: migrator.chain, value: 0n })

--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -40,16 +40,18 @@ function useChainlinkRoundDataSet() {
   const { chainlinkOracleAddress } = useConfig()
 
   const { data, error } = useContractReads({
-    contracts: Array.from({ length: 50 }).map(
-      (_, i) =>
-        ({
-          chainId,
-          abi: chainlinkOracleABI,
-          address: chainlinkOracleAddress,
-          functionName: 'getRoundData',
-          args: [(lastRound.data ?? 0n) - BigInt(i)] as const,
-        } as const),
-    ),
+    contracts:
+      lastRound?.data &&
+      Array.from({ length: 50 }).map(
+        (_, i) =>
+          ({
+            chainId,
+            abi: chainlinkOracleABI,
+            address: chainlinkOracleAddress,
+            functionName: 'getRoundData',
+            args: [(lastRound.data ?? 0n) - BigInt(i)] as const,
+          } as const),
+      ),
     enabled: !!lastRound.data,
     keepPreviousData: true,
   })

--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -25,7 +25,7 @@ function useChainlinkLatestRound() {
   const { chainId } = useActiveChainId()
   const chainlinkOracleContract = useChainlinkOracleContract(chainlinkOracleAddress)
   return useContractRead({
-    abi: chainlinkOracleContract.abi,
+    abi: chainlinkOracleABI,
     address: chainlinkOracleContract.address,
     functionName: 'latestRound',
     enabled: !!chainlinkOracleContract,

--- a/apps/web/src/views/Predictions/hooks/usePollOraclePrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePollOraclePrice.ts
@@ -1,16 +1,15 @@
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useContractRead } from 'wagmi'
-import { useChainlinkOracleContract } from 'hooks/useContract'
+import { chainlinkOracleABI } from 'config/abi/chainlinkOracle'
 import { useConfig } from '../context/ConfigProvider'
 
 const usePollOraclePrice = () => {
   const { chainlinkOracleAddress } = useConfig()
 
-  const chainlinkOracleContract = useChainlinkOracleContract(chainlinkOracleAddress)
   const { chainId } = useActiveChainId()
 
   const { data: price = 0n, refetch } = useContractRead({
-    abi: chainlinkOracleContract?.abi,
+    abi: chainlinkOracleABI,
     address: chainlinkOracleAddress,
     functionName: 'latestAnswer',
     watch: true,

--- a/packages/farms/package.json
+++ b/packages/farms/package.json
@@ -13,7 +13,7 @@
     "wrangler": "2.15.0"
   },
   "dependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "date-fns": "^2.29.3",
     "bignumber.js": "^9.0.0",
     "@pancakeswap/swap-sdk-core": "workspace:*",

--- a/packages/pools/package.json
+++ b/packages/pools/package.json
@@ -12,20 +12,20 @@
     "@pancakeswap/token-lists": "workspace:*",
     "@pancakeswap/tokens": "workspace:*",
     "@pancakeswap/utils": "workspace:*",
-    "viem": "^0.3.30",
-    "wagmi": "1.0.5"
+    "viem": "^0.3.39",
+    "wagmi": "1.0.9"
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "@types/lodash": "^4.14.168",
     "@pancakeswap/tsconfig": "workspace:*",
     "typechain": "^6.1.0",
     "typescript": "^5.0.4",
     "vitest": "^0.27.2",
-    "wagmi": "1.0.5"
+    "wagmi": "1.0.9"
   }
 }

--- a/packages/smart-router/package.json
+++ b/packages/smart-router/package.json
@@ -29,7 +29,7 @@
     "mnemonist": "^0.38.3",
     "stats-lite": "^2.2.0",
     "tiny-invariant": "^1.1.0",
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/swap-sdk/package.json
+++ b/packages/swap-sdk/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "@pancakeswap/swap-sdk-core": "workspace:*",
     "big.js": "^5.2.2",
     "decimal.js-light": "^2.5.0",

--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -80,14 +80,14 @@
     "@pancakeswap/tokens": "workspace:*",
     "@pancakeswap/hooks": "workspace:*",
     "@pancakeswap/farms": "workspace:*",
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "next": "*",
     "next-seo": "*",
     "remark-gfm": "*",
     "react-device-detect": "*",
     "react-transition-group": "*",
     "js-cookie": "*",
-    "wagmi": "1.0.5"
+    "wagmi": "1.0.9"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -106,7 +106,7 @@
     "@pancakeswap/hooks": "workspace:*",
     "@pancakeswap/utils": "workspace:*",
     "@pancakeswap/farms": "workspace:*",
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "next": "*",
     "next-seo": "*",
     "remark-gfm": "*",

--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -87,7 +87,7 @@
     "react-device-detect": "*",
     "react-transition-group": "*",
     "js-cookie": "*",
-    "wagmi": "*"
+    "wagmi": "1.0.5"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "peerDependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "date-fns": "^2.29.3",
     "styled-components": "^5.3.3",
     "lodash": "^4.17.21",
@@ -17,7 +17,7 @@
     "@pancakeswap/aptos-swap-sdk": "workspace:*"
   },
   "devDependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "styled-components": "^5.3.3",
     "@types/styled-components": "^5.1.26",
     "@pancakeswap/swap-sdk-core": "workspace:*",

--- a/packages/v3-sdk/package.json
+++ b/packages/v3-sdk/package.json
@@ -25,7 +25,7 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "@pancakeswap/sdk": "workspace:*",
     "@pancakeswap/swap-sdk-core": "workspace:*",
     "@pancakeswap/tokens": "workspace:*",

--- a/packages/wagmi/package.json
+++ b/packages/wagmi/package.json
@@ -20,23 +20,23 @@
   "peerDependencies": {
     "@blocto/sdk": "^0.3.1",
     "@wagmi/connectors": "^1.0.3",
-    "@wagmi/core": "^1.0.5",
+    "@wagmi/core": "^1.0.8",
     "react-dom": "^18.0.0",
     "react": "^18.0.0",
-    "viem": "^0.3.30",
-    "wagmi": "1.0.5"
+    "viem": "^0.3.39",
+    "wagmi": "1.0.9"
   },
   "devDependencies": {
     "@blocto/sdk": "^0.3.1",
     "@pancakeswap/tsconfig": "workspace:*",
     "@types/react": "^18.0.17",
     "@wagmi/connectors": "^1.0.3",
-    "@wagmi/core": "^1.0.5",
+    "@wagmi/core": "^1.0.8",
     "react-dom": "^18.0.0",
     "react": "^18.0.0",
     "tsup": "^6.7.0",
-    "viem": "^0.3.30",
-    "wagmi": "1.0.5"
+    "viem": "^0.3.39",
+    "wagmi": "1.0.9"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -506,8 +506,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     devDependencies:
       '@next/eslint-plugin-next':
         specifier: 13.4.2
@@ -757,11 +757,11 @@ importers:
         specifier: ^8.0.0
         version: 8.3.2
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       wagmi:
-        specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        specifier: 1.0.9
+        version: 1.0.9(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1060,8 +1060,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.168
@@ -1169,14 +1169,14 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       vitest:
         specifier: ^0.27.2
         version: 0.27.2
       wagmi:
-        specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        specifier: 1.0.9
+        version: 1.0.9(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
 
   packages/smart-router:
     dependencies:
@@ -1200,7 +1200,7 @@ importers:
         version: 1.3.3
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@9.2.1)
+        version: 4.3.4(supports-color@8.1.1)
       graphql:
         specifier: ^16.6.0
         version: 16.6.0
@@ -1220,8 +1220,8 @@ importers:
         specifier: ^1.1.0
         version: 1.2.0
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -1275,8 +1275,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     devDependencies:
       '@swc/core':
         specifier: ^1.2.215
@@ -1679,8 +1679,8 @@ importers:
         specifier: ^27.1.3
         version: 27.1.3(@babel/core@7.21.3)(babel-jest@29.3.1)(esbuild@0.17.12)(jest@29.3.1)(typescript@5.0.4)
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       vite:
         specifier: ^4.3.1
         version: 4.3.1(@types/node@18.16.2)
@@ -1688,8 +1688,8 @@ importers:
         specifier: ^0.27.2
         version: 0.27.2
       wagmi:
-        specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        specifier: 1.0.9
+        version: 1.0.9(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
 
   packages/utils:
     dependencies:
@@ -1740,8 +1740,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.5(react@18.2.0)
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       vitest:
         specifier: ^0.30.1
         version: 0.30.1
@@ -1776,8 +1776,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     devDependencies:
       '@pancakeswap/utils':
         specifier: workspace:*
@@ -1805,10 +1805,10 @@ importers:
         version: 18.2.0
       '@wagmi/connectors':
         specifier: ^1.0.3
-        version: 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        version: 1.0.3(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
       '@wagmi/core':
-        specifier: ^1.0.5
-        version: 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        specifier: ^1.0.8
+        version: 1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
       react:
         specifier: ^18.0.0
         version: 18.2.0
@@ -1819,11 +1819,11 @@ importers:
         specifier: ^6.7.0
         version: 6.7.0(@swc/core@1.2.218)(postcss@8.4.21)(typescript@5.0.4)
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       wagmi:
-        specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        specifier: 1.0.9
+        version: 1.0.9(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
 
   packages/worker-utils: {}
 
@@ -1857,8 +1857,8 @@ importers:
         specifier: ^2.6.7
         version: 2.6.7(encoding@0.1.13)
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)(zod@3.21.4)
 
 packages:
 
@@ -1968,7 +1968,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1990,7 +1990,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2118,7 +2118,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -2134,7 +2134,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -5326,7 +5326,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.4.0
       globals: 13.19.0
       ignore: 5.2.0
@@ -5768,7 +5768,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6490,7 +6490,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       semver: 7.5.0
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -10208,7 +10208,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.48.2
       '@typescript-eslint/type-utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -10236,7 +10236,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.0
       '@typescript-eslint/type-utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
@@ -10274,7 +10274,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.48.2
       '@typescript-eslint/types': 5.48.2
       '@typescript-eslint/typescript-estree': 5.48.2(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10294,7 +10294,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.0
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10329,7 +10329,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.48.2(typescript@5.0.4)
       '@typescript-eslint/utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -10349,7 +10349,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -10378,7 +10378,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.48.2
       '@typescript-eslint/visitor-keys': 5.48.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -10399,7 +10399,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/visitor-keys': 5.59.0
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -10753,7 +10753,7 @@ packages:
     dependencies:
       '@vanilla-extract/integration': 6.2.1(@types/node@13.13.52)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       loader-utils: 2.0.2
       webpack: 5.74.0(esbuild@0.17.12)
     transitivePeerDependencies:
@@ -10773,7 +10773,7 @@ packages:
     dependencies:
       '@vanilla-extract/integration': 6.2.1(@types/node@18.0.4)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       loader-utils: 2.0.2
       webpack: 5.74.0(esbuild@0.17.12)
     transitivePeerDependencies:
@@ -10856,16 +10856,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@wagmi/chains@0.2.16(typescript@5.0.4):
-    resolution: {integrity: sha512-rkWaI2PxCnbD8G07ZZff5QXftnSkYL0h5f4DkHCG3fGYYr/ZDvmCL4bMae7j7A9sAif1csPPBmbCzHp3R5ogCQ==}
-    peerDependencies:
-      typescript: '>=4.9.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.0.4
-
   /@wagmi/chains@0.2.22(typescript@5.0.4):
     resolution: {integrity: sha512-TdiOzJT6TO1JrztRNjTA5Quz+UmQlbvWFG8N41u9tta0boHA1JCAzGGvU6KuIcOmJfRJkKOUIt67wlbopCpVHg==}
     peerDependencies:
@@ -10877,8 +10867,8 @@ packages:
       typescript: 5.0.4
     dev: false
 
-  /@wagmi/chains@0.2.23(typescript@5.0.4):
-    resolution: {integrity: sha512-oIc4ZpUL6bH/HdS7ROPWlFnP5U3XBujO/OiX4csRIezyLjMQ9FNXQRZShhi5ddL0Kj1RDbyVLe9K/QotEm1vig==}
+  /@wagmi/chains@0.3.1(typescript@5.0.4):
+    resolution: {integrity: sha512-NN5qziBLFeXnx0+3ywdiKKXUSW4H73Wc1jRrygl9GKXVPawU0GBMudwXUfV7VOu6E9vmG7Arj0pVsEwq63b2Ew==}
     peerDependencies:
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -10959,7 +10949,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4):
+  /@wagmi/connectors@1.0.3(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -10975,14 +10965,49 @@ packages:
       '@ledgerhq/connect-kit-loader': 1.0.1
       '@safe-global/safe-apps-provider': 0.15.2(encoding@0.1.13)
       '@safe-global/safe-apps-sdk': 7.10.1(encoding@0.1.13)
-      '@wagmi/chains': 0.2.23(typescript@5.0.4)
       '@walletconnect/ethereum-provider': 2.7.4(@web3modal/standalone@2.4.1)(encoding@0.1.13)
       '@walletconnect/legacy-provider': 2.0.0(encoding@0.1.13)
       '@web3modal/standalone': 2.4.1(react@18.2.0)
       abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+      viem: 0.3.39(typescript@5.0.4)(zod@3.21.4)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - react
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: true
+
+  /@wagmi/connectors@2.0.0(@wagmi/chains@0.3.1)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4):
+    resolution: {integrity: sha512-W7GFLdLaJiqISm65pwoe0DePLjL3klyugCwQwlunFXHNHvYSsoWkzDjb1H5XJwx9g+dTVNwJVg8TE7WfaUdilg==}
+    peerDependencies:
+      '@wagmi/chains': '>=0.3.0'
+      typescript: '>=4.9.4'
+      viem: ~0.3.35
+    peerDependenciesMeta:
+      '@wagmi/chains':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.6.6(encoding@0.1.13)
+      '@ledgerhq/connect-kit-loader': 1.0.1
+      '@safe-global/safe-apps-provider': 0.15.2(encoding@0.1.13)
+      '@safe-global/safe-apps-sdk': 7.10.1(encoding@0.1.13)
+      '@wagmi/chains': 0.3.1(typescript@5.0.4)
+      '@walletconnect/ethereum-provider': 2.7.4(@web3modal/standalone@2.4.1)(encoding@0.1.13)
+      '@walletconnect/legacy-provider': 2.0.0(encoding@0.1.13)
+      '@web3modal/standalone': 2.4.1(react@18.2.0)
+      abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
+      eventemitter3: 4.0.7
+      typescript: 5.0.4
+      viem: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -11045,21 +11070,21 @@ packages:
       - typescript
     dev: false
 
-  /@wagmi/core@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4):
-    resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
+  /@wagmi/core@1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4):
+    resolution: {integrity: sha512-0NknHYf7KivPK9PXzfWP2zxNeHG9kDZEW3NXRQ7Wyd4l6LiX3pBMtHnb1grlqhzrirApqOwhzViyRaznl3IwCg==}
     peerDependencies:
-      typescript: '>=4.9.4'
-      viem: ~0.3.18
+      typescript: ^5.0.4
+      viem: ~0.3.35
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/chains': 0.2.23(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
-      abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
+      '@wagmi/chains': 0.3.1(typescript@5.0.4)
+      '@wagmi/connectors': 2.0.0(@wagmi/chains@0.3.1)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
+      abitype: 0.8.2(typescript@5.0.4)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+      viem: 0.3.39(typescript@5.0.4)(zod@3.21.4)
       zustand: 4.3.1(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -11933,7 +11958,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11941,7 +11966,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -14476,7 +14501,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
-    dev: true
 
   /debug@4.3.4(supports-color@9.2.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -14489,6 +14513,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.2.1
+    dev: true
 
   /decamelize-keys@1.1.0:
     resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
@@ -14677,7 +14702,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15339,7 +15364,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.17.12
     transitivePeerDependencies:
       - supports-color
@@ -15864,7 +15889,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -16827,7 +16852,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -17308,7 +17333,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17318,7 +17343,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17345,7 +17370,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17355,7 +17380,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17979,7 +18004,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -20101,7 +20126,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -21061,7 +21086,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -21631,7 +21656,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -21710,7 +21735,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -23244,7 +23269,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -23839,7 +23864,7 @@ packages:
       colord: 2.9.2
       cosmiconfig: 7.0.1
       css-functions-list: 3.0.1
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -23928,6 +23953,7 @@ packages:
   /supports-color@9.2.1:
     resolution: {integrity: sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==}
     engines: {node: '>=12'}
+    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -24490,7 +24516,7 @@ packages:
       bundle-require: 4.0.1(esbuild@0.17.12)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.17.12
       execa: 5.1.1
       globby: 11.1.0
@@ -24700,7 +24726,7 @@ packages:
       typescript: '>=4.1.0'
     dependencies:
       '@types/prettier': 2.7.2
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 7.0.1
       glob: 7.2.3
       js-sha3: 0.8.0
@@ -25147,15 +25173,15 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /viem@0.3.30(typescript@5.0.4)(zod@3.21.4):
-    resolution: {integrity: sha512-4jokEVR2vtDl6zSpZiPUaHviK2dzW6uxCAVUArlh0Jhrc4ms0dkhn5E4iwk1CWMto8+YeLFEgY4gr9P10ryoEQ==}
+  /viem@0.3.39(typescript@5.0.4)(zod@3.21.4):
+    resolution: {integrity: sha512-hWPPLsaT3UdFBbECZrqDnE7lbYzLmAf9lIqvzsab3zXVV2y/HeNm63r0xRLdMRKfCC68AppEZUttOHyo2W/1ZQ==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
-      '@wagmi/chains': 0.2.16(typescript@5.0.4)
+      '@wagmi/chains': 0.3.1(typescript@5.0.4)
       abitype: 0.8.2(typescript@5.0.4)(zod@3.21.4)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       ws: 8.12.0
@@ -25171,7 +25197,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 0.2.0
       picocolors: 1.0.0
@@ -25194,7 +25220,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25216,7 +25242,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25238,7 +25264,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25261,7 +25287,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25281,7 +25307,7 @@ packages:
     peerDependencies:
       vite: '>2.0.0-0'
     dependencies:
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.0.2(typescript@5.0.4)
       vite: 4.3.1(@types/node@18.0.4)
@@ -25416,7 +25442,7 @@ packages:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       local-pkg: 0.4.3
       picocolors: 1.0.0
       source-map: 0.6.1
@@ -25480,7 +25506,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4(supports-color@9.2.1)
+      debug: 4.3.4(supports-color@8.1.1)
       local-pkg: 0.4.3
       magic-string: 0.30.0
       pathe: 1.1.0
@@ -25565,12 +25591,12 @@ packages:
       - zod
     dev: false
 
-  /wagmi@1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4):
-    resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
+  /wagmi@1.0.9(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4):
+    resolution: {integrity: sha512-LIExrD43Kyy8YIG02AQ4+heQc324h4lgTsQcpIDkLcOnwCV24uNSe/Ib1/F2k0N51uUsFoBdB5hjAaT6Ww7AtQ==}
     peerDependencies:
       react: '>=17.0.0'
-      typescript: '>=4.9.4'
-      viem: ~0.3.18
+      typescript: ^5.0.4
+      viem: ~0.3.35
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -25578,12 +25604,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.1
       '@tanstack/react-query': 4.29.1(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.1(@tanstack/react-query@4.29.1)
-      '@wagmi/core': 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
-      abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
+      '@wagmi/core': 1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)(zod@3.21.4)
+      abitype: 0.8.2(typescript@5.0.4)(zod@3.21.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+      viem: 0.3.39(typescript@5.0.4)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,9 +505,9 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
-      wagmi:
-        specifier: ^0.12.8
-        version: 0.12.13(encoding@0.1.13)(ethers@5.7.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
+      viem:
+        specifier: ^0.3.30
+        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
     devDependencies:
       '@next/eslint-plugin-next':
         specifier: 13.4.2
@@ -1200,7 +1200,7 @@ importers:
         version: 1.3.3
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4(supports-color@9.2.1)
       graphql:
         specifier: ^16.6.0
         version: 16.6.0
@@ -1688,8 +1688,8 @@ importers:
         specifier: ^0.27.2
         version: 0.27.2
       wagmi:
-        specifier: '*'
-        version: 0.12.13(encoding@0.1.13)(ethers@5.7.2)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
+        specifier: 1.0.5
+        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
 
   packages/utils:
     dependencies:
@@ -1968,7 +1968,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1990,7 +1990,7 @@ packages:
       '@babel/traverse': 7.21.5(supports-color@5.5.0)
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2118,7 +2118,7 @@ packages:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -2134,7 +2134,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.21.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.0
@@ -5326,7 +5326,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       espree: 9.4.0
       globals: 13.19.0
       ignore: 5.2.0
@@ -5768,7 +5768,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -6490,7 +6490,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       semver: 7.5.0
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -10208,7 +10208,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.48.2
       '@typescript-eslint/type-utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -10236,7 +10236,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.0
       '@typescript-eslint/type-utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
       '@typescript-eslint/utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
@@ -10274,7 +10274,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.48.2
       '@typescript-eslint/types': 5.48.2
       '@typescript-eslint/typescript-estree': 5.48.2(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10294,7 +10294,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.59.0
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -10329,7 +10329,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.48.2(typescript@5.0.4)
       '@typescript-eslint/utils': 5.48.2(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -10349,7 +10349,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.0(typescript@5.0.4)
       '@typescript-eslint/utils': 5.59.0(eslint@8.32.0)(typescript@5.0.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       eslint: 8.32.0
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
@@ -10378,7 +10378,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.48.2
       '@typescript-eslint/visitor-keys': 5.48.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -10399,7 +10399,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.0
       '@typescript-eslint/visitor-keys': 5.59.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
@@ -10753,7 +10753,7 @@ packages:
     dependencies:
       '@vanilla-extract/integration': 6.2.1(@types/node@13.13.52)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       loader-utils: 2.0.2
       webpack: 5.74.0(esbuild@0.17.12)
     transitivePeerDependencies:
@@ -10773,7 +10773,7 @@ packages:
     dependencies:
       '@vanilla-extract/integration': 6.2.1(@types/node@18.0.4)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       loader-utils: 2.0.2
       webpack: 5.74.0(esbuild@0.17.12)
     transitivePeerDependencies:
@@ -10875,6 +10875,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.0.4
+    dev: false
 
   /@wagmi/chains@0.2.23(typescript@5.0.4):
     resolution: {integrity: sha512-oIc4ZpUL6bH/HdS7ROPWlFnP5U3XBujO/OiX4csRIezyLjMQ9FNXQRZShhi5ddL0Kj1RDbyVLe9K/QotEm1vig==}
@@ -10956,6 +10957,7 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
 
   /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
@@ -11019,6 +11021,7 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
 
   /@wagmi/core@0.7.9(ethers@5.7.2)(react@18.2.0)(typescript@5.0.4):
     resolution: {integrity: sha512-97KCELUP5Q1AagRyE7SmpLh4/v3xdcy/XMbybLvvtQbgmi3y5oEzy4h/wJMY1hEZlmicqyWZAHHm6xIr1tP5HA==}
@@ -11118,6 +11121,7 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/core@2.7.4:
     resolution: {integrity: sha512-nDJJZALZJI8l8JvjwZE4UmUzDzQBnTTJlQa/rc5MoGYtir0hfsQEl3sPkPcXbkkW5q+cHiynXsDcgM4740fmNQ==}
@@ -11217,6 +11221,7 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/ethereum-provider@2.7.4(@web3modal/standalone@2.4.1)(encoding@0.1.13):
     resolution: {integrity: sha512-R5hcByY9zIsvyTHFUS+3xqtzs2REezED4tZFyXk0snJjWlnlL2EdeHaCjr5n+SIZDin4CMj1EAFC0ZrM4KoA4Q==}
@@ -11436,6 +11441,7 @@ packages:
       - bufferutil
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/sign-client@2.7.4:
     resolution: {integrity: sha512-hZoCB51GB4u32yxzYnxp8dpzXgo6E7ZWUVOgnihmoMPjgJahPtvB/Ip9jYxI3fuV+ZPQYNlxQgEvR9X+2fLz+g==}
@@ -11486,6 +11492,7 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
+    dev: false
 
   /@walletconnect/types@2.7.4:
     resolution: {integrity: sha512-Nagfz8DqLxf0UlVd7xopgBX60EJp1xUEq7J30ALlTbWqEhCHuLK/qPk5vGdJ9Q6+ZDpTW9ShLq1DNf+5nVpVDQ==}
@@ -11542,6 +11549,7 @@ packages:
       - encoding
       - lokijs
       - utf-8-validate
+    dev: false
 
   /@walletconnect/universal-provider@2.7.4(encoding@0.1.13):
     resolution: {integrity: sha512-suH3o5LpTX7hlx5lU98oLdEM0Ws5ZysjQ4Zr6EWIK1DVT8EDdWbw49ggJSW9IYRLQ2xG22jDvmTIdFAexYOgng==}
@@ -11608,6 +11616,7 @@ packages:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - lokijs
+    dev: false
 
   /@walletconnect/utils@2.7.4:
     resolution: {integrity: sha512-2WEeKB9h/FQvyNmIBYwLtjdLm3Oo55EwtJoxkC00SA7xjf8jYxZ8q2y4P/CJP8oO5ruxBK5Ft0smKvPHXsE58Q==}
@@ -11810,6 +11819,7 @@ packages:
         optional: true
     dependencies:
       typescript: 5.0.4
+    dev: false
 
   /abitype@0.8.1(typescript@5.0.4)(zod@3.21.4):
     resolution: {integrity: sha512-n8Di6AWb3i7HnEkBvecU6pG0a5nj5YwMvdAIwPLsQK95ulRy/XS113s/RXvSfTX1iOQJYFrEO3/q4SMWu7OwTA==}
@@ -11923,7 +11933,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11931,7 +11941,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -14466,6 +14476,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /debug@4.3.4(supports-color@9.2.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -14478,7 +14489,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 9.2.1
-    dev: true
 
   /decamelize-keys@1.1.0:
     resolution: {integrity: sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==}
@@ -14667,7 +14677,7 @@ packages:
     hasBin: true
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15329,7 +15339,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       esbuild: 0.17.12
     transitivePeerDependencies:
       - supports-color
@@ -15854,7 +15864,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -16817,7 +16827,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -17298,7 +17308,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17308,7 +17318,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17335,7 +17345,7 @@ packages:
     engines: {node: '>= 6.0.0'}
     dependencies:
       agent-base: 5.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17345,7 +17355,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17969,7 +17979,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -20091,7 +20101,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -21051,7 +21061,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -21621,7 +21631,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -21700,7 +21710,7 @@ packages:
     engines: {node: '>=8.16.0'}
     dependencies:
       '@types/mime-types': 2.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -23234,7 +23244,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -23829,7 +23839,7 @@ packages:
       colord: 2.9.2
       cosmiconfig: 7.0.1
       css-functions-list: 3.0.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       execall: 2.0.0
       fast-glob: 3.2.11
       fastest-levenshtein: 1.0.12
@@ -23918,7 +23928,6 @@ packages:
   /supports-color@9.2.1:
     resolution: {integrity: sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /supports-hyperlinks@2.3.0:
     resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
@@ -24481,7 +24490,7 @@ packages:
       bundle-require: 4.0.1(esbuild@0.17.12)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       esbuild: 0.17.12
       execa: 5.1.1
       globby: 11.1.0
@@ -24691,7 +24700,7 @@ packages:
       typescript: '>=4.1.0'
     dependencies:
       '@types/prettier': 2.7.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       fs-extra: 7.0.1
       glob: 7.2.3
       js-sha3: 0.8.0
@@ -25162,7 +25171,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       mlly: 1.2.0
       pathe: 0.2.0
       picocolors: 1.0.0
@@ -25185,7 +25194,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25207,7 +25216,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25229,7 +25238,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25252,7 +25261,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
@@ -25272,7 +25281,7 @@ packages:
     peerDependencies:
       vite: '>2.0.0-0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       globrex: 0.1.2
       tsconfck: 2.0.2(typescript@5.0.4)
       vite: 4.3.1(@types/node@18.0.4)
@@ -25407,7 +25416,7 @@ packages:
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       local-pkg: 0.4.3
       picocolors: 1.0.0
       source-map: 0.6.1
@@ -25471,7 +25480,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@9.2.1)
       local-pkg: 0.4.3
       magic-string: 0.30.0
       pathe: 1.1.0
@@ -25554,6 +25563,7 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
+    dev: false
 
   /wagmi@1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4):
     resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "devDependencies": {
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "ethers": "^5.0.0",
     "@types/lodash": "^4.14.168",
     "node-fetch": "^2.6.7",

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["RISK_APP_SECRET", "SERVER_NODE_REAL_API_ETH", "SERVER_NODE_REAL_API_GOERLI"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "test": {


### PR DESCRIPTION
- Narrow the type of `TAbi` to `Abi`
- Change the `chainlinkOracleContract.abi` import to `chainlinkOracleABI`
- Remove the unused `chainlinkOracleContract` import from `usePollOraclePrice`

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a9d2ca3</samp>

### Summary
🔧🚀🧹

<!--
1.  🔧 - This emoji represents a fix or improvement of existing code or functionality. The `useChainlinkLatestRound` hook was improved by using a constant instead of a hook and a contract property.
2.  🚀 - This emoji represents a performance enhancement or optimization. The contract helpers were optimized by using a `Narrow` type for ABI parameters, which reduces the size and complexity of the generated code.
3.  🧹 - This emoji represents a code cleanup or refactoring. The `usePollOraclePrice` hook was refactored to use a constant for the Chainlink oracle ABI, which makes the code more readable and consistent.
-->
Refactored and optimized the code related to the Chainlink oracle integration in the Predictions view. Used a constant for the oracle ABI and improved the type safety and performance of the contract helpers.

> _We break the chains of dependency_
> _We use the `Narrow` type for clarity_
> _We simplify the oracle ABI_
> _We refactor the code for victory_

### Walkthrough
*  Narrow down the ABI types for the contracts using the `Narrow` type from `abitype` to improve type safety and reduce bundle size ([link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL57-R57), [link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL90-R90))
*  Replace the `useChainlinkOracleContract` hook with the `chainlinkOracleABI` constant in the `useChainlinkLatestRound` hook and the `usePollOraclePrice` hook to avoid unnecessary dependencies and simplify the code ([link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-41549a2512665a69201044aec755a51cec8ebed48e994e5d69a11dcdd256316bL28-R28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-4f8ed743707990b1be77bf4aec90ca47a519455a8bf0173533b1ddd9b6f0661aL3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-4f8ed743707990b1be77bf4aec90ca47a519455a8bf0173533b1ddd9b6f0661aL9-R12))
*  Update the `getContract` function in `contractHelpers.ts` to use the `Narrow` type for the `abi` parameter ([link](https://github.com/pancakeswap/pancake-frontend/pull/7008/files?diff=unified&w=0#diff-dbcbcd450dce97f74ff9b8fff28d36fc457775363d349db2a45e504060c0754aL90-R90))


