### PR TITLE
fix: farm auction v3 info page

### DIFF
--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -125,7 +125,12 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
             </SubMenuItem>
           )}
           {lpAddress && (
-            <SubMenuItem as={LinkExternal} href={`/info/pairs/${lpAddress}`} bold={false} color="text">
+            <SubMenuItem
+              as={LinkExternal}
+              href={`/info/${shouldUseV3Format && 'v3'}/pairs/${lpAddress}`}
+              bold={false}
+              color="text"
+            >
               {t('LP Info')}
             </SubMenuItem>
           )}

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -127,7 +127,7 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
           {lpAddress && (
             <SubMenuItem
               as={LinkExternal}
-              href={`/info/${shouldUseV3Format && 'v3'}/pairs/${lpAddress}`}
+              href={`/info${shouldUseV3Format && '/v3'}/pairs/${lpAddress}`}
               bold={false}
               color="text"
             >


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4bec39d</samp>

### Summary
🌐🆕🚜

<!--
1.  🌐 - This emoji represents the web or internet, and it can be used to indicate a change related to links, URLs, or web pages. In this case, the change modifies the `href` attribute of a link component, so this emoji is relevant.
2.  🆕 - This emoji represents something new or updated, and it can be used to indicate a change related to a new feature, version, or format. In this case, the change adds support for the v3 format of the PancakeSwap info site, which is a new feature and version of the existing site, so this emoji is relevant.
3.  🚜 - This emoji represents a tractor or farming, and it can be used to indicate a change related to farms, pools, or yield farming. In this case, the change is part of a larger feature that adds support for v3 farms and pools to the Farm Auction page, which is a page related to yield farming, so this emoji is relevant.
-->
Updated the `LinkExternal` component in `AuctionLeaderboardTable.tsx` to handle v2 and v3 LP info links. This is part of adding v3 support to the Farm Auction page.

> _`LinkExternal` changes_
> _v2 or v3 info page_
> _cut by a question_

### Walkthrough
*  Modify the external link to LP info page to use the correct format based on the pair version ([link](https://github.com/pancakeswap/pancake-frontend/pull/7233/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L128-R133))
*  Use the new hook and utility function in the `AuctionLeaderboardTable` component to determine the `shouldUseV3Format` variable and pass it to the `LinkExternal` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7233/files?diff=unified&w=0#diff-53f3d93eb1586dc003b3f9ba204c74128608c6c7fbaa766777c9ad815127ca02L128-R133))


