### PR TITLE
fix: wagmi bigint on cache

### DIFF
--- a/apps/aptos/pages/_app.tsx
+++ b/apps/aptos/pages/_app.tsx
@@ -17,11 +17,6 @@ import ListsUpdater from 'state/lists/updater'
 import TransactionUpdater from 'state/transactions/updater'
 import { WrongNetworkModal } from 'components/WrongNetworkModal'
 
-// @ts-ignore
-// eslint-disable-next-line func-names
-BigInt.prototype.toJSON = function () {
-  return this.toString()
-}
 
 // This config is required for number formatting
 BigNumber.config({

--- a/apps/aptos/pages/_app.tsx
+++ b/apps/aptos/pages/_app.tsx
@@ -17,7 +17,6 @@ import ListsUpdater from 'state/lists/updater'
 import TransactionUpdater from 'state/transactions/updater'
 import { WrongNetworkModal } from 'components/WrongNetworkModal'
 
-
 // This config is required for number formatting
 BigNumber.config({
   EXPONENTIAL_AT: 1000,

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -32,12 +32,6 @@ import GlobalStyle from '../style/Global'
 
 const EasterEgg = dynamic(() => import('components/EasterEgg'), { ssr: false })
 
-// @ts-ignore
-// eslint-disable-next-line func-names
-BigInt.prototype.toJSON = function () {
-  return this.toString()
-}
-
 // This config is required for number formatting
 BigNumber.config({
   EXPONENTIAL_AT: 1000,

--- a/apps/web/src/utils/wagmi.ts
+++ b/apps/web/src/utils/wagmi.ts
@@ -112,7 +112,7 @@ export const noopStorage = {
 export const wagmiConfig = createConfig({
   storage: createStorage({
     storage: typeof window !== 'undefined' ? window.localStorage : noopStorage,
-    key: 'wagmi_v1',
+    key: 'wagmi_v1.1',
   }),
   autoConnect: false,
   publicClient,

--- a/packages/uikit/src/widgets/Modal/useModal.ts
+++ b/packages/uikit/src/widgets/Modal/useModal.ts
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useEffect, useRef } from "react";
 import get from "lodash/get";
+import { serialize } from "wagmi";
 import { Context } from "./ModalContext";
 import { Handler } from "./types";
 
@@ -35,7 +36,7 @@ const useModal = (
       // Do not try to replace JSON.stringify with isEqual, high risk of infinite rerenders
       // TODO: Find a good way to handle modal updates, this whole flow is just backwards-compatible workaround,
       // would be great to simplify the logic here
-      if (modalProps && oldModalProps && JSON.stringify(modalProps) !== JSON.stringify(oldModalProps)) {
+      if (modalProps && oldModalProps && serialize(modalProps) !== serialize(oldModalProps)) {
         setModalNode(modal);
       }
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f295a10</samp>

### Summary
🔧🗑️🚀

<!--
1.  🔧 - This emoji represents a wrench, which can symbolize fixing or improving something. This emoji could be used for the first change, as it removes a problematic method that was causing issues with the serialization of big numbers in the app.
2. 🗑️ - This emoji represents a wastebasket, which can symbolize deleting or removing something. This emoji could be used for the second change, as it removes the same method that was no longer needed after the refactor.
3. 🚀 - This emoji represents a rocket, which can symbolize launching or boosting something. This emoji could be used for the third change, as it improves the performance and accuracy of the modal component by using a better serialization function.
-->
This pull request refactors the serialization of modal props and app data to use the `serialize` function from the `wagmi` package, which can handle big numbers and circular references. This improves the performance and accuracy of the modal component and the app data. The pull request also removes the redundant custom toJSON methods for BigInt objects from the `aptos` and `web` apps.

> _Sing, O Muse, of the cunning refactorer_
> _Who freed the app from the custom `toJSON`_
> _And made the big numbers shine like the stars_
> _With the `serialize` function of `wagmi`._

### Walkthrough
*  Refactor the app to use a custom serialize function instead of JSON.stringify to handle big numbers and circular references ([link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-17d59c4dfd457c10672222cb737947ec12293d9aa0f4e85f42bcb36c801f0bc5L20-L24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93L35-L40), [link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212L38-R39))
  - Remove the custom toJSON method for BigInt objects from `_app.tsx` files in both `aptos` and `web` apps, as it causes serialization issues ([link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-17d59c4dfd457c10672222cb737947ec12293d9aa0f4e85f42bcb36c801f0bc5L20-L24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93L35-L40))
  - Import the serialize function from the `wagmi` package, a utility library for big numbers and circular references, in `useModal.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212R3))
  - Use the serialize function instead of JSON.stringify to compare the modal props and update the modal node in the `useModal` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7068/files?diff=unified&w=0#diff-2bd8d390739e44b55aceb26855f49870203230b3ab22aa8b694968d6e5e3b212L38-R39))


