### PR TITLE
feat: US citizen

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -24,7 +24,7 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
     mobileConfig.push(mobileConfig.splice(4, 1)[0])
     return isMobile ? mobileConfig : config(t, isDark, languageCode, chainId)
   }, [t, isDark, languageCode, chainId, isMobile])
-  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   return useMemo(() => {
     if (menuItemsStatus && Object.keys(menuItemsStatus).length) {

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -3,7 +3,7 @@ import { useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { LinkStatus } from '@pancakeswap/uikit/src/widgets/Menu/types'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import { useMemo } from 'react'
 import { multiChainPaths } from 'state/info/constant'
 import config, { ConfigMenuItemsType } from '../config/config'
@@ -24,7 +24,7 @@ export const useMenuItems = (onUsCitizenModalPresent?: () => void): ConfigMenuIt
     mobileConfig.push(mobileConfig.splice(4, 1)[0])
     return isMobile ? mobileConfig : config(t, isDark, languageCode, chainId)
   }, [t, isDark, languageCode, chainId, isMobile])
-  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   return useMemo(() => {
     if (menuItemsStatus && Object.keys(menuItemsStatus).length) {

--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { usePhishingBanner } from '@pancakeswap/utils/user'
+import { IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import GlobalSettings from './GlobalSettings'
 import { SettingsMode } from './GlobalSettings/types'
 import { useMenuItems } from './hooks/useMenuItems'
@@ -26,7 +27,7 @@ const Menu = (props) => {
   const { currentLanguage, setLanguage, t } = useTranslation()
   const { pathname } = useRouter()
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
     true,
     false,
     'usCitizenConfirmModal',

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -22,18 +22,18 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
     t,
     currentLanguage: { code },
   } = useTranslation()
-  const { handleClose } = useUserNotUsCitizenAcknowledgement(id)
+  const [, setHasAcceptedRisk] = useUserNotUsCitizenAcknowledgement(id)
   const { chainId } = useActiveChainId()
   const { isDark } = useTheme()
 
   const handleSuccess = useCallback(() => {
-    handleClose()
+    setHasAcceptedRisk(true)
     if (id === IdType.PERPETUALS) {
       const url = getPerpetualUrl({ chainId, languageCode: code, isDark })
       window.open(url, '_blank', 'noopener noreferrer')
     }
     onDismiss?.()
-  }, [id, handleClose, onDismiss, chainId, code, isDark])
+  }, [id, setHasAcceptedRisk, onDismiss, chainId, code, isDark])
 
   return (
     <DisclaimerModal

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -1,5 +1,5 @@
 import DisclaimerModal from 'components/DisclaimerModal'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import { memo, useCallback } from 'react'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 import { useActiveChainId } from 'hooks/useActiveChainId'
@@ -8,25 +8,32 @@ import { Text, Link } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 
 interface USCitizenConfirmModalProps {
+  id: IdType
   title: string
   onDismiss?: () => void
 }
 
-const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmModalProps>> = ({ title, onDismiss }) => {
+const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmModalProps>> = ({
+  id,
+  title,
+  onDismiss,
+}) => {
   const {
     t,
     currentLanguage: { code },
   } = useTranslation()
-  const [, setHasAcceptedRisk] = useUserNotUsCitizenAcknowledgement()
+  const { handleClose } = useUserNotUsCitizenAcknowledgement(id)
   const { chainId } = useActiveChainId()
   const { isDark } = useTheme()
 
   const handleSuccess = useCallback(() => {
-    setHasAcceptedRisk(true)
-    const url = getPerpetualUrl({ chainId, languageCode: code, isDark })
-    window.open(url, '_blank', 'noopener noreferrer')
+    handleClose()
+    if (id === IdType.PERPETUALS) {
+      const url = getPerpetualUrl({ chainId, languageCode: code, isDark })
+      window.open(url, '_blank', 'noopener noreferrer')
+    }
     onDismiss?.()
-  }, [setHasAcceptedRisk, chainId, code, isDark, onDismiss])
+  }, [id, handleClose, onDismiss, chainId, code, isDark])
 
   return (
     <DisclaimerModal

--- a/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
+++ b/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
@@ -1,8 +1,45 @@
 import { useAtom } from 'jotai'
+import { useMemo } from 'react'
 import { atomWithStorage } from 'jotai/utils'
 
-const userNotUsCitizenAcknowledgementAtom = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement', false)
+export enum IdType {
+  IFO = 'ifo',
+  PERPETUALS = 'perpetuals',
+  AFFILIATE_PROGRAM = 'affiliate-program',
+}
 
-export function useUserNotUsCitizenAcknowledgement() {
-  return useAtom(userNotUsCitizenAcknowledgementAtom)
+type UsCitizenAcknowledgementList = Record<IdType, Record<'hide', null | boolean>>
+
+const defaultList: UsCitizenAcknowledgementList = {
+  [IdType.IFO]: {
+    hide: false,
+  },
+  [IdType.PERPETUALS]: {
+    hide: false,
+  },
+  [IdType.AFFILIATE_PROGRAM]: {
+    hide: false,
+  },
+}
+
+const userNotUsCitizenAcknowledgementAtom = atomWithStorage('pcs:NotUsCitizenAcknowledgement-v2', defaultList)
+
+export function useUserNotUsCitizenAcknowledgement(id: IdType) {
+  const [lists, setLists] = useAtom(userNotUsCitizenAcknowledgementAtom)
+
+  const hideModal = useMemo(() => lists[id].hide, [id, lists])
+
+  const handleClose = () => {
+    setLists({
+      ...lists,
+      [id]: {
+        hide: true,
+      },
+    })
+  }
+
+  return {
+    hideModal,
+    handleClose,
+  }
 }

--- a/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
+++ b/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
@@ -1,5 +1,5 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { useAtom } from 'jotai'
-import { useMemo } from 'react'
 import { atomWithStorage } from 'jotai/utils'
 
 export enum IdType {
@@ -8,38 +8,17 @@ export enum IdType {
   AFFILIATE_PROGRAM = 'affiliate-program',
 }
 
-type UsCitizenAcknowledgementList = Record<IdType, Record<'hide', null | boolean>>
-
-const defaultList: UsCitizenAcknowledgementList = {
-  [IdType.IFO]: {
-    hide: false,
-  },
-  [IdType.PERPETUALS]: {
-    hide: false,
-  },
-  [IdType.AFFILIATE_PROGRAM]: {
-    hide: false,
-  },
-}
-
-const userNotUsCitizenAcknowledgementAtom = atomWithStorage('pcs:NotUsCitizenAcknowledgement-v2', defaultList)
+const perpetuals = atomWithStorage('pcs:NotUsCitizenAcknowledgement-perpetuals', false)
+const ifo = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement-ifo', false)
+const affiliateProgram = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement-affiliate-program', false)
 
 export function useUserNotUsCitizenAcknowledgement(id: IdType) {
-  const [lists, setLists] = useAtom(userNotUsCitizenAcknowledgementAtom)
-
-  const hideModal = useMemo(() => lists[id].hide, [id, lists])
-
-  const handleClose = () => {
-    setLists({
-      ...lists,
-      [id]: {
-        hide: true,
-      },
-    })
-  }
-
-  return {
-    hideModal,
-    handleClose,
+  switch (id) {
+    case IdType.IFO:
+      return useAtom(ifo)
+    case IdType.AFFILIATE_PROGRAM:
+      return useAtom(affiliateProgram)
+    default:
+      return useAtom(perpetuals)
   }
 }

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 
 const Congratulations = () => {
   const {
@@ -15,13 +15,13 @@ const Congratulations = () => {
   const { chainId } = useActiveChainId()
   const { isDark } = useTheme()
   const [isOpen, setIsOpen] = useState(false)
-  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.AFFILIATE_PROGRAM)
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
 
   return (
     <>
       <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} closeOnOverlayClick onDismiss={() => setIsOpen(false)}>
-        <USCitizenConfirmModal title={t('PancakeSwap Affiliate Program')} />
+        <USCitizenConfirmModal title={t('PancakeSwap Affiliate Program')} id={IdType.AFFILIATE_PROGRAM} />
       </ModalV2>
       <Flex flexDirection="column" padding={['24px', '24px', '24px', '24px', '80px 24px']}>
         <Text lineHeight="110%" maxWidth="190px" fontSize={['24px']} bold m="12px 0">

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -15,7 +15,7 @@ const Congratulations = () => {
   const { chainId } = useActiveChainId()
   const { isDark } = useTheme()
   const [isOpen, setIsOpen] = useState(false)
-  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.AFFILIATE_PROGRAM)
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.AFFILIATE_PROGRAM)
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
 
   return (

--- a/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
@@ -3,7 +3,7 @@ import { ArrowForwardIcon, Button, Link, Text, useMatchBreakpoints, useModal, Fl
 import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import Image from 'next/legacy/image'
 import { memo, useMemo } from 'react'
 import styled, { useTheme } from 'styled-components'
@@ -153,12 +153,12 @@ const PerpetualBanner = () => {
 
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
     true,
     false,
     'usCitizenConfirmModal',
   )
-  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   return (
     <S.Wrapper

--- a/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
@@ -158,7 +158,7 @@ const PerpetualBanner = () => {
     false,
     'usCitizenConfirmModal',
   )
-  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   return (
     <S.Wrapper

--- a/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
@@ -10,7 +10,7 @@ import {
 } from '@pancakeswap/uikit'
 import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import Image from 'next/legacy/image'
 import { memo, useMemo, useRef } from 'react'
 import styled, { useTheme } from 'styled-components'
@@ -56,12 +56,12 @@ const PerpetualBanner = () => {
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const headerRef = useRef<HTMLDivElement>(null)
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} />,
+    <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
     true,
     false,
     'usCitizenConfirmModal',
   )
-  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   useIsomorphicEffect(() => {
     const target = headerRef.current

--- a/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
@@ -61,7 +61,7 @@ const PerpetualBanner = () => {
     false,
     'usCitizenConfirmModal',
   )
-  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.PERPETUALS)
 
   useIsomorphicEffect(() => {
     const target = headerRef.current

--- a/apps/web/src/views/Ifos/index.tsx
+++ b/apps/web/src/views/Ifos/index.tsx
@@ -14,7 +14,7 @@ export const IfoPageLayout = ({ children }) => {
   const isExact = router.route === '/ifo'
   useFetchIfo()
 
-  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.IFO)
+  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.IFO)
   const [onUSCitizenModalPresent] = useModal(
     <USCitizenConfirmModal title={t('PancakeSwap IFOs')} id={IdType.IFO} />,
     true,
@@ -23,9 +23,13 @@ export const IfoPageLayout = ({ children }) => {
   )
 
   useEffect(() => {
-    if (!userNotUsCitizenAcknowledgement) {
-      onUSCitizenModalPresent()
-    }
+    const timer = setTimeout(() => {
+      if (!userNotUsCitizenAcknowledgement) {
+        onUSCitizenModalPresent()
+      }
+    }, 1000)
+
+    return () => clearTimeout(timer)
   }, [userNotUsCitizenAcknowledgement, onUSCitizenModalPresent])
 
   return (

--- a/apps/web/src/views/Ifos/index.tsx
+++ b/apps/web/src/views/Ifos/index.tsx
@@ -3,7 +3,7 @@ import { SubMenuItems, useModal } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { useRouter } from 'next/router'
 import { useFetchIfo } from 'state/pools/hooks'
-import { useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCitizenAcknowledgement'
+import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
 import Hero from './components/Hero'
 import IfoProvider from './contexts/IfoContext'
@@ -14,9 +14,9 @@ export const IfoPageLayout = ({ children }) => {
   const isExact = router.route === '/ifo'
   useFetchIfo()
 
-  const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement()
+  const { hideModal: userNotUsCitizenAcknowledgement } = useUserNotUsCitizenAcknowledgement(IdType.IFO)
   const [onUSCitizenModalPresent] = useModal(
-    <USCitizenConfirmModal title={t('PancakeSwap IFOs')} />,
+    <USCitizenConfirmModal title={t('PancakeSwap IFOs')} id={IdType.IFO} />,
     true,
     false,
     'usCitizenConfirmModal',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5e63f3e</samp>

### Summary
🇺🇸🚫🛠️

<!--
1.  🇺🇸 - This emoji represents the US citizenship theme that is common to all the changes, as they all involve adding or modifying logic related to confirming that the user is not a US citizen for different features.
2.  🚫 - This emoji represents the negative or prohibitive aspect of the changes, as they all involve hiding or blocking access to certain features for US citizens, or requiring them to acknowledge that they are not eligible to use them.
3.  🛠️ - This emoji represents the refactoring and improvement aspect of the changes, as they all involve using a more flexible and reusable hook and enum to handle the user acknowledgement logic and state, and updating the modal component to support different features.
-->
Added user confirmation of not being a US citizen for features that are restricted or regulated in the US, such as perpetuals, IFOs, and affiliate program. Used an enum `IdType` and a custom hook `useUserNotUsCitizenAcknowledgement` to handle the modal logic and state for each feature. Refactored the existing hook `useUserIsUsCitizenAcknowledgement` to support multiple features. Updated the menu, banners, and modals components to use the new hook and enum.

> _`USCitizenConfirmModal`_
> _asks before some features_
> _autumn leaves falling_

### Walkthrough
*  Refactor `useUserIsUsCitizenAcknowledgement` hook to use a record of `IdType` and `hide` properties for different features ([link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-0be3f268ca12a01083bf89935454337314fb2de999f86be70e2444cd079a7f97L2-R45))
*  Import `IdType` enum from `useUserIsUsCitizenAcknowledgement` hook in various components that require user confirmation of not being a US citizen ([link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL6-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-128603fbd7fa98404a4bc03c4d7e4d2a80c1d222b84e0606b851e459a75a3793R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-711e29b77996d41f2fb3a31b3315592b88720363b92f6647f7f85d6eb64a1097L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a9dbefb1fbe66e6a6021569ef44f6903854ae58cd74af8fd0c77b080a5edceafL8-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a0c4a81cbfb69f07ce0d2c2fb718d01b4430a42e3ec8ed49521d9dc3bfe34c9eL6-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-e468011e07f3d7556d4740492ead9d03c9a7a56b30bf10c2923e8febdcce7cf0L13-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7L6-R6))
*  Destructure `useUserNotUsCitizenAcknowledgement` hook to get the `hideModal` property for the corresponding feature in `useMenuItems`, `Congratulations`, `PerpetualApolloXCampaignBanner`, `PerpetualBanner`, and `Ifos` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-b86c9302201027cdb305dc610167684031e184d1c81fb76659485559f3ca09aeL27-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a9dbefb1fbe66e6a6021569ef44f6903854ae58cd74af8fd0c77b080a5edceafL18-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a0c4a81cbfb69f07ce0d2c2fb718d01b4430a42e3ec8ed49521d9dc3bfe34c9eL156-R161), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-e468011e07f3d7556d4740492ead9d03c9a7a56b30bf10c2923e8febdcce7cf0L59-R64), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7L17-R19))
*  Pass the feature id as a prop to the `USCitizenConfirmModal` component in `Menu`, `Congratulations`, `PerpetualApolloXCampaignBanner`, `PerpetualBanner`, and `Ifos` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-128603fbd7fa98404a4bc03c4d7e4d2a80c1d222b84e0606b851e459a75a3793L29-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a9dbefb1fbe66e6a6021569ef44f6903854ae58cd74af8fd0c77b080a5edceafL24-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-a0c4a81cbfb69f07ce0d2c2fb718d01b4430a42e3ec8ed49521d9dc3bfe34c9eL156-R161), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-e468011e07f3d7556d4740492ead9d03c9a7a56b30bf10c2923e8febdcce7cf0L59-R64), [link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7L17-R19))
*  Modify the `USCitizenConfirmModal` component to accept an `id` prop of type `IdType` and use the `useUserNotUsCitizenAcknowledgement` hook with the `id` prop to get the `handleClose` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7092/files?diff=unified&w=0#diff-711e29b77996d41f2fb3a31b3315592b88720363b92f6647f7f85d6eb64a1097L11-R36))


