### PR TITLE
fix: reth farm issue

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -50,9 +50,9 @@ export const farmsV3 = defineFarmV3Configs([
   // Keep those farms on top
   {
     pid: 31,
-    lpAddress: Pool.getAddress(ethereumTokens.rETH, ethereumTokens.wbtc, FeeAmount.MEDIUM),
-    token0: ethereumTokens.rETH,
-    token1: ethereumTokens.wbtc,
+    lpAddress: Pool.getAddress(ethereumTokens.wbtc, ethereumTokens.rETH, FeeAmount.MEDIUM),
+    token0: ethereumTokens.wbtc,
+    token1: ethereumTokens.rETH,
     feeAmount: FeeAmount.MEDIUM,
   },
   {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 61777d5</samp>

### Summary
🔀🔄🎛️

<!--
1.  🔀 - This emoji represents swapping or changing the order of something, which is what was done to the tokens in the `farmsV3` array.
2.  🔄 - This emoji also represents swapping or changing the order of something, and it is often used to indicate a refresh or update of data or information, which is relevant for the price calculations and display issues that were fixed by this change.
3.  🎛️ - This emoji represents a control knob or panel, which could symbolize adjusting or fine-tuning the settings or parameters of something, which is what was done to the tokens in the `farmsV3` array to match the Uniswap V3 pool contract.
-->
Swapped token order for WBTC/rETH farm to align with Uniswap V3 pool contract. Fixed price and display issues in `packages/farms/constants/1.ts`.

> _`farmsV3` array_
> _swapped tokens for one pool_
> _autumn leaves falling_

### Walkthrough
*  Swap the order of the tokens in the farm with pid 31 to match the Uniswap V3 pool contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/7014/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8L53-R55))


