### PR TITLE
fix: Invalid quote when pool liquidity is not enough

### DIFF
--- a/packages/smart-router/evm/v3-router/providers/offChainQuoteProvider.ts
+++ b/packages/smart-router/evm/v3-router/providers/offChainQuoteProvider.ts
@@ -143,6 +143,12 @@ function createGetV3Quote(isExactIn = true) {
       const [quote, poolAfter] = isExactIn
         ? await v3Pool.getOutputAmount(amount.wrapped)
         : await v3Pool.getInputAmount(amount.wrapped)
+
+      // Not enough liquidity to perform the swap
+      if (quote.quotient <= 0n) {
+        return null
+      }
+
       const { tickCurrent: tickAfter } = poolAfter
       const numOfTicksCrossed = TickList.countInitializedTicksCrossed(ticks, tick, tickAfter)
       return {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca16327</samp>

### Summary
🚫📉💱

<!--
1.  🚫 - This emoji represents the null return value and the prevention of invalid quotes.
2.  📉 - This emoji represents the negative or zero quotient and the low liquidity situation.
3.  💱 - This emoji represents the swap operation and the quote function.
-->
Fix a bug in `offChainQuoteProvider.ts` that could return invalid quotes for swaps with insufficient liquidity. Add a check to return null if the quote.quotient is zero or negative.

> _`getQuote` checks pool_
> _No swap if quotient too low_
> _Null quote in winter_

### Walkthrough
*  Add a check to return null for invalid quotes ([link](https://github.com/pancakeswap/pancake-frontend/pull/7137/files?diff=unified&w=0#diff-4c1f2664e26cded0059425986c453f84854b4ce728e2ec1753c3e455b0d63237R146-R151))


