### PR TITLE
fix: farm APR tooptip style

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -206,7 +206,10 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
           {t('Farm APR')}:{' '}
           <b>
             {canBoosted && <>{parseFloat(cakeAprDisplay) * USER_ESTIMATED_MULTIPLIER}% </>}
-            <Text display="inline-block" style={{ textDecoration: canBoosted ? 'line-through' : 'none' }}>
+            <Text
+              display="inline-block"
+              style={{ textDecoration: canBoosted ? 'line-through' : 'none', fontWeight: 800 }}
+            >
               {cakeAprDisplay}%
             </Text>
           </b>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9502a8c</samp>

### Summary
🍰🔥🎨

<!--
1.  🍰 - This emoji represents the cake APR and the main feature of the farm card. It also conveys a sense of reward and sweetness for the users who stake their tokens and earn cake.
2.  🔥 - This emoji represents the higher font weight and the increased visibility of the cake APR. It also suggests that the cake APR is hot, attractive, and competitive among other farms.
3.  🎨 - This emoji represents the design and layout improvement of the farm card. It also implies that the UI is more colorful, appealing, and user-friendly.
-->
Increased font weight of cake APR on farm card. This is part of a PR to enhance the farm card UI.

> _`Text` component shines_
> _Cake APR more visible_
> _Winter harvest time_

### Walkthrough
*  Increase the font weight of the cake APR text to 800 for better visibility and consistency ([link](https://github.com/pancakeswap/pancake-frontend/pull/7207/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L209-R212))


