### PR TITLE
fix: isPositionOutOfRange when tick is zero

### DIFF
--- a/packages/utils/isPositionOutOfRange.ts
+++ b/packages/utils/isPositionOutOfRange.ts
@@ -2,7 +2,10 @@ export function isPositionOutOfRange(
   tickCurrent?: number,
   position?: { tickLower?: number; tickUpper?: number },
 ): boolean {
-  return tickCurrent && position && position.tickLower && position.tickUpper
+  return (tickCurrent || tickCurrent === 0) &&
+    position &&
+    (position.tickLower || position.tickLower === 0) &&
+    (position.tickUpper || position.tickUpper === 0)
     ? tickCurrent < position.tickLower || tickCurrent >= position.tickUpper
     : false
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b6f2d2</samp>

### Summary
🐛📊🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  📊 - This emoji represents a chart or data, which is related to the liquidity ranges and positions that the function deals with.
3.  🛠️ - This emoji represents a tool or improvement, which is also relevant to the function's functionality and performance.
-->
Fixed a bug in `isPositionOutOfRange` function that caused incorrect liquidity ranges for some positions with zero ticks. Updated `packages/utils/isPositionOutOfRange.ts` file.

> _`isPositionOutOfRange`_
> _Fixed a bug with zero ticks_
> _Liquidity blooms_

### Walkthrough
* Fix a bug in `isPositionOutOfRange` function that caused incorrect liquidity ranges for some positions ([link](https://github.com/pancakeswap/pancake-frontend/pull/7145/files?diff=unified&w=0#diff-3111b3f0274c3928731d85996a2c13312fdb3838b111c28c2e574a79e6707eb1L5-R8))


