### PR TITLE
fix: allow failure on lm pool fetching

### DIFF
--- a/packages/farms/src/fetchFarmsV3.ts
+++ b/packages/farms/src/fetchFarmsV3.ts
@@ -317,9 +317,6 @@ type Slot0 = [
 ]
 type LmPool = `0x${string}`
 
-type LmLiquidity = bigint
-type LmRewardGrowthGlobalX128 = bigint
-
 async function fetchLmPools(
   lmPoolAddresses: Address[],
   chainId: number,
@@ -345,10 +342,10 @@ async function fetchLmPools(
 
   const resp = await provider({ chainId }).multicall({
     contracts: lmPoolCalls,
-    allowFailure: false,
+    allowFailure: true,
   })
 
-  const chunked = chunk(resp, chunkSize) as [LmLiquidity, LmRewardGrowthGlobalX128][]
+  const chunked = chunk(resp, chunkSize)
 
   const lmPools: Record<
     string,
@@ -360,8 +357,8 @@ async function fetchLmPools(
 
   for (const [index, res] of chunked.entries()) {
     lmPools[lmPoolAddresses[index]] = {
-      liquidity: res?.[0]?.toString() ?? '0',
-      rewardGrowthGlobalX128: res?.[1]?.toString() ?? '0',
+      liquidity: res?.[0]?.result?.toString() ?? '0',
+      rewardGrowthGlobalX128: res?.[1]?.result?.toString() ?? '0',
     }
   }
 

--- a/packages/farms/tests/v3.test.ts
+++ b/packages/farms/tests/v3.test.ts
@@ -25,6 +25,10 @@ describe('Config farms V3', () => {
     expect(Pool.getAddress(farm.token, farm.quoteToken, farm.feeAmount)).toEqual(farm.lpAddress)
   })
 
+  it.each(mainnetFarms.flat())('should be sorted', (farm) => {
+    expect(farm.token0.sortsBefore(farm.token1)).toBeTruthy()
+  })
+
   it.each(mainnetFarms)('should has related common price', (...farms) => {
     const commonPrice: CommonPrice = {}
     for (const commonToken of priceHelperTokens[farms[0].token.chainId as keyof typeof priceHelperTokens].list) {


### PR DESCRIPTION
- Allow failure for `multicall` in `fetchLmPools`
- Add a test for `sortsBefore` function in `mainnetFarms`

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7abf358</samp>

### Summary
🧪♻️🚀

<!--
1.  🧪 for adding a new test case
2.  ♻️ for refactoring the code
3.  🚀 for improving the performance and reliability of the multicall function
-->
Refactored `fetchFarmsV3` function to use new `multicall` format and added a test case to verify `lpAddress` of each farm.

> _We test the farms of the v3_
> _We check the lpAddress of each_
> _We sort the tokens by their hex_
> _We face the multicall of death_

### Walkthrough
*  Remove unused type aliases and simplify `multicall` function in `fetchFarmsV3.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7018/files?diff=unified&w=0#diff-d3babe079368d69111b752814a4382eb279623a4c5bdb0b8b4cc40fb1d1a603bL320-L322), [link](https://github.com/pancakeswap/pancake-frontend/pull/7018/files?diff=unified&w=0#diff-d3babe079368d69111b752814a4382eb279623a4c5bdb0b8b4cc40fb1d1a603bL348-R348))
*  Handle failed calls gracefully and use optional chaining in `lmPools` object in `fetchFarmsV3.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7018/files?diff=unified&w=0#diff-d3babe079368d69111b752814a4382eb279623a4c5bdb0b8b4cc40fb1d1a603bL363-R361))
*  Add test case to check `lpAddress` of each farm in `v3.test.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7018/files?diff=unified&w=0#diff-93988026ed78fbcb524dc37a2e87e98f64c6ad18137cfcc61834fc25808bab55R28-R31))


