### PR TITLE
fix: Wallet connect modal is not on the correct layer

### DIFF
--- a/apps/web/src/style/Global.tsx
+++ b/apps/web/src/style/Global.tsx
@@ -18,6 +18,16 @@ const GlobalStyle = createGlobalStyle`
       max-width: 100%;
     }
   }
+
+  #__next {
+    position: relative;
+    z-index: 1;
+  }
+
+  #portal-root {
+    position: relative;
+    z-index: 2;
+  }
 `
 
 export default GlobalStyle


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f360a78</samp>

### Summary
🎨🚀🐛

<!--
1.  🎨 - This emoji is often used to indicate changes related to styling, layout, or appearance of the UI. Since this change adds CSS rules, it is relevant to this category.
2.  🚀 - This emoji is often used to indicate changes related to performance, optimization, or enhancement of the code or functionality. Since this change is part of a larger refactor that improves the modal and popover components, it is relevant to this category.
3.  🐛 - This emoji is often used to indicate changes related to fixing bugs, errors, or issues. Since this change might prevent potential conflicts or glitches with other CSS libraries or components, it is relevant to this category.
-->
Set CSS position and z-index for Next.js and portal root elements. This helps render modals and popovers correctly using React portals.

> _`#__next` and `#portal-root`_
> _positioned with z-index_
> _autumn leaves fall behind_

### Walkthrough
* Set the position and z-index of the root elements for Next.js and React portals ([link](https://github.com/pancakeswap/pancake-frontend/pull/7225/files?diff=unified&w=0#diff-65d91b88bc1a60f697c05c9dca2b9df865bd3a9765441f34fb2b381cbfc1b1d5R21-R30))


