### PR TITLE
fix: (trading-reward): Show unlocks in 0 seconds when pool position is unlocked

### DIFF
--- a/apps/web/src/views/TradingReward/components/Banner.tsx
+++ b/apps/web/src/views/TradingReward/components/Banner.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text, Button, Link } from '@pancakeswap/uikit'
+import { Box, Flex, Text, Button, Link, NextLinkFromReactRouter } from '@pancakeswap/uikit'
 import { useTheme } from '@pancakeswap/hooks'
 import styled from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
@@ -159,9 +159,9 @@ const TradingRewardBanner = () => {
             {t('Earn CAKE while trading your favorite tokens on PancakeSwap.')}
           </Text>
           <Flex>
-            <Link href="/swap?showTradingReward=true" external>
+            <NextLinkFromReactRouter to="/swap?showTradingReward=true">
               <Button>{t('Start Trading')}</Button>
-            </Link>
+            </NextLinkFromReactRouter>
             <Link href="#howToEarn">
               <Button ml="12px" variant="secondary">
                 {`${t('How to Earn')}?`}

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/NoCakeLockedOrExtendLock.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/NoCakeLockedOrExtendLock.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Text, Flex, Pool } from '@pancakeswap/uikit'
+import { Box, Text, Flex, Pool, SkeletonV2 } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
@@ -13,6 +13,7 @@ import useUserDataInVaultPresenter from 'views/Pools/components/LockedPool/hooks
 import formatSecondsToWeeks from 'views/Pools/components/utils/formatSecondsToWeeks'
 import { Incentives } from 'views/TradingReward/hooks/useAllTradingRewardPair'
 import { ONE_WEEK_DEFAULT } from '@pancakeswap/pools'
+import { getVaultPosition, VaultPosition } from 'utils/cakePool'
 
 const Container = styled(Flex)`
   justify-content: space-between;
@@ -103,6 +104,16 @@ const NoCakeLockedOrExtendLock: React.FC<React.PropsWithChildren<NoCakeLockedOrE
     return new BigNumber(week).times(ONE_WEEK_DEFAULT).toNumber()
   }, [incentives, thresholdLockTime, userData])
 
+  const position = useMemo(
+    () =>
+      getVaultPosition({
+        userShares: userData?.userShares,
+        locked: userData?.locked,
+        lockEndTime: userData?.lockEndTime,
+      }),
+    [userData],
+  )
+
   return (
     <Flex flexDirection={['column', 'column', 'column', 'row']}>
       <Flex flexDirection="column" width={['100%', '100%', '100%', '354px']}>
@@ -154,12 +165,14 @@ const NoCakeLockedOrExtendLock: React.FC<React.PropsWithChildren<NoCakeLockedOrE
                   <Text fontSize="12px" color="textSubtle" textTransform="uppercase" bold>
                     {`CAKE ${t('Locked')}`}
                   </Text>
-                  <Text bold fontSize="20px" lineHeight="110%" color={cakeAsNumberBalance > 0 ? 'text' : 'failure'}>
-                    {cakeAsDisplayBalance}
-                  </Text>
-                  <Text fontSize="12px" lineHeight="110%" color={cakeAsNumberBalance > 0 ? 'text' : 'failure'}>
-                    {`~$${formatNumber(cakePrice)} USD`}
-                  </Text>
+                  <SkeletonV2 isDataReady={!!cakeAsDisplayBalance} wrapperProps={{ height: 'fit-content' }}>
+                    <Text bold fontSize="20px" lineHeight="110%" color={cakeAsNumberBalance > 0 ? 'text' : 'failure'}>
+                      {cakeAsDisplayBalance}
+                    </Text>
+                    <Text fontSize="12px" lineHeight="110%" color={cakeAsNumberBalance > 0 ? 'text' : 'failure'}>
+                      {`~$${formatNumber(cakePrice)} USD`}
+                    </Text>
+                  </SkeletonV2>
                 </Flex>
               </Flex>
               <Flex>
@@ -173,7 +186,11 @@ const NoCakeLockedOrExtendLock: React.FC<React.PropsWithChildren<NoCakeLockedOrE
                     lineHeight="110%"
                     color={isValidLockDuration && secondDuration > 0 ? 'text' : 'failure'}
                   >
-                    {secondDuration === 0 ? t('0 Weeks') : remainingTime}
+                    {position >= VaultPosition.LockedEnd
+                      ? t('Unlocked')
+                      : secondDuration === 0
+                      ? t('0 Weeks')
+                      : remainingTime}
                   </Text>
                 </Flex>
               </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7b88fa</samp>

### Summary
🎁🚀🕒

<!--
1.  🎁 - This emoji could represent the trading reward banner and view, as well as the improved user experience of navigating to them. It suggests that the user is getting a gift or reward for their trading activity, and that the banner and view are designed to make them feel appreciated and valued.
2.  🚀 - This emoji could represent the use of `NextLinkFromReactRouter` for internal navigation, as well as the loading placeholder and vault position check for the CAKE balance and price display. It suggests that the user is experiencing a fast and smooth transition between pages, and that the data they see is accurate and up-to-date. It also implies that the user's CAKE balance and price are increasing or have the potential to increase, as rockets are often associated with growth and success.
3.  🕒 - This emoji could represent the updated lock time display that reflects the user's lock status. It suggests that the user is aware of how much time they have left to unlock their rewards, and that the display is clear and consistent. It also implies that the user has some control over their lock time, as they can choose to extend it or not.
-->
Improved the trading reward banner navigation and the CAKE balance and lock time display. Fixed a bug where the vault position was not checked for the trading reward view.

> _We're sailing on the `NextLinkFromReactRouter`_
> _To trade some CAKE and earn a reward_
> _We'll check our vault and load our balance faster_
> _And lock our tokens till the time is right_

### Walkthrough
* Replace external `Link` component with internal `NextLinkFromReactRouter` component for routing to swap page with trading reward modal ([link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-03134056bc43863a3b5bcd8fe4cfeb2bf9f191923365ae993ce3259ea819a093L1-R1),[link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-03134056bc43863a3b5bcd8fe4cfeb2bf9f191923365ae993ce3259ea819a093L162-R164))
* Import and use `SkeletonV2` component from `@pancakeswap/uikit` to display loading placeholder for CAKE balance and price in `NoCakeLockedOrExtendLock` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426L2-R2),[link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426L157-R175))
* Import and use `getVaultPosition` and `VaultPosition` utilities from `utils/cakePool` to determine user's position in auto CAKE vault based on shares, lock status and lock end time ([link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426R16),[link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426R107-R116))
* Modify `Text` component in `NoCakeLockedOrExtendLock` component to show `Unlocked` if user's position is `LockedEnd` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7089/files?diff=unified&w=0#diff-434c62198fff3bb5b97f7dfe66fe5807b4f12417d8b6c3c3b74ac324bf268426L176-R193))


