### PR TITLE
fix: (liquidity): Farm hint shown when another account active

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -300,7 +300,7 @@ export default function PoolPage() {
       data: calldata,
       value: hexToBigInt(value),
       account,
-      chain: signer.chain,
+      chain: signer?.chain,
     }
 
     getViemClients({ chainId })
@@ -444,7 +444,7 @@ export default function PoolPage() {
   }
 
   const farmingTips =
-    hasActiveFarm && !isStakedInMCv3 ? (
+    ownsNFT && hasActiveFarm && !isStakedInMCv3 ? (
       <Message variant="primary" mb="2em">
         <Box>
           <Text display="inline" bold mr="0.25em">{`${currencyQuote?.symbol}-${currencyBase?.symbol}`}</Text>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 31819af</samp>

### Summary
🐛🔒🌱

<!--
1.  🐛 - This emoji represents a bug fix, which is what the first part of the pull request does by preventing an error when viewing liquidity NFTs without a wallet connection.
2.  🔒 - This emoji represents security or privacy, which is what the second part of the pull request does by adding a condition to show farming tips only to NFT owners, respecting their ownership and privacy.
3.  🌱 - This emoji represents growth or improvement, which is what the overall pull request does by enhancing the user experience and functionality of the liquidity NFTs feature.
-->
Fix liquidity NFT page error and show farming tips to owners. This pull request improves the user experience and functionality of the `liquidity/[tokenId].tsx` page by handling the case of no wallet connection and displaying farming tips only to relevant users.

> _Oh, we're the crew of the `NFT` ship, and we sail the crypto sea_
> _We fix the bugs and add the features, with our wallets and our keys_
> _We heave away and haul the code, on the count of one, two, three_
> _And we show the tips to NFT owners, but not to the rest, you see_

### Walkthrough
*  Add optional chaining to `signer.chain` to prevent errors when wallet is not connected ([link](https://github.com/pancakeswap/pancake-frontend/pull/7072/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL303-R303))
*  Check if user owns NFT before showing farming tips message ([link](https://github.com/pancakeswap/pancake-frontend/pull/7072/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL447-R447))


