### PR TITLE
chore: remove uns banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -11,7 +11,6 @@ import FarmV3MigrationBanner from '../FarmV3MigrationBanner'
 import useIsRenderCompetitionBanner from './useIsRenderCompetitionBanner'
 import useIsRenderIfoBanner from './useIsRenderIFOBanner'
 import TradingRewardBanner from '../TradingRewardBanner'
-import UnsDomainBanner from '../UnsDomainBanner'
 
 interface IBannerConfig {
   shouldRender: boolean
@@ -37,7 +36,6 @@ export const useMultipleBannerConfig = () => {
 
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
-      { shouldRender: true, banner: <UnsDomainBanner /> },
       { shouldRender: true, banner: <PancakeProtectorBanner /> },
       { shouldRender: true, banner: <TradingRewardBanner /> },
       { shouldRender: true, banner: <LiquidStakingBanner /> },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abe050b</samp>

### Summary
🗑️🧹🔥

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that something was removed or deleted, such as a component or an import.
2.  🧹 - This emoji means "broom" and can be used to indicate that something was cleaned up or simplified, such as the banner logic or the code structure.
3.  🔥 - This emoji means "fire" and can be used to indicate that something was dropped or discontinued, such as a feature or a product decision.
-->
Removed UNS domain banner from home page. This reduces clutter and removes an unused feature.

> _No more `UnsDomainBanner`, no more lies_
> _We don't need your feature, we defy_
> _Simplify the logic, cut the code_
> _We are the masters of our own mode_

### Walkthrough
*  Remove UNS domain banner feature from home page ([link](https://github.com/pancakeswap/pancake-frontend/pull/7103/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L14), [link](https://github.com/pancakeswap/pancake-frontend/pull/7103/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L40))


