### PR TITLE
fix: Disclaimers disappear when global claim check ondismiss

### DIFF
--- a/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
@@ -69,8 +69,8 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
     <V3AirdropModal
       data={account ? (data?.v3WhitelistAddress[account.toLowerCase()] as WhitelistType) : (null as WhitelistType)}
       onClick={async () => {
-        const { cakeAmountInWei, nft1, nft2 } = data.v3ForSC[account.toLowerCase()]
-        const proof = data?.v3MerkleProofs?.merkleProofs?.[account.toLowerCase()]
+        const { cakeAmountInWei, nft1, nft2 } = data?.v3ForSC[account?.toLowerCase()] || {}
+        const proof = data?.v3MerkleProofs?.merkleProofs?.[account?.toLowerCase()]
         const receipt = await fetchWithCatchTxError(() =>
           v3Airdop.write.claim([cakeAmountInWei, nft1, nft2, proof], {
             account: v3Airdop.account,
@@ -82,13 +82,16 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
         }
       }}
     />,
+    true,
+    false,
+    'v3AirdropModal',
   )
 
   // Check claim status
   useEffect(() => {
     const fetchClaimAnniversaryStatus = async () => {
       const canV3ClaimReward = await v3Airdop.read.isClaimed([account])
-      const isWhitelistAddress = data?.v3WhitelistAddress[account.toLowerCase()]
+      const isWhitelistAddress = data?.v3WhitelistAddress[account?.toLowerCase()]
       // TODO: also need check json acc is whitelisted or not.
       if (!canV3ClaimReward && isWhitelistAddress) {
         setCanClaimReward(true)

--- a/packages/uikit/src/widgets/Modal/useModal.ts
+++ b/packages/uikit/src/widgets/Modal/useModal.ts
@@ -15,6 +15,11 @@ const useModal = (
   const onPresentCallback = useCallback(() => {
     onPresent(currentModal.current, modalId, closeOnOverlayClick);
   }, [modalId, onPresent, closeOnOverlayClick]);
+  const onDismissCallback = useCallback(() => {
+    if (nodeId === modalId) {
+      onDismiss?.();
+    }
+  }, [modalId, onDismiss, nodeId]);
 
   // Updates the "modal" component if props are changed
   // Use carefully since it might result in unnecessary rerenders
@@ -36,7 +41,7 @@ const useModal = (
     }
   }, [updateOnPropsChange, nodeId, modalId, isOpen, modal, modalNode, setModalNode]);
 
-  return [onPresentCallback, onDismiss];
+  return [onPresentCallback, onDismissCallback];
 };
 
 export default useModal;


### PR DESCRIPTION
To reproduce: 

Go to prediction page directly with clean cache
See disclaimer appears then disappears without accepting it.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at adcfeff</samp>

### Summary
🐛🎁🎨

<!--
1.  🐛 - This emoji is often used to represent bug fixes, and it fits well with the first sentence of the pull request description.
2.  🎁 - This emoji is suitable for representing rewards, airdrops, and anniversary events, and it matches the second sentence of the pull request description.
3.  🎨 - This emoji is commonly used to indicate UI improvements or enhancements, and it relates to the third sentence of the pull request description.
-->
This pull request fixes some UI and modal bugs in the web app. It improves the error handling and display for claiming rewards in `GlobalCheckClaimStatus` and prevents closing all modals when dismissing one in `useModal`.

> _The pull request had some fixes and enhancements_
> _For the airdrop and anniversary events_
> _It used `account` with optional chaining_
> _And `fetchWithCatchTxError` with new naming_
> _And it solved the modal closing incidents_

### Walkthrough
*  Add optional chaining to `account` variable to prevent errors when fetching data for claim modal and claim anniversary status ([link](https://github.com/pancakeswap/pancake-frontend/pull/7053/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L72-R73), [link](https://github.com/pancakeswap/pancake-frontend/pull/7053/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L91-R94))
*  Add arguments to `fetchWithCatchTxError` function call to enable auto-close, disable success toast, and specify modal ID for transaction confirmation modal ([link](https://github.com/pancakeswap/pancake-frontend/pull/7053/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4R85-R87))
*  Wrap `onDismiss` function with a condition that checks modal ID in `useModal` hook to fix bug where closing one modal would close all modals ([link](https://github.com/pancakeswap/pancake-frontend/pull/7053/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212R18-R22))
*  Return `onDismissCallback` function instead of `onDismiss` function from `useModal` hook to allow consumers to use the correct callback function for dismissing the modal ([link](https://github.com/pancakeswap/pancake-frontend/pull/7053/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212L39-R44))


