### PR TITLE
fix: Remove trading reward token mark on v2 tokens

### DIFF
--- a/apps/web/src/views/Swap/components/HotTokenList/SwapTokenTable.tsx
+++ b/apps/web/src/views/Swap/components/HotTokenList/SwapTokenTable.tsx
@@ -193,7 +193,9 @@ const DataRow: React.FC<
         {type === 'volume' && <Text fontWeight={400}>${formatAmount(tokenData.volumeUSD)}</Text>}
         {type === 'liquidity' && <Text fontWeight={400}>${formatAmount(tokenData.tvlUSD)}</Text>}
         <Flex alignItems="center" justifyContent="flex-end">
-          {tokenData?.pairs?.length > 0 && <TradingRewardIcon pairs={tokenData.pairs} />}
+          {dataSource === InfoDataSource.V3 && tokenData?.pairs?.length > 0 && (
+            <TradingRewardIcon pairs={tokenData.pairs} />
+          )}
           <Button
             variant="text"
             scale="sm"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca41964</samp>

### Summary
🔄🏆🚫

<!--
1.  🔄 - This emoji represents the swapping or trading of tokens on Uniswap, which is the main feature of the SwapTokenTable component.
2.  🏆 - This emoji represents the trading reward icon, which is a trophy that indicates that a token is eligible for the Uniswap V3 fee switch program, which rewards traders with a portion of the protocol fees.
3.  🚫 - This emoji represents the conditional rendering of the TradingRewardIcon component, which is only shown if the dataSource prop is V3, otherwise it is hidden. This emoji conveys the idea of excluding or preventing something from being displayed.
-->
Hide trading reward icon for non-V3 tokens in swap token table. Add `dataSource` prop to `SwapTokenRow` and `TradingRewardIcon` components to check token source.

> _`dataSource` checks_
> _Trading reward icon shows_
> _Only for V3_

### Walkthrough
*  Add a dataSource prop to SwapTokenTable and SwapTokenRow components to indicate the source of the token data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7253/files?diff=unified&w=0#diff-cd83ef0d5bf0df561dd9cb31a4dc00a8d039531e875f0b4d341a7e615aec5787L196-R198),                            F0


