### PR TITLE
fix: loading user data in eth

### DIFF
--- a/apps/web/src/state/farms/hooks.ts
+++ b/apps/web/src/state/farms/hooks.ts
@@ -12,7 +12,6 @@ import {
   DeserializedFarmsState,
   DeserializedFarmUserData,
   supportedChainIdV2,
-  bCakeSupportedChainId,
 } from '@pancakeswap/farms'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useCakePriceAsBN } from '@pancakeswap/utils/useCakePrice'
@@ -77,7 +76,7 @@ export const usePollFarmsWithUserData = () => {
     : ['farmsWithUserData', account, chainId]
 
   useSWRImmutable(
-    account && chainId && bCakeSupportedChainId.includes(chainId) && !isProxyContractLoading ? name : null,
+    account && chainId && !isProxyContractLoading ? name : null,
     async () => {
       const farmsConfig = await getFarmConfig(chainId)
       if (!farmsConfig) return


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd3c591</samp>

### Summary
🧹🚀🌐

<!--
1.  🧹 - This emoji represents cleaning or simplifying the code, as the redundant check was removed.
2.  🚀 - This emoji represents improving the performance or speed of the code, as the unnecessary requests were avoided.
3.  🌐 - This emoji represents supporting different networks or chains, as the `getFarmConfig` function handles the logic for different chains.
-->
Simplify the condition for fetching farms data with user data in `hooks.ts`. Remove the redundant check for supported chains and rely on `getFarmConfig` function.

> _`getFarmConfig` knows_
> _which farms to fetch for each chain_
> _no need to repeat_

### Walkthrough
*  Simplify the condition for fetching farms data with user data by removing the redundant check for supported chain ID ([link](https://github.com/pancakeswap/pancake-frontend/pull/7215/files?diff=unified&w=0#diff-d2eaffdd7ab90a7ab1ad130cf4adcf8ef339e13c92c8f75b72b6acc3a5e7508dL80-R80))


