### PR TITLE
fix(Lottery): Fix enable button is displayed when don't input anything

### DIFF
--- a/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -282,6 +282,8 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
     new BigNumber(ticketsToBuy).lte(0) ||
     getTicketsForPurchase().length !== parseInt(ticketsToBuy, 10)
 
+  const isApproveDisabled = isApproved || disableBuying
+
   if (buyingStage === BuyingStage.EDIT) {
     return (
       <EditNumbersModal
@@ -408,9 +410,9 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
         {account ? (
           <>
             <ApproveConfirmButtons
-              isApproveDisabled={isApproved || !ticketsToBuy}
+              isApproveDisabled={isApproveDisabled}
               isApproving={isApproving}
-              isConfirmDisabled={disableBuying || !ticketsToBuy}
+              isConfirmDisabled={disableBuying}
               isConfirming={isConfirming}
               onApprove={handleApprove}
               onConfirm={handleConfirm}

--- a/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -161,7 +161,7 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
     const getMaxPossiblePurchase = () => {
       const maxBalancePurchase = memoisedUserCake.div(priceTicketInCake)
       const limitedMaxPurchase = limitNumberByMaxTicketsPerBuy(maxBalancePurchase)
-      let maxPurchase
+      let maxPurchase = limitedMaxPurchase
 
       // If the users' max CAKE balance purchase is less than the contract limit - factor the discount logic into the max number of tickets they can purchase
       if (limitedMaxPurchase.lt(maxNumberTicketsPerBuyOrClaim)) {
@@ -174,8 +174,6 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
 
         // Add the additional tickets that can be bought with the discount, to the original max purchase
         maxPurchase = limitedMaxPurchase.plus(secondTicketDiscountBuy)
-      } else {
-        maxPurchase = limitedMaxPurchase
       }
 
       if (hasFetchedBalance && maxPurchase.lt(1)) {
@@ -410,9 +408,9 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
         {account ? (
           <>
             <ApproveConfirmButtons
-              isApproveDisabled={isApproved}
+              isApproveDisabled={isApproved || !ticketsToBuy}
               isApproving={isApproving}
-              isConfirmDisabled={disableBuying}
+              isConfirmDisabled={disableBuying || !ticketsToBuy}
               isConfirming={isConfirming}
               onApprove={handleApprove}
               onConfirm={handleConfirm}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at de8838e</samp>

### Summary
🎟️🐛🚫

<!--
1.  🎟️ - This emoji represents the buy tickets modal and the lottery feature in general, as it is a common symbol for tickets or raffles.
2.  🐛 - This emoji represents the bug fixes that were done to ensure the max purchase limit is always defined and the redundant assignment is removed, as it is a common symbol for errors or glitches.
3.  🚫 - This emoji represents the disabling of the buttons if the user has not entered any tickets, as it is a common symbol for prohibition or restriction.
-->
Fix buy tickets modal logic and UI for lottery. Improve validation and feedback for `BuyTicketsModal.tsx` and avoid unnecessary calculations.

> _Oh we're the crew of the lottery ship_
> _And we're fixing up the `buy tickets` modal_
> _We'll make it work without a glitch_
> _Or we'll never see a penny of our haul_

### Walkthrough
* Initialize `maxPurchase` with `limitedMaxPurchase` to avoid undefined value ([link](https://github.com/pancakeswap/pancake-frontend/pull/7151/files?diff=unified&w=0#diff-abd919febc0e5341b48ee4617c147ad9260f060d34749279a36ece8bbc59bcf9L164-R164))
* Remove redundant assignment of `maxPurchase` to `limitedMaxPurchase` in `else` branch ([link](https://github.com/pancakeswap/pancake-frontend/pull/7151/files?diff=unified&w=0#diff-abd919febc0e5341b48ee4617c147ad9260f060d34749279a36ece8bbc59bcf9L177-L178))
* Disable approve and confirm buttons if no tickets entered in `BuyTicketsModal.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7151/files?diff=unified&w=0#diff-abd919febc0e5341b48ee4617c147ad9260f060d34749279a36ece8bbc59bcf9L413-R413))


