### PR TITLE
chore(Farm): Adjustment FarmAuctionTag position

### DIFF
--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -250,29 +250,25 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
             <FarmMobileCell colSpan={3}>
               <Flex justifyContent="space-between" alignItems="center">
                 <FarmCell {...props.farm} />
-
-                {props.type === 'community' || props?.farm?.isCommunity ? (
-                  <FarmAuctionTag marginRight="16px" scale="sm" />
-                ) : (
-                  <Flex
-                    mr="16px"
-                    alignItems={isMobile ? 'end' : 'center'}
-                    flexDirection={isMobile ? 'column' : 'row'}
-                    style={{ gap: '4px' }}
-                  >
-                    {props.type === 'v2' ? (
-                      props?.details?.isStable ? (
-                        <StableFarmTag scale="sm" />
-                      ) : (
-                        <V2Tag scale="sm" />
-                      )
-                    ) : null}
-                    {props.type === 'v3' && <V3FeeTag feeAmount={props.details.feeAmount} scale="sm" />}
-                    {props?.details?.boosted ? (
-                      <BoostedTag style={{ background: 'none', verticalAlign: 'bottom' }} scale="sm" />
-                    ) : null}
-                  </Flex>
-                )}
+                <Flex
+                  mr="16px"
+                  alignItems={isMobile ? 'end' : 'center'}
+                  flexDirection={isMobile ? 'column' : 'row'}
+                  style={{ gap: '4px' }}
+                >
+                  {props.type === 'v2' ? (
+                    props?.details?.isStable ? (
+                      <StableFarmTag scale="sm" />
+                    ) : (
+                      <V2Tag scale="sm" />
+                    )
+                  ) : null}
+                  {props.type === 'v3' && <V3FeeTag feeAmount={props.details.feeAmount} scale="sm" />}
+                  {props.type === 'community' || props?.farm?.isCommunity ? <FarmAuctionTag scale="sm" /> : null}
+                  {props?.details?.boosted ? (
+                    <BoostedTag style={{ background: 'none', verticalAlign: 'bottom' }} scale="sm" />
+                  ) : null}
+                </Flex>
               </Flex>
             </FarmMobileCell>
           </tr>

--- a/packages/uikit/src/widgets/Farm/components/Tags/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/Tags/index.tsx
@@ -46,7 +46,11 @@ const FarmAuctionTag: React.FC<React.PropsWithChildren<TagProps>> = (props) => {
   return (
     <>
       {tooltipVisible && tooltip}
-      <TooltipText ref={targetRef} style={{ textDecoration: "none" }}>
+      <TooltipText
+        ref={targetRef}
+        display="flex"
+        style={{ textDecoration: "none", justifyContent: "center", alignSelf: "center" }}
+      >
         <Tag variant="failure" outline startIcon={<CommunityIcon width="18px" color="failure" mr="4px" />} {...props}>
           {t("Farm Auction")}
         </Tag>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd5e07c</samp>

### Summary
📱🏷️🛠️

<!--
1.  📱 - This emoji represents the mobile device aspect of the change, as it affects how the tags are rendered on smaller screens.
2.  🏷️ - This emoji represents the tag component that is being modified, as it is the main element that is being changed in the logic and style.
3.  🛠️ - This emoji represents the improvement and simplification of the code, as it makes it more consistent and easier to read.
-->
Simplify and improve the rendering and styling of farm tags on mobile and desktop devices. Modify `Row.tsx` and `Tags/index.tsx` to use consistent logic and flex properties for the tags and tooltips.

> _`FarmAuctionTag` shines_
> _Simpler logic, better style_
> _Tooltip like snowflake_

### Walkthrough
*  Simplify the logic for rendering farm tags on mobile devices ([link](https://github.com/pancakeswap/pancake-frontend/pull/7095/files?diff=unified&w=0#diff-e6295a992a6cf20971c1af9eb6022b30c3c97ceb1bb8629884a0513ed135bb86L253-R271))
*  Adjust the style of the tooltip text for the farm auction tag ([link](https://github.com/pancakeswap/pancake-frontend/pull/7095/files?diff=unified&w=0#diff-d10ba872d561ab4ac00ac17ef0b15f894c386d1896687698cd47cfc9113944e5L49-R53))



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/a3d3689f-6f47-4d76-b8f9-dc30645a3912)
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/bc565f41-fc6f-49bf-ae25-a6748e0d35fc)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/40ba7355-529b-4c8f-a0f4-484aa5d612c6)
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/76537aad-4de7-4bd5-a891-434496fb1038)

