### PR TITLE
fix(Affiliate Program):  List Error

### DIFF
--- a/apps/web/src/config/constants/contracts.ts
+++ b/apps/web/src/config/constants/contracts.ts
@@ -200,7 +200,7 @@ export default {
   },
   affiliateProgram: {
     1: '0x',
-    56: '0x92C73D90F709DFf7e5E7307e8F2EE20e39396b12',
+    56: '0x195ebeC15Be47a68F300B81de1c1E8cb23cBaC80',
     97: '0x1B8a475B5E5De05fB3Ac2D9ec3C2809fBF24e51c',
   },
 } as const satisfies Record<string, Record<number, `0x${string}`>>

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/SingleHistoricalReward.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/SingleHistoricalReward.tsx
@@ -117,7 +117,7 @@ const SingleHistoricalReward: React.FC<React.PropsWithChildren<SingleHistoricalR
               </tr>
             ) : (
               <>
-                {!dataList && dataList?.total === 0 ? (
+                {!dataList || dataList?.total === 0 ? (
                   <tr>
                     <Td colSpan={isDesktop ? 3 : 2} textAlign="center">
                       {t('No results')}

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/SingleHistoricalReward.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/SingleHistoricalReward.tsx
@@ -117,7 +117,7 @@ const SingleHistoricalReward: React.FC<React.PropsWithChildren<SingleHistoricalR
               </tr>
             ) : (
               <>
-                {dataList?.total === 0 ? (
+                {!dataList && dataList?.total === 0 ? (
                   <tr>
                     <Td colSpan={isDesktop ? 3 : 2} textAlign="center">
                       {t('No results')}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 07d8877</samp>

### Summary
🐛📊🚸

<!--
1.  🐛 - This emoji represents a bug fix, since the change prevents a possible error and makes the logic more robust.
2.  📊 - This emoji represents a data or analytics related change, since the change affects the rendering of a table that displays rewards data for affiliates.
3.  🚸 - This emoji represents a user experience or accessibility improvement, since the change makes the message more clear and consistent for users who have no rewards data.
-->
Fixed a potential error and improved the UI logic for showing a no-rewards message in the `SingleHistoricalReward` component of the affiliates program dashboard.

> _`dataList` checked_
> _No rewards? Show message_
> _Winter of content_

### Walkthrough
*  Fix possible error and incorrect message when rendering historical rewards table ([link](https://github.com/pancakeswap/pancake-frontend/pull/7165/files?diff=unified&w=0#diff-e21709793826fbde19c1d13a724f541a09badad793f0d49ec5ce0723a9750585L120-R120))


