### PR TITLE
feat: Add US warning modal for IFO

### DIFF
--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -25,7 +25,15 @@ const Menu = (props) => {
   const cakePriceUsd = useCakeBusdPrice({ forceMainnet: true })
   const { currentLanguage, setLanguage, t } = useTranslation()
   const { pathname } = useRouter()
-  const [onUSCitizenModalPresent] = useModal(<USCitizenConfirmModal />, true, false, 'usCitizenConfirmModal')
+  const [onUSCitizenModalPresent] = useModal(
+    <USCitizenConfirmModal
+      title={t('PancakeSwap Perpetuals')}
+      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
+    />,
+    true,
+    false,
+    'usCitizenConfirmModal',
+  )
   const [showPhishingWarningBanner] = usePhishingBanner()
 
   const menuItems = useMenuItems(onUSCitizenModalPresent)

--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -26,10 +26,7 @@ const Menu = (props) => {
   const { currentLanguage, setLanguage, t } = useTranslation()
   const { pathname } = useRouter()
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal
-      title={t('PancakeSwap Perpetuals')}
-      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
-    />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
     true,
     false,
     'usCitizenConfirmModal',

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -5,10 +5,19 @@ import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useTheme } from 'styled-components'
 import { Text, Link } from '@pancakeswap/uikit'
-
 import { useTranslation } from '@pancakeswap/localization'
 
-const USCitizenConfirmModal: React.FC<{ onDismiss?: () => void }> = ({ onDismiss }) => {
+interface USCitizenConfirmModalProps {
+  title: string
+  headerText: string
+  onDismiss?: () => void
+}
+
+const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmModalProps>> = ({
+  title,
+  headerText,
+  onDismiss,
+}) => {
   const {
     t,
     currentLanguage: { code },
@@ -26,9 +35,9 @@ const USCitizenConfirmModal: React.FC<{ onDismiss?: () => void }> = ({ onDismiss
 
   return (
     <DisclaimerModal
-      modalHeader={t('PancakeSwap Perpetuals')}
-      id="disclaimer-perpetual-us-citizen"
-      header={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
+      modalHeader={title}
+      id="disclaimer-us-citizen"
+      header={headerText}
       checks={[
         {
           key: 'checkbox',

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -9,15 +9,10 @@ import { useTranslation } from '@pancakeswap/localization'
 
 interface USCitizenConfirmModalProps {
   title: string
-  headerText: string
   onDismiss?: () => void
 }
 
-const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmModalProps>> = ({
-  title,
-  headerText,
-  onDismiss,
-}) => {
+const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmModalProps>> = ({ title, onDismiss }) => {
   const {
     t,
     currentLanguage: { code },
@@ -37,7 +32,7 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
     <DisclaimerModal
       modalHeader={title}
       id="disclaimer-us-citizen"
-      header={headerText}
+      header={t('To proceed to %title%, please check the checkbox below:', { title })}
       checks={[
         {
           key: 'checkbox',

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -21,7 +21,10 @@ const Congratulations = () => {
   return (
     <>
       <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} closeOnOverlayClick onDismiss={() => setIsOpen(false)}>
-        <USCitizenConfirmModal />
+        <USCitizenConfirmModal
+          title={t('PancakeSwap Affiliate Program')}
+          headerText={t('To proceed to Pancakeswap Affiliate Program, please check the checkbox below:')}
+        />
       </ModalV2>
       <Flex flexDirection="column" padding={['24px', '24px', '24px', '24px', '80px 24px']}>
         <Text lineHeight="110%" maxWidth="190px" fontSize={['24px']} bold m="12px 0">

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -21,10 +21,7 @@ const Congratulations = () => {
   return (
     <>
       <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} closeOnOverlayClick onDismiss={() => setIsOpen(false)}>
-        <USCitizenConfirmModal
-          title={t('PancakeSwap Affiliate Program')}
-          headerText={t('To proceed to Pancakeswap Affiliate Program, please check the checkbox below:')}
-        />
+        <USCitizenConfirmModal title={t('PancakeSwap Affiliate Program')} />
       </ModalV2>
       <Flex flexDirection="column" padding={['24px', '24px', '24px', '24px', '80px 24px']}>
         <Text lineHeight="110%" maxWidth="190px" fontSize={['24px']} bold m="12px 0">

--- a/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
@@ -153,10 +153,7 @@ const PerpetualBanner = () => {
 
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal
-      title={t('PancakeSwap Perpetuals')}
-      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
-    />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
     true,
     false,
     'usCitizenConfirmModal',

--- a/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
@@ -152,7 +152,15 @@ const PerpetualBanner = () => {
   const { chainId } = useActiveChainId()
 
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
-  const [onUSCitizenModalPresent] = useModal(<USCitizenConfirmModal />, true, false, 'usCitizenConfirmModal')
+  const [onUSCitizenModalPresent] = useModal(
+    <USCitizenConfirmModal
+      title={t('PancakeSwap Perpetuals')}
+      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
+    />,
+    true,
+    false,
+    'usCitizenConfirmModal',
+  )
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
 
   return (

--- a/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
@@ -55,14 +55,22 @@ const PerpetualBanner = () => {
 
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const headerRef = useRef<HTMLDivElement>(null)
-  const [onUSCitizenModalPresent] = useModal(<USCitizenConfirmModal />, true, false, 'usCitizenConfirmModal')
+  const [onUSCitizenModalPresent] = useModal(
+    <USCitizenConfirmModal
+      title={t('PancakeSwap Perpetuals')}
+      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
+    />,
+    true,
+    false,
+    'usCitizenConfirmModal',
+  )
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
 
   useIsomorphicEffect(() => {
     const target = headerRef.current
+    if (!target || !isMobile) return
     target.style.fontSize = '' // reset
     target.style.lineHeight = ''
-    if (!target || !isMobile) return
     if (target.offsetHeight > HEADING_ONE_LINE_HEIGHT) {
       target.style.fontSize = '18px'
       target.style.lineHeight = `${HEADING_ONE_LINE_HEIGHT}px`

--- a/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
@@ -56,10 +56,7 @@ const PerpetualBanner = () => {
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const headerRef = useRef<HTMLDivElement>(null)
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal
-      title={t('PancakeSwap Perpetuals')}
-      headerText={t('To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:')}
-    />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
     true,
     false,
     'usCitizenConfirmModal',

--- a/apps/web/src/views/Ifos/index.tsx
+++ b/apps/web/src/views/Ifos/index.tsx
@@ -1,7 +1,10 @@
-import { SubMenuItems } from '@pancakeswap/uikit'
+import { useEffect } from 'react'
+import { SubMenuItems, useModal } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { useRouter } from 'next/router'
 import { useFetchIfo } from 'state/pools/hooks'
+import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
 import Hero from './components/Hero'
 import IfoProvider from './contexts/IfoContext'
 
@@ -10,6 +13,23 @@ export const IfoPageLayout = ({ children }) => {
   const router = useRouter()
   const isExact = router.route === '/ifo'
   useFetchIfo()
+
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const [onUSCitizenModalPresent] = useModal(
+    <USCitizenConfirmModal
+      title={t('PancakeSwap IFOs')}
+      headerText={t('To proceed to Pancakeswap IFOs, please check the checkbox below:')}
+    />,
+    true,
+    false,
+    'usCitizenConfirmModal',
+  )
+
+  useEffect(() => {
+    if (!userNotUsCitizenAcknowledgement) {
+      onUSCitizenModalPresent()
+    }
+  }, [userNotUsCitizenAcknowledgement, onUSCitizenModalPresent])
 
   return (
     <IfoProvider>

--- a/apps/web/src/views/Ifos/index.tsx
+++ b/apps/web/src/views/Ifos/index.tsx
@@ -16,10 +16,7 @@ export const IfoPageLayout = ({ children }) => {
 
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal
-      title={t('PancakeSwap IFOs')}
-      headerText={t('To proceed to Pancakeswap IFOs, please check the checkbox below:')}
-    />,
+    <USCitizenConfirmModal title={t('PancakeSwap IFOs')} />,
     true,
     false,
     'usCitizenConfirmModal',

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2530,5 +2530,7 @@
   "Game": "Game",
   "Get your custom branded subdomains .pancake.crypto for just $9.99": "Get your custom branded subdomains .pancake.crypto for just $9.99",
   "Get your domain": "Get your domain",
-  "Subdomains .pancake.crypto for just $9.99": "Subdomains .pancake.crypto for just $9.99"
+  "Subdomains .pancake.crypto for just $9.99": "Subdomains .pancake.crypto for just $9.99",
+  "PancakeSwap IFOs": "PancakeSwap IFOs",
+  "To proceed to Pancakeswap IFOs, please check the checkbox below:": "To proceed to Pancakeswap IFOs, please check the checkbox below:"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2349,7 +2349,6 @@
   "I confirm that I am not from a prohibited jurisdiction and I am eligible to trade derivatives on this platform": "I confirm that I am not from a prohibited jurisdiction and I am eligible to trade derivatives on this platform",
   "By proceeding, you agree to comply with our": "By proceeding, you agree to comply with our",
   "and all relevant laws and regulations": "and all relevant laws and regulations",
-  "To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:": "To proceed to Pancakeswap Perpetuals Trading, please check the checkbox below:",
   "Terms Of Service": "Terms Of Service",
   "This transaction will not succeed due to price movement. Try increasing your slippage tolerance. Note: fee on transfer and rebase tokens are incompatible with Pancakeswap V3.": "This transaction will not succeed due to price movement. Try increasing your slippage tolerance. Note: fee on transfer and rebase tokens are incompatible with Pancakeswap V3.",
   "The output token cannot be transferred. There may be an issue with the output token. Note: fee on transfer and rebase tokens are incompatible with Pancakeswap V3.": "The output token cannot be transferred. There may be an issue with the output token. Note: fee on transfer and rebase tokens are incompatible with Pancakeswap V3.",
@@ -2532,7 +2531,6 @@
   "Get your domain": "Get your domain",
   "Subdomains .pancake.crypto for just $9.99": "Subdomains .pancake.crypto for just $9.99",
   "PancakeSwap IFOs": "PancakeSwap IFOs",
-  "To proceed to Pancakeswap IFOs, please check the checkbox below:": "To proceed to Pancakeswap IFOs, please check the checkbox below:",
   "PancakeSwap Affiliate Program": "PancakeSwap Affiliate Program",
-  "To proceed to Pancakeswap Affiliate Program, please check the checkbox below:": "To proceed to Pancakeswap Affiliate Program, please check the checkbox below:"
+  "To proceed to %title%, please check the checkbox below:": "To proceed to %title%, please check the checkbox below:"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2532,5 +2532,7 @@
   "Get your domain": "Get your domain",
   "Subdomains .pancake.crypto for just $9.99": "Subdomains .pancake.crypto for just $9.99",
   "PancakeSwap IFOs": "PancakeSwap IFOs",
-  "To proceed to Pancakeswap IFOs, please check the checkbox below:": "To proceed to Pancakeswap IFOs, please check the checkbox below:"
+  "To proceed to Pancakeswap IFOs, please check the checkbox below:": "To proceed to Pancakeswap IFOs, please check the checkbox below:",
+  "PancakeSwap Affiliate Program": "PancakeSwap Affiliate Program",
+  "To proceed to Pancakeswap Affiliate Program, please check the checkbox below:": "To proceed to Pancakeswap Affiliate Program, please check the checkbox below:"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 79f22f8</samp>

### Summary
🇺🇸🔄🚀

<!--
1.  🇺🇸 - This emoji represents the US citizen disclaimer modal that is the main feature of these changes.
2.  🔄 - This emoji represents the reusability and customization of the `USCitizenConfirmModal` component that was achieved by passing props for the title and header text.
3.  🚀 - This emoji represents the IFOs page, which is a new page that was added to the app and where the US citizen disclaimer modal was also implemented.
-->
Added a reusable `USCitizenConfirmModal` component to ask the user to confirm that they are not a US citizen before accessing certain features. Customized the modal content for the IFOs page and the perpetuals page using props and translations. Updated the `Menu` and the perpetuals banners to use the modal component with the appropriate props.

> _You can't escape the modal of doom_
> _It haunts you on every page you view_
> _`USCitizenConfirmModal` is the name of your bane_
> _It asks you to renounce your citizenship in vain_

### Walkthrough
*  Add title and headerText props to `USCitizenConfirmModal` component to customize modal content for different pages ([link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-711e29b77996d41f2fb3a31b3315592b88720363b92f6647f7f85d6eb64a1097L8-R20),[link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-711e29b77996d41f2fb3a31b3315592b88720363b92f6647f7f85d6eb64a1097L29-R40))
*  Update `onUSCitizenModalPresent` hook to pass title and headerText props to `USCitizenConfirmModal` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-128603fbd7fa98404a4bc03c4d7e4d2a80c1d222b84e0606b851e459a75a3793L28-R36))
*  Use `onUSCitizenModalPresent` hook and title and headerText props in `PerpetualBanner` and `PerpetualApolloXCampaignBanner` components to display modal for perpetuals page ([link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-a0c4a81cbfb69f07ce0d2c2fb718d01b4430a42e3ec8ed49521d9dc3bfe34c9eL155-R163),[link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-e468011e07f3d7556d4740492ead9d03c9a7a56b30bf10c2923e8febdcce7cf0L58-R73))
*  Use `useUserNotUsCitizenAcknowledgement` hook and `useModal` hook to display `USCitizenConfirmModal` component with title and headerText props for IFOs page in `IfoPageLayout` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7L1-R7),[link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7R17-R33))
*  Add new strings for title and headerText props of `USCitizenConfirmModal` component for IFOs page in `translations.json` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7075/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2533-R2535))


![Screenshot 2023-06-07 at 10 00 01 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/53b15acc-51c2-47e5-9627-916510eaf12e)
