### PR TITLE
feat(Trading Reward): New Rewards Breakdown UI

### DIFF
--- a/apps/web/src/views/TradingReward/components/RewardsBreakdown/DesktopView.tsx
+++ b/apps/web/src/views/TradingReward/components/RewardsBreakdown/DesktopView.tsx
@@ -43,7 +43,7 @@ const DesktopView: React.FC<React.PropsWithChildren<RewardsBreakdownDesktopViewP
               </tr>
             ) : (
               <>
-                {list.pairs.length === 0 ? (
+                {!list?.pairs || list?.pairs?.length === 0 ? (
                   <tr style={{ display: 'table', tableLayout: 'fixed', width: '100%' }}>
                     <Td colSpan={4} textAlign="center">
                       {t('No results')}
@@ -51,7 +51,7 @@ const DesktopView: React.FC<React.PropsWithChildren<RewardsBreakdownDesktopViewP
                   </tr>
                 ) : (
                   <>
-                    {list.pairs.map((pair) => (
+                    {list?.pairs?.map((pair) => (
                       <tr key={pair.address} style={{ display: 'table', tableLayout: 'fixed', width: '100%' }}>
                         <Td width="40%">
                           <PairInfo

--- a/apps/web/src/views/TradingReward/components/RewardsBreakdown/MobileView.tsx
+++ b/apps/web/src/views/TradingReward/components/RewardsBreakdown/MobileView.tsx
@@ -33,7 +33,7 @@ const MobileView: React.FC<React.PropsWithChildren<RewardsBreakdownMobileViewPro
         </StyledMobileRow>
       ) : (
         <>
-          {list?.pairs?.length === 0 ? (
+          {!list?.pairs || list?.pairs?.length === 0 ? (
             <StyledMobileRow>
               <Text padding="48px 0px" textAlign="center">
                 {t('No results')}
@@ -41,7 +41,7 @@ const MobileView: React.FC<React.PropsWithChildren<RewardsBreakdownMobileViewPro
             </StyledMobileRow>
           ) : (
             <>
-              {list.pairs.map((pair) => (
+              {list?.pairs?.map((pair) => (
                 <StyledMobileRow>
                   <PairInfo
                     chainId={pair.chainId}

--- a/apps/web/src/views/TradingReward/index.tsx
+++ b/apps/web/src/views/TradingReward/index.tsx
@@ -92,7 +92,6 @@ const TradingReward = () => {
       />
       <HowToEarn />
       <RewardsBreakdown
-        latestCampaignId={campaignId}
         allUserCampaignInfo={allUserCampaignInfo}
         allTradingRewardPairData={allTradingRewardPairData}
         campaignPairs={allTradingRewardPairData.campaignPairs}

--- a/apps/web/src/views/TradingReward/top-traders.tsx
+++ b/apps/web/src/views/TradingReward/top-traders.tsx
@@ -88,7 +88,6 @@ const TradingRewardTopTraders = () => {
       <Leaderboard campaignId={campaignId} incentives={currentUserIncentive} />
       <HowToEarn />
       <RewardsBreakdown
-        latestCampaignId={campaignId}
         allUserCampaignInfo={allUserCampaignInfo}
         allTradingRewardPairData={allTradingRewardPairData}
         campaignPairs={allTradingRewardPairData.campaignPairs}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52a44c5</samp>

### Summary
🗑️🐛🔄

<!--
1.  🗑️ - This emoji represents the removal of the `latestCampaignId` prop from the `RewardsBreakdown` component, as it is no longer needed or used in the component logic. It also implies that the code is cleaner and simpler without the unnecessary prop.
2. 🐛 - This emoji represents the bug fixes in the rewards breakdown table and the mobile view component, as they prevent errors and crashes when the `pairs` data is `undefined` or `null`. It also implies that the code is more robust and reliable with the extra checks and safeguards.
3. 🔄 - This emoji represents the update in the `RewardsBreakdown` component that allows the user to switch between the current and previous rounds of rewards using a button menu. It also implies that the code is more dynamic and interactive with the pagination logic and the conditional rendering.
-->
This pull request improves the trading reward feature by fixing some potential rendering errors, adding a button menu to switch between reward rounds, and removing unused props from the `RewardsBreakdown` component. It affects the files `DesktopView.tsx`, `MobileView.tsx`, `index.tsx`, and `top-traders.tsx` in the `RewardsBreakdown` folder, and the file `index.tsx` in the `TradingReward` folder.

> _Sing, O Muse, of the skillful coder who refined the rewards breakdown_
> _And removed the needless prop of `latestCampaignId` from the components_
> _That display the glorious prizes of the trading contest to the traders_
> _Who compete with zeal and cunning for the best of crypto pairs._

### Walkthrough
*  Add a button menu to switch between current and previous rounds of rewards in the `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L1-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13R57), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L84-R136))
*  Find the current round of rewards based on the campaign claim time and the current time in the `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13R57))
*  Adjust the list state and the pagination logic based on the active index of the button menu and the existence of the current round in the `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L63-R96), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L84-R136), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L98))
*  Add some conditions and styles to improve the layout and prevent errors in the `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L84-R136), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-d0cf24bc78fd41475144556445d7673e34f1d792bcda3efd5e624bab6631ced1L46-R46), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-d0cf24bc78fd41475144556445d7673e34f1d792bcda3efd5e624bab6631ced1L54-R54), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-cf88c6203950e52a3f8ea80d48d574d1ce87b9695f6965cf3e812ebda2d5119fL36-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-cf88c6203950e52a3f8ea80d48d574d1ce87b9695f6965cf3e812ebda2d5119fL44-R44))
*  Remove the unused `latestCampaignId` prop from the `RewardsBreakdown` component and its parent components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-8899ffb1860eb76dfa9555198ba793b2cd223454ddb9d53864b20d5a1ac094a7L95), [link](https://github.com/pancakeswap/pancake-frontend/pull/7285/files?diff=unified&w=0#diff-905d0511435088804181a66cc5ab45ff12f7236f3e07a3d752c1c2cdfa3b4247L91))


