### PR TITLE
fix: Transaction updater not handling failed transactions

### DIFF
--- a/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
+++ b/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
@@ -27,15 +27,11 @@ export function usePublicNodeWaitForTransaction() {
 
   const waitForTransaction_ = useCallback(
     async (opts: WaitForTransactionArgs): Promise<TransactionReceipt> => {
-      let receipt
       // our custom node might be late to sync up
       if (viemClientsPublicNodes[chainId]) {
-        receipt = await viemClientsPublicNodes[chainId].waitForTransactionReceipt(opts)
-      } else {
-        receipt = await waitForTransaction(opts)
+        return viemClientsPublicNodes[chainId].waitForTransactionReceipt(opts)
       }
-
-      return receipt
+      return waitForTransaction({ ...opts, chainId })
     },
     [chainId],
   )

--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -4,7 +4,6 @@ import pickBy from 'lodash/pickBy'
 import forEach from 'lodash/forEach'
 import { useTranslation } from '@pancakeswap/localization'
 import { usePublicClient } from 'wagmi'
-import { waitForTransaction } from 'wagmi/actions'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { Box, Text, useToast } from '@pancakeswap/uikit'
 import { FAST_INTERVAL } from 'config/constants'
@@ -50,10 +49,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
       (transaction) => {
         const getTransaction = async () => {
           try {
-            const receipt = await waitForTransaction({
-              hash: transaction.hash,
-              chainId,
-            })
+            const receipt: any = await provider.waitForTransactionReceipt({ hash: transaction.hash })
 
             dispatch(
               finalizeTransaction({
@@ -110,7 +106,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
     chainId && Boolean(nonBscFarmPendingTxns?.length) && ['checkNonBscFarmTransaction', FAST_INTERVAL, chainId],
     () => {
       nonBscFarmPendingTxns.forEach((hash) => {
-        const steps = transactions[hash]?.nonBscFarm?.steps
+        const steps = transactions[hash]?.nonBscFarm?.steps || []
         if (steps.length) {
           const pendingStep = steps.findIndex(
             (step: NonBscFarmTransactionStep) => step.status === FarmTransactionStatus.PENDING,
@@ -133,7 +129,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
                     : FarmTransactionStatus.PENDING
                 const isFinalStepComplete = status === FarmTransactionStatus.SUCCESS && steps.length === pendingStep + 1
 
-                const newSteps = transaction.nonBscFarm.steps.map((step, index) => {
+                const newSteps = transaction?.nonBscFarm?.steps?.map((step, index) => {
                   let newObj = {}
                   if (index === pendingStep) {
                     newObj = { ...step, status, tx: destinationTxHash }
@@ -149,12 +145,12 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
                     nonBscFarm: {
                       ...transaction.nonBscFarm,
                       steps: newSteps,
-                      status: isFinalStepComplete ? FarmTransactionStatus.SUCCESS : transaction.nonBscFarm.status,
+                      status: isFinalStepComplete ? FarmTransactionStatus.SUCCESS : transaction?.nonBscFarm?.status,
                     },
                   }),
                 )
 
-                const isStakeType = transactions[hash].nonBscFarm.type === NonBscFarmStepType.STAKE
+                const isStakeType = transactions[hash]?.nonBscFarm?.type === NonBscFarmStepType.STAKE
                 if (isFinalStepComplete) {
                   const toastTitle = isStakeType ? t('Staked!') : t('Unstaked!')
                   toastSuccess(
@@ -175,7 +171,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
                         <Text
                           as="span"
                           bold
-                        >{`${transaction.nonBscFarm.amount} ${transaction.nonBscFarm.lpSymbol}`}</Text>
+                        >{`${transaction?.nonBscFarm?.amount} ${transaction?.nonBscFarm?.lpSymbol}`}</Text>
                         <Text as="span" ml="4px">
                           {errorText}
                         </Text>


### PR DESCRIPTION
Wagmi's waitForTransaction method (which is a wrapper for viem's waitForTransactionReceipt function) throws callexecutionexception (https://github.com/wagmi-dev/wagmi/blob/c02fd1caab61c93c41c8f2be78066d04e5fd9e56/packages/core/src/actions/transactions/waitForTransaction.ts#L51) instead of returning receipt with success false, although viem's function returns receipt when transaction failed.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 798115e</samp>

### Summary
🧹🛠️🚨

<!--
1.  🧹 for simplifying and cleaning up the code
2.  🛠️ for refactoring and fixing the node provider logic
3.  🚨 for adding error handling and improving the code quality
-->
This pull request improves the handling of non-BSC transactions by using a custom node provider and simplifying the `waitForTransaction` logic. It also cleans up some unused or redundant code in `updater.tsx` and `usePublicNodeWaitForTransaction.ts`.

> _The `waitForTransaction_` function_
> _Was simplified by a reduction_
> _Of the `receipt` var_
> _And a `chainId` star_
> _That passed as an option construction_

### Walkthrough
*  Simplify `waitForTransaction_` function by removing `receipt` variable and passing `chainId` as an option ([link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-d786cc146504c4301c7541b5288f2ee020d8178c141dd28bb12e4d9fbe5aeca2L30-R34))
*  Remove unused import of `waitForTransaction` from `wagmi/actions` in `updater.tsx` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L7))
*  Replace `waitForTransaction` function from `wagmi/actions` with `waitForTransactionReceipt` function from `provider` object in `getTransaction` function to use custom node provider for non-BSC transactions ([link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L53-R52))
*  Add fallback value of empty array for `steps` variable in `nonBscFarmPendingTxns` loop to prevent possible error ([link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L113-R109))
*  Add optional chaining operators to `transaction` and `nonBscFarm` properties in `newSteps`, `dispatch`, `isStakeType`, and `toastDescription` variables to prevent possible error ([link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L136-R132), [link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L152-R153), [link](https://github.com/pancakeswap/pancake-frontend/pull/7136/files?diff=unified&w=0#diff-7cf13ed80cc566159f67b4de7e56c226970328f377b6835e715068b9117aaac7L178-R174))


