### PR TITLE
style: Fix NFT background image height

### DIFF
--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
@@ -42,6 +42,7 @@ const StyledCollectionCard = styled(Card)<{ disabled?: boolean }>`
 `
 
 const StyledImage = styled(Image)`
+  max-height: 125px;
   border-radius: 4px;
 `
 

--- a/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
+++ b/apps/web/src/views/Nft/market/components/CollectibleCard/CollectionCard.tsx
@@ -1,6 +1,4 @@
 import { Card, CardBody, Flex, Heading, ProfileAvatar, NextLinkFromReactRouter } from '@pancakeswap/uikit'
-
-import Image from 'next/image'
 import styled, { css } from 'styled-components'
 
 interface CollectionCardProps {
@@ -41,9 +39,14 @@ const StyledCollectionCard = styled(Card)<{ disabled?: boolean }>`
   }
 `
 
-const StyledImage = styled(Image)`
-  max-height: 125px;
+const StyledImage = styled(Flex)<{ backgroundImageUrl: string }>`
+  width: 100%;
+  height: 125px;
   border-radius: 4px;
+  background-size: cover;
+  background-repeat: non-repeat;
+  background-position: center;
+  background-image: ${({ backgroundImageUrl }) => `url('${backgroundImageUrl}')`};
 `
 
 const CollectionCard: React.FC<React.PropsWithChildren<CollectionCardProps>> = ({
@@ -56,7 +59,7 @@ const CollectionCard: React.FC<React.PropsWithChildren<CollectionCardProps>> = (
 }) => {
   const renderBody = () => (
     <CardBody p="8px">
-      <StyledImage src={bgSrc} alt={`nft-collection-card-${collectionName}`} height={125} width={375} />
+      <StyledImage backgroundImageUrl={bgSrc} />
       <Flex
         position="relative"
         height="65px"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b22c7e</samp>

### Summary
📏🛠️📱

<!--
1.  📏 - This emoji can be used to represent the `max-height` property, which sets a fixed limit on the height of an element and affects its layout and sizing.
2.  🛠️ - This emoji can be used to represent the improvement or adjustment of the NFT market page, which is a feature or functionality of the application that the developers are working on or fixing.
3.  📱 - This emoji can be used to represent the responsiveness or adaptability of the NFT market page, which means that it can adjust to different screen sizes and devices and provide a consistent and user-friendly experience.
-->
Added `max-height` to `StyledCollectionCard` to fix layout issues on NFT market page.

> _`max-height` added_
> _to `StyledCollectionCard`_
> _autumn leaves don't spill_

### Walkthrough
*  Add `max-height` property to `StyledCollectionCard` component to limit the height of the collection card and prevent it from overflowing the container ([link](https://github.com/pancakeswap/pancake-frontend/pull/7131/files?diff=unified&w=0#diff-e8e7db66c523bdbce83fde378c815c22bfb6cc42097e283115e53cd677e6b5c5R45))



Before
![before](https://github.com/pancakeswap/pancake-frontend/assets/98292246/3685a99f-bc7b-41b6-a703-f1b24e710f05)


After
![after](https://github.com/pancakeswap/pancake-frontend/assets/98292246/d4e7bb88-fe3d-4a20-9b1a-ba514a81e6ac)

