### PR TITLE
chore: hardcode info for farm auction v3

### DIFF
--- a/apps/web/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
@@ -4,6 +4,7 @@ import { Text, Flex, Box, CardFooter, ExpandableLabel } from '@pancakeswap/uikit
 import { useTranslation } from '@pancakeswap/localization'
 import { Auction, AuctionStatus } from 'config/constants/types'
 import WhitelistedBiddersButton from '../WhitelistedBiddersButton'
+import { HARD_CODED_START_AUCTION_ID, HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../../constants'
 
 const FooterInner = styled(Box)`
   background-color: ${({ theme }) => theme.colors.dropdown};
@@ -13,6 +14,7 @@ const AuctionFooter: React.FC<React.PropsWithChildren<{ auction: Auction }>> = (
   const [isExpanded, setIsExpanded] = useState(false)
   const { t } = useTranslation()
   const { topLeaderboard, status } = auction
+  const shouldUseV3Format = auction?.id >= HARD_CODED_START_AUCTION_ID
 
   const isLiveOrPendingAuction = status === AuctionStatus.Pending || status === AuctionStatus.Open
 
@@ -31,7 +33,11 @@ const AuctionFooter: React.FC<React.PropsWithChildren<{ auction: Auction }>> = (
             )}
             <Flex justifyContent="space-between" width="100%" pt="8px" px="8px">
               <Text color="textSubtle">{t('Multiplier per farm')}</Text>
-              <Text>1x {t('each')}</Text>
+              <Text>
+                {shouldUseV3Format
+                  ? `${HARD_CODE_TOP_THREE_AUCTION_DATAS.map((d) => d[1]).join('x,')}x`
+                  : `1x ${t('each')}`}
+              </Text>
             </Flex>
             <Flex justifyContent="space-between" width="100%" pt="8px" px="8px">
               <Text color="textSubtle">{t('Total whitelisted bidders')}</Text>

--- a/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
@@ -16,6 +16,7 @@ import {
 import { useTranslation } from '@pancakeswap/localization'
 import AuctionLeaderboardTable from './AuctionLeaderboard/AuctionLeaderboardTable'
 import { useFarmAuction } from '../hooks/useFarmAuction'
+import { HARD_CODED_START_AUCTION_ID } from '../constants'
 
 interface AuctionHistoryProps {
   mostRecentClosedAuctionId: number
@@ -58,7 +59,11 @@ const AuctionHistory: React.FC<React.PropsWithChildren<AuctionHistoryProps>> = (
 
   let auctionTable =
     auction && bidders ? (
-      <AuctionLeaderboardTable bidders={bidders} noBidsText="No bids were placed in this auction" />
+      <AuctionLeaderboardTable
+        bidders={bidders}
+        shouldUseV3Format={auction?.id >= HARD_CODED_START_AUCTION_ID}
+        noBidsText="No bids were placed in this auction"
+      />
     ) : (
       <Flex justifyContent="center" alignItems="center" p="24px" height="250px">
         <Spinner />

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -72,11 +72,18 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
             <Text bold={isTopPosition} mr="4px">
               {farmName}
             </Text>
-            {!isMobile && shouldUseV3Format && (
-              <Text mr="3px">({HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[0]}% fee tier)</Text>
-            )}
+
             {!isMobile && (
-              <Text>[{shouldUseV3Format ? HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[1] ?? 1 : 1}x]</Text>
+              <>
+                {shouldUseV3Format ? (
+                  <>
+                    <Text mr="3px">({HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[0]}% fee tier)</Text>
+                    <Text>[{HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[1] ?? 1}x]</Text>
+                  </>
+                ) : (
+                  <Text>(1x)</Text>
+                )}
+              </>
             )}
           </Flex>
           <Text fontSize="12px" color="textSubtle">

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { usePriceCakeUSD } from 'state/farms/hooks'
 import { Bidder } from 'config/constants/types'
 import WhitelistedBiddersModal from '../WhitelistedBiddersModal'
+import { HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../../constants'
 
 const LeaderboardContainer = styled.div`
   display: grid;
@@ -42,12 +43,16 @@ interface LeaderboardRowProps {
   bidder: Bidder
   cakePriceBusd: BigNumber
   isMobile: boolean
+  index: number
+  shouldUseV3Format: boolean
 }
 
 const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = ({
   bidder,
   cakePriceBusd,
   isMobile,
+  index,
+  shouldUseV3Format,
 }) => {
   const { t } = useTranslation()
   const { isTopPosition, position, samePositionAsAbove, farmName, tokenName, amount, projectSite, lpAddress, account } =
@@ -67,7 +72,12 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
             <Text bold={isTopPosition} mr="4px">
               {farmName}
             </Text>
-            {!isMobile && <Text>(1x)</Text>}
+            {!isMobile && shouldUseV3Format && (
+              <Text mr="3px">({HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[0]}% fee tier)</Text>
+            )}
+            {!isMobile && (
+              <Text>[{shouldUseV3Format ? HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[1] ?? 1 : 1}x]</Text>
+            )}
           </Flex>
           <Text fontSize="12px" color="textSubtle">
             {tokenName}
@@ -119,10 +129,9 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
   )
 }
 
