### PR TITLE
chore: Remove offchain quoting

### DIFF
--- a/packages/smart-router/evm/v3-router/functions/getBestRouteCombinationByQuotes.ts
+++ b/packages/smart-router/evm/v3-router/functions/getBestRouteCombinationByQuotes.ts
@@ -256,7 +256,7 @@ export function getBestSwapRouteBy(
                       if (isV3Pool(p)) {
                         return `V3 fee ${p.fee} ${p.token0.symbol}-${p.token1.symbol}`
                       }
-                      return `Stable ${p}`
+                      return `Stable ${p.balances.map((b) => b.currency).join('-')}`
                     })
                     .join(', ')} ${r.quote.toExact()}`,
               )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7839ee5</samp>

### Summary
🐛🔥🧹

<!--
1.  🐛 - This emoji represents a bug fix, and is commonly used to indicate that a change fixes an issue or error in the code.
2.  🔥 - This emoji represents removing code or files, and is commonly used to indicate that a change deletes unused or unnecessary code or features.
3.  🧹 - This emoji represents cleaning or simplifying code, and is commonly used to indicate that a change refactors or improves the readability or structure of the code.
-->
This pull request improves the trade logic and UI of the PancakeSwap app by removing unused code, simplifying the `useBestAMMTrade` hook, and fixing a bug in the stable pool display. The changes affect the `apps/web/src/hooks/useBestAMMTrade.ts` and `packages/smart-router/evm/v3-router/functions/getBestRouteCombinationByQuotes.ts` files.

> _There once was a bug in `getBestSwapRouteBy`_
> _That showed the stable pool as one token, oh my!_
> _But the fix was quite easy_
> _Just use the `balances` array_
> _And join the currencies with a dash, no lie_

### Walkthrough
*  Simplify the logic of `useBestAMMTrade` hook by removing the off-chain trade option and returning either the quoter API trade or the quoter worker trade ([link](https://github.com/pancakeswap/pancake-frontend/pull/7150/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7150/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL59-L60), [link](https://github.com/pancakeswap/pancake-frontend/pull/7150/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL72-R70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7150/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL98-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/7150/files?diff=unified&w=0#diff-b799230b7acaccf91346004ce8e813994b30a79d3e04497a6ce341c7d046ec2eL107-R94)) in `apps/web/src/hooks/useBestAMMTrade.ts`


