### PR TITLE
fix: Cannot switch to eth info

### DIFF
--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -293,7 +293,7 @@ export const useGetChainName = () => {
 export const useChainNameByQuery = () => {
   const { query } = useRouter()
   const chainName = useMemo(() => {
-    if (query?.chain === 'eth') return 'ETH'
+    if (query?.chainName === 'eth') return 'ETH'
     return 'BSC'
   }, [query])
   return chainName

--- a/apps/web/src/state/info/utils.ts
+++ b/apps/web/src/state/info/utils.ts
@@ -7,3 +7,15 @@ import { multiChainPaths } from './constant'
 export function getTokenInfoPath(chainId: ChainId, address: string) {
   return `/info/v3${multiChainPaths[chainId]}/tokens/${address}?chain=${CHAIN_QUERY_NAME[chainId]}`
 }
+
+// TODO: refactor
+export function getChainName(chainId: ChainId) {
+  switch (chainId) {
+    case ChainId.BSC:
+      return 'BSC'
+    case ChainId.ETHEREUM:
+      return 'ETH'
+    default:
+      return 'BSC'
+  }
+}

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -10,6 +10,8 @@ import useSWRImmutable from 'swr/immutable'
 import { getDeltaTimestamps } from 'utils/getDeltaTimestamps'
 import { v3InfoClients, v3Clients } from 'utils/graphql'
 import { useBlockFromTimeStampSWR } from 'views/Info/hooks/useBlocksFromTimestamps'
+import { getChainName } from 'state/info/utils'
+
 import { SUBGRAPH_START_BLOCK, DURATION_INTERVAL } from '../constants'
 import { fetchPoolChartData } from '../data/pool/chartData'
 import { fetchPoolDatas } from '../data/pool/poolData'
@@ -184,7 +186,7 @@ export const useTokensData = (addresses: string[], targetChainId?: ChainId): Tok
   const chainName = useChainNameByQuery()
   const chainId = targetChainId ?? multiChainId[chainName]
   const [t24, t48, t7d] = getDeltaTimestamps()
-  const { blocks } = useBlockFromTimeStampSWR([t24, t48, t7d])
+  const { blocks } = useBlockFromTimeStampSWR([t24, t48, t7d], undefined, undefined, getChainName(chainId))
 
   const { data } = useSWRImmutable(
     chainId &&


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf22460</samp>

### Summary
🔗🔄🌐

<!--
1.  🔗 - This emoji represents the chain name and the query parameter change.
2.  🔄 - This emoji represents the utility function that converts the chain id to the chain name.
3.  🌐 - This emoji represents the support for fetching data from different chains.
-->
The pull request adds support for fetching data from different chains in the V3 info page. It uses a new `getChainName` function and updates the `useChainNameByQuery` hook to handle the chain name query parameter.

> _Oh, we're the coders of the high seas_
> _We fetch the data from the chains_
> _We use the `getChainName` function_
> _To avoid confusion and mistakes_

### Walkthrough
*  Update `useChainNameByQuery` hook to use `query.chainName` instead of `query.chain` as the query parameter for the chain name ([link](https://github.com/pancakeswap/pancake-frontend/pull/7251/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292L296-R296))
*  Add `getChainName` function to `state/info/utils.ts` to return the chain name based on the chain id ([link](https://github.com/pancakeswap/pancake-frontend/pull/7251/files?diff=unified&w=0#diff-32d97a974382629891def88b451549a199d0180542f5cc2aae9671c47de110eaR10-R21))
*  Import and use `getChainName` function in `useTokensData` hook to fetch token data from the subgraph based on the chain id ([link](https://github.com/pancakeswap/pancake-frontend/pull/7251/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0R13-R14))
*  Modify `useBlockFromTimeStampSWR` hook to pass the chain name as an argument and use it to construct the subgraph URL for the block query ([link](https://github.com/pancakeswap/pancake-frontend/pull/7251/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L187-R189))


