### PR TITLE
chore: Add subgraph api backup for supported chains

### DIFF
--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -1,10 +1,22 @@
 import { ChainId } from '@pancakeswap/sdk'
 
-export const SUPPORTED_CHAINS = [ChainId.ETHEREUM, ChainId.BSC]
+export const SUPPORTED_CHAINS = [
+  ChainId.ETHEREUM,
+  ChainId.BSC,
+  ChainId.LINEA_TESTNET,
+  ChainId.POLYGON_ZKEVM,
+  ChainId.BSC_TESTNET,
+  ChainId.GOERLI,
+] as const
 
-export const V3_SUBGRAPH_URLS = {
+type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
+
+export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
   [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
   [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
   [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-} satisfies Record<ChainId, string>
+  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
+  [ChainId.LINEA_TESTNET]:
+    'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 873fd7a</samp>

### Summary
🆕🔬🧹

<!--
1.  🆕 - This emoji conveys the idea of adding new features or functionality, which is the case for the two new chains that are supported by the frontend.
2.  🔬 - This emoji conveys the idea of experimentation or research, which is the case for the zkEVM technology that the PancakeSwap team is testing as a potential scaling solution.
3.  🧹 - This emoji conveys the idea of cleaning up or refactoring the code, which is the case for the type improvements and the `const` assertion that were applied to the `SUPPORTED_CHAINS` array and the `V3_SUBGRAPH_URLS` object.
-->
Added support for two new testnet chains using zkEVM technology and improved type safety for the `SUPPORTED_CHAINS` array in `constants.ts`.

> _`SUPPORTED_CHAINS`_
> _Expands for zkEVM testnets_
> _Const and narrow type_

### Walkthrough
*  Add support for two new testnet chains for zkEVM technology ([link](https://github.com/pancakeswap/pancake-frontend/pull/7286/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aL3-R22))


