### PR TITLE
feat: add AMA text for top farm bid

### DIFF
--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -28,7 +28,7 @@ const LeaderboardContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 5fr 3fr 1fr;
   ${({ theme }) => theme.mediaQueries.md} {
-    grid-template-columns: 3fr 5fr 5fr 1fr;
+    grid-template-columns: 3fr 15fr 5fr 1fr;
   }
 `
 
@@ -81,7 +81,14 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
                 {shouldUseV3Format ? (
                   <>
                     <Text mr="3px">({v3FarmAuctionConfig?.[index]?.[0]}% fee tier)</Text>
-                    <Text>[{v3FarmAuctionConfig?.[index]?.[1] ?? 1}x]</Text>
+                    <Text>
+                      [{v3FarmAuctionConfig?.[index]?.[1] ?? 1}x{' '}
+                      {v3FarmAuctionConfig?.[index]?.[2] &&
+                        getBalanceNumber(amount) >= v3FarmAuctionConfig?.[index]?.[2] && (
+                          <Text display="inline-block">+ AMA</Text>
+                        )}
+                      ]
+                    </Text>
                   </>
                 ) : (
                   <Text>(1x)</Text>

--- a/apps/web/src/views/FarmAuction/constants.ts
+++ b/apps/web/src/views/FarmAuction/constants.ts
@@ -6,7 +6,7 @@ export const HARD_CODE_TOP_THREE_AUCTION_DATA = [
   [1, 2],
   [1, 1],
 ]
-// id: [feeTier, multiplier][]
+// id: [feeTier, multiplier, AMACakeUnderLine][]
 export const HARD_CODE_V3_AUCTION_DATA_BY_ID = {
   34: [
     [1, 6],
@@ -14,7 +14,7 @@ export const HARD_CODE_V3_AUCTION_DATA_BY_ID = {
     [1, 1],
   ],
   35: [
-    [0.25, 6],
+    [0.25, 6, 10000],
     [0.25, 2],
     [0.25, 1],
   ],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3c71c40</samp>

### Summary
📊🎙️📝

<!--
1.  📊 - This emoji represents the improvement of the layout and the information of the farm auction leaderboard table, as it suggests data, statistics, or charts.
2.  🎙️ - This emoji represents the introduction of the AMA session indicator for some farms, as it suggests a microphone, speech, or interview.
3.  📝 - This emoji represents the addition and update of some comments and data for the farm auction feature, as it suggests writing, documentation, or notes.
-->
This pull request enhances the farm auction feature by improving the UI of the leaderboard table and adding an AMA reward option for some farms. It modifies `AuctionLeaderboardTable.tsx` and `constants.ts` in the web app.

> _Oh we're the farm auction crew and we've got some work to do_
> _We'll make the leaderboard table look fine_
> _We'll give more space for the names and show the AMA claims_
> _And we'll heave away on the count of three_

### Walkthrough
*  Adjust grid layout of leaderboard table to fit longer farm names on medium screens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7231/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L31-R31))
*  Add "+ AMA" text next to multiplier for top bidder of each farm that has a minimum CAKE amount for AMA session ([link](https://github.com/pancakeswap/pancake-frontend/pull/7231/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L84-R91))
*  Update comment to explain structure of `HARD_CODE_V3_AUCTION_DATA_BY_ID` object, which stores fee tier, multiplier, and AMA CAKE amount for each farm ([link](https://github.com/pancakeswap/pancake-frontend/pull/7231/files?diff=unified&w=0#diff-a089730be3cd1147ad783eec028d5f7d33a66eb5b3a53661026f5c4d6c31fe4aL9-R9))
*  Add AMA CAKE amount (10000) for first fee tier of farm 35 in `constants.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7231/files?diff=unified&w=0#diff-a089730be3cd1147ad783eec028d5f7d33a66eb5b3a53661026f5c4d6c31fe4aL17-R17))


