### PR TITLE
fix(Bridge): Fix menu highlight

### DIFF
--- a/apps/bridge/components/Menu.tsx
+++ b/apps/bridge/components/Menu.tsx
@@ -136,7 +136,11 @@ export function Menu() {
               {menu.items ? (
                 <DropdownMenu items={menu.items}>
                   <NextLink href={menu.href} passHref>
-                    <StyledMenuItem $isActive={nextRouter.pathname === menu.href}>{menu.title}</StyledMenuItem>
+                    <StyledMenuItem
+                      $isActive={menu.items.findIndex((item) => item.href === nextRouter.pathname) !== -1}
+                    >
+                      {menu.title}
+                    </StyledMenuItem>
                   </NextLink>
                 </DropdownMenu>
               ) : (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 477cd50</samp>

### Summary
🌐🎨🚀

<!--
1.  🌐 - This emoji can be used to indicate that the change is related to the navigation or routing of the app, as it suggests a globe or a network of links.
2.  🎨 - This emoji can be used to indicate that the change is related to the styling or appearance of the app, as it suggests a palette or a brush.
3.  🚀 - This emoji can be used to indicate that the change is part of a feature or improvement that enhances the user experience or performance of the app, as it suggests speed or launch.
-->
Improved menu highlighting logic in `Menu.tsx` to reflect sub-page navigation. This is part of a pull request to enhance the bridge app UI.

> _`$isActive` checks_
> _sub-items of the menu too_
> _autumn leaves highlight_

### Walkthrough
*  Highlight the menu item when on a sub-page of the menu by checking the sub-items' paths against the current pathname (`[link](https://github.com/pancakeswap/pancake-frontend/pull/7169/files?diff=unified&w=0#diff-3baac116f2bbf360fd7abf1062862b9172f63a90e55c4f673fde8cd662bd2cd4L139-R143)` in `Menu.tsx`)


