### PR TITLE
chore: Update trading reward banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/TradingRewardBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/TradingRewardBanner.tsx
@@ -164,7 +164,7 @@ const TradingRewardBanner = () => {
         <S.LeftWrapper>
           <StyledBox>{t('Trade to Earn Rewards')}</StyledBox>
           <Flex flexDirection={['column', 'row']} mb={['8px', '8px', '12px']}>
-            <Title>{t('5% trading rebate to be earned!')}</Title>
+            <Title>{t('10% trading rebate to be earned!')}</Title>
           </Flex>
           <Flex style={{ gap: 8 }} flexWrap={isMobile ? 'wrap' : 'nowrap'} flexDirection={['column', 'row']}>
             <NextLinkFromReactRouter to="/swap?showTradingReward=true">

--- a/apps/web/src/views/TradingReward/components/Banner.tsx
+++ b/apps/web/src/views/TradingReward/components/Banner.tsx
@@ -152,7 +152,7 @@ const TradingRewardBanner = () => {
           </Text>
           <Flex mb="16px" flexWrap="wrap">
             <Text bold fontSize="40px" color="secondary" as="span" ml="4px" lineHeight="110%">
-              {t('5% trading rebate to be earned!')}
+              {t('10% trading rebate to be earned!')}
             </Text>
           </Flex>
           <Text bold mb="32px" maxWidth="404px" lineHeight="26.4px" fontSize={['16px', '16px', '16px', '24px']}>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2290,7 +2290,7 @@
   "MMs are temporarily unable to facilitate trades. Please try again later": "MMs are temporarily unable to facilitate trades. Please try again later",
   "Trade to Earn Rewards": "Trade to Earn Rewards",
   "Trading Reward": "Trading Reward",
-  "5% trading rebate to be earned!": "5% trading rebate to be earned!",
+  "10% trading rebate to be earned!": "10% trading rebate to be earned!",
   "Why my traded volume was not tracked?": "Why my traded volume was not tracked?",
   "Volume numbers take time to update and are subject to SubGraph delays. Please check back later": "Volume numbers take time to update and are subject to SubGraph delays. Please check back later",
   "Please ensure your trade is routed through the trading pairs eligible for trading rewards.Check out": "Please ensure your trade is routed through the trading pairs eligible for trading rewards.Check out",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 53709db</samp>

### Summary
📈🔄🌐

<!--
1.  📈 This emoji represents the increase in the rebate rate and the incentive for users to trade more on the platform. It also conveys a positive and optimistic tone for the feature.
2.  🔄 This emoji represents the update or synchronization of the text across different pages and components of the app. It also implies that the change is aligned with the current state of the feature and the app.
3.  🌐 This emoji represents the translation or localization of the text for different languages and markets. It also suggests that the app is accessible and inclusive for a diverse and global audience.
-->
This pull request changes the text in the trading reward banners on the home page and the trading reward page to show the new 10% rebate rate. The change is part of a feature to increase the incentive for users to trade on the platform. It also updates the translation file to support multiple languages.

> _`rebateRate` grows_
> _trading reward banner changes_
> _autumn of incentives_

### Walkthrough
* Increase the trading reward rebate rate from 5% to 10% on the home page and the trading reward page banners ([link](https://github.com/pancakeswap/pancake-frontend/pull/7227/files?diff=unified&w=0#diff-d526ce8ff2949c3f25b7c271b3ed0f3e93ca795f42633d867a0a01a18de8eb91L167-R167), [link](https://github.com/pancakeswap/pancake-frontend/pull/7227/files?diff=unified&w=0#diff-03134056bc43863a3b5bcd8fe4cfeb2bf9f191923365ae993ce3259ea819a093L155-R155))
* Add the new text for the 10% rebate rate to the translation file `translations.json` to support multiple languages ([link](https://github.com/pancakeswap/pancake-frontend/pull/7227/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2293-R2293))


