### PR TITLE
feat: Add v2 pool fallback api

### DIFF
--- a/apis/routing/package.json
+++ b/apis/routing/package.json
@@ -10,7 +10,7 @@
     "graphql-request": "^5.0.0",
     "itty-router": "^2.6.1",
     "itty-router-extras": "^0.4.2",
-    "viem": "^0.3.39",
+    "viem": "^0.3.44",
     "wagmi": "1.0.5"
   },
   "devDependencies": {

--- a/packages/smart-router/evm/constants/common.ts
+++ b/packages/smart-router/evm/constants/common.ts
@@ -1,4 +1,4 @@
-import { Percent } from '@pancakeswap/sdk'
+import { Percent, ChainId } from '@pancakeswap/sdk'
 
 export const BIG_INT_TEN = 10n
 // one basis point
@@ -7,3 +7,10 @@ export const BIPS_BASE = 10000n
 // used to ensure the user doesn't send so much BNB so they end up with <.01
 export const MIN_BNB: bigint = BIG_INT_TEN ** 16n // .01 BNB
 export const BETTER_TRADE_LESS_HOPS_THRESHOLD = new Percent(50n, BIPS_BASE)
+
+export const CHAIN_ID_TO_CHAIN_NAME = {
+  [ChainId.BSC]: 'bsc',
+  [ChainId.ETHEREUM]: 'ethereum',
+  [ChainId.GOERLI]: 'ethereum',
+  [ChainId.BSC_TESTNET]: 'bsc',
+} satisfies Record<ChainId, string>

--- a/packages/smart-router/evm/v3-router/providers/getCommonTokenPrices.ts
+++ b/packages/smart-router/evm/v3-router/providers/getCommonTokenPrices.ts
@@ -1,8 +1,10 @@
-import { Currency, Token } from '@pancakeswap/sdk'
+import { ChainId, Currency, Token } from '@pancakeswap/sdk'
 import { gql } from 'graphql-request'
 
 import { getCheckAgainstBaseTokens } from '../functions'
 import { SubgraphProvider } from '../types'
+import { CHAIN_ID_TO_CHAIN_NAME } from '../../constants'
+import { withFallback } from '../../utils/withFallback'
 
 const tokenPriceQuery = gql`
   query getTokens($pageSize: Int!, $tokenAddrs: [ID!]) {
@@ -16,40 +18,123 @@ const tokenPriceQuery = gql`
 interface Params {
   currencyA?: Currency
   currencyB?: Currency
+}
 
+interface BySubgraphEssentials {
   // V3 subgraph provider
   provider?: SubgraphProvider
 }
 
-export async function getCommonTokenPrices({ currencyA, currencyB, provider }: Params) {
-  if (!provider) {
-    throw new Error('No valid subgraph data provider')
-  }
-  const baseTokens: Token[] = getCheckAgainstBaseTokens(currencyA, currencyB)
-  const client = provider({ chainId: currencyA?.chainId })
-  if (!client || !baseTokens) {
-    return null
-  }
-  const map = new Map<string, number>()
-  const idToToken: { [key: string]: Currency } = {}
-  const addresses = baseTokens.map((t) => {
-    const address = t.address.toLocaleLowerCase()
-    idToToken[address] = t
-    return address
-  })
-  const { tokens: tokenPrices } = await client.request<{ tokens: { id: string; derivedUSD: string }[] }>(
-    tokenPriceQuery,
-    {
-      pageSize: 1000,
-      tokenAddrs: addresses,
-    },
-  )
-  for (const { id, derivedUSD } of tokenPrices) {
-    const token = idToToken[id]
-    if (token) {
-      map.set(token.wrapped.address, parseFloat(derivedUSD) || 0)
-    }
-  }
-
-  return map
+interface ParamsWithFallback extends Params {
+  v3SubgraphProvider?: SubgraphProvider
 }
+
+interface TokenPrice {
+  address: string
+  priceUSD: string
+}
+
+type GetTokenPrices<T> = (params: { addresses: string[]; chainId?: ChainId } & T) => Promise<TokenPrice[]>
+
+function commonTokenPriceProvider<T>(getTokenPrices: GetTokenPrices<T>) {
+  return async function getCommonTokenPrices({ currencyA, currencyB, ...rest }: Params & T) {
+    const baseTokens: Token[] = getCheckAgainstBaseTokens(currencyA, currencyB)
+    if (!baseTokens) {
+      return null
+    }
+    const map = new Map<string, number>()
+    const idToToken: { [key: string]: Currency } = {}
+    const addresses = baseTokens.map((t) => {
+      const address = t.address.toLocaleLowerCase()
+      idToToken[address] = t
+      return address
+    })
+    const tokenPrices = await getTokenPrices({ addresses, chainId: currencyA?.chainId, ...(rest as T) })
+    for (const { address, priceUSD } of tokenPrices) {
+      const token = idToToken[address]
+      if (token) {
+        map.set(token.wrapped.address, parseFloat(priceUSD) || 0)
+      }
+    }
+
+    return map
+  }
+}
+
+export const getCommonTokenPricesBySubgraph = commonTokenPriceProvider<BySubgraphEssentials>(
+  async ({ addresses, chainId, provider }) => {
+    const client = provider?.({ chainId })
+    if (!client) {
+      throw new Error('No valid subgraph data provider')
+    }
+    const { tokens: tokenPrices } = await client.request<{ tokens: { id: string; derivedUSD: string }[] }>(
+      tokenPriceQuery,
+      {
+        pageSize: 1000,
+        tokenAddrs: addresses,
+      },
+    )
+    return tokenPrices.map(({ id, derivedUSD }) => ({
+      address: id,
+      priceUSD: derivedUSD,
+    }))
+  },
+)
+
+const createGetTokenPriceFromLlmaWithCache = (): GetTokenPrices<BySubgraphEssentials> => {
+  // Add cache in case we reach the rate limit of llma api
+  const cache = new Map<string, TokenPrice>()
+
+  return async ({ addresses, chainId }) => {
+    if (!chainId) {
+      throw new Error(`Invalid chain id ${chainId}`)
+    }
+    const [cachedResults, addressesToFetch] = addresses.reduce<[TokenPrice[], string[]]>(
+      ([cachedAddrs, newAddrs], address) => {
+        const cached = cache.get(address.toLocaleLowerCase())
+        if (!cached) {
+          newAddrs.push(address)
+        } else {
+          cachedAddrs.push(cached)
+        }
+        return [cachedAddrs, newAddrs]
+      },
+      [[], []],
+    )
+
+    if (!addressesToFetch.length) {
+      return cachedResults
+    }
+
+    const list = addressesToFetch.map((address) => `${CHAIN_ID_TO_CHAIN_NAME[chainId]}:${address}`).join(',')
+    const result: { coins?: { [key: string]: { price: string } } } = await fetch(
+      `https://coins.llama.fi/prices/current/${list}`,
+    ).then((res) => res.json())
+
+    const { coins = {} } = result
+    return [
+      ...cachedResults,
+      ...Object.entries(coins).map(([key, value]) => {
+        const [, address] = key.split(':')
+        const tokenPrice = { address, priceUSD: value.price }
+        cache.set(address.toLocaleLowerCase(), tokenPrice)
+        return tokenPrice
+      }),
+    ]
+  }
+}
+
+export const getCommonTokenPricesByLlma = commonTokenPriceProvider<BySubgraphEssentials>(
+  createGetTokenPriceFromLlmaWithCache(),
+)
+
+export const getCommonTokenPrices = withFallback([
+  {
+    asyncFn: ({ currencyA, currencyB, v3SubgraphProvider }: ParamsWithFallback) =>
+      getCommonTokenPricesBySubgraph({ currencyA, currencyB, provider: v3SubgraphProvider }),
+    timeout: 3000,
+  },
+  {
+    asyncFn: ({ currencyA, currencyB }: ParamsWithFallback) => getCommonTokenPricesByLlma({ currencyA, currencyB }),
+  },
+])

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/getV2CandidatePools.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/getV2CandidatePools.ts
@@ -33,7 +33,7 @@ export async function getV2PoolsWithTvlByCommonTokenPrices({
   const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
   const [poolsFromOnChain, baseTokenUsdPrices] = await Promise.all([
     getV2PoolsOnChain(pairs, onChainProvider, blockNumber),
-    getCommonTokenPrices({ currencyA, currencyB, provider: v3SubgraphProvider }),
+    getCommonTokenPrices({ currencyA, currencyB, v3SubgraphProvider }),
   ])
 
   if (!poolsFromOnChain || !baseTokenUsdPrices) {
@@ -69,7 +69,7 @@ export async function getV2CandidatePools(params: Params) {
   const { v2SubgraphProvider, currencyA, currencyB, pairs: providedPairs } = params
   const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
 
-  const getPools = withFallback<V2PoolWithTvl[]>([
+  const getPools = withFallback([
     {
       asyncFn: () => getV2PoolsWithTvlByCommonTokenPrices(params),
       timeout: 3000,

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
@@ -91,7 +91,7 @@ export async function getV3CandidatePools(params: Params) {
   const { currencyA, currencyB, pairs: providedPairs, subgraphProvider } = params
   const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
 
-  const getPools = withFallback<V3PoolWithTvl[]>([
+  const getPools = withFallback([
     // Try get pools from on chain and ref tvl by subgraph
     {
       asyncFn: () => getV3PoolsWithTvlFromOnChain(params),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,11 +197,11 @@ importers:
         specifier: ^0.4.2
         version: 0.4.2
       viem:
-        specifier: ^0.3.39
-        version: 0.3.39(typescript@5.0.4)
+        specifier: ^0.3.44
+        version: 0.3.44(typescript@5.0.4)(zod@3.21.4)
       wagmi:
         specifier: 1.0.5
-        version: 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+        version: 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^3.10.0
@@ -1808,7 +1808,7 @@ importers:
         version: 18.2.0
       '@wagmi/connectors':
         specifier: ^1.0.3
-        version: 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+        version: 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)
       '@wagmi/core':
         specifier: ^1.0.8
         version: 1.0.8(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)(zod@3.21.4)
@@ -10962,7 +10962,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
+  /@wagmi/connectors@1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44):
     resolution: {integrity: sha512-5uB+dUDop8s9scdE+S4IhgcfP8oRwdULVvpJ2MusDp+C00+OgvS3SnwZM6+Pjc9tyj5pi143zqsYtDynxFrMEA==}
     peerDependencies:
       '@wagmi/chains': '>=0.2.23'
@@ -10985,7 +10985,7 @@ packages:
       abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.39(typescript@5.0.4)
+      viem: 0.3.44(typescript@5.0.4)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -11083,7 +11083,7 @@ packages:
       - typescript
     dev: false
 
-  /@wagmi/core@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
+  /@wagmi/core@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44):
     resolution: {integrity: sha512-n8Y84WJkofGjhd4a+vpZzPPEQiHnkIGMe0uHOXfkm4eKJZyaJqvVJFPMWE6xFJkk0hxZ+1zw5xn0ZhdroHwHvg==}
     peerDependencies:
       typescript: '>=4.9.4'
@@ -11093,11 +11093,11 @@ packages:
         optional: true
     dependencies:
       '@wagmi/chains': 0.2.23(typescript@5.0.4)
-      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+      '@wagmi/connectors': 1.0.3(@wagmi/chains@0.2.23)(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)
       abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
       eventemitter3: 4.0.7
       typescript: 5.0.4
-      viem: 0.3.39(typescript@5.0.4)
+      viem: 0.3.44(typescript@5.0.4)(zod@3.21.4)
       zustand: 4.3.1(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -25215,24 +25215,6 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /viem@0.3.39(typescript@5.0.4):
-    resolution: {integrity: sha512-hWPPLsaT3UdFBbECZrqDnE7lbYzLmAf9lIqvzsab3zXVV2y/HeNm63r0xRLdMRKfCC68AppEZUttOHyo2W/1ZQ==}
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.0
-      '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
-      '@scure/bip32': 1.3.0
-      '@scure/bip39': 1.2.0
-      '@wagmi/chains': 0.3.1(typescript@5.0.4)
-      abitype: 0.8.2(typescript@5.0.4)(zod@3.21.4)
-      isomorphic-ws: 5.0.0(ws@8.12.0)
-      ws: 8.12.0
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
   /viem@0.3.44(typescript@5.0.4)(zod@3.21.4):
     resolution: {integrity: sha512-AeciSGIjWF2mUAfYMbKSBhj+tZKwijgMUBGLhdQdoZIV1F6gHXZPBYW/a/hwMxvCoz4FTHrZsMzqEih8ypkyPg==}
     dependencies:
@@ -25651,7 +25633,7 @@ packages:
       - zod
     dev: false
 
-  /wagmi@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39):
+  /wagmi@1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44):
     resolution: {integrity: sha512-XsLhNPTD7c+QXaA9elMwDihvcNHBw4Jcu0S/otkn3N4FgWIUVSQGiUYwm3AQrm/UhON0+Q8Y3ICzxB47PSr46g==}
     peerDependencies:
       react: '>=17.0.0'
@@ -25664,12 +25646,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.29.1
       '@tanstack/react-query': 4.29.1(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.29.1(@tanstack/react-query@4.29.1)
-      '@wagmi/core': 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.39)
+      '@wagmi/core': 1.0.5(encoding@0.1.13)(react@18.2.0)(typescript@5.0.4)(viem@0.3.44)
       abitype: 0.8.1(typescript@5.0.4)(zod@3.21.4)
       react: 18.2.0
       typescript: 5.0.4
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 0.3.39(typescript@5.0.4)
+      viem: 0.3.44(typescript@5.0.4)(zod@3.21.4)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f6a2f12</samp>

### Summary
🆙🛠️🗺️

<!--
1.  🆙 - This emoji represents the update of the `viem` dependency version, which is a significant improvement for the web3 development of the smart router.
2.  🛠️ - This emoji represents the refactoring and bug fixing of the `useV2Pools`, `useV2CandidatePools`, `withFallback`, and `getCommonTokenPrices` functions, which are important for the functionality and performance of the smart router.
3.  🗺️ - This emoji represents the mapping of chain ids to chain names and the use of the `ChainId` enum, which are helpful for the token price fetching and the cross-chain compatibility of the smart router.
-->
This pull request improves the smart router functionality and performance by refactoring the hooks and utilities for fetching pools and token prices, updating the dependencies, and using the `ChainId` enum from `@pancakeswap/sdk`. It also modifies the `useV2Pools` and `useV2CandidatePools` hooks in `apps/web/src/hooks/useV2Pools.ts` to use a constant refresh interval for the pools data.

> _We're sailing on the web3 seas with `viem` and `pancakeswap`_
> _We're fetching pools and prices with `withFallback` and `useSWR`_
> _We're refactoring hooks and functions to make them smart and fast_
> _We're heaving on the code review, one, two, three, and blast!_

### Walkthrough
*  Updated `viem` dependency version to `0.3.44` in `apis/routing/package.json` and `pnpm-lock.yaml` to use the latest features and bug fixes of the `viem` library ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-cf61fff9b790e39248334260be81e52e45dd68ec9702d198bbe7ef0d4f55d5a2L13-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL200-R204), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1811-R1811), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10965-R10965), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10988-R10988), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11086-R11086), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11096-R11100), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25218-L25235), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25654-R25636), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25667-R25654))
*  Added `refreshInterval` and `errorRetryCount` options to the `useSWR` hook that fetches the pools data from the smart router in `useV2CandidatePools` hook and removed the `useEffect` hook that manually triggered revalidation based on the block number ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591R30-R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591R76-R77), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591L72-L82))
*  Imported `POOLS_FAST_REVALIDATE` from `config/pools` and used it to compute the refresh interval of the pools data based on the chain id in `useV2Pools` and `useV2CandidatePools` hooks ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591L3-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-2f7c08419a2716c872f9fa484edde9247de065547ae2714ef3172a3b1b4c1591R30-R37))
*  Refactored `getCommonTokenPrices` function into a higher-order function that accepts a `getTokenPrices` function as an argument and returns a function that takes the `currencyA` and `currencyB` as parameters and returns a map of token prices in `getCommonTokenPrices.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-04cf8c01f201ad72486e7a51478c3eb863b8470bbf5f63839849f000a91d9d8dL19-R140))
*  Added a `CHAIN_ID_TO_CHAIN_NAME` constant that maps chain ids to chain names and used it for fetching token prices from the llama api in `common.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-49573f110ec3a7b2c18b2aec89dcca7184192e3187731aaed499af0da5ae3c08L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-49573f110ec3a7b2c18b2aec89dcca7184192e3187731aaed499af0da5ae3c08R10-R16))
*  Changed the type of `AsyncFn` from a generic function that returns a promise of type `T` to a type alias for any async function and changed the `withTimeout` and `asyncCall` functions to accept any async function and its arguments as parameters in `withFallback.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-ef3bd574e63cbd06e69c2fb2763bd36a956941f975c6fa8e0c93213028c8ac88L1-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-ef3bd574e63cbd06e69c2fb2763bd36a956941f975c6fa8e0c93213028c8ac88L10-R22), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-ef3bd574e63cbd06e69c2fb2763bd36a956941f975c6fa8e0c93213028c8ac88L28-R31))
*  Changed the `getCommonTokenPrices` function call to pass the `v3SubgraphProvider` as an argument in `getV2CandidatePools.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-b029378e939f44f0f256261275d5aeac9746e541d5904ced3d48d542ca0efddfL36-R36))
*  Changed the `withFallback` function calls to remove the generic type arguments in `getV2CandidatePools.ts` and `getV3CandidatePools.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-b029378e939f44f0f256261275d5aeac9746e541d5904ced3d48d542ca0efddfL72-R72), [link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L94-R94))
*  Imported `ChainId` and `withFallback` from `@pancakeswap/sdk` and `../../utils` respectively in `getCommonTokenPrices.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7042/files?diff=unified&w=0#diff-04cf8c01f201ad72486e7a51478c3eb863b8470bbf5f63839849f000a91d9d8dL1-R7))


