### PR TITLE
chore: support community tag on v3 farm

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/CardHeading.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/CardHeading.tsx
@@ -65,12 +65,16 @@ const CardHeading: React.FC<React.PropsWithChildren<ExpandableSectionProps>> = (
         <Skeleton mr="8px" width={63} height={63} variant="circle" />
       )}
       <Flex flexDirection="column" alignItems="flex-end" width="100%">
-        {isReady ? <Heading mb="4px">{lpLabel.split(' ')[0]}</Heading> : <Skeleton mb="4px" width={60} height={18} />}
+        {isReady ? (
+          <Heading mb="4px">{lpLabel?.split(' ')?.[0] ?? ''}</Heading>
+        ) : (
+          <Skeleton mb="4px" width={60} height={18} />
+        )}
         <AutoRow gap="4px" justifyContent="flex-end">
           {isReady && isStable ? <StableFarmTag /> : version === 2 ? <V2Tag /> : null}
           {isReady && version === 3 && <V3FeeTag feeAmount={feeAmount} />}
           {isReady && boosted && <BoostedTag />}
-          {isReady && isCommunityFarm && <FarmAuctionTag />}
+          {isReady && isCommunityFarm && <FarmAuctionTag mr="-4px" />}
           {isReady ? (
             <Flex ref={targetRef}>
               <MultiplierTag variant="secondary">{multiplier}</MultiplierTag>

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
@@ -108,6 +108,7 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
           feeAmount={farm.feeAmount}
           farmCakePerSecond={farmCakePerSecond}
           totalMultipliers={totalMultipliers}
+          isCommunityFarm={farm.isCommunity}
         />
         {!removed && (
           <Flex justifyContent="space-between" alignItems="center">
@@ -145,7 +146,7 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
               totalValueLabel={t('Staked Liquidity')}
               lpLabel={lpLabel}
               onAddLiquidity={addLiquidityModal.onOpen}
-              isCommunity={false}
+              isCommunity={farm.isCommunity}
               multiplier={farm.multiplier}
               farmCakePerSecond={farmCakePerSecond}
               totalMultipliers={totalMultipliers}

--- a/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -217,6 +217,7 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({ farms, cake
           quoteToken: farm.quoteToken,
           isReady: farm.multiplier !== undefined,
           isStaking: farm.stakedPositions?.length > 0,
+          isCommunity: farm.isCommunity,
         },
         type: 'v3',
         details: farm,

--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -156,8 +156,8 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
               case 'type':
                 return (
                   <td key={key}>
-                    <CellInner style={{ width: '140px', gap: '4px' }}>
-                      {props[key] === 'community' && <FarmAuctionTag scale="sm" />}
+                    <CellInner style={{ minWidth: '140px', gap: '4px' }}>
+                      {(props[key] === 'community' || props?.farm?.isCommunity) && <FarmAuctionTag scale="sm" />}
                       {props.type === 'v2' ? (
                         props?.details?.isStable ? (
                           <StableFarmTag scale="sm" />
@@ -251,7 +251,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
               <Flex justifyContent="space-between" alignItems="center">
                 <FarmCell {...props.farm} />
 
-                {props.type === 'community' ? (
+                {props.type === 'community' || props?.farm?.isCommunity ? (
                   <FarmAuctionTag marginRight="16px" scale="sm" />
                 ) : (
                   <Flex

--- a/packages/uikit/src/widgets/Farm/types.ts
+++ b/packages/uikit/src/widgets/Farm/types.ts
@@ -32,6 +32,7 @@ export interface FarmTableFarmTokenInfoProps {
   isReady: boolean;
   isStaking?: boolean;
   children?: ReactNode;
+  isCommunity?: boolean;
 }
 
 export type ColumnsDefTypes = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1dda87c</samp>

### Summary
🛠️🌱🏷️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used for the first change that adds optional chaining and nullish coalescing operators to the `lpLabel` variable and a margin-right to the `FarmAuctionTag` component.
2.  🌱 - This emoji represents a seed or a plant, and can be used for the second change that adds the `isCommunity` property to the farm object and passes it to the `Row` component.
3.  🏷️ - This emoji represents a label or a tag, and can be used for the third change that makes the `FarmV3Card` component display a different heading for community farms and shows a `FarmAuctionTag` for community farms in the farm table and the farm cell components.
-->
This pull request adds a new feature to distinguish community farms from other farms in the farm card and farm table components. It uses the `isCommunity` property of the farm object and displays a `FarmAuctionTag` for community farms. It also fixes a potential bug with the `lpLabel` variable.

> _`FarmAuctionTag` shows_
> _community farms in table_
> _autumn harvest time_

### Walkthrough
*  Add `isCommunity` prop to `CardHeading` and `FarmCell` components to display `FarmAuctionTag` for community farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdR111), [link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdL148-R149), [link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-745ddf268270aff7533d4283013f9072c3e4538dc75d863c7e9f321018ded662R220), [link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L159-R160), [link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L254-R254), [link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-79463f58bf7b735da70ee3d28375110f295cfbe984411bc5973a607bca37b575R35))
*  Add optional chaining and nullish coalescing operators to `lpLabel` variable in `CardHeading` to prevent errors if undefined or empty ([link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bL68-R77))
*  Add margin-right to `FarmAuctionTag` component in `CardHeading` to align it with other tags ([link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bL68-R77))
*  Change width style to minWidth in `Row` component to avoid clipping `FarmAuctionTag` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7094/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L159-R160))


