### PR TITLE
fix: Return type of farm actions props

### DIFF
--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -14,9 +14,9 @@ import { useAccount, useSendTransaction, useWalletClient } from 'wagmi'
 
 interface FarmV3ActionContainerChildrenProps {
   attemptingTxn: boolean
-  onStake: () => void
-  onUnstake: () => void
-  onHarvest: () => void
+  onStake: () => Promise<void>
+  onUnstake: () => Promise<void>
+  onHarvest: () => Promise<void>
 }
 
 const useFarmV3Actions = ({ tokenId }: { tokenId: string }): FarmV3ActionContainerChildrenProps => {
@@ -41,7 +41,7 @@ const useFarmV3Actions = ({ tokenId }: { tokenId: string }): FarmV3ActionContain
       to: masterChefV3Address,
       data: calldata,
       value: hexToBigInt(value),
-      chain: signer.chain,
+      chain: signer?.chain,
     }
 
     const resp = await fetchWithCatchTxError(() =>
@@ -86,7 +86,7 @@ const useFarmV3Actions = ({ tokenId }: { tokenId: string }): FarmV3ActionContain
       data: calldata,
       value: hexToBigInt(value),
       account,
-      chain: signer.chain,
+      chain: signer?.chain,
     }
 
     const resp = await fetchWithCatchTxError(() =>
@@ -140,7 +140,7 @@ const useFarmV3Actions = ({ tokenId }: { tokenId: string }): FarmV3ActionContain
           const newTxn = {
             ...txn,
             account,
-            chain: signer.chain,
+            chain: signer?.chain,
             gas: calculateGasMargin(estimate),
           }
 
@@ -198,7 +198,7 @@ export function useFarmsV3BatchHarvest() {
         value: hexToBigInt(value),
         account,
       }
-      const publicClient = getViemClients({ chainId: signer.chain.id })
+      const publicClient = getViemClients({ chainId: signer?.chain?.id })
 
       const resp = await fetchWithCatchTxError(() =>
         publicClient.estimateGas(txn).then((estimate) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dbf7c68</samp>

### Summary
🌾🔗🔄

<!--
1.  🌾 - This emoji represents the farming or harvesting theme of the pull request, as well as the `harvest` action that is modified by the changes.
2.  🔗 - This emoji represents the optional chaining operator that is used to access the `signer.chain` property, as well as the concept of connecting to a blockchain network or signer.
3.  🔄 - This emoji represents the asynchronous nature of the action functions, as well as the use of promises to return the results or errors of the actions.
-->
Improved error handling and result processing for farm actions in `useFarmV3Actions.tsx`. Used optional chaining to avoid errors when accessing `signer` or `signer.chain`.

> _Oh we are the farmers of the crypto sea_
> _We stake and harvest with our `signer` key_
> _But if the `signer.chain` is not in sight_
> _We use the optional chaining to avoid a fright_

### Walkthrough
*  Change the return type of `onStake`, `onUnstake`, and `onHarvest` functions to `Promise<void>` in `FarmV3ActionContainerChildrenProps` interface ([link](https://github.com/pancakeswap/pancake-frontend/pull/7121/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L17-R19)). This allows the caller to await and handle the async transactions.


