### PR TITLE
feat: Add invert price button to farm v3 staked cards

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PoolListItem.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PoolListItem.tsx
@@ -86,7 +86,7 @@ export default function PositionListItem({ positionDetails, children }: Position
   if (priceUpper && priceLower && currencyBase && currencyQuote) {
     subtitle = `${t('Min %minAmount%', {
       minAmount: formatTickPrice(inverted ? priceUpper.invert() : priceLower, tickAtLimit, Bound.LOWER, locale),
-    })}/ ${t('Max %maxAmount%', {
+    })} / ${t('Max %maxAmount%', {
       maxAmount: formatTickPrice(inverted ? priceLower.invert() : priceUpper, tickAtLimit, Bound.UPPER, locale),
     })} ${t('%assetA% per %assetB%', {
       assetA: inverted ? currencyBase?.symbol : currencyQuote?.symbol,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at acc31da</samp>

### Summary
🛠️🔄📝

<!--
1.  🛠️ for fixing minor UI issues
2.  🔄 for adding a feature to invert the price range
3.  📝 for improving the readability and consistency of the UI
-->
This pull request enhances the farm card and pool list components for V3 liquidity pools. It allows users to invert the price range of the pool in the farm card, and it improves the spacing and formatting of the pool list item. It affects the files `FarmV3StakeAndUnStake.tsx` and `PoolListItem.tsx`.

> _Invert the range of the pool, defy the market's rule_
> _Slash and max, a space between, unleash the UI machine_
> _Farm the card, harvest the reward, don't let them take your hoard_
> _Pool the list, fix the glitch, make your fortune with a switch_

### Walkthrough
*  Add a `SyncAltIcon` component to the pool list item that allows the user to invert the price range and swap the asset symbols ([link](https://github.com/pancakeswap/pancake-frontend/pull/7278/files?diff=unified&w=0#diff-8a582a55c28fd93909c966467f9e5085ddc4c08b0128a15e9f1168ab8a9c1cf5L1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7278/files?diff=unified&w=0#diff-8a582a55c28fd93909c966467f9e5085ddc4c08b0128a15e9f1168ab8a9c1cf5L75-R100), [link](https://github.com/pancakeswap/pancake-frontend/pull/7278/files?diff=unified&w=0#diff-8a582a55c28fd93909c966467f9e5085ddc4c08b0128a15e9f1168ab8a9c1cf5L106-R138))
*  Remove the space between the slash and the max amount in the subtitle of the pool list item for consistency and layout ([link](https://github.com/pancakeswap/pancake-frontend/pull/7278/files?diff=unified&w=0#diff-7d976038e45d35fead316a8fb9f21e7b1d4aded9e7dfd0a74c95e03550e398eeL89-R89), [link](https://github.com/pancakeswap/pancake-frontend/pull/7278/files?diff=unified&w=0#diff-8a582a55c28fd93909c966467f9e5085ddc4c08b0128a15e9f1168ab8a9c1cf5L93-R111))


