### PR TITLE
chore: Add second hop config for wbeth

### DIFF
--- a/packages/smart-router/evm/v3-router/constants/poolSelector.ts
+++ b/packages/smart-router/evm/v3-router/constants/poolSelector.ts
@@ -95,6 +95,9 @@ export const V3_TOKEN_POOL_SELECTOR_CONFIG: TokenPoolSelectorConfigChainMap = {
     [bscTokens.ankrETH.address]: {
       topNTokenInOut: 4,
     },
+    [bscTokens.wbeth.address]: {
+      topNSecondHop: 3,
+    },
   },
 }
 

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/poolTvlSelectors.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/poolTvlSelectors.ts
@@ -190,10 +190,16 @@ function poolSelectorFactory<P extends WithTvl>({
         .sort(sortByTvl)
         .slice(0, POOL_SELECTION_CONFIG.topNSecondHop)
 
-    const topByTVLUsingTokenInSecondHops = getTopByTVLUsingTokenSecondHops(topByTVLUsingTokenBase, currencyA)
+    const topByTVLUsingTokenInSecondHops = getTopByTVLUsingTokenSecondHops(
+      [...topByTVLUsingTokenBase, ...topByBaseWithTokenIn],
+      currencyA,
+    )
     addToPoolSet(topByTVLUsingTokenInSecondHops)
 
-    const topByTVLUsingTokenOutSecondHops = getTopByTVLUsingTokenSecondHops(topByTVLUsingTokenQuote, currencyB)
+    const topByTVLUsingTokenOutSecondHops = getTopByTVLUsingTokenSecondHops(
+      [...topByTVLUsingTokenQuote, ...topByBaseWithTokenOut],
+      currencyB,
+    )
     addToPoolSet(topByTVLUsingTokenOutSecondHops)
 
     const pools = [


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d51fddd</samp>

### Summary
🚀🧠🔧

<!--
1.  🚀 - This emoji represents a new feature or improvement that adds value or functionality to the project. The addition of the weth configuration on the BSC network is an example of a new feature that expands the router's capabilities and supports more users and markets.
2.  🧠 - This emoji represents a change that involves logic, algorithms, or heuristics that affect the core functionality or performance of the project. The modification of the pool selector logic to include more pools in the second hop calculation is an example of a change that affects the routing logic and potentially the trade outcomes.
3.  🔧 - This emoji represents a change that involves configuration, settings, or parameters that affect the behavior or appearance of the project. The specification of the top 3 pools for the second hop in the weth configuration is an example of a change that affects the pool selection criteria and the trade options.
-->
This pull request updates the v3 router logic to use more data sources and heuristics to find the best pools for trades involving weth on the Binance Smart Chain network. It adds a configuration for the weth token in `poolSelector.ts` and modifies the pool selector logic in `poolTvlSelectors.ts` to include more pools in the second hop calculation.

> _`weth` config added_
> _pool selector logic changed_
> _autumn of routing_

### Walkthrough
*  Add weth configuration for BSC network to pool selector ([link](https://github.com/pancakeswap/pancake-frontend/pull/7141/files?diff=unified&w=0#diff-b569a56bb679e0cf621a3f3c816de709a7dd79cdc8871666c80722a6d014026fR98-R100))
*  Include base token pools in second hop calculation for pool selector ([link](https://github.com/pancakeswap/pancake-frontend/pull/7141/files?diff=unified&w=0#diff-f5a62707d5349481ab1c54ff3d11d31ef6d21f3c22f4359fea1a65e7efcc25d7L193-R202))


