### PR TITLE
feat: Add pool fallback api endpoint

### DIFF
--- a/apis/routing/package.json
+++ b/apis/routing/package.json
@@ -10,7 +10,7 @@
     "graphql-request": "^5.0.0",
     "itty-router": "^2.6.1",
     "itty-router-extras": "^0.4.2",
-    "viem": "^0.3.30",
+    "viem": "^0.3.39",
     "wagmi": "1.0.5"
   },
   "devDependencies": {

--- a/apis/routing/package.json
+++ b/apis/routing/package.json
@@ -7,8 +7,11 @@
     "@pancakeswap/smart-router": "workspace:*",
     "@pancakeswap/sdk": "workspace:*",
     "@pancakeswap/v3-sdk": "workspace:*",
+    "graphql-request": "^5.0.0",
     "itty-router": "^2.6.1",
-    "itty-router-extras": "^0.4.2"
+    "itty-router-extras": "^0.4.2",
+    "viem": "^0.3.30",
+    "wagmi": "1.0.5"
   },
   "devDependencies": {
     "@types/itty-router-extras": "^0.4.0",

--- a/apis/routing/src/bindings.d.ts
+++ b/apis/routing/src/bindings.d.ts
@@ -7,4 +7,6 @@ declare global {
   const BSC_NODE: string
   const BSC_TESTNET_NODE: string
   const AXIOM_TOKEN: string
+
+  const SUBGRAPH_POOLS: R2Bucket
 }

--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -1,0 +1,10 @@
+import { ChainId } from '@pancakeswap/sdk'
+
+export const SUPPORTED_CHAINS = [ChainId.ETHEREUM, ChainId.BSC]
+
+export const V3_SUBGRAPH_URLS = {
+  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
+  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
+  [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
+  [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
+} satisfies Record<ChainId, string>

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -1,43 +1,53 @@
-import type { Router } from 'itty-router'
+import type { Router, Request, RouteHandler } from 'itty-router'
 import { missing } from 'itty-router-extras'
 
 export const getPoolsObjectName = (chainId: string | number) => `v3_pools_${chainId}_latest`
 
+export const getPoolsTvlObjectName = (chainId: string | number) => `v3_pools_tvl_${chainId}_latest`
+
+const respondWithCache = async (req: Request, event: any, handler: RouteHandler<Request>) => {
+  const url = new URL(req.url)
+  const cacheKey = new Request(url.toString(), req)
+  const cache = caches.default
+  const response = await cache.match(cacheKey)
+  if (response) {
+    return response
+  }
+
+  const res = await handler(req, event)
+  event.waitUntil(cache.put(cacheKey, res.clone()))
+
+  return res
+}
+
 export function poolsRoute(router: Router) {
-  router.get('/v0/v3-pools/:chainId', async (req, event) => {
-    const url = new URL(req.url)
-    const cacheKey = new Request(url.toString(), req)
-    const cache = caches.default
-    const response = await cache.match(cacheKey)
-    if (response) {
-      console.log(`Cache hit for: ${req.url}.`)
-      return response
-    }
-    console.log(`Response for request url: ${req.url} not present in cache. Fetching and caching request.`)
+  const createRoute = (route: string, getObjectName: (chainId: string) => string) => {
+    router.get(route, async (req, event) => {
+      return respondWithCache(req, event, async () => {
+        const chainId = req.params?.chainId
+        const objectName = chainId && getObjectName(chainId)
+        if (!objectName) {
+          return missing('Not Found')
+        }
 
-    const chainId = req.params?.chainId
-    const objectName = chainId && getPoolsObjectName(chainId)
-    if (!objectName) {
-      return missing('Not Found')
-    }
+        const object = await SUBGRAPH_POOLS.get(objectName)
+        if (object === null) {
+          return missing('Not Found')
+        }
 
-    const object = await SUBGRAPH_POOLS.get(objectName)
-    if (object === null) {
-      return missing('Not Found')
-    }
+        const headers = new Headers()
+        object.writeHttpMetadata(headers)
+        headers.set('etag', object.httpEtag)
 
-    const headers = new Headers()
-    object.writeHttpMetadata(headers)
-    headers.set('etag', object.httpEtag)
+        headers.append('Cache-Control', 's-maxage=86400')
 
-    headers.append('Cache-Control', 's-maxage=86400')
-
-    const res = new Response(object.body, {
-      headers,
+        return new Response(object.body, {
+          headers,
+        })
+      })
     })
+  }
 
-    event.waitUntil(cache.put(cacheKey, res.clone()))
-
-    return res
-  })
+  createRoute('/v0/v3-pools/:chainId', getPoolsObjectName)
+  createRoute('/v0/v3-pools-tvl/:chainId', getPoolsTvlObjectName)
 }

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -1,0 +1,43 @@
+import type { Router } from 'itty-router'
+import { missing } from 'itty-router-extras'
+
+export const getPoolsObjectName = (chainId: string | number) => `v3_pools_${chainId}_latest`
+
+export function poolsRoute(router: Router) {
+  router.get('/v0/v3-pools/:chainId', async (req, event) => {
+    const url = new URL(req.url)
+    const cacheKey = new Request(url.toString(), req)
+    const cache = caches.default
+    const response = await cache.match(cacheKey)
+    if (response) {
+      console.log(`Cache hit for: ${req.url}.`)
+      return response
+    }
+    console.log(`Response for request url: ${req.url} not present in cache. Fetching and caching request.`)
+
+    const chainId = req.params?.chainId
+    const objectName = chainId && getPoolsObjectName(chainId)
+    if (!objectName) {
+      return missing('Not Found')
+    }
+
+    const object = await SUBGRAPH_POOLS.get(objectName)
+    if (object === null) {
+      return missing('Not Found')
+    }
+
+    const headers = new Headers()
+    object.writeHttpMetadata(headers)
+    headers.set('etag', object.httpEtag)
+
+    headers.append('Cache-Control', 's-maxage=86400')
+
+    const res = new Response(object.body, {
+      headers,
+    })
+
+    event.waitUntil(cache.put(cacheKey, res.clone()))
+
+    return res
+  })
+}

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -1,7 +1,10 @@
 import { ChainId } from '@pancakeswap/sdk'
-import { OnChainProvider } from '@pancakeswap/smart-router/evm'
+import { OnChainProvider, SubgraphProvider } from '@pancakeswap/smart-router/evm'
 import { createPublicClient, http } from 'viem'
 import { bsc, bscTestnet, goerli, mainnet } from 'wagmi/chains'
+import { GraphQLClient } from 'graphql-request'
+
+import { V3_SUBGRAPH_URLS } from './constants'
 
 const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE]
 requireCheck.forEach((node) => {
@@ -44,4 +47,15 @@ export const viemProviders: OnChainProvider = ({ chainId }: { chainId?: ChainId 
     default:
       return bscClient
   }
+}
+
+export const v3SubgraphClients = {
+  [ChainId.ETHEREUM]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ETHEREUM], { fetch }),
+  [ChainId.GOERLI]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.GOERLI], { fetch }),
+  [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC], { fetch }),
+  [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC_TESTNET], { fetch }),
+}
+
+export const v3SubgraphProvider: SubgraphProvider = ({ chainId = ChainId.BSC }: { chainId?: ChainId }) => {
+  return v3SubgraphClients[chainId] || v3SubgraphClients[ChainId.BSC]
 }

