### PR TITLE
chore: Move finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -86,15 +86,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 323,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.sd,
-    contractAddress: '0xaEC63F134a7853C6DaC9BA428d7962cD7C6c5e30',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.01022',
-    version: 3,
-  },
-  {
     sousId: 321,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.csix,
@@ -112,6 +103,15 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 323,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.sd,
+    contractAddress: '0xaEC63F134a7853C6DaC9BA428d7962cD7C6c5e30',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.01022',
+    version: 3,
+  },
   {
     sousId: 328,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 249ae4d</samp>

### Summary
🏊🏁🔄

<!--
1.  🏊 - This emoji represents a pool, and is used to indicate that the pull request is related to the pool feature of the app.
2.  🏁 - This emoji represents the end of a race, and is used to indicate that the pull request is related to the end status of a pool.
3.  🔄 - This emoji represents a refresh or update, and is used to indicate that the pull request is related to changing the UI based on the pool status.
-->
This pull request updates the pool status for `sousId` 323 in the `pancake-frontend` package. It moves the pool from the `activePools` to the `finishedPools` array in `packages/pools/src/constants/pools/56.ts`.

> _`sousId` three two three_
> _moves from active to finished_
> _autumn harvest done_

### Walkthrough
*  Move the pool with sousId 323 from active to finished pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7096/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL89-L97), [link](https://github.com/pancakeswap/pancake-frontend/pull/7096/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR107-R115))


