### PR TITLE
fix: Crash when single asset deposit

### DIFF
--- a/.changeset/short-news-watch.md
+++ b/.changeset/short-news-watch.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/v3-sdk': patch
+---
+
+fix: Crash when single asset deposit

--- a/packages/v3-sdk/src/utils/feeCalculator.ts
+++ b/packages/v3-sdk/src/utils/feeCalculator.ts
@@ -164,7 +164,10 @@ export function getLiquidityByAmountsAndPrice({
   tickLower,
   sqrtRatioX96,
 }: GetLiquidityOptions) {
-  const isToken0 = amountA.currency.wrapped.sortsBefore(amountB.currency.wrapped)
+  const isToken0 =
+    amountA.currency.wrapped.address !== amountB.currency.wrapped.address
+      ? amountA.currency.wrapped.sortsBefore(amountB.currency.wrapped)
+      : true
   const [inputAmount0, inputAmount1] = isToken0
     ? [amountA.quotient, amountB.quotient]
     : [amountB.quotient, amountA.quotient]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1e511c</samp>

### Summary
🔄🪙🧮

<!--
1.  🔄 This emoji represents the modification or change of the existing logic for `isToken0`.
2.  🪙 This emoji represents the currency or token aspect of the change, as it affects how the tokens are compared and sorted.
3.  🧮 This emoji represents the calculation or computation of the liquidity, as it affects how the amounts are used in the formula.
-->
Fixed a bug in `feeCalculator.ts` that could cause incorrect liquidity calculations for pools with identical tokens. Modified the logic of `isToken0` to handle this case explicitly.

> _`isToken0` fixed_
> _For same currency pools_
> _Autumn leaves sorting_

### Walkthrough
*  Handle the case of identical tokens in fee calculation ([link](https://github.com/pancakeswap/pancake-frontend/pull/7109/files?diff=unified&w=0#diff-f697cf55d931d9b41e18c348bf4335851dbfabe8491aef8d558f60fe93edefe3L167-R170))


