### PR TITLE
chore: Bcake card modal style

### DIFF
--- a/packages/uikit/src/widgets/Farm/components/FarmV3Card/ViewAllFarmModal.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmV3Card/ViewAllFarmModal.tsx
@@ -59,14 +59,10 @@ const ViewAllFarmModal: React.FunctionComponent<React.PropsWithChildren<ViewAllF
             <Text bold m="0 8px">
               {lpSymbol.split(" ")[0]}
             </Text>
-            <AutoRow gap="4px" justifyContent="flex-start" flex={1}>
-              {isReady && multiplier && (
-                <Tag mr="4px" variant="secondary">
-                  {multiplier}
-                </Tag>
-              )}
-              {isReady && feeAmount && <V3FeeTag mr="4px" feeAmount={feeAmount} />}
-              {isReady && boosted && <BoostedTag mr="4px" />}
+            <AutoRow gap="4px" justifyContent="flex-start" flexWrap="nowrap" flex={1}>
+              {isReady && multiplier && <Tag variant="secondary">{multiplier}</Tag>}
+              {isReady && feeAmount && <V3FeeTag feeAmount={feeAmount} />}
+              {isReady && boosted && <BoostedTag />}
               {isReady && isCommunityFarm && <FarmAuctionTag />}
             </AutoRow>
           </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc487db</samp>

### Summary
🏷️🚫📏

<!--
1.  🏷️ - This emoji represents the tags that are displayed for each farm and indicates that they are the main focus of the change.
2.  🚫 - This emoji represents the removal of the `mr` prop, which was adding a right margin to the tags and causing them to wrap to the next line. This emoji suggests that the change is a deletion or a negation of something.
3.  📏 - This emoji represents the addition of the `flexWrap` prop with the value `nowrap`, which ensures that the tags stay on the same line and have a consistent spacing. This emoji suggests that the change is related to the layout or the measurement of the elements.
-->
Refactor the UI of the farm cards and modals to improve readability and consistency. Adjust the `AutoRow` component in `ViewAllFarmModal.tsx` to prevent tag wrapping and spacing issues.

> _`AutoRow` changes_
> _Tags align without wrapping_
> _A crisp autumn look_

### Walkthrough
*  Prevent tags from wrapping to the next line and improve spacing in farm modal ([link](https://github.com/pancakeswap/pancake-frontend/pull/7210/files?diff=unified&w=0#diff-1968f24ccb8c3a13a854438957d81ff901db7335a09fffec8166b73d5ccc7c88L62-R65))


