### PR TITLE
chore: Move finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -50,15 +50,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 328,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.rdnt,
-    contractAddress: '0xb87d170eC2C22F6078C9ed3214aB6f47f4A924D2',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.3342',
-    version: 3,
-  },
-  {
     sousId: 327,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.id,
@@ -121,6 +112,15 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 328,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.rdnt,
+    contractAddress: '0xb87d170eC2C22F6078C9ed3214aB6f47f4A924D2',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.3342',
+    version: 3,
+  },
   {
     sousId: 339,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 897baaa</samp>

### Summary
🏊🏁🎁

<!--
1.  🏊 - This emoji represents a pool, and the movement of a pool from one array to another.
2.  🏁 - This emoji represents the end of a race, or in this case, the end of a pool.
3.  🎁 - This emoji represents a gift, or in this case, the rewards that users can claim from the finished pool.
-->
This pull request updates the pool status for `sousId` 328 in `packages/pools/src/constants/pools/56.ts`. It moves the pool from active to finished to match the contract state.

> _`sousId` three two eight_
> _Pool is finished, rewards wait_
> _Autumn harvest time_

### Walkthrough
* Remove pool with sousId 328 from active pools and add it to finished pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7024/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL53-L61), [link](https://github.com/pancakeswap/pancake-frontend/pull/7024/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR116-R124))


