### PR TITLE
fix(Menu): Fix bottom menu sort on mobile

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -21,7 +21,7 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
 
   const menuItems = useMemo(() => {
     const mobileConfig = [...config(t, isDark, languageCode, chainId)]
-    mobileConfig.push(mobileConfig.splice(4, 1)[0])
+    mobileConfig.push(mobileConfig.splice(5, 1)[0])
     return isMobile ? mobileConfig : config(t, isDark, languageCode, chainId)
   }, [t, isDark, languageCode, chainId, isMobile])
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b45891a</samp>

### Summary
📱➕🔁

<!--
1.  📱 This emoji represents the mobile menu configuration that is being modified.
2.  ➕ This emoji represents the addition of a new menu item for the prediction feature, which is placed before the farms item on the mobile menu.
3.  🔁 This emoji represents the swapping of the positions of the farms and the more item, so that the farms item is moved to the end of the mobile menu.
-->
Adjust mobile menu order to accommodate new prediction feature. Change index of `farms` item in `useMenuItems.ts` to move it to the end.

> _Mobile menu shifts_
> _`farms` item moves to the end_
> _Autumn prediction_

### Walkthrough
* Add a new menu item for the prediction feature with the icon `PredictionsIcon` and the link `/prediction` ()
* Move the farms menu item to the end of the mobile menu configuration by changing its index from 4 to 5 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7035/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL24-R24))



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/7ad109e7-dd4e-4a84-b12c-5a0d5089c294)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/763d0a0e-b655-44a2-92b4-859376808526)
