### PR TITLE
fix: Incorrect token symbol

### DIFF
--- a/.github/workflows/testConfig.yml
+++ b/.github/workflows/testConfig.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/web/src/config/**'
       - 'packages/pools/src/**'
       - 'packages/farms/constants/**'
+      - 'packages/tokens/src/**'
   push:
     branches:
       - develop

--- a/.github/workflows/testConfigPass.yml
+++ b/.github/workflows/testConfigPass.yml
@@ -6,6 +6,7 @@ on:
       - 'apps/web/src/config/**'
       - 'packages/pools/src/**'
       - 'packages/farms/constants/**'
+      - 'packages/tokens/src/**'
 
 jobs:
   test:

--- a/apps/web/src/config/__tests__/tokens.test.ts
+++ b/apps/web/src/config/__tests__/tokens.test.ts
@@ -25,7 +25,7 @@ const bscTokensToTest = omitBy(
 const tokenListsToTest = [bscTokensToTest, ethereumTokens]
 
 const tokenTables: [string, Token][] = tokenListsToTest.reduce(
-  (acc, cur) => [...acc, map(cur, (token, key) => [key, token])],
+  (acc, cur) => [...acc, ...map(cur, (token, key) => [key, token])],
   [],
 )
 
@@ -53,7 +53,7 @@ describe.concurrent(
         })
         const isWhitelisted = whitelist.includes(key.toLowerCase())
         if (!isWhitelisted) expect(key.toLowerCase()).toBe(token.symbol.toLowerCase())
-        expect(token.symbol.toLowerCase()).toBe(symbol.toLowerCase())
+        expect(token.symbol).toBe(symbol)
         expect(token.decimals).toBe(decimals)
       },
     )

--- a/apps/web/src/config/__tests__/tokens.test.ts
+++ b/apps/web/src/config/__tests__/tokens.test.ts
@@ -1,5 +1,5 @@
-import { ChainId, Token } from '@pancakeswap/sdk'
-import { bscTokens } from '@pancakeswap/tokens'
+import { Token } from '@pancakeswap/sdk'
+import { bscTokens, ethereumTokens } from '@pancakeswap/tokens'
 import { erc20ABI } from 'wagmi'
 import map from 'lodash/map'
 import slice from 'lodash/slice'
@@ -13,7 +13,7 @@ const whitelist = ['deprecated_tusd']
 // remove ONE because there are two tokens with the symbol ONE (Harmony ONE and BigONE)
 // remove HERO because there are two tokens with the symbol HERO (StepHero and Hero)
 // remove aBNBc because the token has been exploited
-const tokensToTest = omitBy(
+const bscTokensToTest = omitBy(
   bscTokens,
   (token) =>
     token.symbol.toLowerCase() === 'bnb' ||
@@ -22,8 +22,12 @@ const tokensToTest = omitBy(
     token.symbol.toLowerCase() === 'abnbc' ||
     token.symbol.toLowerCase() === 'hero',
 )
+const tokenListsToTest = [bscTokensToTest, ethereumTokens]
 
-const tokenTables: [string, Token][] = map(tokensToTest, (token, key) => [key, token])
+const tokenTables: [string, Token][] = tokenListsToTest.reduce(
+  (acc, cur) => [...acc, map(cur, (token, key) => [key, token])],
+  [],
+)
 
 describe.concurrent(
   'Config tokens',
@@ -31,8 +35,8 @@ describe.concurrent(
     it.each(slice(tokenTables, tokenTables.length - 50))(
       'Token %s has the correct key, symbol, and decimal',
       async (key: string, token: Token) => {
-        const bscClient = publicClient({ chainId: ChainId.BSC })
-        const [symbol, decimals] = await bscClient.multicall({
+        const client = publicClient({ chainId: token.chainId })
+        const [symbol, decimals] = await client.multicall({
           contracts: [
             {
               abi: erc20ABI,

--- a/apps/web/src/config/__tests__/tokens.test.ts
+++ b/apps/web/src/config/__tests__/tokens.test.ts
@@ -53,7 +53,7 @@ describe.concurrent(
         })
         const isWhitelisted = whitelist.includes(key.toLowerCase())
         if (!isWhitelisted) expect(key.toLowerCase()).toBe(token.symbol.toLowerCase())
-        expect(token.symbol).toBe(symbol)
+        expect(token.symbol.toLocaleLowerCase()).toBe(symbol.toLocaleLowerCase())
         expect(token.decimals).toBe(decimals)
       },
     )

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -236,8 +236,8 @@ export const ethereumTokens = {
     ChainId.ETHEREUM,
     '0x56C03B8C4FA80Ba37F5A7b60CAAAEF749bB5b220',
     18,
-    'Canto',
     'CANTO',
+    'Canto',
     'https://tusd.io/',
   ),
 }

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2630,7 +2630,7 @@ export const bscTokens = {
     ChainId.BSC,
     '0x0034719300501B06E10Ebb1D07ea5967301F0941',
     6,
-    'xAlgo',
+    'xALGO',
     'Governance xAlgo',
     'https://folks.finance/',
   ),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 71e9038</samp>

### Summary
:test_tube::wrench::label:

<!--
1.  :test_tube: for the changes to the `testConfig` and `testConfigPass` workflows, since they are related to testing the token configuration.
2.  :wrench: for the change to the `packages/tokens/src/1.ts` file, since it is a fix for a typo in the token configuration.
3.  :label: for the change to the CANTO token name and symbol, since it is a change to the token metadata.
-->
This pull request updates the `testConfig` and `testConfigPass` workflows to run on changes in the `packages/tokens/src` directory, and fixes a typo in the `CANTO` token information in the `packages/tokens/src/1.ts` file. These changes aim to improve the testing and accuracy of the token configuration.

> _`testConfig` runs_
> _when `packages/tokens/src` changes_
> _a winter bug fixed_

### Walkthrough
*  Add `packages/tokens/src/**` path to `paths` filter of `testConfig` and `testConfigPass` workflows to run them when token configuration is updated ([link](https://github.com/pancakeswap/pancake-frontend/pull/7274/files?diff=unified&w=0#diff-a8fe81691f8f45cf75a64204bfb57a02b773e6b0f37616bf34919bdc26d10bc2R9),[link](https://github.com/pancakeswap/pancake-frontend/pull/7274/files?diff=unified&w=0#diff-33880375608521ad12a29d986475111b693bde023b7d5efbda5c327628579e71R9))
* Fix typo in `ethereumTokens` value in `packages/tokens/src/1.ts` by swapping symbol and name of CANTO token ([link](https://github.com/pancakeswap/pancake-frontend/pull/7274/files?diff=unified&w=0#diff-5f81da2a1b12c306423ba81c127abdc5f541a950a6079e7b4c1d65de467a214eL239-R240))


