### PR TITLE
chore: add loading for ROI calculator price chart

### DIFF
--- a/apps/web/src/hooks/v3/usePairTokensPrice.ts
+++ b/apps/web/src/hooks/v3/usePairTokensPrice.ts
@@ -33,5 +33,6 @@ export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTime
     maxPrice: pairPrice?.maxPrice,
     minPrice: pairPrice?.minPrice,
     averagePrice: pairPrice?.averagePrice,
+    isLoading: pairPrice?.isLoading,
   }
 }

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -112,7 +112,13 @@ export const usePairPriceChartTokenData = (
   address: string,
   duration?: 'day' | 'week' | 'month' | 'year',
   targetChianId?: ChainId,
-): { data: PriceChartEntry[] | undefined; maxPrice?: number; minPrice?: number; averagePrice?: number } => {
+): {
+  data: PriceChartEntry[] | undefined
+  maxPrice?: number
+  minPrice?: number
+  averagePrice?: number
+  isLoading?: boolean
+} => {
   const chainName = useChainNameByQuery()
   const chainId = targetChianId || multiChainId[chainName]
   const utcCurrentTime = dayjs()
@@ -121,7 +127,7 @@ export const usePairPriceChartTokenData = (
     .startOf('hour')
     .unix()
 
-  const { data } = useSWRImmutable(
+  const { data, status } = useSWRImmutable(
     chainId &&
       address &&
       address !== 'undefined' && [`v3/info/token/pairPriceChartToken/${address}/${duration}`, targetChianId ?? chainId],
@@ -141,6 +147,7 @@ export const usePairPriceChartTokenData = (
     maxPrice: data?.maxPrice,
     minPrice: data?.minPrice,
     averagePrice: data?.averagePrice,
+    isLoading: status !== FetchStatus.Fetched,
   }
 }
 

--- a/packages/uikit/src/components/Chart/PairPriceChart.tsx
+++ b/packages/uikit/src/components/Chart/PairPriceChart.tsx
@@ -19,6 +19,7 @@ export type SwapLineChartNewProps = {
   isChangePositive: boolean;
   isChartExpanded: boolean;
   timeWindow: PairDataTimeWindowEnum;
+  isLoading?: boolean;
   priceLineData?: { title: string; color: string; price: number }[];
 } & React.HTMLAttributes<HTMLDivElement>;
 
@@ -43,6 +44,7 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
   isChartExpanded,
   timeWindow,
   priceLineData,
+  isLoading,
   ...rest
 }) => {
   const { isDark } = useTheme();
@@ -194,7 +196,7 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
 
   return (
     <>
-      {!chartCreated && <LineChartLoader />}
+      {(!chartCreated || isLoading) && <LineChartLoader />}
       <div style={{ display: "flex", flex: 1, height: "100%" }} onMouseLeave={handleMouseLeave}>
         <div style={{ flex: 1, maxWidth: "100%" }} ref={chartRef} id="swap-line-chart" {...rest} />
       </div>

--- a/packages/uikit/src/widgets/RoiCalculator/PriceChart.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/PriceChart.tsx
@@ -30,6 +30,7 @@ interface Props {
   maxPrice?: number;
   minPrice?: number;
   averagePrice?: number;
+  isLoading?: boolean;
   onSpanChange?: (spanIndex: number) => void;
 }
 
@@ -43,6 +44,7 @@ export const PriceChart = memo(function PriceChart({
   maxPrice,
   minPrice,
   averagePrice,
+  isLoading,
 }: Props) {
   const { t } = useTranslation();
   const priceLimits = useMemo(
@@ -70,6 +72,7 @@ export const PriceChart = memo(function PriceChart({
           isChartExpanded={false}
           timeWindow={span}
           priceLineData={priceLimits}
+          isLoading={isLoading}
         />
       </Box>
     ) : (

--- a/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
+++ b/packages/uikit/src/widgets/RoiCalculator/RoiCalculator.tsx
@@ -56,6 +56,7 @@ export type RoiCalculatorProps = {
     maxPrice: number;
     minPrice: number;
     averagePrice: number;
+    isLoading: boolean;
   };
   ticks?: TickData[];
   price?: Price<Token, Token>;
@@ -434,6 +435,7 @@ export function RoiCalculator({
         maxPrice={invertPrice && prices?.maxPrice ? prices?.maxPrice : 1 / (prices?.minPrice ?? 1)}
         minPrice={invertPrice && prices?.minPrice ? prices?.minPrice : 1 / (prices?.maxPrice ?? 1)}
         averagePrice={invertPrice && prices?.averagePrice ? prices?.averagePrice : 1 / (prices?.averagePrice ?? 1)}
+        isLoading={prices?.isLoading}
       />
     </Section>
   );


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 866639b</samp>

### Summary
🔄📈🧮

<!--
1.  🔄 - This emoji represents the loading indicator or spinner that is shown when the data is loading. It conveys the idea of waiting or refreshing the data.
2. 📈 - This emoji represents the price chart or line chart that is displayed when the data is loaded. It conveys the idea of growth, trends, or analysis of the token prices.
3. 🧮 - This emoji represents the ROI calculator that is also shown when the data is loaded. It conveys the idea of calculating the return on investment or profit from the token pair.
-->
This pull request adds loading indicators to various components that display pair price charts, such as `PairPriceChart`, `PriceChart`, and `RoiCalculator`. It also refactors the `usePairPriceChartTokenData` and `usePairTokensPrice` hooks to return an `isLoading` property, which is used to show the loading status in the UI.

> _`isLoading` prop_
> _shows when prices are fetched_
> _a winter waiting_

### Walkthrough
*  Add `isLoading` property to `usePairTokensPrice` hook and its return type to indicate the loading status of the pair price data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-11c632dad7ad8c4c8fea0b8983fb21411f1fa15a4f1f314a86520c3d10f16a15R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L115-R121), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L124-R130), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0R150))
*  Pass `isLoading` prop from `usePairTokensPrice` hook to `SwapLineChartNew` component and its wrappers (`PriceChart` and `RoiCalculator`) to show a loading indicator when the chart data is not ready ([link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fR22), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fR47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-8f347f8aa1196f772d8e270651e9985f3ced50f69b2d6bcbddc241304e45762fL197-R199), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-61fbfef37cdb34bae59ead6e9c1974dca6173fad3395c8dcde9953c1cf583baeR33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-61fbfef37cdb34bae59ead6e9c1974dca6173fad3395c8dcde9953c1cf583baeR47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-61fbfef37cdb34bae59ead6e9c1974dca6173fad3395c8dcde9953c1cf583baeR75), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR59), [link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-1da265a2b61cd6604fc701de6a520d682d0f800555bdd1e4c8aefb59af43ea8aR438))
*  Move `usePairPriceChartTokenData` hook from `apps/web/src/views/V3Info/hooks/index.ts` to `apps/web/src/hooks/v3/usePairTokensPrice.ts` as part of a refactoring to consolidate the hooks related to pair tokens price in one file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7146/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L115-R121))


