### PR TITLE
fix: Overflow in homepage in mobile

### DIFF
--- a/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PancakeProtectorBanner.tsx
@@ -77,10 +77,13 @@ const RightWrapper = styled.div`
 const Header = styled.div`
   ${textStyle}
   font-size: 29px;
-  padding-right: 200px;
   margin-bottom: 8px;
   ${({ theme }) => theme.mediaQueries.md} {
     margin-bottom: 10px;
+  }
+  word-spacing: 9999px;
+  ${({ theme }) => theme.mediaQueries.sm} {
+    word-spacing: normal;
   }
 `
 


### PR DESCRIPTION
To reproduce: See horitzontal overflow scroll, when width is 375px

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8fd446</samp>

### Summary
📱📖🎨

<!--
1.  📱 - This emoji represents the responsiveness of the banner on smaller screens, as the text now wraps and fits the container better.
2.  📖 - This emoji represents the readability of the banner, as the text is no longer cut off or overflowing the container.
3.  🎨 - This emoji represents the design and style of the banner, as the word-spacing property adds some visual spacing between the words and the padding-right property is removed to simplify the layout.
-->
Improved the responsiveness and readability of the `PancakeProtectorBanner` component by adjusting the `word-spacing` and `padding-right` properties of the `Header` styled component.

> _`Header` adapts_
> _word-spacing wraps the text_
> _autumn leaves fall_

### Walkthrough
*  Improve banner responsiveness and readability by adjusting word spacing and padding ([link](https://github.com/pancakeswap/pancake-frontend/pull/7173/files?diff=unified&w=0#diff-462e5918a9f05347786f8973e69f0b1c68999afeb91f6858a174b80fa3f7a4fbL80-R87))


