### PR TITLE
style: Error message text style

### DIFF
--- a/packages/uikit/src/__tests__/components/alert.test.tsx
+++ b/packages/uikit/src/__tests__/components/alert.test.tsx
@@ -101,7 +101,7 @@ it("renders correctly", () => {
             class="c6"
             color="text"
             font-size="16px"
-            style="word-break: break-all;"
+            style="word-break: break-word;"
           >
             Description
           </p>

--- a/packages/uikit/src/components/Alert/Alert.tsx
+++ b/packages/uikit/src/components/Alert/Alert.tsx
@@ -85,7 +85,7 @@ const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({ title, children,
       <Details hasHandler={!!onClick}>
         <Text bold>{title}</Text>
         {typeof children === "string" ? (
-          <Text style={{ wordBreak: "break-all" }} as="p">
+          <Text style={{ wordBreak: "break-word" }} as="p">
             {children}
           </Text>
         ) : (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 96ea3ab</samp>

### Summary
🐛🎨🧪

<!--
1.  🐛 - This emoji represents a bug fix, which is what the typo correction is. It conveys that the change fixes a problem or error in the code.
2.  🎨 - This emoji represents an improvement or enhancement to the UI or design, which is what the word-break style does. It conveys that the change makes the UI more appealing or user-friendly.
3.  🧪 - This emoji represents a test or testing, which is what the alert test file is for. It conveys that the change relates to verifying or validating the functionality or behavior of the component.
-->
Fix a typo in the `word-break` style attribute of the Text component in the `Alert` component and its test file. This prevents long words from overflowing the alert box.

> _`word-break` typo_
> _fixed in alert and test files_
> _autumn leaves no gaps_

### Walkthrough
* Fix typo in style attribute of Text component in Alert component and test files ([link](https://github.com/pancakeswap/pancake-frontend/pull/7130/files?diff=unified&w=0#diff-3292d97f970240997a7748505bf9a7a7589e7177633c53cb6acf0e805ae41f40L104-R104), [link](https://github.com/pancakeswap/pancake-frontend/pull/7130/files?diff=unified&w=0#diff-8fd147c76c644ec8c295baedba1e0283cf3eb237789f4316770e0d0cefff53efL88-R88))



Before
![before](https://github.com/pancakeswap/pancake-frontend/assets/98292246/01742a9e-eab2-4731-8921-0612d6750034)

After
![after](https://github.com/pancakeswap/pancake-frontend/assets/98292246/d3cad45c-39db-4cb3-b429-a6d61b027440)
