### PR TITLE
fix: Apr shows value other than 0 when position is inactive

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -73,6 +73,7 @@ import dayjs from 'dayjs'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { hexToBigInt } from 'viem'
 import { getViemClients } from 'utils/viem'
+import isPoolTickInRange from 'utils/isPoolTickInRange'
 
 export const BodyWrapper = styled(Card)`
   border-radius: 24px;
@@ -367,9 +368,7 @@ export default function PoolPage() {
   const priceValueLower = inverted ? price1 : price0
 
   // check if price is within range
-  const below = pool && typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
-  const above = pool && typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
-  const inRange: boolean = typeof below === 'boolean' && typeof above === 'boolean' ? !below && !above : false
+  const inRange = isPoolTickInRange(pool, tickLower, tickUpper)
 
   const nativeCurrency = useNativeCurrency()
   const nativeWrappedSymbol = nativeCurrency.wrapped.symbol
@@ -444,7 +443,7 @@ export default function PoolPage() {
   }
 
   const farmingTips =
-    ownsNFT && hasActiveFarm && !isStakedInMCv3 ? (
+    inRange && ownsNFT && hasActiveFarm && !isStakedInMCv3 ? (
       <Message variant="primary" mb="2em">
         <Box>
           <Text display="inline" bold mr="0.25em">{`${currencyQuote?.symbol}-${currencyBase?.symbol}`}</Text>

--- a/apps/web/src/utils/isPoolTickInRange.ts
+++ b/apps/web/src/utils/isPoolTickInRange.ts
@@ -1,0 +1,9 @@
+import { Pool } from '@pancakeswap/v3-sdk'
+
+const isPoolTickInRange = (pool: Pool, tickLower: number, tickUpper: number) => {
+  const below = pool && typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
+  const above = pool && typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
+  return typeof below === 'boolean' && typeof above === 'boolean' ? !below && !above : false
+}
+
+export default isPoolTickInRange

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -31,6 +31,7 @@ import { useAmountsByUsdValue } from '@pancakeswap/uikit/src/widgets/RoiCalculat
 import { batch } from 'react-redux'
 import { PositionDetails, getPositionFarmApr, getPositionFarmAprFactor } from '@pancakeswap/farms'
 import currencyId from 'utils/currencyId'
+import isPoolTickInRange from 'utils/isPoolTickInRange'
 import { useFarm } from 'hooks/useFarm'
 
 import { useV3FormState } from '../formViews/V3FormView/form/reducer'
@@ -162,6 +163,7 @@ export function AprCalculator({
   const validAmountA = amountA || (inverted ? tokenAmount1 : tokenAmount0) || aprAmountA
   const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || aprAmountB
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
+  const inRange = isPoolTickInRange(pool, tickLower, tickUpper)
   const { apr } = useRoi({
     tickLower,
     tickUpper,
@@ -195,7 +197,7 @@ export function AprCalculator({
     [existingPosition, validAmountA, validAmountB, tickUpper, tickLower, sqrtRatioX96],
   )
   const { positionFarmApr, positionFarmAprFactor } = useMemo(() => {
-    if (!farm || !cakePrice || !positionLiquidity || !amount0 || !amount1) {
+    if (!farm || !cakePrice || !positionLiquidity || !amount0 || !amount1 || !inRange) {
       return {
         positionFarmApr: '0',
         positionFarmAprFactor: new BigNumber(0),
@@ -224,7 +226,7 @@ export function AprCalculator({
         totalStakedLiquidity: lmPoolLiquidity,
       }),
     }
-  }, [farm, cakePrice, positionLiquidity, amount0, amount1])
+  }, [farm, cakePrice, positionLiquidity, amount0, amount1, inRange])
 
   // NOTE: Assume no liquidity when opening modal
   const { onFieldAInput, onBothRangeInput, onSetFullRange } = useV3MintActionHandlers(false)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 71e69bf</samp>

### Summary
🆕♻️📈

<!--
1.  🆕 for adding a new utility function
2.  ♻️ for refactoring the liquidity page component
3.  📈 for updating the APR calculator component
-->
This pull request adds a new utility function `isPoolTickInRange` to check the pool price range for liquidity pools and uses it to refactor and update the liquidity page and the APR calculator components. This improves code quality and accuracy of the farming rewards.

> _`isPoolTickInRange`_
> _A new function for pools_
> _Autumn harvest time_

### Walkthrough
*  Add a new utility function `isPoolTickInRange` to check if the pool price is within the selected range of ticks for a position ([link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-ef21ba2444addc925ac8b43ece27293ef3b7cfe4c41c054c68ccf36015108633R1-R9))
*  Use the `isPoolTickInRange` function in the liquidity page component to simplify the logic for displaying the price range status ([link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR76), [link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL370-R371))
*  Use the `isPoolTickInRange` function in the `AprCalculator` component to determine the eligibility for farming rewards based on the price range ([link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R166))
*  Adjust the `useMemo` hook in the `AprCalculator` component to set the position farm APR and factor to zero if the position is not within the price range ([link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L198-R200), [link](https://github.com/pancakeswap/pancake-frontend/pull/7119/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L227-R229))