--- a/apis/routing/src/subgraphPoolBackup.ts
+++ b/apis/routing/src/subgraphPoolBackup.ts
@@ -1,0 +1,42 @@
+import { SmartRouter } from '@pancakeswap/smart-router/evm'
+
+import { v3SubgraphProvider } from './provider'
+import { SUPPORTED_CHAINS } from './constants'
+import { getPoolsObjectName } from './pools'
+
+// eslint-disable-next-line consistent-return
+async function handleScheduled(event: ScheduledEvent) {
+  switch (event.cron) {
+    case '*/1 * * * *':
+    case '0 0 * * *': {
+      for (const chainId of SUPPORTED_CHAINS) {
+        try {
+          const objectName = getPoolsObjectName(chainId)
+          // eslint-disable-next-line no-await-in-loop
+          const pools = await SmartRouter.getAllV3PoolsFromSubgraph({ chainId, provider: v3SubgraphProvider })
+          const serializedPools = pools.map((p) => ({
+            ...SmartRouter.Transformer.serializePool(p),
+            tvlUSD: p.tvlUSD.toString(),
+          }))
+          // eslint-disable-next-line no-await-in-loop
+          await SUBGRAPH_POOLS.put(objectName, JSON.stringify(serializedPools), {
+            httpMetadata: {
+              contentType: 'application/json',
+            },
+          })
+        } catch (e) {
+          console.error(e)
+        }
+      }
+      break
+    }
+    default:
+      break
+  }
+}
+
+export function setupPoolBackupCrontab() {
+  addEventListener('scheduled', (event) => {
+    event.waitUntil(handleScheduled(event))
+  })
+}

