### PR TITLE
fix: (liquidity): Liquidity brush moves when mouse down

### DIFF
--- a/apps/web/src/components/LiquidityChartRangeInput/Brush.tsx
+++ b/apps/web/src/components/LiquidityChartRangeInput/Brush.tsx
@@ -85,6 +85,7 @@ export const Brush = ({
   const [localBrushExtent, setLocalBrushExtent] = useState<[number, number] | null>(brushExtent)
   const [showLabels, setShowLabels] = useState(false)
   const [hovering, setHovering] = useState(false)
+  const isBrushMouseDown = useRef<boolean>(false)
 
   const previousBrushExtent = usePreviousValue(brushExtent)
 
@@ -110,14 +111,14 @@ export const Brush = ({
   )
 
   // keep local and external brush extent in sync
-  // i.e. snap to ticks on bruhs end
+  // i.e. snap to ticks on brush end
   useEffect(() => {
     setLocalBrushExtent(brushExtent)
   }, [brushExtent])
 
   // initialize the brush
   useEffect(() => {
-    if (!brushRef.current) return
+    if (!brushRef.current || isBrushMouseDown.current) return
 
     brushBehavior.current = brushX<SVGGElement>()
       .extent([
@@ -146,7 +147,7 @@ export const Brush = ({
 
   // respond to xScale changes only
   useEffect(() => {
-    if (!brushRef.current || !brushBehavior.current) return
+    if (!brushRef.current || !brushBehavior.current || isBrushMouseDown.current) return
 
     brushBehavior.current.move(select(brushRef.current) as any, brushExtent.map(xScale) as any)
   }, [brushExtent, xScale])
@@ -191,7 +192,13 @@ export const Brush = ({
           ref={brushRef}
           clipPath={`url(#${id}-brush-clip)`}
           onMouseEnter={() => setHovering(true)}
-          onMouseLeave={() => setHovering(false)}
+          onMouseLeave={() => {
+            isBrushMouseDown.current = false
+            setHovering(false)
+          }}
+          onMouseDown={() => {
+            isBrushMouseDown.current = true
+          }}
         />
 
         {/* custom brush handles */}


### PR DESCRIPTION
When arranging ranges from chart via brushes, it moves to previous position unexpectedly.


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 503975a</samp>

### Summary
🐛🖌️📝

<!--
1.  🐛 - This emoji represents a bug fix, which is what the ref variable `isBrushMouseDown` does by preventing unwanted updates of the brush extent.
2.  🖌️ - This emoji represents a brush, which is the main feature of the code snippet and the source of the bug fix.
3.  📝 - This emoji represents a comment, which is what the typo correction does.
-->
Improved the performance and usability of the `LiquidityChartRangeInput` component by avoiding unnecessary re-rendering of the brush and fixing a typo.

> _To avoid unwanted extent shifts_
> _A ref variable was equipped_
> _`isBrushMouseDown`_
> _Controls the update round_
> _And a comment typo was fixed_

### Walkthrough
*  Prevent brush extent updates when dragging or scaling the brush ([link](https://github.com/pancakeswap/pancake-frontend/pull/7015/files?diff=unified&w=0#diff-0bd41b26ebfb85de39076d36d590f860278fff8a0f581ebd98397495c9e89b13R88), [link](https://github.com/pancakeswap/pancake-frontend/pull/7015/files?diff=unified&w=0#diff-0bd41b26ebfb85de39076d36d590f860278fff8a0f581ebd98397495c9e89b13L120-R121), [link](https://github.com/pancakeswap/pancake-frontend/pull/7015/files?diff=unified&w=0#diff-0bd41b26ebfb85de39076d36d590f860278fff8a0f581ebd98397495c9e89b13L149-R150), [link](https://github.com/pancakeswap/pancake-frontend/pull/7015/files?diff=unified&w=0#diff-0bd41b26ebfb85de39076d36d590f860278fff8a0f581ebd98397495c9e89b13L194-R201))
* Fix typo in comment ([link](https://github.com/pancakeswap/pancake-frontend/pull/7015/files?diff=unified&w=0#diff-0bd41b26ebfb85de39076d36d590f860278fff8a0f581ebd98397495c9e89b13L113-R114))


