### PR TITLE
chore(TradingReward): Adjustment chainTag align

### DIFF
--- a/apps/web/src/views/TradingReward/components/PairInfo.tsx
+++ b/apps/web/src/views/TradingReward/components/PairInfo.tsx
@@ -69,7 +69,7 @@ const PairInfo: React.FunctionComponent<React.PropsWithChildren<PairInfoProps>> 
               <V3FeeTag feeAmount={feeAmount} scale="sm" />
               <V3Tag ml="4px" scale="sm" />
             </Flex>
-            <Flex ml="4px">
+            <Flex ml="4px" mt="-2px">
               {chainId === ChainId.ETHEREUM && <EthTag />}
               {chainId === ChainId.BSC && <BscTag />}
             </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa793b2</samp>

### Summary
🎨🔧📐

<!--
1.  🎨 - This emoji can be used to indicate a change that improves the aesthetics or design of something, such as the alignment of the tags.
2.  🔧 - This emoji can be used to indicate a change that fixes or adjusts something, such as the margin of the flex component.
3.  📐 - This emoji can be used to indicate a change that involves measurements or geometry, such as the 2 pixels of negative margin.
-->
Improved the alignment of tags in the pair info component. Adjusted the top margin of the `Flex` component in `PairInfo.tsx`.

> _`Flex` shifts up a bit_
> _`EthTag` and `BscTag` align_
> _Autumn of `V3Tag`_

### Walkthrough
*  Adjusted the top margin of the `Flex` component that contains the `EthTag` and `BscTag` components to align them better with the `V3Tag` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7290/files?diff=unified&w=0#diff-f96cc39a6581759fcde93b9f49a1481751e21d16c4fa791dd4f0dac5014c80f4L72-R72)). This change improves the visual appearance of the pair info component in `PairInfo.tsx`.



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/87161409-85bd-4105-88e0-1ca755987307)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/7a2b22be-1603-4d4a-a327-7ab7c9004e86)