### PR TITLE
chore: Move finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -40,15 +40,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 343,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.edu,
-    contractAddress: '0x3d2d34Ea77B3702B7634C8D208feC5E08CEa88B6',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.05425',
-    version: 3,
-  },
-  {
     sousId: 325,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.lvl,
@@ -66,6 +57,15 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 343,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.edu,
+    contractAddress: '0x3d2d34Ea77B3702B7634C8D208feC5E08CEa88B6',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.05425',
+    version: 3,
+  },
   {
     sousId: 342,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e61994</samp>

### Summary
🏊🏁💰

<!--
1.  🏊 - This emoji represents a pool, and is used to indicate that the pull request is related to the pool arrays.
2.  🏁 - This emoji represents the end of a race or a competition, and is used to indicate that the pool has finished and the winners have been determined.
3.  💰 - This emoji represents money or wealth, and is used to indicate that the users can claim or unstake their tokens from the pool.
-->
Move a finished pool from active to finished in `packages/pools/src/constants/pools/56.ts`. This improves the accuracy and usability of the pools feature on the website.

> _`sousId` three four three_
> _moves from active to finished_
> _autumn harvest time_

### Walkthrough
*  Move the pool with sousId 343 from active to finished pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7260/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL43-L51), [link](https://github.com/pancakeswap/pancake-frontend/pull/7260/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR61-R69))


