### PR TITLE
feat: Info Page Rename Old TUSD

### DIFF
--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -79,12 +79,12 @@ export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNa
   return multiChainQueryClient[chainName]
 }
 
-export const v2SubgraphTokenName = {
+export const subgraphTokenName = {
   '0x738d96caf7096659db4c1afbf1e1bdfd281f388c': 'Ankr Staked MATIC',
   '0x14016e85a25aeb13065688cafb43044c2ef86784': 'True USD Old',
 }
 
-export const v2SubgraphTokenSymbol = {
+export const subgraphTokenSymbol = {
   '0x14016e85a25aeb13065688cafb43044c2ef86784': 'TUSDOLD',
 }
 

--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -81,6 +81,7 @@ export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNa
 
 export const v2SubgraphTokenName = {
   '0x738d96caf7096659db4c1afbf1e1bdfd281f388c': 'Ankr Staked MATIC',
+  '0x14016E85a25aeb13065688cAFB43044C2ef86784': 'TUSDOLD',
 }
 
 export const checkIsStableSwap = () => window.location.href.includes('stableSwap')

--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -81,7 +81,11 @@ export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNa
 
 export const v2SubgraphTokenName = {
   '0x738d96caf7096659db4c1afbf1e1bdfd281f388c': 'Ankr Staked MATIC',
-  '0x14016E85a25aeb13065688cAFB43044C2ef86784': 'TUSDOLD',
+  '0x14016e85a25aeb13065688cafb43044c2ef86784': 'True USD Old',
+}
+
+export const v2SubgraphTokenSymbol = {
+  '0x14016e85a25aeb13065688cafb43044c2ef86784': 'TUSDOLD',
 }
 
 export const checkIsStableSwap = () => window.location.href.includes('stableSwap')

--- a/apps/web/src/state/info/queries/pools/poolData.ts
+++ b/apps/web/src/state/info/queries/pools/poolData.ts
@@ -4,7 +4,7 @@ import { Block, PoolData } from 'state/info/types'
 import { getChangeForPeriod } from 'utils/getChangeForPeriod'
 import { getLpFeesAndApr } from 'utils/getLpFeesAndApr'
 import { getAmountChange, getPercentChange } from 'views/Info/utils/infoDataHelpers'
-import { v2SubgraphTokenSymbol } from 'state/info/constant'
+import { subgraphTokenSymbol } from 'state/info/constant'
 
 import {
   MultiChainName,
@@ -201,12 +201,12 @@ export const fetchAllPoolDataWithAddress = async (
           token0: {
             address: current?.token0?.id ?? '',
             name: current?.token0?.name ?? '',
-            symbol: v2SubgraphTokenSymbol[current?.token0?.id?.toLocaleLowerCase()] ?? current?.token0?.symbol ?? '',
+            symbol: subgraphTokenSymbol[current?.token0?.id?.toLocaleLowerCase()] ?? current?.token0?.symbol ?? '',
           },
           token1: {
             address: current?.token1?.id ?? '',
             name: current?.token1?.name ?? '',
-            symbol: v2SubgraphTokenSymbol[current?.token1?.id?.toLocaleLowerCase()] ?? current?.token1?.symbol ?? '',
+            symbol: subgraphTokenSymbol[current?.token1?.id?.toLocaleLowerCase()] ?? current?.token1?.symbol ?? '',
           },
           token0Price: current.token0Price,
           token1Price: current.token1Price,

--- a/apps/web/src/state/info/queries/pools/poolData.ts
+++ b/apps/web/src/state/info/queries/pools/poolData.ts
@@ -4,6 +4,7 @@ import { Block, PoolData } from 'state/info/types'
 import { getChangeForPeriod } from 'utils/getChangeForPeriod'
 import { getLpFeesAndApr } from 'utils/getLpFeesAndApr'
 import { getAmountChange, getPercentChange } from 'views/Info/utils/infoDataHelpers'
+import { v2SubgraphTokenSymbol } from 'state/info/constant'
 
 import {
   MultiChainName,
@@ -200,12 +201,12 @@ export const fetchAllPoolDataWithAddress = async (
           token0: {
             address: current?.token0?.id ?? '',
             name: current?.token0?.name ?? '',
-            symbol: current?.token0?.symbol ?? '',
+            symbol: v2SubgraphTokenSymbol[current?.token0?.id?.toLocaleLowerCase()] ?? current?.token0?.symbol ?? '',
           },
           token1: {
             address: current?.token1?.id ?? '',
             name: current?.token1?.name ?? '',
-            symbol: current?.token1?.symbol ?? '',
+            symbol: v2SubgraphTokenSymbol[current?.token1?.id?.toLocaleLowerCase()] ?? current?.token1?.symbol ?? '',
           },
           token0Price: current.token0Price,
           token1Price: current.token1Price,

--- a/apps/web/src/views/Info/Tokens/TokenPage.tsx
+++ b/apps/web/src/views/Info/Tokens/TokenPage.tsx
@@ -25,7 +25,7 @@ import { CHAIN_QUERY_NAME } from 'config/chains'
 import { ONE_HOUR_SECONDS } from 'config/constants/info'
 import { Duration } from 'date-fns'
 import { useMemo } from 'react'
-import { multiChainId, multiChainScan, v2SubgraphTokenName } from 'state/info/constant'
+import { multiChainId, multiChainScan, v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
 import {
   useChainIdByQuery,
   useChainNameByQuery,
@@ -173,7 +173,7 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
                     {v2SubgraphTokenName[tokenData.address] ?? tokenData.name}
                   </Text>
                   <Text ml="12px" lineHeight="1" color="textSubtle" fontSize={isXs || isSm ? '14px' : '20px'}>
-                    ({tokenData.symbol})
+                    ({v2SubgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})
                   </Text>
                 </Flex>
                 <Flex mt="8px" ml="46px" alignItems="center">

--- a/apps/web/src/views/Info/Tokens/TokenPage.tsx
+++ b/apps/web/src/views/Info/Tokens/TokenPage.tsx
@@ -25,7 +25,7 @@ import { CHAIN_QUERY_NAME } from 'config/chains'
 import { ONE_HOUR_SECONDS } from 'config/constants/info'
 import { Duration } from 'date-fns'
 import { useMemo } from 'react'
-import { multiChainId, multiChainScan, v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
+import { multiChainId, multiChainScan, subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
 import {
   useChainIdByQuery,
   useChainNameByQuery,
@@ -170,10 +170,10 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
                     fontSize={isXs || isSm ? '24px' : '40px'}
                     id="info-token-name-title"
                   >
-                    {v2SubgraphTokenName[tokenData.address] ?? tokenData.name}
+                    {subgraphTokenName[tokenData.address] ?? tokenData.name}
                   </Text>
                   <Text ml="12px" lineHeight="1" color="textSubtle" fontSize={isXs || isSm ? '14px' : '20px'}>
-                    ({v2SubgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})
+                    ({subgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})
                   </Text>
                 </Flex>
                 <Flex mt="8px" ml="46px" alignItems="center">

--- a/apps/web/src/views/Info/components/InfoSearch/index.tsx
+++ b/apps/web/src/views/Info/components/InfoSearch/index.tsx
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { checkIsStableSwap, v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
+import { checkIsStableSwap, subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
 import {
   useChainIdByQuery,
   useChainNameByQuery,
@@ -323,8 +323,8 @@ const Search = () => {
                     <Flex>
                       <CurrencyLogo address={token.address} chainName={chainName} />
                       <Text ml="10px">
-                        <Text>{`${v2SubgraphTokenName[token.address] ?? token.name} (${
-                          v2SubgraphTokenSymbol[token.address] ?? token.symbol
+                        <Text>{`${subgraphTokenName[token.address] ?? token.name} (${
+                          subgraphTokenSymbol[token.address] ?? token.symbol
                         })`}</Text>
                       </Text>
                       <SaveIcon

--- a/apps/web/src/views/Info/components/InfoSearch/index.tsx
+++ b/apps/web/src/views/Info/components/InfoSearch/index.tsx
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { checkIsStableSwap, v2SubgraphTokenName } from 'state/info/constant'
+import { checkIsStableSwap, v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
 import {
   useChainIdByQuery,
   useChainNameByQuery,
@@ -323,7 +323,9 @@ const Search = () => {
                     <Flex>
                       <CurrencyLogo address={token.address} chainName={chainName} />
                       <Text ml="10px">
-                        <Text>{`${v2SubgraphTokenName[token.address] ?? token.name} (${token.symbol})`}</Text>
+                        <Text>{`${v2SubgraphTokenName[token.address] ?? token.name} (${
+                          v2SubgraphTokenSymbol[token.address] ?? token.symbol
+                        })`}</Text>
                       </Text>
                       <SaveIcon
                         id="watchlist-icon"

--- a/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
@@ -11,7 +11,7 @@ import {
   NextLinkFromReactRouter,
 } from '@pancakeswap/uikit'
 import { useMultiChainPath, useStableSwapPath, useChainNameByQuery } from 'state/info/hooks'
-import { v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
+import { subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
 import { TokenData } from 'state/info/types'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import Percent from 'views/Info/components/Percent'
@@ -114,8 +114,8 @@ const DataRow: React.FC<React.PropsWithChildren<{ tokenData: TokenData; index: n
           {(isXs || isSm) && <Text ml="8px">{tokenData.symbol}</Text>}
           {!isXs && !isSm && (
             <Flex marginLeft="10px">
-              <Text>{v2SubgraphTokenName[tokenData.address] ?? tokenData.name}</Text>
-              <Text ml="8px">({v2SubgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})</Text>
+              <Text>{subgraphTokenName[tokenData.address] ?? tokenData.name}</Text>
+              <Text ml="8px">({subgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})</Text>
             </Flex>
           )}
         </Flex>

--- a/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
@@ -11,7 +11,7 @@ import {
   NextLinkFromReactRouter,
 } from '@pancakeswap/uikit'
 import { useMultiChainPath, useStableSwapPath, useChainNameByQuery } from 'state/info/hooks'
-import { v2SubgraphTokenName } from 'state/info/constant'
+import { v2SubgraphTokenName, v2SubgraphTokenSymbol } from 'state/info/constant'
 import { TokenData } from 'state/info/types'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import Percent from 'views/Info/components/Percent'
@@ -115,7 +115,7 @@ const DataRow: React.FC<React.PropsWithChildren<{ tokenData: TokenData; index: n
           {!isXs && !isSm && (
             <Flex marginLeft="10px">
               <Text>{v2SubgraphTokenName[tokenData.address] ?? tokenData.name}</Text>
-              <Text ml="8px">({tokenData.symbol})</Text>
+              <Text ml="8px">({v2SubgraphTokenSymbol[tokenData.address] ?? tokenData.symbol})</Text>
             </Flex>
           )}
         </Flex>

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -11,7 +11,7 @@ import { useChainNameByQuery } from 'state/info/hooks'
 import { Transaction, TransactionType } from 'state/info/types'
 import styled from 'styled-components'
 import { getBlockExploreLink } from 'utils'
-import { v2SubgraphTokenSymbol } from 'state/info/constant'
+import { subgraphTokenSymbol } from 'state/info/constant'
 
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { useDomainNameForAddress } from 'hooks/useDomain'
@@ -101,10 +101,13 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
   const { t } = useTranslation()
   const abs0 = Math.abs(transaction.amountToken0)
   const abs1 = Math.abs(transaction.amountToken1)
-  const outputTokenSymbol = transaction.amountToken0 < 0 ? transaction.token0Symbol : transaction.token1Symbol
-  const inputTokenSymbol = transaction.amountToken1 < 0 ? transaction.token0Symbol : transaction.token1Symbol
   const chainName = useChainNameByQuery()
   const { domainName } = useDomainNameForAddress(transaction.sender)
+  const token0Symbol = subgraphTokenSymbol[transaction.token0Address.toLowerCase()] ?? transaction.token0Symbol
+  const token1Symbol = subgraphTokenSymbol[transaction.token1Address.toLowerCase()] ?? transaction.token1Symbol
+  const outputTokenSymbol = transaction.amountToken0 < 0 ? token0Symbol : token1Symbol
+  const inputTokenSymbol = transaction.amountToken1 < 0 ? token0Symbol : token1Symbol
+
   return (
     <ResponsiveGrid>
       <LinkExternal
@@ -114,21 +117,17 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
         <Text>
           {transaction.type === TransactionType.MINT
             ? t('Add %token0% and %token1%', {
-                token0:
-                  v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? transaction.token0Symbol,
-                token1:
-                  v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? transaction.token1Symbol,
+                token0: token0Symbol,
+                token1: token1Symbol,
               })
             : transaction.type === TransactionType.SWAP
             ? t('Swap %token0% for %token1%', {
-                token0: v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? inputTokenSymbol,
-                token1: v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? outputTokenSymbol,
+                token0: inputTokenSymbol,
+                token1: outputTokenSymbol,
               })
             : t('Remove %token0% and %token1%', {
-                token0:
-                  v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? transaction.token0Symbol,
-                token1:
-                  v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? transaction.token1Symbol,
+                token0: token0Symbol,
+                token1: token1Symbol,
               })}
         </Text>
       </LinkExternal>

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -11,6 +11,7 @@ import { useChainNameByQuery } from 'state/info/hooks'
 import { Transaction, TransactionType } from 'state/info/types'
 import styled from 'styled-components'
 import { getBlockExploreLink } from 'utils'
+import { v2SubgraphTokenSymbol } from 'state/info/constant'
 
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { useDomainNameForAddress } from 'hooks/useDomain'
@@ -112,10 +113,23 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
       >
         <Text>
           {transaction.type === TransactionType.MINT
-            ? t('Add %token0% and %token1%', { token0: transaction.token0Symbol, token1: transaction.token1Symbol })
+            ? t('Add %token0% and %token1%', {
+                token0:
+                  v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? transaction.token0Symbol,
+                token1:
+                  v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? transaction.token1Symbol,
+              })
             : transaction.type === TransactionType.SWAP
-            ? t('Swap %token0% for %token1%', { token0: inputTokenSymbol, token1: outputTokenSymbol })
-            : t('Remove %token0% and %token1%', { token0: transaction.token0Symbol, token1: transaction.token1Symbol })}
+            ? t('Swap %token0% for %token1%', {
+                token0: v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? inputTokenSymbol,
+                token1: v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? outputTokenSymbol,
+              })
+            : t('Remove %token0% and %token1%', {
+                token0:
+                  v2SubgraphTokenSymbol[transaction?.token0Address?.toLocaleLowerCase()] ?? transaction.token0Symbol,
+                token1:
+                  v2SubgraphTokenSymbol[transaction?.token1Address?.toLocaleLowerCase()] ?? transaction.token1Symbol,
+              })}
         </Text>
       </LinkExternal>
       <Text>${formatAmount(transaction.amountUSD)}</Text>

--- a/apps/web/src/views/V3Info/components/PoolTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/PoolTable/index.tsx
@@ -5,6 +5,7 @@ import NextLink from 'next/link'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useChainNameByQuery, useMultiChainPath } from 'state/info/hooks'
 import styled from 'styled-components'
+import { subgraphTokenSymbol } from 'state/info/constant'
 import { DoubleCurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import { Arrow, Break, ClickableColumnHeader, PageButtons, TableWrapper } from 'views/Info/components/InfoTables/shared'
 import { POOL_HIDE, v3InfoPath } from '../../constants'
@@ -74,7 +75,8 @@ const DataRow = ({ poolData, index, chainPath }: { poolData: PoolData; index: nu
               chainName={chainName}
             />
             <Text ml="8px">
-              {poolData.token0.symbol}/{poolData.token1.symbol}
+              {subgraphTokenSymbol[poolData.token0.address] ?? poolData.token0.symbol}/
+              {subgraphTokenSymbol[poolData.token1.address] ?? poolData.token1.symbol}
             </Text>
             <GreyBadge ml="10px" style={{ fontSize: 14 }}>
               {feeTierPercent(poolData.feeTier)}

--- a/apps/web/src/views/V3Info/components/Search/index.tsx
+++ b/apps/web/src/views/V3Info/components/Search/index.tsx
@@ -5,7 +5,7 @@ import { MINIMUM_SEARCH_CHARACTERS } from 'config/constants/info'
 import orderBy from 'lodash/orderBy'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { checkIsStableSwap } from 'state/info/constant'
+import { checkIsStableSwap, subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
 import { useChainNameByQuery, useMultiChainPath } from 'state/info/hooks'
 import { useWatchlistPools, useWatchlistTokens } from 'state/user/hooks'
 import styled from 'styled-components'
@@ -213,7 +213,7 @@ const Search = () => {
   const [showWatchlist, setShowWatchlist] = useState(false)
   const tokensForList = useMemo(() => {
     if (showWatchlist) {
-      return watchListTokenData.filter((token) => tokenIncludesSearchTerm(token, value))
+      return watchListTokenData?.filter((token) => tokenIncludesSearchTerm(token, value))
     }
     return orderBy(tokens, (token) => token.volumeUSD, 'desc')
   }, [showWatchlist, tokens, watchListTokenData, value])
@@ -323,7 +323,9 @@ const Search = () => {
                     <Flex>
                       <CurrencyLogo address={token.address} chainName={chainName} />
                       <Text ml="10px">
-                        <Text>{`${token.name} (${token.symbol})`}</Text>
+                        <Text>{`${subgraphTokenName[token.address] ?? token.name} (${
+                          subgraphTokenSymbol[token.address] ?? token.symbol
+                        })`}</Text>
                       </Text>
                       {/* <SaveIcon
                         id="watchlist-icon"
@@ -390,7 +392,9 @@ const Search = () => {
                         chainName={chainName}
                       />
                       <Text ml="10px" style={{ whiteSpace: 'nowrap' }}>
-                        <Text>{`${p.token0.symbol} / ${p.token1.symbol}`}</Text>
+                        <Text>{`${subgraphTokenSymbol[p.token0.address] ?? p.token0.symbol} / ${
+                          subgraphTokenSymbol[p.token1.address] ?? p.token1.symbol
+                        }`}</Text>
                       </Text>
                       <GreyBadge ml="10px" style={{ fontSize: 14 }}>
                         {feeTierPercent(p.feeTier)}

--- a/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@pancakeswap/uikit'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useChainNameByQuery } from 'state/info/hooks'
-import { multiChainId } from 'state/info/constant'
+import { multiChainId, subgraphTokenSymbol } from 'state/info/constant'
 import styled from 'styled-components'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { Arrow, Break, ClickableColumnHeader, PageButtons, TableWrapper } from 'views/Info/components/InfoTables/shared'
@@ -94,9 +94,11 @@ const SORT_FIELD = {
 const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) => {
   const abs0 = Math.abs(transaction.amountToken0)
   const abs1 = Math.abs(transaction.amountToken1)
-  const outputTokenSymbol = transaction.amountToken0 < 0 ? transaction.token0Symbol : transaction.token1Symbol
-  const inputTokenSymbol = transaction.amountToken1 < 0 ? transaction.token0Symbol : transaction.token1Symbol
   const chainName = useChainNameByQuery()
+  const token0Symbol = subgraphTokenSymbol[transaction.token0Address.toLowerCase()] ?? transaction.token0Symbol
+  const token1Symbol = subgraphTokenSymbol[transaction.token1Address.toLowerCase()] ?? transaction.token1Symbol
+  const outputTokenSymbol = transaction.amountToken0 < 0 ? token0Symbol : token1Symbol
+  const inputTokenSymbol = transaction.amountToken1 < 0 ? token0Symbol : token1Symbol
 
   return (
     <ResponsiveGrid>
@@ -106,18 +108,18 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
       >
         <Text fontWeight={400}>
           {transaction.type === TransactionType.MINT
-            ? `Add ${transaction.token0Symbol} and ${transaction.token1Symbol}`
+            ? `Add ${token0Symbol} and ${token1Symbol}`
             : transaction.type === TransactionType.SWAP
             ? `Swap ${inputTokenSymbol} for ${outputTokenSymbol}`
-            : `Remove ${transaction.token0Symbol} and ${transaction.token1Symbol}`}
+            : `Remove ${token0Symbol} and ${token1Symbol}`}
         </Text>
       </LinkExternal>
       <Text fontWeight={400}>{formatDollarAmount(transaction.amountUSD)}</Text>
       <Text fontWeight={400}>
-        <HoverInlineText text={`${formatAmount(abs0)}  ${transaction.token0Symbol}`} maxCharacters={16} />
+        <HoverInlineText text={`${formatAmount(abs0)}  ${token0Symbol}`} maxCharacters={16} />
       </Text>
       <Text fontWeight={400}>
-        <HoverInlineText text={`${formatAmount(abs1)}  ${transaction.token1Symbol}`} maxCharacters={16} />
+        <HoverInlineText text={`${formatAmount(abs1)}  ${token1Symbol}`} maxCharacters={16} />
       </Text>
       <Text fontWeight={400}>
         <LinkExternal

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -20,7 +20,6 @@ import {
 import Page from 'components/Layout/Page'
 import { TabToggle, TabToggleGroup } from 'components/TabToggle'
 import dayjs from 'dayjs'
-// import { useActiveChainId } from 'hooks/useActiveChainId'
 import { CHAIN_QUERY_NAME } from 'config/chains'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useTheme from 'hooks/useTheme'
@@ -29,9 +28,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { getBlockExploreLink } from 'utils'
 import { formatAmount } from 'utils/formatInfoNumbers'
 
-// import { useSavedTokens } from 'state/user/hooks'
 import truncateHash from '@pancakeswap/utils/truncateHash'
-import { multiChainId, multiChainScan } from 'state/info/constant'
+import { multiChainId, multiChainScan, subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
 import { useChainNameByQuery, useMultiChainPath, useStableSwapPath } from 'state/info/hooks'
 import styled from 'styled-components'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
@@ -155,9 +153,6 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
   const chainName = useChainNameByQuery()
   const { chainId } = useActiveChainId()
 
-  // watchlist
-  // const [savedTokens, addSavedToken] = useSavedTokens()
-
   return (
     <Page>
       {tokenData ? (
@@ -184,7 +179,7 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                     <Text color="primary">{t('Tokens')}</Text>
                   </NextLinkFromReactRouter>
                   <Flex>
-                    <Text mr="8px">{tokenData.symbol}</Text>
+                    <Text mr="8px">{subgraphTokenSymbol[address.toLowerCase()] ?? tokenData.symbol}</Text>
                     <Text>{`(${truncateHash(address)})`}</Text>
                   </Flex>
                 </Breadcrumbs>
@@ -216,10 +211,10 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                       fontSize={isXs || isSm ? '24px' : '40px'}
                       id="info-token-name-title"
                     >
-                      {tokenData.name}
+                      {subgraphTokenName[address.toLowerCase()] ?? tokenData.name}
                     </Text>
                     <Text ml="12px" lineHeight="1" color="textSubtle" fontSize={isXs || isSm ? '14px' : '20px'}>
-                      ({tokenData.symbol})
+                      ({subgraphTokenSymbol[address.toLowerCase()] ?? tokenData.symbol})
                     </Text>
                   </Flex>
                   <Flex mt="8px" ml="46px" alignItems="center">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 31c0bbc</samp>

### Summary
🗺️🔄🆕

<!--
1.  🗺️ - This emoji can represent the subgraph, which is a way of mapping data from the blockchain to a queryable format. It can also suggest the idea of adding or updating an entry in a mapping object.
2.  🔄 - This emoji can represent the change of address for the TUSD token, which implies a migration or swap from the old to the new version. It can also suggest the idea of fixing or updating something that was outdated or incorrect.
3.  🆕 - This emoji can represent the addition of support for new tokens, which implies a feature or enhancement that expands the scope or functionality of the subgraph. It can also suggest the idea of introducing something new or novel.
-->
Add old TUSD token name to v2 subgraph mapping. This helps display correct data for some historical transactions and pools involving the old TUSD token.

> _`v2SubgraphTokenName`_
> _Maps old and new addresses_
> _Autumn of TUSD_

### Walkthrough
*  Add old TUSD token name to v2 subgraph mapping ([link](https://github.com/pancakeswap/pancake-frontend/pull/7189/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R84))


