### PR TITLE
chore: Update domain of trading rebate api endpoint

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -70,7 +70,7 @@ export const V3_SUBGRAPH_URLS = {
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
 } satisfies Record<ChainId, string | null>
 
-export const TRADING_REWARD_API = 'https://pancake-trading-fee-rebate-api.pancake.run/api/v1'
+export const TRADING_REWARD_API = 'https://pancake-trading-fee-rebate-api.pancakeswap.com/api/v1'
 
 export const QUOTING_API = `${process.env.NEXT_PUBLIC_QUOTING_API}/v0/quote`
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9de25b3</samp>

### Summary
🥞🌐🔄

<!--
1.  🥞 - This emoji represents the PancakeSwap platform and its native token, CAKE. It is also a common symbol for pancakes in general, which fits the theme of the project. This emoji could be used to indicate that the change was related to the PancakeSwap platform or its features.
2.  🌐 - This emoji represents the internet, the web, or domains. It is often used to indicate a website, a link, or a global network. This emoji could be used to indicate that the change was related to the domain name or the URL of the API endpoint.
3.  🔄 - This emoji represents a refresh, a reload, or an update. It is often used to indicate that something has changed, been replaced, or been improved. This emoji could be used to indicate that the change was an update or a migration to a new domain.
-->
Updated the trading reward API endpoint to use the new pancakeswap.com domain. This reflects the recent rebranding and domain migration of the PancakeSwap platform.

> _`TRADING_REWARD_API`_
> _Changed domain to match branding_
> _A fresh spring update_

### Walkthrough
* Change the trading reward API endpoint to use pancakeswap.com domain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7243/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L73-R73))