-const AuctionLeaderboardTable: React.FC<React.PropsWithChildren<{ bidders: Bidder[]; noBidsText: string }>> = ({
-  bidders,
-  noBidsText,
-}) => {
+const AuctionLeaderboardTable: React.FC<
+  React.PropsWithChildren<{ bidders: Bidder[]; noBidsText: string; shouldUseV3Format?: boolean }>
+> = ({ bidders, noBidsText, shouldUseV3Format = false }) => {
   const [visibleBidders, setVisibleBidders] = useState(10)
   const cakePriceBusd = usePriceCakeUSD()
   const { t } = useTranslation()
@@ -163,8 +172,15 @@ const AuctionLeaderboardTable: React.FC<React.PropsWithChildren<{ bidders: Bidde
         </Text>
         <Box />
         {/* Rows */}
-        {bidders.slice(0, visibleBidders).map((bidder) => (
-          <LeaderboardRow key={bidder.account} bidder={bidder} cakePriceBusd={cakePriceBusd} isMobile={isMobile} />
+        {bidders.slice(0, visibleBidders).map((bidder, index) => (
+          <LeaderboardRow
+            key={bidder.account}
+            bidder={bidder}
+            cakePriceBusd={cakePriceBusd}
+            isMobile={isMobile}
+            index={index}
+            shouldUseV3Format={shouldUseV3Format}
+          />
         ))}
       </LeaderboardContainer>
       <Flex mt="16px" px="24px" flexDirection="column" justifyContent="center" alignItems="center">

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
@@ -8,6 +8,7 @@ import AuctionHistory from '../AuctionHistory'
 import AuctionProgress from './AuctionProgress'
 import AuctionRibbon from './AuctionRibbon'
 import AuctionLeaderboardTable from './AuctionLeaderboardTable'
+import { HARD_CODED_START_AUCTION_ID } from '../../constants'
 
 const AuctionLeaderboardCard = styled(Card)`
   width: 100%;
@@ -74,7 +75,11 @@ const CurrentAuctionCard: React.FC<React.PropsWithChildren<AuctionLeaderboardPro
           </Text>
           <AuctionRibbon auction={auction} noAuctionHistory={getMostRecentClosedAuctionId(id, status) === null} />
           <AuctionProgress auction={auction} />
-          <AuctionLeaderboardTable bidders={bidders} noBidsText={t('No bids yet')} />
+          <AuctionLeaderboardTable
+            bidders={bidders}
+            noBidsText={t('No bids yet')}
+            shouldUseV3Format={id >= HARD_CODED_START_AUCTION_ID}
+          />
         </Box>
       ) : (
         <AuctionHistory mostRecentClosedAuctionId={getMostRecentClosedAuctionId(id, status)} />

--- a/apps/web/src/views/FarmAuction/components/CongratulationsCard.tsx
+++ b/apps/web/src/views/FarmAuction/components/CongratulationsCard.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import useCongratulateAuctionWinner from '../hooks/useCongratulateAuctionWinner'
 import WhitelistedBiddersButton from './WhitelistedBiddersButton'
+import { HARD_CODED_START_AUCTION_ID, HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../constants'
 
 const StyledReclaimBidCard = styled(Card)`
   margin-top: 16px;
@@ -17,6 +18,7 @@ const CongratulationsCard: React.FC<React.PropsWithChildren<{ currentAuction: Au
 }) => {
   const { t } = useTranslation()
   const wonAuction = useCongratulateAuctionWinner(currentAuction, bidders)
+  const shouldUseV3Format = currentAuction?.id >= HARD_CODED_START_AUCTION_ID
 
   if (!wonAuction) {
     return null
@@ -35,7 +37,11 @@ const CongratulationsCard: React.FC<React.PropsWithChildren<{ currentAuction: Au
         <Flex flexDirection="column" mb="24px">
           <Flex justifyContent="space-between" width="100%" pt="8px">
             <Text color="textSubtle">{t('Multiplier per farm')}</Text>
-            <Text>1x {t('each')}</Text>
+            <Text>
+              {shouldUseV3Format
+                ? `${HARD_CODE_TOP_THREE_AUCTION_DATAS.map((d) => d[1]).join('x,')}x`
+                : `1x ${t('each')}`}
+            </Text>
           </Flex>
           <Flex justifyContent="space-between" width="100%" pt="8px">
             <Text color="textSubtle">{t('Total whitelisted bidders')}</Text>

--- a/apps/web/src/views/FarmAuction/constants.ts
+++ b/apps/web/src/views/FarmAuction/constants.ts
@@ -1,0 +1,7 @@
+export const HARD_CODED_START_AUCTION_ID = 34
+
+export const HARD_CODE_TOP_THREE_AUCTION_DATAS = [
+  [1, 6],
+  [1, 2],
+  [1, 1],
+]

--- a/apps/web/src/views/FarmAuction/constants.ts
+++ b/apps/web/src/views/FarmAuction/constants.ts
@@ -1,5 +1,6 @@
 export const HARD_CODED_START_AUCTION_ID = 34
 
+// [feeTier, multiplier][]
 export const HARD_CODE_TOP_THREE_AUCTION_DATAS = [
   [1, 6],
   [1, 2],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 85ca959</samp>

### Summary
🏆🌾🎁

<!--
1.  🏆 - This emoji represents the auction leaderboard and the top three bidders, which are the main focus of these changes. It also conveys a sense of achievement and competition, which are relevant to the farm auction feature.
2.  🌾 - This emoji represents the farm auction itself, which is the context of these changes. It also suggests the idea of farming and earning rewards, which are the incentives for participating in the auction.
3.  🎁 - This emoji represents the congratulations card, which is a new component added by these changes. It also suggests the idea of receiving a prize or a reward for winning the auction, which is another incentive for participating.
-->
This pull request updates the farm auction UI components to use a new format and data for the top three bidders in the v3 auctions. It uses hard-coded constants from `constants.ts` to switch between the old and new formats based on the auction id. It affects the auction leaderboard, footer, congratulations card, and history components.

> _Oh we're the coders of the farm auction site_
> _We've made some changes to the leaderboard's plight_
> _We've used some constants from a common file_
> _To show the fee tier and the multiplier_

### Walkthrough
*  Add two constants for the start auction id and the top three bidders data in `constants.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-a089730be3cd1147ad783eec028d5f7d33a66eb5b3a53661026f5c4d6c31fe4aR1-R7))
*  Import the constants and use them to define a boolean variable `shouldUseV3Format` in `AuctionDetailsCard/AuctionFooter.tsx`, `AuctionHistory.tsx`, `AuctionLeaderboard/index.tsx`, and `CongratulationsCard.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0R17), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-a4caf83485e72681882202dbe7ec5da2f9b40eb5ad9280327ceaa201c1cbf85dR19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-ff6c4f42cf9c40ffe1da92a0ac85550eeedcf045bba206856b8e03d24f595120R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168R21))
*  Pass the `shouldUseV3Format` variable as a prop to the `AuctionLeaderboardTable` component in `AuctionHistory.tsx` and `AuctionLeaderboard/index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-a4caf83485e72681882202dbe7ec5da2f9b40eb5ad9280327ceaa201c1cbf85dL61-R66), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-ff6c4f42cf9c40ffe1da92a0ac85550eeedcf045bba206856b8e03d24f595120L77-R82))
*  Add the `shouldUseV3Format` prop and the index of the bidder to the `LeaderboardRowProps` interface and the `LeaderboardRow` component in `AuctionLeaderboard/AuctionLeaderboardTable.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02R46-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02R54-R55), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L122-R134))
*  Use the `shouldUseV3Format` prop and the index to display the hard-coded fee tier and multiplier for the top three bidders in the `LeaderboardRow` component, or the default value of 1x otherwise ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L70-R80), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L166-R183))
*  Use the `shouldUseV3Format` variable to display the hard-coded multiplier per farm for the top three bidders in the `AuctionDetailsCard/AuctionFooter.tsx` and `CongratulationsCard.tsx` components, or the default value of 1x each otherwise ([link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0L34-R40), [link](https://github.com/pancakeswap/pancake-frontend/pull/7069/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168L38-R44))


