### PR TITLE
chore: Sort ETH farm list

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -49,6 +49,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 19,
+    lpAddress: Pool.getAddress(ethereumTokens.rETH, ethereumTokens.weth, FeeAmount.LOW),
+    token0: ethereumTokens.rETH,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 31,
     lpAddress: Pool.getAddress(ethereumTokens.rETH, ethereumTokens.wbtc, FeeAmount.MEDIUM),
     token0: ethereumTokens.rETH,
@@ -152,13 +159,6 @@ export const farmsV3 = defineFarmV3Configs([
     token0: ethereumTokens.weth,
     token1: ethereumTokens.rpl,
     feeAmount: FeeAmount.MEDIUM,
-  },
-  {
-    pid: 19,
-    lpAddress: Pool.getAddress(ethereumTokens.rETH, ethereumTokens.weth, FeeAmount.LOW),
-    token0: ethereumTokens.rETH,
-    token1: ethereumTokens.weth,
-    feeAmount: FeeAmount.LOW,
   },
   {
     pid: 20,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 43e570d</samp>

### Summary
🌾🗑️🔄

<!--
1.  🌾 for adding a new farm
2.  🗑️ for removing a duplicate farm
3.  🔄 for changing the liquidity pools
-->
This pull request updates the farms configuration for rETH and wETH pools. It fixes a bug with a duplicate farm and adds a new farm for `packages/farms/constants/1.ts`.

> _Sing, O Muse, of the code that reshaped the farms of rETH and wETH,_
> _The pools of liquidity where the brave and the cunning stake their wealth._
> _How the skilled developer, with a keen and discerning eye,_
> _Removed the duplicate farm with pid `19` and the same `lpAddress` as the other._

### Walkthrough
*  Add new farm for rETH-wETH liquidity pool with low fee amount ([link](https://github.com/pancakeswap/pancake-frontend/pull/7012/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R52-R58))
*  Remove duplicate farm for the same liquidity pool with low fee amount ([link](https://github.com/pancakeswap/pancake-frontend/pull/7012/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8L157-L163))


