### PR TITLE
fix: (trading-reward): Active reward campaigns not filtered correctly

### DIFF
--- a/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useTradingRewardStatus.ts
@@ -6,7 +6,7 @@ export const useTradingRewardStatus = () => {
   const latestCampaignId = allTradingRewardPairData.campaignIds?.[allTradingRewardPairData.campaignIds.length - 1]
 
   return useMemo(() => {
-    const currentTime = new Date().getTime() / 1000
+    const currentTime = Date.now() / 1000
     if (latestCampaignId) {
       const incentive = allTradingRewardPairData.campaignIdsIncentive.find(
         (i) => i.campaignId.toLowerCase() === latestCampaignId?.toLowerCase(),

--- a/apps/web/src/views/Swap/hooks/useTradingRewardTokenList.tsx
+++ b/apps/web/src/views/Swap/hooks/useTradingRewardTokenList.tsx
@@ -9,7 +9,7 @@ const useTradingRewardTokenList = () => {
   const { data } = useAllTradingRewardPair(RewardStatus.ALL)
 
   const uniqueAddressList = useMemo(() => {
-    const currentTime = new Date().getTime() / 1000
+    const currentTime = Date.now() / 1000
 
     // eslint-disable-next-line array-callback-return, consistent-return
     const activeRewardCampaignId = data.campaignIds.filter((campaignId) => {
@@ -17,7 +17,7 @@ const useTradingRewardTokenList = () => {
       if (incentive.campaignClaimTime > currentTime) {
         return campaignId
       }
-      return campaignId
+      return []
     })
 
     const activeCampaignPairs: { [key in string]: Array<string> } = {}

--- a/apps/web/src/views/TradingReward/components/CurrentRewardPool.tsx
+++ b/apps/web/src/views/TradingReward/components/CurrentRewardPool.tsx
@@ -95,7 +95,7 @@ const CurrentRewardPool: React.FC<React.PropsWithChildren<CurrentRewardPoolProps
   const cakePriceBusd = usePriceCakeUSD()
   const { totalReward, campaignClaimTime } = incentives ?? {}
 
-  const currentDate = new Date().getTime() / 1000
+  const currentDate = Date.now() / 1000
   const timeRemaining = campaignClaimTime - currentDate
   const timeUntil = getTimePeriods(timeRemaining)
 

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/CurrentPeriod.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/CurrentPeriod.tsx
@@ -35,7 +35,7 @@ const CurrentPeriod: React.FC<React.PropsWithChildren<CurrentPeriodProps>> = ({
   const { t } = useTranslation()
   const pool = useDeserializedPoolByVaultKey(VaultKey.CakeVault)
 
-  const currentDate = new Date().getTime() / 1000
+  const currentDate = Date.now() / 1000
   const timeRemaining = campaignClaimTime - currentDate
 
   return (

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/NoCakeLockedOrExtendLock.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/NoCakeLockedOrExtendLock.tsx
@@ -96,7 +96,7 @@ const NoCakeLockedOrExtendLock: React.FC<React.PropsWithChildren<NoCakeLockedOrE
   )
 
   const minLockWeekInSeconds = useMemo(() => {
-    const currentTime = new Date().getTime() / 1000
+    const currentTime = Date.now() / 1000
     const minusTime = new BigNumber(userData.lockEndTime).gt(0) ? userData.lockEndTime : currentTime
     const lockDuration = new BigNumber(incentives?.campaignClaimTime ?? 0).plus(thresholdLockTime).minus(minusTime)
     const week = Math.ceil(new BigNumber(lockDuration).div(ONE_WEEK_DEFAULT).toNumber())

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/TotalPeriod.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/TotalPeriod.tsx
@@ -78,7 +78,7 @@ const TotalPeriod: React.FC<React.PropsWithChildren<TotalPeriodProps>> = ({
 
   const rewardExpiredSoonData = useMemo(() => unclaimData[0], [unclaimData])
 
-  const currentDate = new Date().getTime() / 1000
+  const currentDate = Date.now() / 1000
   const timeRemaining = rewardExpiredSoonData?.campaignClaimEndTime - currentDate
   const expiredTime = getTimePeriods(timeRemaining)
 

--- a/apps/web/src/views/TradingReward/index.tsx
+++ b/apps/web/src/views/TradingReward/index.tsx
@@ -41,7 +41,7 @@ const TradingReward = () => {
   )
 
   const totalAvailableClaimData = useMemo(() => {
-    const currentTime = new Date().getTime() / 1000
+    const currentTime = Date.now() / 1000
 
     return allUserCampaignInfo
       .map((item) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3ad0d30</samp>

### Summary
🕒🔄🐛

<!--
1.  🕒 - This emoji represents the concept of time, which is relevant to all the changes that involve getting the current time in seconds.
2.  🔄 - This emoji represents the concept of refactoring, which is the main purpose of this pull request, as it improves the readability and performance of the code without changing its functionality.
3.  🐛 - This emoji represents the concept of fixing, which is the secondary purpose of this pull request, as it resolves a bug in the `useTradingRewardTokenList` hook that could cause incorrect reward token list.
-->
Refactor and fix the `useTradingRewardTokenList` hook and use `Date.now()` instead of `new Date().getTime()` in various components related to the trading reward feature. These changes improve the code readability and prevent adding expired campaigns to the reward token list.

> _`Date.now()` is the way to go_
> _No more `new Date().getTime()` woe_
> _Refactor the code and fix the hook_
> _Claim your reward before it's took_

### Walkthrough
*  Simplify code by using `Date.now()` instead of `new Date().getTime()` to get current time in seconds ([link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-750bc10b5a40d71eefc9da39629f7004b51d41beeefac6b05b0b5d25937e76c2L12-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-62ccb9de8712a407f9355d3ce3e989bd4e4172c8f732bc362ab6ab7b916da632L98-R98), [link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-d4f6a7601549cdb7819f8346e49466ec5846603d2dc8c7e13b61d3c655cb5d5fL38-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426L99-R99), [link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-b0cc533d8cfd76b0074f2267c964e7a36bd008408c58c932d5b45adb322c3b23L81-R81), [link](https://github.com/pancakeswap/pancake-frontend/pull/7064/files?diff=unified&w=0#diff-8899ffb1860eb76dfa9555198ba793b2cd223454ddb9d53864b20d5a1ac094a7L44-R44))


