### PR TITLE
chore: Add linea testnet network switcher

### DIFF
--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -44,8 +44,7 @@ const NetworkSelect = ({ switchNetwork, chainId }) => {
       {chains
         .filter(
           (chain) =>
-            // chain.id === ChainId.LINEA_TESTNET ||
-            !('testnet' in chain && chain.testnet) || chain.id === chainId,
+            chain.id === ChainId.LINEA_TESTNET || !('testnet' in chain && chain.testnet) || chain.id === chainId,
         )
         .map((chain) => (
           <UserMenuItem

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -43,6 +43,7 @@ import { useAtom } from 'jotai'
 import { FindOtherLP } from '@pancakeswap/uikit/src/widgets/Liquidity'
 import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import { isV3MigrationSupported } from 'utils/isV3MigrationSupported'
 
 const Body = styled(CardBody)`
   background-color: ${({ theme }) => theme.colors.dropdownDeep};
@@ -195,12 +196,15 @@ export default function PoolListPage() {
   }, [selectedTypeIndex, stablePairsSection, t, v2Loading, v2PairsSection, v3Loading, v3PairsSection])
 
   const [onPresentTransactionsModal] = useModal(<TransactionsModal />)
+  const isMigrationSupported = useMemo(() => isV3MigrationSupported(chainId), [chainId])
 
   return (
     <Page>
-      <Flex m="24px 0" maxWidth="854px">
-        <FarmV3MigrationBanner />
-      </Flex>
+      {isMigrationSupported && (
+        <Flex m="24px 0" maxWidth="854px">
+          <FarmV3MigrationBanner />
+        </Flex>
+      )}
       <AppBody
         style={{
           maxWidth: '854px',

--- a/apps/web/src/pages/migration.tsx
+++ b/apps/web/src/pages/migration.tsx
@@ -1,8 +1,8 @@
-import { CHAIN_IDS } from 'utils/wagmi'
+import { V3_MIGRATION_SUPPORTED_CHAINS } from 'utils/isV3MigrationSupported'
 import Migration from '../views/Migration/v3'
 
 const MigrationPage = () => <Migration />
 
-MigrationPage.chains = CHAIN_IDS
+MigrationPage.chains = V3_MIGRATION_SUPPORTED_CHAINS
 
 export default MigrationPage

--- a/apps/web/src/utils/isV3MigrationSupported.ts
+++ b/apps/web/src/utils/isV3MigrationSupported.ts
@@ -1,0 +1,7 @@
+import { ChainId } from '@pancakeswap/sdk'
+
+export const V3_MIGRATION_SUPPORTED_CHAINS = [ChainId.BSC, ChainId.ETHEREUM]
+
+export function isV3MigrationSupported(chainId: ChainId) {
+  return V3_MIGRATION_SUPPORTED_CHAINS.includes(chainId)
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9a31210</samp>

### Summary
🌐🔧🧪

<!--
1.  🌐 - This emoji represents the concept of networks or chains, and could be used to indicate that the change affects the network switcher component and the available chains.
2.  🔧 - This emoji represents the idea of configuration or settings, and could be used to indicate that the change involves enabling or disabling a chain option that was previously commented out.
3.  🧪 - This emoji represents the notion of testing or experimentation, and could be used to indicate that the change is part of a feature to support Linea Testnet integration, which is a testnet environment for the Linea protocol.
-->
Enable Linea Testnet option in `NetworkSelect` component. This allows users to switch to the Linea Testnet chain from the network switcher in the web app.

> _`NetworkSelect` shows_
> _Linea Testnet chain now_
> _Autumn of testing_

### Walkthrough
*  Enable Linea Testnet chain in network switcher by uncommenting the corresponding option in `NetworkSelect` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7206/files?diff=unified&w=0#diff-5b02b946734e39568c018763a8445fe22e5633c04fa393f78eaec1947165713dL47-R47))


