### PR TITLE
chore: Use nanoid instead of uuid

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -103,7 +103,7 @@
     "zod": "^3.21.4",
     "polished": "^4.2.2",
     "tiny-invariant": "^1.1.0",
-    "uuid": "^8.0.0",
+    "nanoid": "^4.0.2",
     "viem": "^1.2.9"
   },
   "devDependencies": {

--- a/apps/web/src/pages/api/risk/[chainId]/[address].ts
+++ b/apps/web/src/pages/api/risk/[chainId]/[address].ts
@@ -1,8 +1,8 @@
 import { NextApiHandler } from 'next'
 import { enum as zEnum, string as zString, object as zObject } from 'zod'
-import { v4 as uuid } from 'uuid'
 import HmacSHA256 from 'crypto-js/hmac-sha256'
 import EncodeHex from 'crypto-js/enc-hex'
+import { nanoid } from 'nanoid'
 
 const host = 'https://avengerdao.org'
 const url = '/api/v1/address-security'
@@ -30,7 +30,7 @@ const handler: NextApiHandler = async (req, res) => {
   const { chainId, address: address_ } = parsed.data
   const address = address_.toLowerCase()
   const timeStamp = new Date().valueOf().toString()
-  const nonce = uuid().replaceAll('-', '')
+  const nonce = nanoid().replaceAll('-', '').replaceAll('_', '')
   const body = JSON.stringify({
     chainId,
     address,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      nanoid:
+        specifier: ^4.0.2
+        version: 4.0.2
       next:
         specifier: 13.4.2
         version: 13.4.2(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
@@ -769,9 +772,6 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.1.3
-      uuid:
-        specifier: ^8.0.0
-        version: 8.3.2
       viem:
         specifier: ^1.2.9
         version: 1.2.9(typescript@5.1.3)(zod@3.21.4)
@@ -21151,6 +21151,12 @@ packages:
   /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+
+  /nanoid@4.0.2:
+    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
+    engines: {node: ^14 || ^16 || >=18}
+    hasBin: true
+    dev: false
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}


### PR DESCRIPTION
Although it is currently only used in server in api, it is better to have nanoid since the bundle size smaller than the uuideck

To review: 

Check token risk is working in swap

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 20c6a2b</samp>

### Summary
🔄🚀🗑️

<!--
1.  🔄 - This emoji indicates that something was replaced or swapped, such as a dependency or a function. It can also be used for refactoring or updating code.
2.  🚀 - This emoji signifies that something was improved or optimized, such as performance, speed, or efficiency. It can also be used for adding new features or enhancements.
3.  🗑️ - This emoji denotes that something was removed or deleted, such as a dependency, a file, or a line of code. It can also be used for cleaning up or simplifying code.
-->
Replaced `uuid` with `nanoid` for nonce generation in the risk API handler and updated the project dependencies accordingly. This improves the performance and security of the API.

> _We're sailing on the web with `nanoid`_
> _We've left behind the old `uuid`_
> _We're faster and we're lighter than before_
> _So heave away and pull the code once more_

### Walkthrough
* Replace `uuid` dependency with `nanoid` for generating random strings ([link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L106-R106), [link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL765-L767), [link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20569-R20574))
* Use `nanoid` instead of `uuid` to create nonces for API requests in `apps/web/src/pages/api/risk/[chainId]/[address].ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-ec27de19b451e65fcc87aee4dbe743649a9ab558b5a5cdb0ef92e73381aae06fL3-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-ec27de19b451e65fcc87aee4dbe743649a9ab558b5a5cdb0ef92e73381aae06fL33-R33))
* Remove dashes and underscores from `nanoid` output to comply with API signature format in `apps/web/src/pages/api/risk/[chainId]/[address].ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-ec27de19b451e65fcc87aee4dbe743649a9ab558b5a5cdb0ef92e73381aae06fL33-R33))
* Add `nanoid` dependency to `pnpm-lock.yaml` to lock version and integrity ([link](https://github.com/pancakeswap/pancake-frontend/pull/7045/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR687-R689))


