### PR TITLE
fix: Disclaimers can't be dismissed when going back

### DIFF
--- a/apps/web/src/views/LimitOrders/components/ClaimWarning.tsx
+++ b/apps/web/src/views/LimitOrders/components/ClaimWarning.tsx
@@ -32,7 +32,6 @@ function ClaimWarning() {
       onSuccess={handleSuccess}
     />,
     false,
-    false,
   )
 
   useEffect(() => {
@@ -40,11 +39,8 @@ function ClaimWarning() {
       onPresentRiskDisclaimer()
     }
 
-    return () => {
-      onDismiss()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasAcceptedRisk])
+    return onDismiss
+  }, [hasAcceptedRisk, onDismiss, onPresentRiskDisclaimer])
 
   return null
 }

--- a/apps/web/src/views/Predictions/components/RiskDisclaimer.tsx
+++ b/apps/web/src/views/Predictions/components/RiskDisclaimer.tsx
@@ -32,7 +32,6 @@ function RiskDisclaimer() {
       onSuccess={handleSuccess}
     />,
     false,
-    false,
   )
 
   useEffect(() => {
@@ -40,11 +39,8 @@ function RiskDisclaimer() {
       onPresentRiskDisclaimer()
     }
 
-    return () => {
-      onDismiss()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasAcceptedRisk])
+    return onDismiss
+  }, [onDismiss, onPresentRiskDisclaimer, hasAcceptedRisk])
 
   return null
 }

--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -103,17 +103,17 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     setCloseOnOverlayClick(true);
   }, []);
 
-  const handleOverlayDismiss = () => {
+  const handleOverlayDismiss = useCallback(() => {
     if (closeOnOverlayClick) {
       handleDismiss();
     }
-  };
+  }, [closeOnOverlayClick, handleDismiss]);
 
   const providerValue = useMemo(() => {
     return { isOpen, nodeId, modalNode, setModalNode, onPresent: handlePresent, onDismiss: handleDismiss };
   }, [isOpen, nodeId, modalNode, setModalNode, handlePresent, handleDismiss]);
 
-  const portal = getPortalRoot();
+  const portal = useMemo(() => getPortalRoot(), []);
 
   return (
     <Context.Provider value={providerValue}>


### PR DESCRIPTION
To reproduce: 

Go to limit or prediction with fresh cache
See disclaimer
Use back button 
See disclaimer can't disappear

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f74f91e</samp>

### Summary
🧹🚀👁️

<!--
1.  🧹 for refactoring and cleaning up the code
2.  🚀 for improving the performance and efficiency of the code
3.  👁️ for enhancing the user interface and user experience of the modal components
-->
This pull request refactors and optimizes the modal components and their usage in the web app. It removes unused arguments from the `useModal` hook, simplifies the cleanup functions of the `useEffect` hooks, and avoids unnecessary re-renders of the `ModalProvider` component.

> _We're the crew of the `useModal` hook_
> _We don't need no extra arg to make it work_
> _We clean up our effects with a simple trick_
> _And we memoize our functions for a faster ship_

### Walkthrough
*  Remove unnecessary `false` argument from `useModal` hook in `ClaimWarning` and `RiskDisclaimer` components (`[link](https://github.com/pancakeswap/pancake-frontend/pull/7270/files?diff=unified&w=0#diff-7abfbef0f2d5a6aa275a2dae379bef26c7e6ac0e21efd3d99f8477f34a8e98f0L35)`, `[link](https://github.com/pancakeswap/pancake-frontend/pull/7270/files?diff=unified&w=0#diff-0f7e889c11e50f265da3b9b801a6bb4e20dca0b531c41278fc83467481b0f981L35)`)


