### PR TITLE
fix: Latest price from chart not updating when changing tokens

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -61,7 +61,7 @@ export function useSingleTokenSwapInfo(
 
   const amount = useMemo(() => tryParseAmount('1', inputCurrency ?? undefined), [inputCurrency])
 
-  const { trade: bestTradeExactIn } = useBestAMMTrade({
+  const { trade: bestTradeExactIn, isLoading } = useBestAMMTrade({
     amount,
     currency: outputCurrency,
     baseCurrency: inputCurrency,
@@ -73,7 +73,7 @@ export function useSingleTokenSwapInfo(
     type: 'api',
     autoRevalidate: false,
   })
-  if (!inputCurrency || !outputCurrency || !bestTradeExactIn) {
+  if (!inputCurrency || !outputCurrency || !bestTradeExactIn || isLoading) {
     return null
   }
 

--- a/packages/uikit/src/components/Chart/PairPriceChart.tsx
+++ b/packages/uikit/src/components/Chart/PairPriceChart.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "@pancakeswap/localization";
 import { format } from "date-fns";
 import { createChart, IChartApi, LineStyle, UTCTimestamp } from "lightweight-charts";
-import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "styled-components";
 import LineChartLoader from "./LineChartLoaderSVG";
 
@@ -187,10 +187,15 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
     priceLineData,
   ]);
 
+  const handleMouseLeave = useCallback(() => {
+    if (setHoverValue) setHoverValue(undefined);
+    if (setHoverDate) setHoverDate(undefined);
+  }, [setHoverValue, setHoverDate]);
+
   return (
     <>
       {!chartCreated && <LineChartLoader />}
-      <div style={{ display: "flex", flex: 1, height: "100%" }}>
+      <div style={{ display: "flex", flex: 1, height: "100%" }} onMouseLeave={handleMouseLeave}>
         <div style={{ flex: 1, maxWidth: "100%" }} ref={chartRef} id="swap-line-chart" {...rest} />
       </div>
     </>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5455cf8</samp>

### Summary
🔄📈🐁

<!--
1.  🔄 - This emoji represents the loading state feature, as it suggests a circular motion of refreshing or waiting for data.
2. 📈 - This emoji represents the improvement to the pair price chart, as it suggests a positive trend or growth in the data displayed on the chart.
3. 🐁 - This emoji represents the mouse leave handler, as it suggests the animal that is commonly associated with the computer input device.
-->
This pull request enhances the single token swap feature and the pair price chart component. It adds a loading state to the `useBestAMMTrade` hook, fixes a hover state bug in the `PairPriceChart` component, and improves its performance with `useCallback`.

> _To swap tokens with ease and with speed_
> _We added an `isLoading` flag indeed_
> _And to make the chart nice_
> _We cleared the hover slice_
> _With a `useCallback` hook we agreed_

### Walkthrough
*  Add `isLoading` flag to `useBestAMMTrade` hook and use it to return null from `useSingleTokenSwapInfo` function if data is loading ([link](https://github.com/pancakeswap/pancake-frontend/pull/7133/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L64-R64), [link](https://github.com/pancakeswap/pancake-frontend/pull/7133/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L76-R76))
*  Import `useCallback` hook from React and use it to create `handleMouseLeave` function for `PairPriceChart` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7133/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fL4-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7133/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fL190-R198))
*  Pass `handleMouseLeave` function as a prop to the `div` element that wraps the chart in `PairPriceChart.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7133/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fL190-R198))


