### PR TITLE
fix: Hovered price can't be removed after mouse leaving

### DIFF
--- a/apps/web/src/views/Swap/components/Chart/BasicChart.tsx
+++ b/apps/web/src/views/Swap/components/Chart/BasicChart.tsx
@@ -40,9 +40,10 @@ const BasicChart = ({
   } = useMemo(() => getTimeWindowChange(pairPrices), [pairPrices])
   const { changePercentage, changeValue, isChangePositive } = useMemo(() => {
     if (hoverValue) {
-      if (pairPrices[pairPrices.length - 1]) {
+      const lastItem = pairPrices[pairPrices.length - 1]
+      if (lastItem) {
         const copyPairPrices = [...pairPrices]
-        copyPairPrices[pairPrices.length - 1].value = hoverValue
+        copyPairPrices[pairPrices.length - 1] = { ...lastItem, value: hoverValue }
         return getTimeWindowChange(copyPairPrices)
       }
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0369810</samp>

### Summary
🐛📈🖱️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  📈 - This emoji represents a chart or graph, which is the component that is affected by this change.
3.  🖱️ - This emoji represents a mouse or cursor, which is the user interaction that triggers this change.
-->
Fix chart update bug in `BasicChart.tsx` by creating a copy of the last pair price instead of mutating the original array.

> _`pairPrices` changed_
> _Copy last item for hover_
> _Chart shows autumn fall_

### Walkthrough
*  Fix chart update bug when hovering over last data point ([link](https://github.com/pancakeswap/pancake-frontend/pull/7279/files?diff=unified&w=0#diff-e35fbc60c35e09589e6357aa58e60471a8e71dc9323b890d3e5540ad9713eb17L43-R46))


