### PR TITLE
fix: Hide Trading Reward Token List

### DIFF
--- a/apps/web/src/views/Swap/components/HotTokenList/index.tsx
+++ b/apps/web/src/views/Swap/components/HotTokenList/index.tsx
@@ -89,24 +89,26 @@ const HotTokenList: React.FC<{ handleOutputSelect: (newCurrencyOutput: Currency)
           <ButtonMenuItem>{t('Volume (24H)')}</ButtonMenuItem>
         </ButtonMenu>
       </MenuWrapper>
-      <Flex
-        mb="24px"
-        alignItems="center"
-        ml={['20px', '20px', '20px', '20px', '-4px']}
-        onClick={() => setConfirmed(!confirmed)}
-        style={{ cursor: 'pointer' }}
-      >
-        <Checkbox
-          scale="sm"
-          name="confirmed"
-          type="checkbox"
-          checked={confirmed}
-          onChange={() => setConfirmed(!confirmed)}
-        />
-        <Text ml="8px" style={{ userSelect: 'none' }}>
-          {t('Show pairs with trading rewards')}
-        </Text>
-      </Flex>
+      {tokenPairs.length > 0 && (
+        <Flex
+          mb="24px"
+          alignItems="center"
+          ml={['20px', '20px', '20px', '20px', '-4px']}
+          onClick={() => setConfirmed(!confirmed)}
+          style={{ cursor: 'pointer' }}
+        >
+          <Checkbox
+            scale="sm"
+            name="confirmed"
+            type="checkbox"
+            checked={confirmed}
+            onChange={() => setConfirmed(!confirmed)}
+          />
+          <Text ml="8px" style={{ userSelect: 'none' }}>
+            {t('Show pairs with trading rewards')}
+          </Text>
+        </Flex>
+      )}
       {index === 0 ? (
         <TokenTable
           tokenDatas={filterFormattedTokens}

--- a/apps/web/src/views/Swap/hooks/useTradingRewardTokenList.tsx
+++ b/apps/web/src/views/Swap/hooks/useTradingRewardTokenList.tsx
@@ -14,10 +14,9 @@ const useTradingRewardTokenList = () => {
     // eslint-disable-next-line array-callback-return, consistent-return
     const activeRewardCampaignId = data.campaignIds.filter((campaignId) => {
       const incentive = data.campaignIdsIncentive.find((i) => i.campaignId === campaignId)
-      if (incentive.campaignClaimTime > currentTime) {
+      if (currentTime <= incentive.campaignClaimTime) {
         return campaignId
       }
-      return []
     })
 
     const activeCampaignPairs: { [key in string]: Array<string> } = {}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fdb9cf</samp>

### Summary
🐛🎁♻️

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the change that fixes the filter logic for active reward campaign ids.
2.  🎁 - This emoji represents a new feature or enhancement, which is the case for the change that adds the condition to render the checkbox for showing pairs with trading rewards only when available.
3.  ♻️ - This emoji represents a refactor or code improvement, which is the case for the change that simplifies the comparison operator for filtering the active reward campaign ids.
-->
This pull request adds a feature to show trading rewards for certain token pairs on the swap page. It modifies `HotTokenList` to conditionally render a checkbox for filtering by reward pairs, and fixes a bug in `useTradingRewardTokenList` that caused undefined values in the token list.

> _`Checkbox` appears_
> _only when `tokenPairs` exist_
> _autumn leaves falling_

### Walkthrough
*  Add a condition to render the checkbox for showing pairs with trading rewards only when there are token pairs available ([link](https://github.com/pancakeswap/pancake-frontend/pull/7184/files?diff=unified&w=0#diff-70f0b7608e434a24546cbd6d627ef2dcb410121dc032bea2b9fec7d6c43db468L92-R111)). This prevents the checkbox from appearing when the token list is empty or loading. This change affects the `HotTokenList` component in `apps/web/src/views/Swap/components/HotTokenList/index.tsx`.


