### PR TITLE
chore: IFO flatfee rebase

### DIFF
--- a/apps/web/src/config/constants/ifo.ts
+++ b/apps/web/src/config/constants/ifo.ts
@@ -629,28 +629,6 @@ const ifos: Ifo[] = [
     tokenOfferingPrice: null,
     version: 1,
   },
-  {
-    id: 'test',
-    address: '0xF2F1E57D5EC65C206315803f83CCDce713E367c2',
-    isActive: true,
-    name: 'USDT',
-    plannedStartTime: 1683698400, // Wed May 10 2023 14:03:14
-    poolBasic: {
-      raiseAmount: '$1',
-    },
-    poolUnlimited: {
-      raiseAmount: '$2',
-    },
-    currency: bscTokens.cake,
-    token: bscTokens.usdt,
-    campaignId: '512200000',
-    articleUrl: 'https://pancakeswap.finance/voting/',
-    tokenOfferingPrice: 1.0,
-    version: 3.3,
-    twitterUrl: 'https://twitter.com/pancakeswap',
-    description: 'Spend CAKE, buy USDT, but on vesting',
-    vestingTitle: 'Use CAKE to buy USDT',
-  },
 ]
 
 export default ifos

--- a/apps/web/src/config/constants/ifo.ts
+++ b/apps/web/src/config/constants/ifo.ts
@@ -646,7 +646,7 @@ const ifos: Ifo[] = [
     campaignId: '512200000',
     articleUrl: 'https://pancakeswap.finance/voting/',
     tokenOfferingPrice: 1.0,
-    version: 3.2,
+    version: 3.3,
     twitterUrl: 'https://twitter.com/pancakeswap',
     description: 'Spend CAKE, buy USDT, but on vesting',
     vestingTitle: 'Use CAKE to buy USDT',

--- a/apps/web/src/config/constants/ifo.ts
+++ b/apps/web/src/config/constants/ifo.ts
@@ -631,12 +631,12 @@ const ifos: Ifo[] = [
   },
   {
     id: 'test',
-    address: '0xcbCB78767868eed65Fd6a12b694bb2e980DfA243',
+    address: '0xF2F1E57D5EC65C206315803f83CCDce713E367c2',
     isActive: true,
     name: 'USDT',
-    plannedStartTime: 1683607200, // Tuesday, 9 May 2023 04:40:00
+    plannedStartTime: 1683698400, // Wed May 10 2023 14:03:14
     poolBasic: {
-      raiseAmount: '$0.1',
+      raiseAmount: '$1',
     },
     poolUnlimited: {
       raiseAmount: '$2',

--- a/apps/web/src/config/constants/ifo.ts
+++ b/apps/web/src/config/constants/ifo.ts
@@ -629,6 +629,28 @@ const ifos: Ifo[] = [
     tokenOfferingPrice: null,
     version: 1,
   },
+  {
+    id: 'test',
+    address: '0x6DA6f3AFFB86633aDeE5DaD9059CE23db2004b59',
+    isActive: true,
+    name: 'USDT',
+    plannedStartTime: 1683547200, // Mon May 08 2023 20:00:00 GMT+0800
+    poolBasic: {
+      raiseAmount: '$10',
+    },
+    poolUnlimited: {
+      raiseAmount: '$20',
+    },
+    currency: bscTokens.cake,
+    token: bscTokens.usdt,
+    campaignId: '512200000',
+    articleUrl: 'https://pancakeswap.finance/voting/',
+    tokenOfferingPrice: 1.0,
+    version: 3.2,
+    twitterUrl: 'https://twitter.com/pancakeswap',
+    description: 'Spend CAKE, buy USDT, but on vesting',
+    vestingTitle: 'Use CAKE to buy USDT',
+  },
 ]
 
 export default ifos

--- a/apps/web/src/config/constants/ifo.ts
+++ b/apps/web/src/config/constants/ifo.ts
@@ -631,15 +631,15 @@ const ifos: Ifo[] = [
   },
   {
     id: 'test',
-    address: '0x6DA6f3AFFB86633aDeE5DaD9059CE23db2004b59',
+    address: '0xcbCB78767868eed65Fd6a12b694bb2e980DfA243',
     isActive: true,
     name: 'USDT',
-    plannedStartTime: 1683547200, // Mon May 08 2023 20:00:00 GMT+0800
+    plannedStartTime: 1683607200, // Tuesday, 9 May 2023 04:40:00
     poolBasic: {
-      raiseAmount: '$10',
+      raiseAmount: '$0.1',
     },
     poolUnlimited: {
-      raiseAmount: '$20',
+      raiseAmount: '$2',
     },
     currency: bscTokens.cake,
     token: bscTokens.usdt,

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -215,8 +215,8 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
               value={`$${ifo.tokenOfferingPrice}`}
             />
           )}
-          {poolId === PoolIds.poolUnlimited && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
-          {poolId === PoolIds.poolUnlimited && (
+          {!!poolCharacteristic.taxRate && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
+          {!!poolCharacteristic.taxRate && (
             <FooterEntry
               label={t('Price per %symbol% with fee:', { symbol: ifo.token.symbol })}
               value={pricePerTokenWithFee}
@@ -257,7 +257,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
       return (
         <StyledIfoCardDetails flexDirection="column">
           {(poolId === PoolIds.poolBasic || ifo.isActive) && tokenEntry}
-          {poolId === PoolIds.poolUnlimited && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
+          {!!poolCharacteristic.taxRate && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
           <FooterEntry label={t('Total committed:')} value={currencyPriceInUSD.gt(0) ? totalCommitted : null} />
           <FooterEntry label={t('Funds to raise:')} value={ifo[poolId].raiseAmount} />
           {raisingTokenToBurn && <FooterEntry label={t('CAKE to burn:')} value={raisingTokenToBurn} />}

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -134,6 +134,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
   const { status, currencyPriceInUSD } = publicIfoData
   const poolCharacteristic = publicIfoData[poolId]
   const walletCharacteristic = walletIfoData[poolId]
+  const { hasTax } = poolCharacteristic
 
   let version3MaxTokens = walletIfoData.ifoCredit?.creditLeft
     ? // if creditLeft > limit show limit else show creditLeft
@@ -215,8 +216,8 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
               value={`$${ifo.tokenOfferingPrice}`}
             />
           )}
-          {!!poolCharacteristic.taxRate && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
-          {!!poolCharacteristic.taxRate && (
+          {hasTax && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
+          {hasTax && (
             <FooterEntry
               label={t('Price per %symbol% with fee:', { symbol: ifo.token.symbol })}
               value={pricePerTokenWithFee}
@@ -257,7 +258,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
       return (
         <StyledIfoCardDetails flexDirection="column">
           {(poolId === PoolIds.poolBasic || ifo.isActive) && tokenEntry}
-          {!!poolCharacteristic.taxRate && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
+          {hasTax && <FooterEntry label={t('Additional fee:')} value={taxRate} />}
           <FooterEntry label={t('Total committed:')} value={currencyPriceInUSD.gt(0) ? totalCommitted : null} />
           <FooterEntry label={t('Funds to raise:')} value={ifo[poolId].raiseAmount} />
           {raisingTokenToBurn && <FooterEntry label={t('CAKE to burn:')} value={raisingTokenToBurn} />}
@@ -267,7 +268,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
               value={`$${ifo.tokenOfferingPrice ? ifo.tokenOfferingPrice : '?'}`}
             />
           )}
-          {ifo.version > 1 && poolId === PoolIds.poolUnlimited && (
+          {ifo.version > 1 && hasTax && (
             <FooterEntry
               label={t('Price per %symbol% with fee:', { symbol: ifo.token.symbol })}
               value={pricePerTokenWithFee}

--- a/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
@@ -199,7 +199,7 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
         secondsUntilStart: (startBlockNum - currentBlock) * BSC_BLOCK_TIME,
         poolBasic: {
           ...poolBasicFormatted,
-          taxRate: 0,
+          taxRate: taxRateNum,
           distributionRatio: round(
             poolBasicFormatted.offeringAmountPool.div(totalOfferingAmount).toNumber(),
             ROUND_DIGIT,

--- a/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
@@ -17,9 +17,6 @@ import { getStatus } from '../helpers'
 // https://github.com/pancakeswap/pancake-contracts/blob/master/projects/ifo/contracts/IFOV2.sol#L431
 // 1,000,000,000 / 100
 const TAX_PRECISION = new BigNumber(10000000000)
-const NEW_TAX_PRECISION = new BigNumber(10 ** 12)
-
-const getTaxPrecision = (version: number) => (version >= 3.3 ? NEW_TAX_PRECISION : TAX_PRECISION)
 
 const NO_QUALIFIED_NFT_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -45,7 +42,7 @@ const ROUND_DIGIT = 3
  * Gets all public data of an IFO
  */
 const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
-  const { address, plannedStartTime, version } = ifo
+  const { address, plannedStartTime } = ifo
   const cakePriceUsd = usePriceCakeUSD()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
   const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePriceUsd : lpTokenPriceInUsd
@@ -198,10 +195,9 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
 
       const startBlockNum = startBlock ? startBlock[0].toNumber() : 0
       const endBlockNum = endBlock ? endBlock[0].toNumber() : 0
-      const taxPrecision = getTaxPrecision(version)
-      const taxRateNum = taxRate ? new BigNumber(taxRate.toString()).div(taxPrecision).toNumber() : 0
+      const taxRateNum = taxRate ? new BigNumber(taxRate.toString()).div(TAX_PRECISION).toNumber() : 0
       const privateSaleTaxRateNum = privateSaleTaxRate
-        ? new BigNumber(privateSaleTaxRate.toString()).div(taxPrecision).toNumber()
+        ? new BigNumber(privateSaleTaxRate.toString()).div(TAX_PRECISION).toNumber()
         : 0
 
       const status = getStatus(currentBlock, startBlockNum, endBlockNum)
@@ -252,7 +248,7 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
         vestingStartTime: vestingStartTime.result ? Number(vestingStartTime.result) : 0,
       }))
     },
-    [plannedStartTime, address, version],
+    [plannedStartTime, address],
   )
 
   return { ...state, currencyPriceInUSD, fetchIfoData }

--- a/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
@@ -193,8 +193,8 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
       const poolBasicFormatted = formatPool(poolBasic)
       const poolUnlimitedFormatted = formatPool(poolUnlimited)
 
-      const startBlockNum = startBlock ? startBlock[0].toNumber() : 0
-      const endBlockNum = endBlock ? endBlock[0].toNumber() : 0
+      const startBlockNum = startBlock ? Number(startBlock) : 0
+      const endBlockNum = endBlock ? Number(endBlock) : 0
       const taxRateNum = taxRate ? new BigNumber(taxRate.toString()).div(TAX_PRECISION).toNumber() : 0
       const privateSaleTaxRateNum = privateSaleTaxRate
         ? new BigNumber(privateSaleTaxRate.toString()).div(TAX_PRECISION).toNumber()

--- a/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
@@ -17,6 +17,9 @@ import { getStatus } from '../helpers'
 // https://github.com/pancakeswap/pancake-contracts/blob/master/projects/ifo/contracts/IFOV2.sol#L431
 // 1,000,000,000 / 100
 const TAX_PRECISION = new BigNumber(10000000000)
+const NEW_TAX_PRECISION = new BigNumber(10 ** 12)
+
+const getTaxPrecision = (version: number) => (version >= 3.3 ? NEW_TAX_PRECISION : TAX_PRECISION)
 
 const NO_QUALIFIED_NFT_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -42,7 +45,7 @@ const ROUND_DIGIT = 3
  * Gets all public data of an IFO
  */
 const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
-  const { address, plannedStartTime } = ifo
+  const { address, plannedStartTime, version } = ifo
   const cakePriceUsd = usePriceCakeUSD()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
   const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePriceUsd : lpTokenPriceInUsd
@@ -97,50 +100,64 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
   const fetchIfoData = useCallback(
     async (currentBlock: number) => {
       const client = publicClient({ chainId: ChainId.BSC })
-      const [startBlock, endBlock, poolBasic, poolUnlimited, taxRate, numberPoints, thresholdPoints] =
-        await client.multicall({
-          contracts: [
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'startBlock',
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'endBlock',
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'viewPoolInformation',
-              args: [0n],
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'viewPoolInformation',
-              args: [1n],
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'viewPoolTaxRateOverflow',
-              args: [1n],
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'numberPoints',
-            },
-            {
-              abi: ifoV2ABI,
-              address,
-              functionName: 'thresholdPoints',
-            },
-          ],
-          allowFailure: false,
-        })
+      const [
+        startBlock,
+        endBlock,
+        poolBasic,
+        poolUnlimited,
+        taxRate,
+        numberPoints,
+        thresholdPoints,
+        privateSaleTaxRate,
+      ] = await client.multicall({
+        contracts: [
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'startBlock',
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'endBlock',
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'viewPoolInformation',
+            args: [0n],
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'viewPoolInformation',
+            args: [1n],
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'viewPoolTaxRateOverflow',
+            args: [1n],
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'numberPoints',
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'thresholdPoints',
+          },
+          {
+            abi: ifoV2ABI,
+            address,
+            functionName: 'viewPoolTaxRateOverflow',
+            args: [0n],
+          },
+        ],
+        allowFailure: false,
+      })
 
       const [admissionProfile, pointThreshold, vestingStartTime, basicVestingInformation, unlimitedVestingInformation] =
         await client.multicall({
@@ -179,9 +196,13 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
       const poolBasicFormatted = formatPool(poolBasic)
       const poolUnlimitedFormatted = formatPool(poolUnlimited)
 
-      const startBlockNum = startBlock ? Number(startBlock) : 0
-      const endBlockNum = endBlock ? Number(endBlock) : 0
-      const taxRateNum = taxRate ? new BigNumber(taxRate.toString()).div(TAX_PRECISION).toNumber() : 0
+      const startBlockNum = startBlock ? startBlock[0].toNumber() : 0
+      const endBlockNum = endBlock ? endBlock[0].toNumber() : 0
+      const taxPrecision = getTaxPrecision(version)
+      const taxRateNum = taxRate ? new BigNumber(taxRate.toString()).div(taxPrecision).toNumber() : 0
+      const privateSaleTaxRateNum = privateSaleTaxRate
+        ? new BigNumber(privateSaleTaxRate.toString()).div(taxPrecision).toNumber()
+        : 0
 
       const status = getStatus(currentBlock, startBlockNum, endBlockNum)
       const totalBlocks = endBlockNum - startBlockNum
@@ -199,7 +220,7 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
         secondsUntilStart: (startBlockNum - currentBlock) * BSC_BLOCK_TIME,
         poolBasic: {
           ...poolBasicFormatted,
-          taxRate: taxRateNum,
+          taxRate: privateSaleTaxRateNum,
           distributionRatio: round(
             poolBasicFormatted.offeringAmountPool.div(totalOfferingAmount).toNumber(),
             ROUND_DIGIT,
@@ -231,7 +252,7 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
         vestingStartTime: vestingStartTime.result ? Number(vestingStartTime.result) : 0,
       }))
     },
-    [plannedStartTime, address],
+    [plannedStartTime, address, version],
   )
 
   return { ...state, currencyPriceInUSD, fetchIfoData }

--- a/apps/web/src/views/Ifos/types.ts
+++ b/apps/web/src/views/Ifos/types.ts
@@ -19,6 +19,7 @@ export interface PoolCharacteristics {
   needQualifiedNFT?: boolean
   needQualifiedPoints?: boolean
   vestingInformation?: VestingInformation
+  hasTax?: boolean
 }
 
 // IFO data unrelated to the user returned by useGetPublicIfoData


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 95ce39c</samp>

### Summary
🧪🛠️🐛

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, which can be used to indicate the addition of a new test IFO configuration.
2.  🛠️ - This emoji represents tools, fixing, or construction, which can be used to indicate the addition of a new optional property to the interface and the update of the components to use it.
3.  🐛 - This emoji represents bugs, errors, or problems, which can be used to indicate the fixing of some bugs in the hook and the formatting of the tax rate.
-->
This pull request adds support for displaying and fetching the tax rate of IFO pools, and adds a new test IFO configuration for development purposes. It also fixes some bugs and improves the code quality of the IFO-related components and hooks. It modifies the files `IfoCardDetails.tsx`, `useGetPublicIfoData.ts`, `ifo.ts`, and `types.ts`.

> _This pull request is quite a mix_
> _It adds a new test IFO `ifo.ts`_
> _It also defines `hasTax` for pools_
> _And fixes some bugs and some rules_
> _To make the IFO data more robust_

### Walkthrough
*  Add a new test IFO configuration with USDT and CAKE tokens and a vesting feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-ed9f603aef08f97c4e697adb54f782c92560ff51571483b83175a849352580b8R632-R653))
*  Add a new `hasTax` variable to the `IfoCardDetails.tsx` and `StyledIfoCardDetails.tsx` components to indicate whether the pool has a tax or not ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612R137), [link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612L260-R261), [link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612L270-R271))
*  Replace the condition `poolId === PoolIds.poolUnlimited` with `hasTax` in the conditional rendering of the additional fee and the price per token with fee entries in the `IfoCardDetails.tsx` and `StyledIfoCardDetails.tsx` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612L218-R220), [link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612L260-R261), [link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-69971bbc57e339a6cfa84034c29fa72f8aff26f8f534ed3fa4e5e61c2a7db612L270-R271))
*  Add a new multicall contract to the `useGetPublicIfoData` hook to fetch the tax rate of the basic pool from the smart contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-2df6284ab3632793c5c484d18abea9e79f5d09168215efd00d86126d60664a6bL100-R157))
*  Convert the start block, end block, and tax rate values from the multicall response to numbers using the `[0].toNumber()` method ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-2df6284ab3632793c5c484d18abea9e79f5d09168215efd00d86126d60664a6bL182-R201))
*  Assign the tax rate of the basic pool to the `taxRate` property of the `poolBasic` object in the return value of the `useGetPublicIfoData` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-2df6284ab3632793c5c484d18abea9e79f5d09168215efd00d86126d60664a6bL202-R219))
*  Add a new optional `hasTax` property to the `PoolCharacteristics` interface to define the shape of the `poolCharacteristic` prop ([link](https://github.com/pancakeswap/pancake-frontend/pull/7032/files?diff=unified&w=0#diff-bd00288114b44d7d49b9bff3b41dcc046bd1a2ee46faf1c56f6912c3178fb402R22))


