### PR TITLE
chore: Whitelist reth in route quoting

### DIFF
--- a/packages/smart-router/evm/constants/exchange.ts
+++ b/packages/smart-router/evm/constants/exchange.ts
@@ -66,6 +66,9 @@ export const ADDITIONAL_BASES: {
     // alETH - ALCX
     [ethereumTokens.alcx.address]: [ethereumTokens.alETH],
     [ethereumTokens.alETH.address]: [ethereumTokens.alcx],
+
+    // rETH - ETH
+    [ethereumTokens.weth.address]: [ethereumTokens.rETH],
   },
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c6f14a9</samp>

### Summary
🔄🌉🚀

<!--
1.  🔄 - This emoji represents the exchange or swap feature of the smart router, which is the main functionality affected by this change.
2.  🌉 - This emoji represents the bridge or cross-chain aspect of the rETH and ETH tokens, which are both pegged to the value of Ethereum on different blockchains. This change enables users to move their value across chains using the smart router.
3.  🚀 - This emoji represents the potential growth or opportunity that this change brings to the smart router and its users, as it expands the range of tokens and markets that can be accessed through the smart router. This change also aligns with the vision of the smart router to be a universal and interoperable liquidity aggregator.
-->
Add support for rETH-ETH pair in smart router exchange. This enables swapping between two Ethereum tokens on Binance Smart Chain.

> _Swap rETH and ETH_
> _`EXCHANGE_TOKENS` expands_
> _Winter of gas fees_

### Walkthrough
*  Add rETH and ETH pair to supported tokens for exchange feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/7030/files?diff=unified&w=0#diff-78ce9cd83b6e1807ee9752c395d004a76077b4df666c24beafa7932c76193b02R69-R71))


