### PR TITLE
fix: Sid name

### DIFF
--- a/apps/web/src/hooks/useSid.ts
+++ b/apps/web/src/hooks/useSid.ts
@@ -32,7 +32,7 @@ export const useSidNameForAddress = (address: string, fetchData = true) => {
   const { data: sidName, status } = useSWRImmutable(
     fetchData && address ? ['sidName', chainId, address.toLowerCase()] : null,
     async () => {
-      const reverseNode = `${address.slice(2)}.addr.reverse`
+      const reverseNode = `${address.toLowerCase().slice(2)}.addr.reverse`
       const reverseNameHash = namehash(reverseNode)
       const resolverAddress = await sidContract.read.resolver([reverseNameHash])
       if (parseInt(resolverAddress, 16) === 0) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b37f36c</samp>

### Summary
🐛🔍📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It also conveys that the issue was causing some unexpected or incorrect behavior in the code.
2.  🔍 - This emoji represents a search or lookup operation, which is what the reverseNode variable is used for. It also conveys that the change was related to finding the correct SID name for an address.
3.  📝 - This emoji represents a text or string manipulation, which is what the lowercasing of the address does. It also conveys that the change was a minor or cosmetic one that did not affect the logic or functionality of the code.
-->
Fixed reverse lookup bug for SID names by lowercasing addresses in `useSid` hook. This change affects the `reverseNode` variable in `apps/web/src/hooks/useSid.ts`.

> _`reverseNode` fixed_
> _lowercase address for SID_
> _autumn bug report_

### Walkthrough
* Fix reverse lookup of SID name for addresses with uppercase letters by using lowercased address in `reverseNode` variable ([link](https://github.com/pancakeswap/pancake-frontend/pull/7026/files?diff=unified&w=0#diff-45f316aa86596809d99247170f1501adc0a4fa2f0c39acb796c6abb56a55b5c3L35-R35))


