### PR TITLE
chore: sort banners

### DIFF
--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -37,8 +37,8 @@ export const useMultipleBannerConfig = () => {
 
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
-      { shouldRender: true, banner: <PancakeProtectorBanner /> },
       { shouldRender: true, banner: <UnsDomainBanner /> },
+      { shouldRender: true, banner: <PancakeProtectorBanner /> },
       { shouldRender: true, banner: <TradingRewardBanner /> },
       { shouldRender: true, banner: <LiquidStakingBanner /> },
       { shouldRender: true, banner: <V3LaunchBanner /> },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ee0ece</samp>

### Summary
🔄🆕🤝

<!--
1.  🔄 - This emoji represents the change in the order of the `NO_SHUFFLE_BANNERS` array, which implies a rearrangement or shuffling of the elements.
2. 🆕 - This emoji represents the introduction of the new UNS domain feature, which is a partnership between PancakeSwap and Unstoppable Domains.
3. 🤝 - This emoji represents the collaboration or partnership between PancakeSwap and Unstoppable Domains, which is the main reason for promoting the UNS domain feature.
-->
Changed the order of home page banners to highlight the UNS domain feature. Modified the `NO_SHUFFLE_BANNERS` array in `useMultipleBannerConfig.tsx` to move the `UnsDomainBanner` to the first position.

> _`NO_SHUFFLE_BANNERS`_
> _Reordered for UNS domains_
> _A spring partnership_

### Walkthrough
* Reorder the banners on the home page to show the UNS domain feature first ([link](https://github.com/pancakeswap/pancake-frontend/pull/7078/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L40-R41))


