### PR TITLE
fix: Don't return old trade when currency change

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -61,7 +61,7 @@ export function useSingleTokenSwapInfo(
 
   const amount = useMemo(() => tryParseAmount('1', inputCurrency ?? undefined), [inputCurrency])
 
-  const { trade: bestTradeExactIn, isLoading } = useBestAMMTrade({
+  const { trade: bestTradeExactIn } = useBestAMMTrade({
     amount,
     currency: outputCurrency,
     baseCurrency: inputCurrency,
@@ -73,7 +73,7 @@ export function useSingleTokenSwapInfo(
     type: 'api',
     autoRevalidate: false,
   })
-  if (!inputCurrency || !outputCurrency || !bestTradeExactIn || isLoading) {
+  if (!inputCurrency || !outputCurrency || !bestTradeExactIn) {
     return null
   }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dece9c7</samp>

### Summary
🚀🧹🛠️

<!--
1.  🚀 - This emoji represents the improvement in performance and logic of the `bestTradeHookFactory` function, as it reduces unnecessary re-renders and calls to the `SmartRouter` methods.
2.  🧹 - This emoji represents the removal of the `isLoading` variable and its return condition, as it cleans up the code and simplifies the logic of the `useSingleTokenSwapInfo` function.
3.  🛠️ - This emoji represents the refactoring and fixing of the trade data handling and caching, as it ensures that the trade data is consistent and valid across different scenarios and inputs.
-->
Improved the efficiency and accuracy of finding the best AMM trade by refactoring the `bestTradeHookFactory` and `useSingleTokenSwapInfo` functions in `useBestAMMTrade.ts` and `swap/hooks.ts`.

> _We are the traders of the night_
> _We use the hooks and effects to fight_
> _We discard the old and cache the new_
> _We call the SmartRouter with valid args, we do_

### Walkthrough
* Import and use `useEffect`, `useRef` and `useDeferredValue` hooks to implement a `keepPreviousData` option for the `useQuery` hook in the `bestTradeHookFactory` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eR167-R172), [link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL255-R265), [link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eR271-R276), [link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L64-R64), [link](https://github.com/pancakeswap/pancake-frontend/pull/7143/files?diff=unified&w=0#diff-9c9d1c7d1b4f2fd3accab05994fc9d38a2f7c292a12354fa2fdf9811ca25b390L76-R76)) in `useBestAMMTrade.ts`


