### PR TITLE
fix: Not using the best amm quote when swap with exact output

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -133,9 +133,11 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
     }
 
     // console.log('[BEST Trade] Offchain trade is used', tradeFromOffchain)
-    return quoterTrade.outputAmount.greaterThan(tradeFromOffchain.outputAmount)
-      ? bestTradeFromQuoter_
-      : bestTradeFromOffchain
+    const quoterBetter =
+      quoterTrade.tradeType === TradeType.EXACT_INPUT
+        ? quoterTrade.outputAmount.greaterThan(tradeFromOffchain.outputAmount)
+        : quoterTrade.inputAmount.lessThan(tradeFromOffchain.inputAmount)
+    return quoterBetter ? bestTradeFromQuoter_ : bestTradeFromOffchain
   }, [bestTradeFromOffchain, bestTradeFromQuoterApi, bestTradeFromQuoterWorker, isQuoterAPIEnabled])
 }
 

--- a/packages/smart-router/evm/v3-router/utils/pool.ts
+++ b/packages/smart-router/evm/v3-router/utils/pool.ts
@@ -80,12 +80,12 @@ export const getPoolAddress = memoize(
     if (isStablePool(pool)) {
       const { balances } = pool
       const tokenAddresses = balances.map((b) => b.currency.wrapped.address)
-      return `${balances[0]?.currency.chainId}_${tokenAddresses.join('_')}`
+      return `${pool.type}_${balances[0]?.currency.chainId}_${tokenAddresses.join('_')}`
     }
     const [token0, token1] = isV2Pool(pool)
       ? [pool.reserve0.currency.wrapped, pool.reserve1.currency.wrapped]
       : [pool.token0.wrapped, pool.token1.wrapped]
-    return `${token0.chainId}_${token0.address}_${token1.address}`
+    return `${pool.type}_${token0.chainId}_${token0.address}_${token1.address}`
   },
 )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e4865b</samp>

### Summary
🐛🏎️📊

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the change. It indicates that the change resolves an issue that caused incorrect behavior or results in the previous version of the code.
2.  🏎️ - This emoji represents speed or performance, which is one of the factors that the change considers when comparing the quoter and the offchain trades. It indicates that the change tries to find the fastest and most accurate trade among the available sources, and avoids unnecessary calls to the quoter service.
3.  📊 - This emoji represents data or analytics, which is the domain of the change. It indicates that the change deals with trade data, quotes, and amounts, and uses them to find the best AMM trade for the user.
-->
Fix logic of comparing quoter and offchain trades in `useBestAMMTrade` hook. Use quoter trade only if it has a better amount than offchain trade for the given trade type.

> _`useBestAMMTrade`_
> _Fixes quoter bug in fall_
> _Offchain may win now_

### Walkthrough
* Fix the comparison logic of trade amounts in `useBestAMMTrade` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7138/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL136-R140))


