### PR TITLE
feat: new v3 farm auction config

### DIFF
--- a/apps/web/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionDetailsCard/AuctionFooter.tsx
@@ -4,7 +4,8 @@ import { Text, Flex, Box, CardFooter, ExpandableLabel } from '@pancakeswap/uikit
 import { useTranslation } from '@pancakeswap/localization'
 import { Auction, AuctionStatus } from 'config/constants/types'
 import WhitelistedBiddersButton from '../WhitelistedBiddersButton'
-import { HARD_CODED_START_AUCTION_ID, HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../../constants'
+import { HARD_CODED_START_AUCTION_ID } from '../../constants'
+import { useV3FarmAuctionConfig } from '../../hooks/useV3FarmAuctionConfig'
 
 const FooterInner = styled(Box)`
   background-color: ${({ theme }) => theme.colors.dropdown};
@@ -15,6 +16,7 @@ const AuctionFooter: React.FC<React.PropsWithChildren<{ auction: Auction }>> = (
   const { t } = useTranslation()
   const { topLeaderboard, status } = auction
   const shouldUseV3Format = auction?.id >= HARD_CODED_START_AUCTION_ID
+  const v3FarmAuctionConfig = useV3FarmAuctionConfig(auction.id)
 
   const isLiveOrPendingAuction = status === AuctionStatus.Pending || status === AuctionStatus.Open
 
@@ -34,9 +36,7 @@ const AuctionFooter: React.FC<React.PropsWithChildren<{ auction: Auction }>> = (
             <Flex justifyContent="space-between" width="100%" pt="8px" px="8px">
               <Text color="textSubtle">{t('Multiplier per farm')}</Text>
               <Text>
-                {shouldUseV3Format
-                  ? `${HARD_CODE_TOP_THREE_AUCTION_DATAS.map((d) => d[1]).join('x,')}x`
-                  : `1x ${t('each')}`}
+                {shouldUseV3Format ? `${v3FarmAuctionConfig.map((d) => d[1]).join('x,')}x` : `1x ${t('each')}`}
               </Text>
             </Flex>
             <Flex justifyContent="space-between" width="100%" pt="8px" px="8px">

--- a/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
@@ -16,7 +16,6 @@ import {
 import { useTranslation } from '@pancakeswap/localization'
 import AuctionLeaderboardTable from './AuctionLeaderboard/AuctionLeaderboardTable'
 import { useFarmAuction } from '../hooks/useFarmAuction'
-import { HARD_CODED_START_AUCTION_ID } from '../constants'
 
 interface AuctionHistoryProps {
   mostRecentClosedAuctionId: number
@@ -61,7 +60,7 @@ const AuctionHistory: React.FC<React.PropsWithChildren<AuctionHistoryProps>> = (
     auction && bidders ? (
       <AuctionLeaderboardTable
         bidders={bidders}
-        shouldUseV3Format={auction?.id >= HARD_CODED_START_AUCTION_ID}
+        auctionId={auction?.id || 0}
         noBidsText="No bids were placed in this auction"
       />
     ) : (

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -21,7 +21,8 @@ import { useTranslation } from '@pancakeswap/localization'
 import { usePriceCakeUSD } from 'state/farms/hooks'
 import { Bidder } from 'config/constants/types'
 import WhitelistedBiddersModal from '../WhitelistedBiddersModal'
-import { HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../../constants'
+import { HARD_CODED_START_AUCTION_ID } from '../../constants'
+import { useV3FarmAuctionConfig } from '../../hooks/useV3FarmAuctionConfig'
 
 const LeaderboardContainer = styled.div`
   display: grid;
@@ -44,7 +45,7 @@ interface LeaderboardRowProps {
   cakePriceBusd: BigNumber
   isMobile: boolean
   index: number
-  shouldUseV3Format: boolean
+  auctionId: number
 }
 
 const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = ({
@@ -52,9 +53,11 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
   cakePriceBusd,
   isMobile,
   index,
-  shouldUseV3Format,
+  auctionId,
 }) => {
   const { t } = useTranslation()
+  const shouldUseV3Format = auctionId >= HARD_CODED_START_AUCTION_ID
+  const v3FarmAuctionConfig = useV3FarmAuctionConfig(auctionId)
   const { isTopPosition, position, samePositionAsAbove, farmName, tokenName, amount, projectSite, lpAddress, account } =
     bidder
   return (
@@ -77,8 +80,8 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
               <>
                 {shouldUseV3Format ? (
                   <>
-                    <Text mr="3px">({HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[0]}% fee tier)</Text>
-                    <Text>[{HARD_CODE_TOP_THREE_AUCTION_DATAS?.[index]?.[1] ?? 1}x]</Text>
+                    <Text mr="3px">({v3FarmAuctionConfig?.[index]?.[0]}% fee tier)</Text>
+                    <Text>[{v3FarmAuctionConfig?.[index]?.[1] ?? 1}x]</Text>
                   </>
                 ) : (
                   <Text>(1x)</Text>
@@ -137,8 +140,8 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
 }
 
 const AuctionLeaderboardTable: React.FC<
-  React.PropsWithChildren<{ bidders: Bidder[]; noBidsText: string; shouldUseV3Format?: boolean }>
-> = ({ bidders, noBidsText, shouldUseV3Format = false }) => {
+  React.PropsWithChildren<{ bidders: Bidder[]; noBidsText: string; auctionId: number }>
+> = ({ bidders, noBidsText, auctionId }) => {
   const [visibleBidders, setVisibleBidders] = useState(10)
   const cakePriceBusd = usePriceCakeUSD()
   const { t } = useTranslation()
@@ -186,7 +189,7 @@ const AuctionLeaderboardTable: React.FC<
             cakePriceBusd={cakePriceBusd}
             isMobile={isMobile}
             index={index}
-            shouldUseV3Format={shouldUseV3Format}
+            auctionId={auctionId}
           />
         ))}
       </LeaderboardContainer>

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
@@ -75,11 +75,7 @@ const CurrentAuctionCard: React.FC<React.PropsWithChildren<AuctionLeaderboardPro
           </Text>
           <AuctionRibbon auction={auction} noAuctionHistory={getMostRecentClosedAuctionId(id, status) === null} />
           <AuctionProgress auction={auction} />
-          <AuctionLeaderboardTable
-            bidders={bidders}
-            noBidsText={t('No bids yet')}
-            shouldUseV3Format={id >= HARD_CODED_START_AUCTION_ID}
-          />
+          <AuctionLeaderboardTable bidders={bidders} noBidsText={t('No bids yet')} auctionId={id} />
         </Box>
       ) : (
         <AuctionHistory mostRecentClosedAuctionId={getMostRecentClosedAuctionId(id, status)} />

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/index.tsx
@@ -1,14 +1,13 @@
+import { useTranslation } from '@pancakeswap/localization'
+import { Box, Card, Flex, Spinner, Text } from '@pancakeswap/uikit'
+import { TabToggle, TabToggleGroup } from 'components/TabToggle'
+import { Auction, AuctionStatus, Bidder } from 'config/constants/types'
 import { useState } from 'react'
 import styled from 'styled-components'
-import { Text, Card, Flex, Box, Spinner } from '@pancakeswap/uikit'
-import { useTranslation } from '@pancakeswap/localization'
-import { Auction, AuctionStatus, Bidder } from 'config/constants/types'
-import { TabToggleGroup, TabToggle } from 'components/TabToggle'
 import AuctionHistory from '../AuctionHistory'
+import AuctionLeaderboardTable from './AuctionLeaderboardTable'
 import AuctionProgress from './AuctionProgress'
 import AuctionRibbon from './AuctionRibbon'
-import AuctionLeaderboardTable from './AuctionLeaderboardTable'
-import { HARD_CODED_START_AUCTION_ID } from '../../constants'
 
 const AuctionLeaderboardCard = styled(Card)`
   width: 100%;

--- a/apps/web/src/views/FarmAuction/components/CongratulationsCard.tsx
+++ b/apps/web/src/views/FarmAuction/components/CongratulationsCard.tsx
@@ -1,11 +1,12 @@
-import styled from 'styled-components'
-import { Text, Heading, Card, CardHeader, CardBody, Flex } from '@pancakeswap/uikit'
-import { Auction, Bidder } from 'config/constants/types'
 import { useTranslation } from '@pancakeswap/localization'
+import { Card, CardBody, CardHeader, Flex, Heading, Text } from '@pancakeswap/uikit'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
+import { Auction, Bidder } from 'config/constants/types'
+import styled from 'styled-components'
+import { HARD_CODED_START_AUCTION_ID } from '../constants'
 import useCongratulateAuctionWinner from '../hooks/useCongratulateAuctionWinner'
+import { useV3FarmAuctionConfig } from '../hooks/useV3FarmAuctionConfig'
 import WhitelistedBiddersButton from './WhitelistedBiddersButton'
-import { HARD_CODED_START_AUCTION_ID, HARD_CODE_TOP_THREE_AUCTION_DATAS } from '../constants'
 
 const StyledReclaimBidCard = styled(Card)`
   margin-top: 16px;
@@ -19,6 +20,7 @@ const CongratulationsCard: React.FC<React.PropsWithChildren<{ currentAuction: Au
   const { t } = useTranslation()
   const wonAuction = useCongratulateAuctionWinner(currentAuction, bidders)
   const shouldUseV3Format = currentAuction?.id >= HARD_CODED_START_AUCTION_ID
+  const v3FarmAuctionConfig = useV3FarmAuctionConfig(currentAuction?.id)
 
   if (!wonAuction) {
     return null
@@ -37,11 +39,7 @@ const CongratulationsCard: React.FC<React.PropsWithChildren<{ currentAuction: Au
         <Flex flexDirection="column" mb="24px">
           <Flex justifyContent="space-between" width="100%" pt="8px">
             <Text color="textSubtle">{t('Multiplier per farm')}</Text>
-            <Text>
-              {shouldUseV3Format
-                ? `${HARD_CODE_TOP_THREE_AUCTION_DATAS.map((d) => d[1]).join('x,')}x`
-                : `1x ${t('each')}`}
-            </Text>
+            <Text>{shouldUseV3Format ? `${v3FarmAuctionConfig.map((d) => d[1]).join('x,')}x` : `1x ${t('each')}`}</Text>
           </Flex>
           <Flex justifyContent="space-between" width="100%" pt="8px">
             <Text color="textSubtle">{t('Total whitelisted bidders')}</Text>

--- a/apps/web/src/views/FarmAuction/constants.ts
+++ b/apps/web/src/views/FarmAuction/constants.ts
@@ -1,8 +1,21 @@
 export const HARD_CODED_START_AUCTION_ID = 34
 
 // [feeTier, multiplier][]
-export const HARD_CODE_TOP_THREE_AUCTION_DATAS = [
+export const HARD_CODE_TOP_THREE_AUCTION_DATA = [
   [1, 6],
   [1, 2],
   [1, 1],
 ]
+// id: [feeTier, multiplier][]
+export const HARD_CODE_V3_AUCTION_DATA_BY_ID = {
+  34: [
+    [1, 6],
+    [1, 2],
+    [1, 1],
+  ],
+  35: [
+    [0.25, 6],
+    [0.25, 2],
+    [0.25, 1],
+  ],
+}

--- a/apps/web/src/views/FarmAuction/hooks/useV3FarmAuctionConfig.ts
+++ b/apps/web/src/views/FarmAuction/hooks/useV3FarmAuctionConfig.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react'
+import { HARD_CODE_V3_AUCTION_DATA_BY_ID, HARD_CODE_TOP_THREE_AUCTION_DATA } from '../constants'
+
+export const useV3FarmAuctionConfig = (farmAuctionId?: number) => {
+  const v3FarmAuctionConfig = useMemo(() => {
+    if (HARD_CODE_V3_AUCTION_DATA_BY_ID[farmAuctionId]) {
+      return HARD_CODE_V3_AUCTION_DATA_BY_ID[farmAuctionId]
+    }
+    return HARD_CODE_TOP_THREE_AUCTION_DATA
+  }, [farmAuctionId])
+  return v3FarmAuctionConfig
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e21f7f9</samp>

### Summary
🆔🪝🔄

<!--
1.  🆔 - This emoji represents the addition of the `auctionId` prop to the components, which is used to identify the auction and fetch the correct data for it.
2.  🪝 - This emoji represents the use of custom hooks to encapsulate the logic of getting the fee tier and multiplier data for each auction, and to fallback to the default data if the id is not found in the map.
3.  🔄 - This emoji represents the removal of hard-coded data and the replacement with dynamic data that changes based on the auction id. This makes the components more flexible and responsive to different auction configurations.
-->
Refactored the farm auction components to use a custom hook to get the fee tier and multiplier data for each auction dynamically based on the id. This makes the components more flexible and responsive to different auction configurations. Removed unnecessary props and constants and updated the naming convention.

> _Sing, O Muse, of the code review that changed the auction table_
> _How the wise developer removed the `shouldUseV3Format` prop_
> _And added the `auctionId` to fetch the fee tier and multiplier_
> _By using the `useV3FarmAuctionConfig` hook, a clever crop_

### Walkthrough
*  Add `useV3FarmAuctionConfig` custom hook to get fee tier and multiplier data for each auction based on id ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-5ad38c4baab8d54082c385e68803b67e5997270128602869f7cde0e90942a035R1-R12))
*  Replace `HARD_CODE_TOP_THREE_AUCTION_DATAS` constant with `HARD_CODE_TOP_THREE_AUCTION_DATA` and `HARD_CODE_V3_AUCTION_DATA_BY_ID` constants to store auction data in a map by id ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-a089730be3cd1147ad783eec028d5f7d33a66eb5b3a53661026f5c4d6c31fe4aL4-R21))
*  Use `useV3FarmAuctionConfig` hook in `AuctionFooter` component to show correct multiplier per farm for current auction ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0L7-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-08e727f871d9cf5e16b32d9e2adf94be01fb2fbe0f51b7b3f3ccde60977042a0L37-R39))
*  Use `useV3FarmAuctionConfig` hook in `LeaderboardRow` component to show correct fee tier and multiplier for each bidder for current auction ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L24-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L47-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L55-R60), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L80-R84))
*  Use `useV3FarmAuctionConfig` hook in `CongratulationsCard` component to show correct multiplier per farm for current auction ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168L1-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168R23), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-29b5578250b2dd3269de24e696bcf29e4dfddd9a08454f4610267ceb1c5dd168L40-R42))
*  Remove `shouldUseV3Format` prop and use `auctionId` prop instead to determine whether to use v3 format or not in `AuctionLeaderboardTable` and `LeaderboardRow` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L140-R144), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L189-R192), [link](https://github.com/pancakeswap/pancake-frontend/pull/7226/files?diff=unified&w=0#diff-ff6c4f42cf9c40ffe1da92a0ac85550eeedcf045bba206856b8e03d24f595120L78-R78))