--- a/apis/routing/src/subgraphPoolBackup.ts
+++ b/apis/routing/src/subgraphPoolBackup.ts
@@ -2,7 +2,7 @@ import { SmartRouter } from '@pancakeswap/smart-router/evm'
 
 import { v3SubgraphProvider } from './provider'
 import { SUPPORTED_CHAINS } from './constants'
-import { getPoolsObjectName } from './pools'
+import { getPoolsObjectName, getPoolsTvlObjectName } from './pools'
 
 // eslint-disable-next-line consistent-return
 async function handleScheduled(event: ScheduledEvent) {
@@ -10,19 +10,29 @@ async function handleScheduled(event: ScheduledEvent) {
     case '0 0 * * *': {
       for (const chainId of SUPPORTED_CHAINS) {
         try {
-          const objectName = getPoolsObjectName(chainId)
           // eslint-disable-next-line no-await-in-loop
           const pools = await SmartRouter.getAllV3PoolsFromSubgraph({ chainId, provider: v3SubgraphProvider })
           const serializedPools = pools.map((p) => ({
             ...SmartRouter.Transformer.serializePool(p),
             tvlUSD: p.tvlUSD.toString(),
           }))
+          const poolsTvl = pools.map((p) => ({
+            address: p.address,
+            tvlUSD: p.tvlUSD.toString(),
+          }))
           // eslint-disable-next-line no-await-in-loop
-          await SUBGRAPH_POOLS.put(objectName, JSON.stringify(serializedPools), {
-            httpMetadata: {
-              contentType: 'application/json',
-            },
-          })
+          await Promise.all([
+            SUBGRAPH_POOLS.put(getPoolsObjectName(chainId), JSON.stringify(serializedPools), {
+              httpMetadata: {
+                contentType: 'application/json',
+              },
+            }),
+            SUBGRAPH_POOLS.put(getPoolsTvlObjectName(chainId), JSON.stringify(poolsTvl), {
+              httpMetadata: {
+                contentType: 'application/json',
+              },
+            }),
+          ])
         } catch (e) {
           console.error(e)
         }

--- a/apis/routing/src/subgraphPoolBackup.ts
+++ b/apis/routing/src/subgraphPoolBackup.ts
@@ -7,7 +7,6 @@ import { getPoolsObjectName } from './pools'
 // eslint-disable-next-line consistent-return
 async function handleScheduled(event: ScheduledEvent) {
   switch (event.cron) {
-    case '*/1 * * * *':
     case '0 0 * * *': {
       for (const chainId of SUPPORTED_CHAINS) {
         try {

--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -9,7 +9,7 @@ main = "src/index.ts"
 name = "routing-dev"
 node_compat = true
 [triggers]
-crons = ["*/10 * * * *", "0 0 * * *"]
+crons = ["0 0 * * *"]
 
 [env.production]
 kv_namespaces = [
@@ -20,7 +20,7 @@ r2_buckets = [
 ]
 name = "routing"
 [env.production.triggers]
-crons = ["*/10 * * * *", "0 0 * * *"]
+crons = ["0 0 * * *"]
 
 # - AXIOM_TOKEN
 # The necessary secrets are:

--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -2,16 +2,25 @@ compatibility_date = "2022-05-20"
 kv_namespaces = [
   {binding = "POOLS", id = "29d3e7e6c3c44fa7bf7174ee2b7b1295", preview_id = "c808d98df0444ae1a680bc84a029baaa"},
 ]
+r2_buckets = [
+  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools", preview_bucket_name = "subgraph-pools-dev" }
+]
 main = "src/index.ts"
 name = "routing-dev"
 node_compat = true
+[triggers]
+crons = ["*/10 * * * *", "0 0 * * *"]
 
 [env.production]
 kv_namespaces = [
   {binding = "POOLS", id = "5261431ca6b74625b08ffe288b86a2a5"},
 ]
+r2_buckets = [
+  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools", preview_bucket_name = "subgraph-pools-dev" }
+]
 name = "routing"
-
+[env.production.triggers]
+crons = ["*/10 * * * *", "0 0 * * *"]
 
 # - AXIOM_TOKEN
 # The necessary secrets are:

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
@@ -1,4 +1,4 @@
-import { BigintIsh, Currency } from '@pancakeswap/sdk'
+import { BigintIsh, Currency, ChainId } from '@pancakeswap/sdk'
 import memoize from 'lodash/memoize'
 import { Address } from 'viem'
 
@@ -22,8 +22,12 @@ interface Params {
   pairs?: [Currency, Currency][]
 }
 
+interface V3PoolTvlReference extends Pick<V3PoolWithTvl, 'address'> {
+  tvlUSD: bigint | string
+}
+
 const getV3PoolTvl = memoize(
-  (pools: V3PoolWithTvl[], poolAddress: Address) => {
+  (pools: V3PoolTvlReference[], poolAddress: Address) => {
     const poolWithTvl = pools.find((p) => p.address === poolAddress)
     return poolWithTvl?.tvlUSD || 0n
   },
@@ -32,41 +36,76 @@ const getV3PoolTvl = memoize(
 
 // Get pools from onchain and use the tvl data from subgraph as reference
 // The reason we do this is the data from subgraph might delay
-export async function getV3PoolsWithTvlFromOnChain(params: Params): Promise<V3PoolWithTvl[]> {
-  const { subgraphProvider, currencyA, currencyB, pairs: providedPairs, onChainProvider, blockNumber } = params
-  const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
+const v3PoolsOnChainProviderFactory = (tvlReferenceProvider: (params: Params) => Promise<V3PoolTvlReference[]>) => {
+  return async function getV3PoolsWithTvlFromOnChain(params: Params): Promise<V3PoolWithTvl[]> {
+    const { currencyA, currencyB, pairs: providedPairs, onChainProvider, blockNumber } = params
+    const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
 
-  const [fromOnChain, fromSubgraph] = await Promise.allSettled([
-    getV3PoolsWithoutTicksOnChain(pairs, onChainProvider, blockNumber),
-    getV3PoolSubgraph({ provider: subgraphProvider, pairs }),
-  ])
+    const [fromOnChain, tvlReference] = await Promise.allSettled([
+      getV3PoolsWithoutTicksOnChain(pairs, onChainProvider, blockNumber),
+      tvlReferenceProvider(params),
+    ])
 
-  if (fromOnChain.status === 'fulfilled' && fromSubgraph.status === 'fulfilled') {
-    const { value: poolsFromOnChain } = fromOnChain
-    const { value: poolsFromSubgraph } = fromSubgraph
-    return poolsFromOnChain.map((pool) => {
-      const tvlUSD = getV3PoolTvl(poolsFromSubgraph, pool.address)
-      return {
-        ...pool,
-        tvlUSD,
-      }
-    })
+    if (fromOnChain.status === 'fulfilled' && tvlReference.status === 'fulfilled') {
+      const { value: poolsFromOnChain } = fromOnChain
+      const { value: poolTvlReferences } = tvlReference
+      return poolsFromOnChain.map((pool) => {
+        const tvlUSD = BigInt(getV3PoolTvl(poolTvlReferences, pool.address))
+        return {
+          ...pool,
+          tvlUSD,
+        }
+      })
+    }
+    throw new Error(JSON.stringify([fromOnChain, tvlReference]))
   }
-
-  // Use pools from subgraph if on chain query is not working
-  if (fromOnChain.status !== 'fulfilled' && fromSubgraph.status === 'fulfilled') {
-    return fromSubgraph.value
-  }
-  throw new Error(JSON.stringify([fromOnChain, fromSubgraph]))
 }
 
+const getV3PoolsWithTvlFromOnChain = v3PoolsOnChainProviderFactory((params: Params) => {
+  const { currencyA, currencyB, pairs: providedPairs, subgraphProvider } = params
+  const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
+  return getV3PoolSubgraph({ provider: subgraphProvider, pairs })
+})
+
+const createFallbackTvlRefGetter = () => {
+  const cache = new Map<ChainId, V3PoolTvlReference[]>()
+  return async (params: Params) => {
+    const { currencyA } = params
+    if (!currencyA?.chainId) {
+      throw new Error(`Cannot get tvl references at chain ${currencyA?.chainId}`)
+    }
+    const cached = cache.get(currencyA.chainId)
+    if (cached) {
+      return cached
+    }
+    const res = await fetch(`https://routing-dev.pancake-swap.workers.dev/v0/v3-pools-tvl/${currencyA.chainId}`)
+    const refs: V3PoolTvlReference[] = await res.json()
+    cache.set(currencyA.chainId, refs)
+    return refs
+  }
+}
+
+const getV3PoolsWithTvlFromOnChainFallback = v3PoolsOnChainProviderFactory(createFallbackTvlRefGetter())
+
 export async function getV3CandidatePools(params: Params) {
-  const { currencyA, currencyB } = params
+  const { currencyA, currencyB, pairs: providedPairs, subgraphProvider } = params
+  const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
+
   const getPools = withFallback<V3PoolWithTvl[]>([
+    // Try get pools from on chain and ref tvl by subgraph
     {
       asyncFn: () => getV3PoolsWithTvlFromOnChain(params),
+      timeout: 3000,
     },
-    // TODO fallback to ipfs or other storage
+    // Fallback to get pools from on chain and ref tvl by subgraph cache
+    {
+      asyncFn: () => getV3PoolsWithTvlFromOnChainFallback(params),
+      timeout: 3000,
+    },
+    // Fallback to get all pools info from subgraph
+    {
+      asyncFn: () => getV3PoolSubgraph({ provider: subgraphProvider, pairs }),
+    },
   ])
 
   const pools = await getPools()

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/subgraphPoolProviders.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/subgraphPoolProviders.ts
@@ -1,9 +1,9 @@
-import { ChainId, Currency } from '@pancakeswap/sdk'
+import { ChainId, Currency, Token } from '@pancakeswap/sdk'
 import { parseProtocolFees, Pool, FeeAmount } from '@pancakeswap/v3-sdk'
 import { gql } from 'graphql-request'
 import type { GraphQLClient } from 'graphql-request'
 import memoize from 'lodash/memoize'
-import { Address } from 'viem'
+import { Address, getAddress } from 'viem'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 
 import { PoolType, SubgraphProvider, V2PoolWithTvl, V3PoolWithTvl, WithTvl } from '../../types'
@@ -222,4 +222,127 @@ export const getV2PoolSubgraph = subgraphPoolProviderFactory<PoolMeta, V2PoolWit
       }
     })
   },
+})
+
+interface AllPoolsFactoryParams<P extends WithTvl> {
+  // Function identifier
+  id: string
+
+  // Page number starts from 0
+  getPoolsFromSubgraph: (params: {
+    lastId: string
+    pageSize: number
+    client: GraphQLClient
+    chainId: number
+  }) => Promise<P[]>
+
+  getPoolId: (p: P) => string
+}
+
+function subgraphAllPoolsQueryFactory<P extends WithTvl>({
+  getPoolsFromSubgraph,
+  getPoolId,
+}: AllPoolsFactoryParams<P>) {
+  return async function getAllPools({
+    provider,
+    chainId,
+    pageSize = 1000,
+  }: {
+    chainId?: ChainId
+    provider?: SubgraphProvider
+    pageSize?: number
+  }): Promise<P[]> {
+    if (!provider || !chainId) {
+      throw new Error('No valid subgraph data provider')
+    }
+    const client = provider({ chainId })
+
+    if (!client) {
+      throw new Error(`No subgraph client found for chainId ${chainId}`)
+    }
+
+    let hasMorePools = true
+    let lastId = ''
+    let pools: P[] = []
+    while (hasMorePools) {
+      // eslint-disable-next-line no-await-in-loop
+      const poolsAtCurrentPage = await getPoolsFromSubgraph({ client, lastId, pageSize, chainId })
+      if (poolsAtCurrentPage.length < pageSize) {
+        hasMorePools = false
+        pools = [...pools, ...poolsAtCurrentPage]
+        break
+      }
+      lastId = getPoolId(poolsAtCurrentPage[poolsAtCurrentPage.length - 1])
+      pools = [...pools, ...poolsAtCurrentPage]
+    }
+    return pools
+  }
+}
+
+const queryAllV3Pools = gql`
+  query getPools($pageSize: Int!, $id: String) {
+    pools(first: $pageSize, where: { id_gt: $id }) {
+      id
+      tick
+      token0 {
+        symbol
+        id
+        decimals
+      }
+      token1 {
+        symbol
+        id
+        decimals
+      }
+      sqrtPrice
+      feeTier
+      liquidity
+      feeProtocol
+      totalValueLockedUSD
+    }
+  }
+`
+
+interface TokenFromSubgraph {
+  symbol: string
+  id: string
+  decimals: string
+}
+
+export interface V3DetailedPoolSubgraphResult extends V3PoolSubgraphResult {
+  token0: TokenFromSubgraph
+  token1: TokenFromSubgraph
+}
+
+export const getAllV3PoolsFromSubgraph = subgraphAllPoolsQueryFactory<V3PoolWithTvl>({
+  id: 'getAllV3PoolsFromSubgraph',
+  getPoolsFromSubgraph: async ({ lastId, pageSize, client, chainId }) => {
+    const { pools: poolsFromSubgraph } = await client.request<{ pools: V3DetailedPoolSubgraphResult[] }>(
+      queryAllV3Pools,
+      {
+        pageSize,
+        id: lastId,
+      },
+    )
+
+    return poolsFromSubgraph.map(
+      ({ id, liquidity, sqrtPrice, tick, totalValueLockedUSD, feeProtocol, token0, token1, feeTier }) => {
+        const [token0ProtocolFee, token1ProtocolFee] = parseProtocolFees(feeProtocol)
+        return {
+          type: PoolType.V3 as const,
+          fee: Number(feeTier),
+          token0: new Token(chainId, getAddress(token0.id), Number(token0.decimals), token0.symbol),
+          token1: new Token(chainId, getAddress(token1.id), Number(token1.decimals), token1.symbol),
+          liquidity: BigInt(liquidity),
+          sqrtRatioX96: BigInt(sqrtPrice),
+          tick: Number(tick),
+          address: getAddress(id),
+          tvlUSD: BigInt(Number.parseInt(totalValueLockedUSD)),
+          token0ProtocolFee,
+          token1ProtocolFee,
+        }
+      },
+    )
+  },
+  getPoolId: (p) => p.address,
 })

--- a/packages/smart-router/evm/v3-router/schema.ts
+++ b/packages/smart-router/evm/v3-router/schema.ts
@@ -55,7 +55,7 @@ const zStablePool = z
   })
   .required()
 
-const zPools = z.array(z.union([zV2Pool, zV3Pool, zStablePool]))
+export const zPools = z.array(z.union([zV2Pool, zV3Pool, zStablePool]))
 
 export const zRouterGetParams = z
   .object({
@@ -100,3 +100,4 @@ export const zRouterPostParams = z
 
 export type RouterPostParams = z.infer<typeof zRouterPostParams>
 export type RouterGetParams = z.infer<typeof zRouterGetParams>
+export type SerializedPools = z.infer<typeof zPools>

--- a/packages/smart-router/evm/v3-router/smartRouter.ts
+++ b/packages/smart-router/evm/v3-router/smartRouter.ts
@@ -13,6 +13,7 @@ export {
   getV3CandidatePools,
   getStableCandidatePools,
   getCandidatePools,
+  getAllV3PoolsFromSubgraph,
   v2PoolTvlSelector as v2PoolSubgraphSelection,
   v3PoolTvlSelector as v3PoolSubgraphSelection,
 } from './providers'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,12 +187,21 @@ importers:
       '@pancakeswap/worker-utils':
         specifier: workspace:*
         version: link:../../packages/worker-utils
+      graphql-request:
+        specifier: ^5.0.0
+        version: 5.0.0(encoding@0.1.13)(graphql@16.6.0)
       itty-router:
         specifier: ^2.6.1
         version: 2.6.1
       itty-router-extras:
         specifier: ^0.4.2
         version: 0.4.2
+      viem:
+        specifier: ^0.3.30
+        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+      wagmi:
+        specifier: 1.0.5
+        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^3.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,11 +197,11 @@ importers:
         specifier: ^0.4.2
         version: 0.4.2
       viem:
-        specifier: ^0.3.30
-        version: 0.3.30(typescript@5.0.4)(zod@3.21.4)
+        specifier: ^0.3.39
+        version: 0.3.39(typescript@5.0.4)
       wagmi:
         specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)(viem@0.3.30)(zod@3.21.4)
+        version: 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^3.10.0
@@ -1808,7 +1808,7 @@ importers:
         version: 18.2.0
       '@wagmi/connectors':
         specifier: ^1.0.3
-        version: 1.0.3(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)
+        version: 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
       '@wagmi/core':
         specifier: ^1.0.8
         version: 1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)(zod@3.21.4)
@@ -10870,6 +10870,16 @@ packages:
       typescript: 5.0.4
     dev: false
 
+  /@wagmi/chains@0.2.23(typescript@5.0.4):
+    resolution: {integrity: sha512-oIc4ZpUL6bH/HdS7ROPWlFnP5U3XBujO/OiX4csRIezyLjMQ9FNXQRZShhi5ddL0Kj1RDbyVLe9K/QotEm1vig==}
+    peerDependencies:
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.0.4
+
   /@wagmi/chains@0.3.1(typescript@5.0.4):
     resolution: {integrity: sha512-NN5qziBLFeXnx0+3ywdiKKXUSW4H73Wc1jRrygl9GKXVPawU0GBMudwXUfV7VOu6E9vmG7Arj0pVsEwq63b2Ew==}
     peerDependencies:
@@ -10952,7 +10962,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors@1.0.3(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44):
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -10968,13 +10978,14 @@ packages:
       '@ledgerhq/connect-kit-loader': 1.0.1
       '@safe-global/safe-apps-provider': 0.15.2(encoding@0.1.13)
       '@safe-global/safe-apps-sdk': 7.10.1(encoding@0.1.13)
+      '@wagmi/chains': 0.2.23(typescript@5.0.4)
       '@walletconnect/ethereum-provider': 2.7.4(@web3modal/standalone@2.4.1)(encoding@0.1.13)
       '@walletconnect/legacy-provider': 2.0.0(encoding@0.1.13)
       '@web3modal/standalone': 2.4.1(react@18.2.0)
       abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.44(typescript@5.0.4)(zod@3.21.4)
+      viem: 0.3.39(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -10985,7 +10996,6 @@ packages:
       - supports-color
       - utf-8-validate
       - zod
-    dev: true
 
   /@wagmi/connectors@2.0.0(@wagmi/chains@0.3.1)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)(zod@3.21.4):
     resolution: {integrity: sha512-W7GFLdLaJiqISm65pwoe0DePLjL3klyugCwQwlunFXHNHvYSsoWkzDjb1H5XJwx9g+dTVNwJVg8TE7WfaUdilg==}
@@ -11071,6 +11081,35 @@ packages:
       - immer
       - react
       - typescript
+    dev: false
+
+  /@wagmi/core@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
+    resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
+    peerDependencies:
+      typescript: '>=4.9.4'
+      viem: ~0.3.18
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@wagmi/chains': 0.2.23(typescript@5.0.4)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+      abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
+      eventemitter3: 4.0.7
+      typescript: 5.0.4
+      viem: 0.3.39(typescript@5.0.4)
+      zustand: 4.3.1(react@18.2.0)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react
+      - supports-color
+      - utf-8-validate
+      - zod
     dev: false
 
   /@wagmi/core@1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)(zod@3.21.4):
@@ -25176,6 +25215,24 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
+  /viem@0.3.39(typescript@5.0.4):
+    resolution: {integrity: sha512-hWPPLsaT3UdFBbECZrqDnE7lbYzLmAf9lIqvzsab3zXVV2y/HeNm63r0xRLdMRKfCC68AppEZUttOHyo2W/1ZQ==}
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.0
+      '@noble/curves': 1.0.0
+      '@noble/hashes': 1.3.0
+      '@scure/bip32': 1.3.0
+      '@scure/bip39': 1.2.0
+      '@wagmi/chains': 0.3.1(typescript@5.0.4)
+      abitype: 0.8.2(typescript@5.0.4)(zod@3.21.4)
+      isomorphic-ws: 5.0.0(ws@8.12.0)
+      ws: 8.12.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   /viem@0.3.44(typescript@5.0.4)(zod@3.21.4):
     resolution: {integrity: sha512-AeciSGIjWF2mUAfYMbKSBhj+tZKwijgMUBGLhdQdoZIV1F6gHXZPBYW/a/hwMxvCoz4FTHrZsMzqEih8ypkyPg==}
     dependencies:
@@ -25580,6 +25637,39 @@ packages:
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react-dom
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /wagmi@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
+    resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
+    peerDependencies:
+      react: '>=17.0.0'
+      typescript: '>=4.9.4'
+      viem: ~0.3.18
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@tanstack/query-sync-storage-persister': 4.29.1
+      '@tanstack/react-query': 4.29.1(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-query-persist-client': 4.29.1(@tanstack/react-query@4.29.1)
+      '@wagmi/core': 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+      abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
+      react: 18.2.0
+      typescript: 5.0.4
+      use-sync-external-store: 1.2.0(react@18.2.0)
+      viem: 0.3.39(typescript@5.0.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b0138e2</samp>

### Summary
🌐🗄️🏊

<!--
1.  🌐 - This emoji represents the addition of the `graphql-request` package and the use of GraphQL clients to query the v3 subgraph for pools data. It also symbolizes the support for multiple chains and subgraph URLs in the routing and smart router packages.
2.  🗄️ - This emoji represents the addition of the KV namespace and the cron triggers to fetch and store the v3 pools data from the subgraph. It also symbolizes the use of the `viem` package to cache and access the data in the worker script.
3.  🏊 - This emoji represents the addition of the `wagmi` package and the use of the v3 pools data for routing and swapping in the smart router. It also symbolizes the integration of the v3 router logic and the zod schema for data validation.
-->
Added support for v3 pools data from the subgraph in the `apis/routing` and `packages/smart-router/evm/v3-router` packages. This allows the frontend to access and use the latest v3 pools data for routing and swapping. Added KV namespace, cron triggers, and router handler for v3 pools data in `wrangler.toml`, `provider.ts`, `constants.ts`, `pools.ts`, and `subgraphPoolBackup.ts`. Added new dependencies and schema for v3 pools data in `pnpm-lock.yaml`, `package.json`, and `schema.ts`.

> _To fetch and cache v3 pools data_
> _We added some packages and crontab_
> _We used `graphql-request`_
> _And `viem` to attest_
> _The data for the `smart-router` to grab_

### Walkthrough
*  Add dependencies and configure KV namespace for v3 pools data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-cf61fff9b790e39248334260be81e52e45dd68ec9702d198bbe7ef0d4f55d5a2L10-R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-afd427bcc9ce9cf37fc7b54d9fc359d12b3ad250fe0b684e4f02209bb59c5c9eL5-R12))
*  Create and export GraphQL clients for v3 subgraph for each supported chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR1-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0R51-R61), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8L4-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8L92-R76))
*  Implement and export function to query v3 subgraph for all pools data and transform them into `V3PoolWithTvl` type ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-3ce88921cda46cc4402a25349c4733909b25a978c2df41d0a9b02efcf30693feR226-R348), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2863ea0f924ed09be85e3f2bac863b72a69df228eb193ea3ecb985b5491a3deaR16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8L4-R10))
*  Register scheduled event listener to fetch and store v3 pools data from subgraph every 10 minutes and every day ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-c3e6dd8a21710e37af3c9a7814b32177df5db9668681747813c613bb1cd2b27bR1-R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-afd427bcc9ce9cf37fc7b54d9fc359d12b3ad250fe0b684e4f02209bb59c5c9eL13-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8R204-R208))
*  Create router handler for `/v0/v3-pools/:chainId` endpoint to return cached pools data or fetch from subgraph if not available ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-a8df7c6f7fba88fdd849a4583391294966a4265a36dd737602fee6cf3dd345daR1-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8R204-R208))
*  Export zod schema and type alias for pools data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-3b2f28d1974418c89ece64ef60a1154a63f86a299d22ec8ea53f8de5b0971fd8L58-R58), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-3b2f28d1974418c89ece64ef60a1154a63f86a299d22ec8ea53f8de5b0971fd8R103))
*  Use `getAddress` to convert token addresses to checksum format ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L2-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-3ce88921cda46cc4402a25349c4733909b25a978c2df41d0a9b02efcf30693feL1-R6))
*  Remove unused `subgraphProvider` function and `V3_SUBGRAPH_URLS` object ([link](https://github.com/pancakeswap/pancake-frontend/pull/7031/files?diff=unified&w=0#diff-2d09a59c399d19a0d475510816b73e37263a1e12bb4273cc62d4b310a3230af8L21-R24))


