### PR TITLE
chore(TradingReward): Adjustment chainTag align

### DIFF
--- a/apps/web/src/views/TradingReward/components/PairInfo.tsx
+++ b/apps/web/src/views/TradingReward/components/PairInfo.tsx
@@ -72,7 +72,7 @@ const PairInfo: React.FunctionComponent<React.PropsWithChildren<PairInfoProps>> 
               <V3FeeTag feeAmount={feeAmount} scale="sm" />
               <V3Tag ml="4px" scale="sm" />
             </Flex>
-            <Flex ml={['0', '0', '4px']} mt={['4px', '4px', '0']}>
+            <Flex ml={['0', '0', '4px']} mt={['4px', '4px', '-2px']}>
               {chainId === ChainId.ETHEREUM && <EthTag />}
               {chainId === ChainId.BSC && <BscTag />}
             </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b876ba4</samp>

### Summary
🎨🧭📐

<!--
1.  🎨 - This emoji can be used to indicate a UI improvement or a design change, as it suggests a creative or artistic aspect. The margin-top adjustment is a minor UI improvement that affects the appearance and alignment of the components.
2.  🧭 - This emoji can be used to indicate a navigation or layout change, as it suggests a direction or orientation aspect. The margin-top adjustment is a layout change that affects the position and spacing of the components.
3.  📐 - This emoji can be used to indicate a measurement or alignment change, as it suggests a geometric or mathematical aspect. The margin-top adjustment is a measurement change that affects the size and margin of the components.
-->
Adjusted the margin-top of the tags in the `PairInfo` component to improve the UI of the trading rewards feature. This component displays the trading pair, volume, and fees for each eligible pair in `apps/web/src/views/TradingReward/components/PairInfo.tsx`.

> _`PairInfo` improved_
> _`Flex` margin-top adjusted_
> _Spring of rewards_

### Walkthrough
*  Adjusted the margin-top of the Flex component to align the EthTag and BscTag components with the V3Tag component in the PairInfo component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7105/files?diff=unified&w=0#diff-f96cc39a6581759fcde93b9f49a1481751e21d16c4fa791dd4f0dac5014c80f4L75-R75)). This component shows the trading pair, volume, and fees for the trading rewards feature in `PairInfo.tsx`.



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/8fc6588d-c368-4289-a037-8c1ae5fbc624)


After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/fdbba53f-eae2-45c2-9a3f-ec981ca01355)
