### PR TITLE
fix: (info): Transactions shows bscscan logo on other chains

### DIFF
--- a/apps/aptos/components/Menu/WalletInfo.tsx
+++ b/apps/aptos/components/Menu/WalletInfo.tsx
@@ -11,6 +11,7 @@ import {
   Message,
   Skeleton,
   Text,
+  AptosIcon,
 } from '@pancakeswap/uikit'
 import { useAuth } from 'hooks/useAuth'
 
@@ -69,7 +70,7 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
       </Flex>
       {account && (
         <Flex alignItems="center" justifyContent="end" mb="24px">
-          <ScanLink href={getBlockExploreLink(account.address, 'address', chainId)}>
+          <ScanLink icon={<AptosIcon />} href={getBlockExploreLink(account.address, 'address', chainId)}>
             {t('View on %site%', {
               site: t('Explorer'),
             })}

--- a/apps/aptos/components/Menu/WalletInfo.tsx
+++ b/apps/aptos/components/Menu/WalletInfo.tsx
@@ -7,7 +7,7 @@ import {
   CopyAddress,
   Flex,
   InjectedModalProps,
-  LinkExternal,
+  ScanLink,
   Message,
   Skeleton,
   Text,
@@ -69,11 +69,11 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
       </Flex>
       {account && (
         <Flex alignItems="center" justifyContent="end" mb="24px">
-          <LinkExternal isAptosScan href={getBlockExploreLink(account.address, 'address', chainId)}>
+          <ScanLink href={getBlockExploreLink(account.address, 'address', chainId)}>
             {t('View on %site%', {
               site: t('Explorer'),
             })}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       )}
       <Button variant="secondary" width="100%" onClick={handleLogout}>

--- a/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
+++ b/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, LinkExternal, Pool, Text, TimerIcon, useTooltip } from '@pancakeswap/uikit'
+import { Flex, LinkExternal, Pool, Text, TimerIcon, useTooltip, ScanLink } from '@pancakeswap/uikit'
 import { memo, useMemo } from 'react'
 import useLedgerTimestamp from 'hooks/useLedgerTimestamp'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
@@ -156,14 +156,9 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
       </Flex>
       {poolContractAddress && (
         <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-          <LinkExternal
-            isAptosScan
-            href={getBlockExploreLinkDefault(poolContractAddress, 'address', chainId)}
-            bold={false}
-            small
-          >
+          <ScanLink href={getBlockExploreLinkDefault(poolContractAddress, 'address', chainId)} bold={false} small>
             {t('View Contract')}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       )}
     </>

--- a/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
+++ b/apps/aptos/components/Pools/components/PoolCard/PoolStatsInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, LinkExternal, Pool, Text, TimerIcon, useTooltip, ScanLink } from '@pancakeswap/uikit'
+import { Flex, LinkExternal, Pool, Text, TimerIcon, useTooltip, ScanLink, AptosIcon } from '@pancakeswap/uikit'
 import { memo, useMemo } from 'react'
 import useLedgerTimestamp from 'hooks/useLedgerTimestamp'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
@@ -156,7 +156,12 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
       </Flex>
       {poolContractAddress && (
         <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-          <ScanLink href={getBlockExploreLinkDefault(poolContractAddress, 'address', chainId)} bold={false} small>
+          <ScanLink
+            icon={<AptosIcon />}
+            href={getBlockExploreLinkDefault(poolContractAddress, 'address', chainId)}
+            bold={false}
+            small
+          >
             {t('View Contract')}
           </ScanLink>
         </Flex>

--- a/apps/aptos/components/SearchModal/ImportToken.tsx
+++ b/apps/aptos/components/SearchModal/ImportToken.tsx
@@ -7,7 +7,7 @@ import {
   Flex,
   Message,
   Checkbox,
-  LinkExternal,
+  ScanLink,
   Tag,
   Grid,
   AutoColumn,
@@ -77,11 +77,11 @@ function ImportToken({ tokens, handleCurrencySelect }: ImportProps) {
             {chainId && (
               <Flex justifyContent="space-between" width="100%">
                 <Text mr="4px">{address}</Text>
-                <LinkExternal isAptosScan href={getBlockExploreLink(token.address, 'token', chainId)}>
+                <ScanLink href={getBlockExploreLink(token.address, 'token', chainId)}>
                   {t('View on %site%', {
                     site: t('Explorer'),
                   })}
-                </LinkExternal>
+                </ScanLink>
               </Flex>
             )}
           </Grid>

--- a/apps/aptos/components/SearchModal/ImportToken.tsx
+++ b/apps/aptos/components/SearchModal/ImportToken.tsx
@@ -12,6 +12,7 @@ import {
   Grid,
   AutoColumn,
   ListLogo,
+  AptosIcon,
 } from '@pancakeswap/uikit'
 import { getBlockExploreLink } from 'utils'
 import truncateHash from '@pancakeswap/utils/truncateHash'
@@ -77,7 +78,7 @@ function ImportToken({ tokens, handleCurrencySelect }: ImportProps) {
             {chainId && (
               <Flex justifyContent="space-between" width="100%">
                 <Text mr="4px">{address}</Text>
-                <ScanLink href={getBlockExploreLink(token.address, 'token', chainId)}>
+                <ScanLink icon={<AptosIcon />} href={getBlockExploreLink(token.address, 'token', chainId)}>
                   {t('View on %site%', {
                     site: t('Explorer'),
                   })}

--- a/apps/aptos/components/Toast/DescriptionWithTx.tsx
+++ b/apps/aptos/components/Toast/DescriptionWithTx.tsx
@@ -1,5 +1,5 @@
 // TODO: aptos merge
-import { ScanLink, Text } from '@pancakeswap/uikit'
+import { AptosIcon, ScanLink, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import truncateHash from '@pancakeswap/utils/truncateHash'
 import { useActiveChainId } from 'hooks/useNetwork'
@@ -18,7 +18,7 @@ const DescriptionWithTx: React.FC<React.PropsWithChildren<DescriptionWithTxProps
     <>
       {typeof children === 'string' ? <Text as="p">{children}</Text> : children}
       {txHash && (
-        <ScanLink href={getBlockExploreLink(txHash, 'transaction', chainId)}>
+        <ScanLink icon={<AptosIcon />} href={getBlockExploreLink(txHash, 'transaction', chainId)}>
           {t('View on %site%', { site: 'Explorer' })}: {truncateHash(txHash, 8, 0)}
         </ScanLink>
       )}

--- a/apps/aptos/components/Toast/DescriptionWithTx.tsx
+++ b/apps/aptos/components/Toast/DescriptionWithTx.tsx
@@ -1,5 +1,5 @@
 // TODO: aptos merge
-import { LinkExternal, Text } from '@pancakeswap/uikit'
+import { ScanLink, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import truncateHash from '@pancakeswap/utils/truncateHash'
 import { useActiveChainId } from 'hooks/useNetwork'
@@ -18,9 +18,9 @@ const DescriptionWithTx: React.FC<React.PropsWithChildren<DescriptionWithTxProps
     <>
       {typeof children === 'string' ? <Text as="p">{children}</Text> : children}
       {txHash && (
-        <LinkExternal isAptosScan href={getBlockExploreLink(txHash, 'transaction', chainId)}>
+        <ScanLink href={getBlockExploreLink(txHash, 'transaction', chainId)}>
           {t('View on %site%', { site: 'Explorer' })}: {truncateHash(txHash, 8, 0)}
-        </LinkExternal>
+        </ScanLink>
       )}
     </>
   )

--- a/apps/aptos/components/TransactionConfirmationModal/index.tsx
+++ b/apps/aptos/components/TransactionConfirmationModal/index.tsx
@@ -2,6 +2,7 @@
 import { ChainId, Currency } from '@pancakeswap/aptos-swap-sdk'
 import { useTranslation } from '@pancakeswap/localization'
 import {
+  AptosIcon,
   ArrowUpIcon,
   AutoColumn,
   Button,
@@ -49,7 +50,7 @@ export function TransactionSubmittedContent({
         <AutoColumn gap="12px" justify="center">
           <Text fontSize="20px">{t('Transaction Submitted')}</Text>
           {chainId && hash && (
-            <ScanLink small href={getBlockExploreLink(hash, 'transaction', chainId)}>
+            <ScanLink small icon={<AptosIcon />} href={getBlockExploreLink(hash, 'transaction', chainId)}>
               {t('View on %site%', {
                 site: t('Explorer'),
               })}

--- a/apps/aptos/components/TransactionConfirmationModal/index.tsx
+++ b/apps/aptos/components/TransactionConfirmationModal/index.tsx
@@ -8,9 +8,9 @@ import {
   ColumnCenter,
   ConfirmationPendingContent,
   InjectedModalProps,
-  LinkExternal,
   Modal,
   ModalProps,
+  ScanLink,
   Text,
 } from '@pancakeswap/uikit'
 import { useCallback } from 'react'
@@ -49,11 +49,11 @@ export function TransactionSubmittedContent({
         <AutoColumn gap="12px" justify="center">
           <Text fontSize="20px">{t('Transaction Submitted')}</Text>
           {chainId && hash && (
-            <LinkExternal isAptosScan small href={getBlockExploreLink(hash, 'transaction', chainId)}>
+            <ScanLink small href={getBlockExploreLink(hash, 'transaction', chainId)}>
               {t('View on %site%', {
                 site: t('Explorer'),
               })}
-            </LinkExternal>
+            </ScanLink>
           )}
           <Button onClick={onDismiss} mt="20px">
             {t('Close')}

--- a/apps/web/src/components/App/Transactions/Transaction.tsx
+++ b/apps/web/src/components/App/Transactions/Transaction.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { CheckmarkIcon, CloseIcon, LinkExternal } from '@pancakeswap/uikit'
+import { CheckmarkIcon, CloseIcon, ScanLink } from '@pancakeswap/uikit'
 import { getBlockExploreLink } from 'utils'
 import { TransactionDetails } from 'state/transactions/reducer'
 import CircleLoader from '../../Loader/CircleLoader'
@@ -30,9 +30,7 @@ export default function Transaction({ tx, chainId }: { tx: TransactionDetails; c
 
   return (
     <TransactionState pending={pending} success={success}>
-      <LinkExternal isBscScan href={getBlockExploreLink(tx.hash, 'transaction', chainId)}>
-        {summary ?? tx.hash}
-      </LinkExternal>
+      <ScanLink href={getBlockExploreLink(tx.hash, 'transaction', chainId)}>{summary ?? tx.hash}</ScanLink>
       <IconWrapper pending={pending} success={success}>
         {pending ? <CircleLoader /> : success ? <CheckmarkIcon color="success" /> : <CloseIcon color="failure" />}
       </IconWrapper>

--- a/apps/web/src/components/App/Transactions/Transaction.tsx
+++ b/apps/web/src/components/App/Transactions/Transaction.tsx
@@ -30,7 +30,9 @@ export default function Transaction({ tx, chainId }: { tx: TransactionDetails; c
 
   return (
     <TransactionState pending={pending} success={success}>
-      <ScanLink href={getBlockExploreLink(tx.hash, 'transaction', chainId)}>{summary ?? tx.hash}</ScanLink>
+      <ScanLink chainId={chainId} href={getBlockExploreLink(tx.hash, 'transaction', chainId)}>
+        {summary ?? tx.hash}
+      </ScanLink>
       <IconWrapper pending={pending} success={success}>
         {pending ? <CircleLoader /> : success ? <CheckmarkIcon color="success" /> : <CloseIcon color="failure" />}
       </IconWrapper>

--- a/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
+++ b/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
@@ -164,7 +164,7 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
               BNB Smart Chain
             </Text>
           </Flex>
-          <ScanLink href={getBlockExploreLink(account, 'address', ChainId.BSC)}>
+          <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(account, 'address', ChainId.BSC)}>
             {getBlockExploreName(ChainId.BSC)}
           </ScanLink>
         </Flex>

--- a/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
+++ b/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
@@ -12,6 +12,7 @@ import {
   useTooltip,
   TooltipText,
   InfoFilledIcon,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { ChainId, WNATIVE } from '@pancakeswap/sdk'
 import { FetchStatus } from 'config/constants/types'
@@ -163,9 +164,9 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
               BNB Smart Chain
             </Text>
           </Flex>
-          <LinkExternal isBscScan href={getBlockExploreLink(account, 'address', ChainId.BSC)}>
+          <ScanLink href={getBlockExploreLink(account, 'address', ChainId.BSC)}>
             {getBlockExploreName(ChainId.BSC)}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
         {chainId === 56 ? (
           <Flex alignItems="center" justifyContent="space-between">

--- a/apps/web/src/components/TransactionDetailModal/FarmTransactionModal/FarmDetail.tsx
+++ b/apps/web/src/components/TransactionDetailModal/FarmTransactionModal/FarmDetail.tsx
@@ -39,7 +39,7 @@ const FarmDetail: React.FC<React.PropsWithChildren<HarvestDetailProps>> = ({ ste
             <Flex>
               {isFail && <WarningIcon mr="4px" color="failure" />}
               {step.tx && (
-                <ScanLink href={getBlockExploreLink(step.tx, 'transaction', step.chainId)}>
+                <ScanLink chainId={step.chainId} href={getBlockExploreLink(step.tx, 'transaction', step.chainId)}>
                   {getBlockExploreName(step.chainId)}
                 </ScanLink>
               )}

--- a/apps/web/src/components/TransactionDetailModal/FarmTransactionModal/FarmDetail.tsx
+++ b/apps/web/src/components/TransactionDetailModal/FarmTransactionModal/FarmDetail.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
-import { Flex, Box, Text, LinkExternal, RefreshIcon, WarningIcon } from '@pancakeswap/uikit'
-import { ChainId } from '@pancakeswap/sdk'
+import { Flex, Box, Text, RefreshIcon, WarningIcon, ScanLink } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { chains } from 'utils/wagmi'
 import { ChainLogo } from 'components/Logo/ChainLogo'
@@ -40,12 +39,9 @@ const FarmDetail: React.FC<React.PropsWithChildren<HarvestDetailProps>> = ({ ste
             <Flex>
               {isFail && <WarningIcon mr="4px" color="failure" />}
               {step.tx && (
-                <LinkExternal
-                  isBscScan={step.chainId === ChainId.BSC}
-                  href={getBlockExploreLink(step.tx, 'transaction', step.chainId)}
-                >
+                <ScanLink href={getBlockExploreLink(step.tx, 'transaction', step.chainId)}>
                   {getBlockExploreName(step.chainId)}
-                </LinkExternal>
+                </ScanLink>
               )}
             </Flex>
           )}

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -11,7 +11,6 @@ import {
   ExpandableLabel,
   Flex,
   Heading,
-  LinkExternal,
   NextLinkFromReactRouter,
   NotFound,
   PreTitle,
@@ -24,6 +23,7 @@ import {
   Message,
   useMatchBreakpoints,
   useModal,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { MasterChefV3, NonfungiblePositionManager, Position } from '@pancakeswap/v3-sdk'
 import { AppHeader } from 'components/App'
@@ -991,9 +991,9 @@ function PositionHistoryRow({
     return (
       <Box>
         <AutoRow gap="8px">
-          <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+          <ScanLink href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
             <Text ellipsis>{dayjs(+positionTx.timestamp * 1_000).format('YYYY/MM/DD')}</Text>
-          </LinkExternal>
+          </ScanLink>
         </AutoRow>
         <Text>{positionHistoryTypeText[type]}</Text>
         <AutoColumn gap="4px">
@@ -1046,9 +1046,9 @@ function PositionHistoryRow({
       p="16px"
     >
       <AutoRow justifyContent="center" gap="8px">
-        <LinkExternal isBscScan href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+        <ScanLink href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
           <Text ellipsis>{date.toLocaleString()}</Text>
-        </LinkExternal>
+        </ScanLink>
       </AutoRow>
       <Text>{positionHistoryTypeText[type]}</Text>
       <AutoColumn gap="4px">

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -991,7 +991,7 @@ function PositionHistoryRow({
     return (
       <Box>
         <AutoRow gap="8px">
-          <ScanLink href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+          <ScanLink chainId={chainId} href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
             <Text ellipsis>{dayjs(+positionTx.timestamp * 1_000).format('YYYY/MM/DD')}</Text>
           </ScanLink>
         </AutoRow>
@@ -1046,7 +1046,7 @@ function PositionHistoryRow({
       p="16px"
     >
       <AutoRow justifyContent="center" gap="8px">
-        <ScanLink href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
+        <ScanLink chainId={chainId} href={getBlockExploreLink(positionTx.id, 'transaction', chainId)}>
           <Text ellipsis>{date.toLocaleString()}</Text>
         </ScanLink>
       </AutoRow>

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -21,6 +21,7 @@ import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import { useTranslation } from '@pancakeswap/localization'
 import { usePriceCakeUSD } from 'state/farms/hooks'
 import { Bidder } from 'config/constants/types'
+import { ChainId } from '@pancakeswap/sdk'
 import WhitelistedBiddersModal from '../WhitelistedBiddersModal'
 import { HARD_CODED_START_AUCTION_ID } from '../../constants'
 import { useV3FarmAuctionConfig } from '../../hooks/useV3FarmAuctionConfig'
@@ -136,7 +137,13 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
             </SubMenuItem>
           )}
           {account && (
-            <SubMenuItem as={ScanLink} href={getBlockExploreLink(account, 'address')} bold={false} color="text">
+            <SubMenuItem
+              as={ScanLink}
+              chainId={ChainId.BSC}
+              href={getBlockExploreLink(account, 'address')}
+              bold={false}
+              color="text"
+            >
               {t('Bidder Address')}
             </SubMenuItem>
           )}

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionLeaderboardTable.tsx
@@ -14,6 +14,7 @@ import {
   EllipsisIcon,
   LinkExternal,
   useMatchBreakpoints,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { getBlockExploreLink } from 'utils'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
@@ -135,13 +136,7 @@ const LeaderboardRow: React.FC<React.PropsWithChildren<LeaderboardRowProps>> = (
             </SubMenuItem>
           )}
           {account && (
-            <SubMenuItem
-              as={LinkExternal}
-              isBscScan
-              href={getBlockExploreLink(account, 'address')}
-              bold={false}
-              color="text"
-            >
+            <SubMenuItem as={ScanLink} href={getBlockExploreLink(account, 'address')} bold={false} color="text">
               {t('Bidder Address')}
             </SubMenuItem>
           )}

--- a/apps/web/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -188,7 +188,7 @@ const FarmCard: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
             />
             <DetailsSection
               removed={removed}
-              scanAddressLink={getBlockExploreLink(lpAddress, 'address', chainId)}
+              scanAddress={{ link: getBlockExploreLink(lpAddress, 'address', chainId), chainId }}
               infoAddress={infoUrl}
               totalValueFormatted={totalValueFormatted}
               lpLabel={lpLabel}

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
@@ -146,7 +146,7 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
             />
             <DetailsSection
               removed={removed}
-              scanAddressLink={getBlockExploreLink(lpAddress, 'address', chainId)}
+              scanAddress={{ link: getBlockExploreLink(lpAddress, 'address', chainId), chainId }}
               infoAddress={infoUrl}
               totalValueFormatted={`$${parseInt(farm.activeTvlUSD).toLocaleString(undefined, {
                 maximumFractionDigits: 0,

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -9,6 +9,7 @@ import {
   useMatchBreakpoints,
   useModalV2,
   ScanLink,
+  LinkExternal,
 } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { CHAIN_QUERY_NAME } from 'config/chains'
@@ -98,6 +99,10 @@ const Container = styled.div<{ expanded }>`
   }
 `
 
+const StyledLinkExternal = styled(LinkExternal)`
+  font-weight: 400;
+`
+
 const StyledScanLink = styled(ScanLink)`
   font-weight: 400;
 `
@@ -161,6 +166,7 @@ export const ActionPanelV3: FC<ActionPanelV3Props> = ({
 }) => {
   const { isDesktop } = useMatchBreakpoints()
   const { t } = useTranslation()
+  const { chainId } = useActiveChainId()
   const { address: account } = useAccount()
   const farm = details
   const isActive = farm.multiplier !== '0X'
@@ -223,10 +229,12 @@ export const ActionPanelV3: FC<ActionPanelV3Props> = ({
               </Flex>
             )}
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledScanLink href={infoUrl}>{t('See Pair Info')}</StyledScanLink>
+              <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
             </Flex>
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledScanLink href={bsc}>{t('View Contract')}</StyledScanLink>
+              <StyledScanLink chainId={chainId} href={bsc}>
+                {t('View Contract')}
+              </StyledScanLink>
             </Flex>
           </>
         }
@@ -344,10 +352,12 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
               </Flex>
             )}
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledScanLink href={infoUrl}>{t('See Pair Info')}</StyledScanLink>
+              <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
             </Flex>
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledScanLink href={bsc}>{t('View Contract')}</StyledScanLink>
+              <StyledScanLink chainId={chainId} href={bsc}>
+                {t('View Contract')}
+              </StyledScanLink>
             </Flex>
           </>
         }

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -4,11 +4,11 @@ import {
   FarmTableMultiplierProps,
   Farm as FarmUI,
   Flex,
-  LinkExternal,
   Skeleton,
   Text,
   useMatchBreakpoints,
   useModalV2,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { CHAIN_QUERY_NAME } from 'config/chains'
@@ -98,7 +98,7 @@ const Container = styled.div<{ expanded }>`
   }
 `
 
-const StyledLinkExternal = styled(LinkExternal)`
+const StyledScanLink = styled(ScanLink)`
   font-weight: 400;
 `
 
@@ -223,12 +223,10 @@ export const ActionPanelV3: FC<ActionPanelV3Props> = ({
               </Flex>
             )}
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
+              <StyledScanLink href={infoUrl}>{t('See Pair Info')}</StyledScanLink>
             </Flex>
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledLinkExternal isBscScan href={bsc}>
-                {t('View Contract')}
-              </StyledLinkExternal>
+              <StyledScanLink href={bsc}>{t('View Contract')}</StyledScanLink>
             </Flex>
           </>
         }
@@ -346,12 +344,10 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
               </Flex>
             )}
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledLinkExternal href={infoUrl}>{t('See Pair Info')}</StyledLinkExternal>
+              <StyledScanLink href={infoUrl}>{t('See Pair Info')}</StyledScanLink>
             </Flex>
             <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-              <StyledLinkExternal isBscScan href={bsc}>
-                {t('View Contract')}
-              </StyledLinkExternal>
+              <StyledScanLink href={bsc}>{t('View Contract')}</StyledScanLink>
             </Flex>
           </>
         }

--- a/apps/web/src/views/Info/Pools/PoolPage.tsx
+++ b/apps/web/src/views/Info/Pools/PoolPage.tsx
@@ -143,7 +143,11 @@ const PoolPage: React.FC<React.PropsWithChildren<{ address: string }>> = ({ addr
               </Flex>
             </Breadcrumbs>
             <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-              <ScanLink mr="8px" href={getBlockExploreLink(address, 'address', multiChainId[chainName])}>
+              <ScanLink
+                chainId={multiChainId[chainName]}
+                mr="8px"
+                href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
+              >
                 {t('View on %site%', { site: multiChainScan[chainName] })}
               </ScanLink>
               <SaveIcon fill={savedPools.includes(address)} onClick={() => addPool(address)} />

--- a/apps/web/src/views/Info/Pools/PoolPage.tsx
+++ b/apps/web/src/views/Info/Pools/PoolPage.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-nested-ternary */
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId } from '@pancakeswap/sdk'
 import {
   Box,
   Breadcrumbs,
@@ -11,8 +10,8 @@ import {
   Flex,
   Heading,
   HelpIcon,
-  LinkExternal,
   NextLinkFromReactRouter,
+  ScanLink,
   Spinner,
   Text,
   useMatchBreakpoints,
@@ -144,13 +143,9 @@ const PoolPage: React.FC<React.PropsWithChildren<{ address: string }>> = ({ addr
               </Flex>
             </Breadcrumbs>
             <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-              <LinkExternal
-                isBscScan={multiChainId[chainName] === ChainId.BSC}
-                mr="8px"
-                href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
-              >
+              <ScanLink mr="8px" href={getBlockExploreLink(address, 'address', multiChainId[chainName])}>
                 {t('View on %site%', { site: multiChainScan[chainName] })}
-              </LinkExternal>
+              </ScanLink>
               <SaveIcon fill={savedPools.includes(address)} onClick={() => addPool(address)} />
             </Flex>
           </Flex>

--- a/apps/web/src/views/Info/Tokens/TokenPage.tsx
+++ b/apps/web/src/views/Info/Tokens/TokenPage.tsx
@@ -145,6 +145,7 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
                 <ScanLink
                   mr="8px"
                   color="primary"
+                  chainId={multiChainId[chainName]}
                   href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
                 >
                   {t('View on %site%', { site: multiChainScan[chainName] })}

--- a/apps/web/src/views/Info/Tokens/TokenPage.tsx
+++ b/apps/web/src/views/Info/Tokens/TokenPage.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-nested-ternary */
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId } from '@pancakeswap/sdk'
 import {
   Box,
   Breadcrumbs,
@@ -9,12 +8,12 @@ import {
   Flex,
   Heading,
   Image,
-  LinkExternal,
   NextLinkFromReactRouter,
   Spinner,
   Text,
   Link as UIKitLink,
   useMatchBreakpoints,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import useInfoUserSavedTokensAndPools from 'hooks/useInfoUserSavedTokensAndPoolsList'
 import { NextSeo } from 'next-seo'
@@ -143,14 +142,13 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
                 </Flex>
               </Breadcrumbs>
               <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-                <LinkExternal
-                  isBscScan={multiChainId[chainName] === ChainId.BSC}
+                <ScanLink
                   mr="8px"
                   color="primary"
                   href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
                 >
                   {t('View on %site%', { site: multiChainScan[chainName] })}
-                </LinkExternal>
+                </ScanLink>
                 {cmcLink && (
                   <StyledCMCLink href={cmcLink} rel="noopener noreferrer nofollow" target="_blank">
                     <Image src="/images/CMC-logo.svg" height={22} width={22} alt={t('View token on CoinMarketCap')} />

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -1,9 +1,8 @@
 // TODO PCS refactor ternaries
 /* eslint-disable no-nested-ternary */
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId } from '@pancakeswap/sdk'
 import truncateHash from '@pancakeswap/utils/truncateHash'
-import { ArrowBackIcon, ArrowForwardIcon, Box, Flex, LinkExternal, Radio, Skeleton, Text } from '@pancakeswap/uikit'
+import { ArrowBackIcon, ArrowForwardIcon, Box, Flex, Radio, ScanLink, Skeleton, Text } from '@pancakeswap/uikit'
 import { ITEMS_PER_INFO_TABLE_PAGE } from 'config/constants/info'
 import { formatDistanceToNowStrict } from 'date-fns'
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
@@ -110,10 +109,7 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
 
   return (
     <ResponsiveGrid>
-      <LinkExternal
-        isBscScan={multiChainId[chainName] === ChainId.BSC}
-        href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
-      >
+      <ScanLink href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}>
         <Text>
           {transaction.type === TransactionType.MINT
             ? t('Add %token0% and %token1%', {
@@ -130,7 +126,7 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
                 token1: token1Symbol,
               })}
         </Text>
-      </LinkExternal>
+      </ScanLink>
       <Text>${formatAmount(transaction.amountUSD)}</Text>
       <Text>
         <Text>{`${formatAmount(abs0)} ${transaction.token0Symbol}`}</Text>
@@ -138,12 +134,9 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
       <Text>
         <Text>{`${formatAmount(abs1)} ${transaction.token1Symbol}`}</Text>
       </Text>
-      <LinkExternal
-        isBscScan={multiChainId[chainName] === ChainId.BSC}
-        href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
-      >
+      <ScanLink href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}>
         {domainName || truncateHash(transaction.sender)}
-      </LinkExternal>
+      </ScanLink>
       <Text>{formatDistanceToNowStrict(parseInt(transaction.timestamp, 10) * 1000)}</Text>
     </ResponsiveGrid>
   )

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -1,6 +1,7 @@
 // TODO PCS refactor ternaries
 /* eslint-disable no-nested-ternary */
 import { useTranslation } from '@pancakeswap/localization'
+import { ChainId } from '@pancakeswap/sdk'
 import truncateHash from '@pancakeswap/utils/truncateHash'
 import { ArrowBackIcon, ArrowForwardIcon, Box, Flex, LinkExternal, Radio, Skeleton, Text } from '@pancakeswap/uikit'
 import { ITEMS_PER_INFO_TABLE_PAGE } from 'config/constants/info'
@@ -109,7 +110,10 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
 
   return (
     <ResponsiveGrid>
-      <LinkExternal isBscScan href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}>
+      <LinkExternal
+        isBscScan={multiChainId[chainName] === ChainId.BSC}
+        href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
+      >
         <Text>
           {transaction.type === TransactionType.MINT
             ? t('Add %token0% and %token1%', {
@@ -134,7 +138,10 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
       <Text>
         <Text>{`${formatAmount(abs1)} ${transaction.token1Symbol}`}</Text>
       </Text>
-      <LinkExternal isBscScan href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}>
+      <LinkExternal
+        isBscScan={multiChainId[chainName] === ChainId.BSC}
+        href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
+      >
         {domainName || truncateHash(transaction.sender)}
       </LinkExternal>
       <Text>{formatDistanceToNowStrict(parseInt(transaction.timestamp, 10) * 1000)}</Text>

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -109,7 +109,10 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
 
   return (
     <ResponsiveGrid>
-      <ScanLink href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}>
+      <ScanLink
+        chainId={multiChainId[chainName]}
+        href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
+      >
         <Text>
           {transaction.type === TransactionType.MINT
             ? t('Add %token0% and %token1%', {
@@ -134,7 +137,10 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
       <Text>
         <Text>{`${formatAmount(abs1)} ${transaction.token1Symbol}`}</Text>
       </Text>
-      <ScanLink href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}>
+      <ScanLink
+        chainId={multiChainId[chainName]}
+        href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
+      >
         {domainName || truncateHash(transaction.sender)}
       </ScanLink>
       <Text>{formatDistanceToNowStrict(parseInt(transaction.timestamp, 10) * 1000)}</Text>

--- a/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/EditStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/EditStage.tsx
@@ -1,4 +1,4 @@
-import { Flex, Grid, Text, Button, LinkExternal, BinanceIcon } from '@pancakeswap/uikit'
+import { Flex, Grid, Text, Button, LinkExternal, BinanceIcon, ScanLink } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { nftsBaseUrl, pancakeBunniesAddress } from 'views/Nft/market/constants'
 import { NftToken } from 'state/nftMarket/types'
@@ -71,14 +71,9 @@ const EditStage: React.FC<React.PropsWithChildren<EditStageProps>> = ({
             {t('View Item')}
           </LinkExternal>
           <HorizontalDivider />
-          <LinkExternal
-            isBscScan
-            p="0px"
-            height="16px"
-            href={getBscScanLinkForNft(nftToSell.collectionAddress, nftToSell.tokenId)}
-          >
+          <ScanLink p="0px" height="16px" href={getBscScanLinkForNft(nftToSell.collectionAddress, nftToSell.tokenId)}>
             BscScan
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       </Flex>
       <Divider />

--- a/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/SellStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/SellStage.tsx
@@ -1,4 +1,4 @@
-import { Flex, Grid, Text, Button, BinanceIcon, LinkExternal, useModal } from '@pancakeswap/uikit'
+import { Flex, Grid, Text, Button, BinanceIcon, LinkExternal, useModal, ScanLink } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { nftsBaseUrl, pancakeBunniesAddress } from 'views/Nft/market/constants'
 import { NftToken } from 'state/nftMarket/types'
@@ -72,14 +72,9 @@ const SellStage: React.FC<React.PropsWithChildren<SellStageProps>> = ({
             {t('View Item')}
           </LinkExternal>
           <HorizontalDivider />
-          <LinkExternal
-            isBscScan
-            p="0px"
-            height="16px"
-            href={getBscScanLinkForNft(nftToSell.collectionAddress, nftToSell.tokenId)}
-          >
+          <ScanLink p="0px" height="16px" href={getBscScanLinkForNft(nftToSell.collectionAddress, nftToSell.tokenId)}>
             BscScan
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       </Flex>
       <Divider />

--- a/apps/web/src/views/Nft/market/components/BuySellModals/shared/TransactionConfirmed.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/shared/TransactionConfirmed.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Button, ArrowUpIcon, LinkExternal } from '@pancakeswap/uikit'
+import { Flex, Text, Button, ArrowUpIcon, ScanLink } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { getBlockExploreLink } from 'utils'
 import { useActiveChainId } from 'hooks/useActiveChainId'
@@ -17,9 +17,7 @@ const TransactionConfirmed: React.FC<React.PropsWithChildren<TransactionConfirme
       <Flex p="16px" flexDirection="column" alignItems="center" justifyContent="space-between" height="150px">
         <ArrowUpIcon width="64px" height="64px" color="primary" />
         <Text bold>{t('Transaction Confirmed')}</Text>
-        <LinkExternal isBscScan href={getBlockExploreLink(txHash, 'transaction', chainId)}>
-          {t('View on BscScan')}
-        </LinkExternal>
+        <ScanLink href={getBlockExploreLink(txHash, 'transaction', chainId)}>{t('View on BscScan')}</ScanLink>
       </Flex>
       <Divider />
       <Flex px="16px" pb="16px" justifyContent="center">

--- a/apps/web/src/views/Nft/market/components/ProfileNftModal.tsx
+++ b/apps/web/src/views/Nft/market/components/ProfileNftModal.tsx
@@ -1,4 +1,14 @@
-import { InjectedModalProps, Modal, Flex, Text, Button, useModal, Grid, LinkExternal } from '@pancakeswap/uikit'
+import {
+  InjectedModalProps,
+  Modal,
+  Flex,
+  Text,
+  Button,
+  useModal,
+  Grid,
+  LinkExternal,
+  ScanLink,
+} from '@pancakeswap/uikit'
 import useTheme from 'hooks/useTheme'
 import styled from 'styled-components'
 import { NftToken } from 'state/nftMarket/types'
@@ -59,14 +69,9 @@ const ProfileNftModal: React.FC<React.PropsWithChildren<ProfileNftModalProps>> =
               {t('View Item')}
             </LinkExternal>
             <HorizontalDivider />
-            <LinkExternal
-              isBscScan
-              p="0px"
-              height="16px"
-              href={getBscScanLinkForNft(nft.collectionAddress, nft.tokenId)}
-            >
+            <ScanLink p="0px" height="16px" href={getBscScanLinkForNft(nft.collectionAddress, nft.tokenId)}>
               BscScan
-            </LinkExternal>
+            </ScanLink>
           </Flex>
         </Flex>
         <TextWrapper p="24px 16px" flexDirection="column">

--- a/apps/web/src/views/PancakeSquad/components/Modals/Confirm/index.tsx
+++ b/apps/web/src/views/PancakeSquad/components/Modals/Confirm/index.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   Heading,
   IconButton,
-  LinkExternal,
   ModalBody,
   ModalWrapper,
   ModalHeader,
@@ -15,6 +14,7 @@ import {
   ModalTitle,
   Spinner,
   Text,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import useTheme from 'hooks/useTheme'
@@ -87,9 +87,9 @@ const ConfirmModal: React.FC<React.PropsWithChildren<ConfirmModalProps>> = ({
               <Text mb="30px" bold>
                 {t('Transaction Submitted')}
               </Text>
-              <LinkExternal isBscScan href={getBlockExploreLink(txHash, 'transaction', chainId)} mb="30px">
+              <ScanLink href={getBlockExploreLink(txHash, 'transaction', chainId)} mb="30px">
                 {t('View on BscScan')}: {truncateHash(txHash, 8, 0)}
-              </LinkExternal>
+              </ScanLink>
               <Flex
                 justifyContent="center"
                 width="100%"

--- a/apps/web/src/views/Pools/components/PoolStatsInfo.tsx
+++ b/apps/web/src/views/Pools/components/PoolStatsInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, LinkExternal, Skeleton, Text, Pool } from '@pancakeswap/uikit'
+import { Flex, LinkExternal, Skeleton, Text, Pool, ScanLink } from '@pancakeswap/uikit'
 import AddToWalletButton, { AddToWalletTextOptions } from 'components/AddToWallet/AddToWalletButton'
 import { useTranslation } from '@pancakeswap/localization'
 import { Token } from '@pancakeswap/sdk'
@@ -135,14 +135,13 @@ const PoolStatsInfo: React.FC<React.PropsWithChildren<ExpandedFooterProps>> = ({
       )}
       {poolContractAddress && (
         <Flex mb="2px" justifyContent={alignLinksToRight ? 'flex-end' : 'flex-start'}>
-          <LinkExternal
-            isBscScan
+          <ScanLink
             href={getBlockExploreLink(vaultKey ? cakeVaultContractAddress : poolContractAddress, 'address', chainId)}
             bold={false}
             small
           >
             {t('View Contract')}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       )}
       {account && tokenAddress && (

--- a/apps/web/src/views/Pottery/components/FinishedRounds/AllHistoryCard/PreviousRoundCardBody.tsx
+++ b/apps/web/src/views/Pottery/components/FinishedRounds/AllHistoryCard/PreviousRoundCardBody.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { Box, Flex, Text, CardBody, CardRibbon, LinkExternal, Skeleton, Balance } from '@pancakeswap/uikit'
+import { Box, Flex, Text, CardBody, CardRibbon, Skeleton, Balance, ScanLink } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import { useTranslation } from '@pancakeswap/localization'
@@ -122,13 +122,12 @@ const PreviousRoundCardBody: React.FC<React.PropsWithChildren<PreviousRoundCardB
               </Text>
             </Flex>
           </Flex>
-          <LinkExternal
-            isBscScan
+          <ScanLink
             m={['10px auto auto auto', '10px auto auto auto', 'auto 0 0 auto']}
             href={getBlockExploreLink(txid, 'transaction')}
           >
             {t('View on BscScan')}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
       </Flex>
     </StyledCardBody>

--- a/apps/web/src/views/Predictions/Leaderboard/components/WalletStatsModal.tsx
+++ b/apps/web/src/views/Predictions/Leaderboard/components/WalletStatsModal.tsx
@@ -6,13 +6,13 @@ import {
   Text,
   IconButton,
   InjectedModalProps,
-  LinkExternal,
   ModalWrapper,
   ModalHeader,
   ProfileAvatar,
   Skeleton,
   Heading,
   useMatchBreakpoints,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { useProfileForAddress } from 'state/profile/hooks'
 import useTheme from 'hooks/useTheme'
@@ -39,7 +39,7 @@ interface WalletStatsModalProps extends InjectedModalProps {
   api: string
 }
 
-const ExternalLink = styled(LinkExternal)`
+const StyledScanLink = styled(ScanLink)`
   color: ${({ theme }) => theme.colors.text};
 
   svg {
@@ -84,9 +84,9 @@ const WalletStatsModal: React.FC<React.PropsWithChildren<WalletStatsModalProps>>
                 {profile?.username}
               </Heading>
             )}
-            <ExternalLink isBscScan href={getBlockExploreLink(address, 'address')}>
+            <StyledScanLink href={getBlockExploreLink(address, 'address')}>
               {domainName || truncateHash(address)}
-            </ExternalLink>
+            </StyledScanLink>
           </Box>
         </Flex>
         <IconButton variant="text" onClick={handleDismiss} aria-label="Close the dialog">

--- a/apps/web/src/views/Predictions/components/History/BetResult.tsx
+++ b/apps/web/src/views/Predictions/components/History/BetResult.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useAccount } from 'wagmi'
-import { Box, Flex, Heading, Text, PrizeIcon, BlockIcon, LinkExternal, useTooltip, InfoIcon } from '@pancakeswap/uikit'
+import { Box, Flex, Heading, Text, PrizeIcon, BlockIcon, useTooltip, InfoIcon, ScanLink } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import useLocalDispatch from 'contexts/LocalRedux/useLocalDispatch'
 import { useTranslation } from '@pancakeswap/localization'
@@ -135,9 +135,9 @@ const BetResult: React.FC<React.PropsWithChildren<BetResultProps>> = ({ bet, res
         )}
         {bet.claimed && bet.claimedHash && (
           <Flex justifyContent="center">
-            <LinkExternal isBscScan href={getBlockExploreLink(bet.claimedHash, 'transaction')} mb="16px">
+            <ScanLink href={getBlockExploreLink(bet.claimedHash, 'transaction')} mb="16px">
               {t('View on BscScan')}
-            </LinkExternal>
+            </ScanLink>
           </Flex>
         )}
         {result === Result.CANCELED && isRefundable && (

--- a/apps/web/src/views/Profile/components/ProfileHeader.tsx
+++ b/apps/web/src/views/Profile/components/ProfileHeader.tsx
@@ -1,7 +1,6 @@
 import {
   Flex,
   IconButton,
-  LinkExternal,
   Button,
   useModal,
   Grid,
@@ -10,6 +9,7 @@ import {
   VisibilityOff,
   VisibilityOn,
   NextLinkFromReactRouter as ReactRouterLink,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { getBlockExploreLink, isAddress } from 'utils'
@@ -175,9 +175,9 @@ const ProfileHeader: React.FC<React.PropsWithChildren<HeaderProps>> = ({
     return (
       <Flex flexDirection="column" mb={[16, null, 0]} mr={[0, null, 16]}>
         {accountPath && profile?.username && (
-          <LinkExternal isBscScan href={getBlockExploreLink(accountPath, 'address')} external bold color="primary">
+          <ScanLink href={getBlockExploreLink(accountPath, 'address')} bold color="primary">
             {domainName || truncateHash(accountPath)}
-          </LinkExternal>
+          </ScanLink>
         )}
         {accountPath && isConnectedAccount && (!profile || !profile?.nft) && getActivateButton()}
       </Flex>

--- a/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Flex,
 } from '@pancakeswap/uikit'
+import { ChainId } from '@pancakeswap/sdk'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useChainNameByQuery } from 'state/info/hooks'
 import { multiChainId, subgraphTokenSymbol } from 'state/info/constant'
@@ -105,7 +106,7 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
     <ResponsiveGrid>
       <LinkExternal
         href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
-        isBscScan={chainName === 'BSC'}
+        isBscScan={multiChainId[chainName] === ChainId.BSC}
       >
         <Text fontWeight={400}>
           {transaction.type === TransactionType.MINT
@@ -125,7 +126,7 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
       <Text fontWeight={400}>
         <LinkExternal
           href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
-          isBscScan={chainName === 'BSC'}
+          isBscScan={multiChainId[chainName] === ChainId.BSC}
         >
           {shortenAddress(transaction.sender)}
         </LinkExternal>

--- a/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
@@ -103,7 +103,10 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
 
   return (
     <ResponsiveGrid>
-      <ScanLink href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}>
+      <ScanLink
+        chainId={multiChainId[chainName]}
+        href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
+      >
         <Text fontWeight={400}>
           {transaction.type === TransactionType.MINT
             ? `Add ${token0Symbol} and ${token1Symbol}`
@@ -120,7 +123,10 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
         <HoverInlineText text={`${formatAmount(abs1)}  ${token1Symbol}`} maxCharacters={16} />
       </Text>
       <Text fontWeight={400}>
-        <ScanLink href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}>
+        <ScanLink
+          chainId={multiChainId[chainName]}
+          href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
+        >
           {shortenAddress(transaction.sender)}
         </ScanLink>
       </Text>

--- a/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/TransactionsTable/index.tsx
@@ -4,12 +4,11 @@ import {
   ArrowForwardIcon,
   AutoColumn,
   Box,
-  LinkExternal,
   SortArrowIcon,
   Text,
   Flex,
+  ScanLink,
 } from '@pancakeswap/uikit'
-import { ChainId } from '@pancakeswap/sdk'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useChainNameByQuery } from 'state/info/hooks'
 import { multiChainId, subgraphTokenSymbol } from 'state/info/constant'
@@ -104,10 +103,7 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
 
   return (
     <ResponsiveGrid>
-      <LinkExternal
-        href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}
-        isBscScan={multiChainId[chainName] === ChainId.BSC}
-      >
+      <ScanLink href={getBlockExploreLink(transaction.hash, 'transaction', multiChainId[chainName])}>
         <Text fontWeight={400}>
           {transaction.type === TransactionType.MINT
             ? `Add ${token0Symbol} and ${token1Symbol}`
@@ -115,7 +111,7 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
             ? `Swap ${inputTokenSymbol} for ${outputTokenSymbol}`
             : `Remove ${token0Symbol} and ${token1Symbol}`}
         </Text>
-      </LinkExternal>
+      </ScanLink>
       <Text fontWeight={400}>{formatDollarAmount(transaction.amountUSD)}</Text>
       <Text fontWeight={400}>
         <HoverInlineText text={`${formatAmount(abs0)}  ${token0Symbol}`} maxCharacters={16} />
@@ -124,12 +120,9 @@ const DataRow = ({ transaction }: { transaction: Transaction; color?: string }) 
         <HoverInlineText text={`${formatAmount(abs1)}  ${token1Symbol}`} maxCharacters={16} />
       </Text>
       <Text fontWeight={400}>
-        <LinkExternal
-          href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}
-          isBscScan={multiChainId[chainName] === ChainId.BSC}
-        >
+        <ScanLink href={getBlockExploreLink(transaction.sender, 'address', multiChainId[chainName])}>
           {shortenAddress(transaction.sender)}
-        </LinkExternal>
+        </ScanLink>
       </Text>
       <Text fontWeight={400}>{formatTime(transaction.timestamp, 0)}</Text>
     </ResponsiveGrid>

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -159,7 +159,11 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
             </Breadcrumbs>
 
             <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-              <ScanLink mr="8px" href={getBlockExploreLink(address, 'address', multiChainId[chainName])}>
+              <ScanLink
+                chainId={multiChainId[chainName]}
+                href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
+                mr="8px"
+              >
                 {t('View on %site%', { site: multiChainScan[chainName] })}
               </ScanLink>
               {/* <SaveIcon fill={watchlistPools.includes(address)} onClick={() => addPoolToWatchlist(address)} /> */}

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId } from '@pancakeswap/sdk'
 import dayjs from 'dayjs'
 import {
   AutoColumn,
@@ -8,12 +7,12 @@ import {
   Card,
   Flex,
   Heading,
-  LinkExternal,
   NextLinkFromReactRouter,
   Spinner,
   Text,
   useMatchBreakpoints,
   Button,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import Page from 'components/Layout/Page'
 import { TabToggle, TabToggleGroup } from 'components/TabToggle'
@@ -160,13 +159,9 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
             </Breadcrumbs>
 
             <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-              <LinkExternal
-                isBscScan={multiChainId[chainName] === ChainId.BSC}
-                mr="8px"
-                href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
-              >
+              <ScanLink mr="8px" href={getBlockExploreLink(address, 'address', multiChainId[chainName])}>
                 {t('View on %site%', { site: multiChainScan[chainName] })}
-              </LinkExternal>
+              </ScanLink>
               {/* <SaveIcon fill={watchlistPools.includes(address)} onClick={() => addPoolToWatchlist(address)} /> */}
             </Flex>
           </Flex>

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { ChainId } from '@pancakeswap/sdk'
 import {
   AutoColumn,
   Box,
@@ -9,13 +8,13 @@ import {
   Flex,
   Heading,
   Image,
-  LinkExternal,
   NextLinkFromReactRouter,
   Spinner,
   Text,
   useMatchBreakpoints,
   Message,
   MessageText,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import Page from 'components/Layout/Page'
 import { TabToggle, TabToggleGroup } from 'components/TabToggle'
@@ -184,14 +183,13 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                   </Flex>
                 </Breadcrumbs>
                 <Flex justifyContent={[null, null, 'flex-end']} mt={['8px', '8px', 0]}>
-                  <LinkExternal
-                    isBscScan={multiChainId[chainName] === ChainId.BSC}
+                  <ScanLink
                     mr="8px"
                     color="primary"
                     href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
                   >
                     {t('View on %site%', { site: multiChainScan[chainName] })}
-                  </LinkExternal>
+                  </ScanLink>
                   {cmcLink && (
                     <StyledCMCLink href={cmcLink} rel="noopener noreferrer nofollow" target="_blank">
                       <Image src="/images/CMC-logo.svg" height={22} width={22} alt={t('View token on CoinMarketCap')} />

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -186,6 +186,7 @@ const TokenPage: React.FC<{ address: string }> = ({ address }) => {
                   <ScanLink
                     mr="8px"
                     color="primary"
+                    chainId={multiChainId[chainName]}
                     href={getBlockExploreLink(address, 'address', multiChainId[chainName])}
                   >
                     {t('View on %site%', { site: multiChainScan[chainName] })}

--- a/apps/web/src/views/Voting/CreateProposal/index.tsx
+++ b/apps/web/src/views/Voting/CreateProposal/index.tsx
@@ -31,6 +31,7 @@ import { useRouter } from 'next/router'
 import { getBlockExploreLink } from 'utils'
 import { DatePicker, DatePickerPortal, TimePicker } from 'views/Voting/components/DatePicker'
 import { useAccount, useWalletClient } from 'wagmi'
+import { ChainId } from '@pancakeswap/sdk'
 import Layout from '../components/Layout'
 import VoteDetailsModal from '../components/VoteDetailsModal'
 import { ADMINS, PANCAKE_SPACE, VOTE_THRESHOLD } from '../config'
@@ -270,14 +271,18 @@ const CreateProposal = () => {
                     <Text color="textSubtle" mr="16px">
                       {t('Creator')}
                     </Text>
-                    <ScanLink href={getBlockExploreLink(account, 'address')}>{truncateHash(account)}</ScanLink>
+                    <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(account, 'address')}>
+                      {truncateHash(account)}
+                    </ScanLink>
                   </Flex>
                 )}
                 <Flex alignItems="center" mb="16px">
                   <Text color="textSubtle" mr="16px">
                     {t('Snapshot')}
                   </Text>
-                  <ScanLink href={getBlockExploreLink(snapshot, 'block')}>{snapshot}</ScanLink>
+                  <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(snapshot, 'block')}>
+                    {snapshot}
+                  </ScanLink>
                 </Flex>
                 {account ? (
                   <>

--- a/apps/web/src/views/Voting/CreateProposal/index.tsx
+++ b/apps/web/src/views/Voting/CreateProposal/index.tsx
@@ -9,11 +9,11 @@ import {
   Flex,
   Heading,
   Input,
-  LinkExternal,
   Text,
   useModal,
   useToast,
   ReactMarkdown,
+  ScanLink,
 } from '@pancakeswap/uikit'
 import snapshot from '@snapshot-labs/snapshot.js'
 import isEmpty from 'lodash/isEmpty'
@@ -270,18 +270,14 @@ const CreateProposal = () => {
                     <Text color="textSubtle" mr="16px">
                       {t('Creator')}
                     </Text>
-                    <LinkExternal isBscScan href={getBlockExploreLink(account, 'address')}>
-                      {truncateHash(account)}
-                    </LinkExternal>
+                    <ScanLink href={getBlockExploreLink(account, 'address')}>{truncateHash(account)}</ScanLink>
                   </Flex>
                 )}
                 <Flex alignItems="center" mb="16px">
                   <Text color="textSubtle" mr="16px">
                     {t('Snapshot')}
                   </Text>
-                  <LinkExternal isBscScan href={getBlockExploreLink(snapshot, 'block')}>
-                    {snapshot}
-                  </LinkExternal>
+                  <ScanLink href={getBlockExploreLink(snapshot, 'block')}>{snapshot}</ScanLink>
                 </Flex>
                 {account ? (
                   <>

--- a/apps/web/src/views/Voting/Proposal/Details.tsx
+++ b/apps/web/src/views/Voting/Proposal/Details.tsx
@@ -5,6 +5,7 @@ import { Proposal } from 'state/types'
 import { getBlockExploreLink } from 'utils'
 import { useTranslation } from '@pancakeswap/localization'
 import truncateHash from '@pancakeswap/utils/truncateHash'
+import { ChainId } from '@pancakeswap/sdk'
 import { IPFS_GATEWAY } from '../config'
 import { ProposalStateTag } from '../components/Proposals/tags'
 
@@ -39,13 +40,13 @@ const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({ proposal }) 
         </Flex>
         <Flex alignItems="center" mb="8px">
           <Text color="textSubtle">{t('Creator')}</Text>
-          <ScanLink href={getBlockExploreLink(proposal.author, 'address')} ml="8px">
+          <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(proposal.author, 'address')} ml="8px">
             {truncateHash(proposal.author)}
           </ScanLink>
         </Flex>
         <Flex alignItems="center" mb="16px">
           <Text color="textSubtle">{t('Snapshot')}</Text>
-          <ScanLink href={getBlockExploreLink(proposal.snapshot, 'block')} ml="8px">
+          <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(proposal.snapshot, 'block')} ml="8px">
             {proposal.snapshot}
           </ScanLink>
         </Flex>

--- a/apps/web/src/views/Voting/Proposal/Details.tsx
+++ b/apps/web/src/views/Voting/Proposal/Details.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardBody, CardHeader, Flex, Heading, LinkExternal, Text } from '@pancakeswap/uikit'
+import { Box, Card, CardBody, CardHeader, Flex, Heading, LinkExternal, ScanLink, Text } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { format } from 'date-fns'
 import { Proposal } from 'state/types'
@@ -39,15 +39,15 @@ const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({ proposal }) 
         </Flex>
         <Flex alignItems="center" mb="8px">
           <Text color="textSubtle">{t('Creator')}</Text>
-          <LinkExternal isBscScan href={getBlockExploreLink(proposal.author, 'address')} ml="8px">
+          <ScanLink href={getBlockExploreLink(proposal.author, 'address')} ml="8px">
             {truncateHash(proposal.author)}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
         <Flex alignItems="center" mb="16px">
           <Text color="textSubtle">{t('Snapshot')}</Text>
-          <LinkExternal isBscScan href={getBlockExploreLink(proposal.snapshot, 'block')} ml="8px">
+          <ScanLink href={getBlockExploreLink(proposal.snapshot, 'block')} ml="8px">
             {proposal.snapshot}
-          </LinkExternal>
+          </ScanLink>
         </Flex>
         <DetailBox p="16px">
           <ProposalStateTag proposalState={proposal.state} mb="8px" />

--- a/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
+++ b/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { getBlockExploreLink } from 'utils'
 import { formatNumber } from '@pancakeswap/utils/formatBalance'
 import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
+import { ChainId } from '@pancakeswap/sdk'
 import { ModalInner, VotingBoxBorder, VotingBoxCardInner } from './styles'
 
 const StyledScanLink = styled(ScanLink)`
@@ -126,7 +127,7 @@ const DetailsView: React.FC<React.PropsWithChildren<DetailsViewProps>> = ({
       </VotingBoxBorder>
       <Text color="secondary" textTransform="uppercase" mb="4px" bold fontSize="14px">
         {t('Your voting power at block')}
-        <StyledScanLink href={getBlockExploreLink(block, 'block')} ml="8px">
+        <StyledScanLink chainId={ChainId.BSC} href={getBlockExploreLink(block, 'block')} ml="8px">
           {block}
         </StyledScanLink>
       </Text>

--- a/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
+++ b/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
-import { Flex, LinkExternal, Text, Box, HelpIcon, useTooltip, RocketIcon, Link } from '@pancakeswap/uikit'
+import { Flex, Text, Box, HelpIcon, useTooltip, RocketIcon, Link, ScanLink } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import styled from 'styled-components'
 import { getBlockExploreLink } from 'utils'
@@ -8,7 +8,7 @@ import { formatNumber } from '@pancakeswap/utils/formatBalance'
 import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
 import { ModalInner, VotingBoxBorder, VotingBoxCardInner } from './styles'
 
-const StyledLinkExternal = styled(LinkExternal)`
+const StyledScanLink = styled(ScanLink)`
   display: inline-flex;
   font-size: 14px;
   > svg {
@@ -126,9 +126,9 @@ const DetailsView: React.FC<React.PropsWithChildren<DetailsViewProps>> = ({
       </VotingBoxBorder>
       <Text color="secondary" textTransform="uppercase" mb="4px" bold fontSize="14px">
         {t('Your voting power at block')}
-        <StyledLinkExternal isBscScan href={getBlockExploreLink(block, 'block')} ml="8px">
+        <StyledScanLink href={getBlockExploreLink(block, 'block')} ml="8px">
           {block}
-        </StyledLinkExternal>
+        </StyledScanLink>
       </Text>
       {Number.isFinite(cakeBalance) && (
         <Flex alignItems="center" justifyContent="space-between" mb="4px">

--- a/apps/web/src/views/Voting/components/Proposal/VoteRow.tsx
+++ b/apps/web/src/views/Voting/components/Proposal/VoteRow.tsx
@@ -1,4 +1,4 @@
-import { Flex, LinkExternal, Text, Farm as FarmUI } from '@pancakeswap/uikit'
+import { Flex, LinkExternal, Text, Farm as FarmUI, ScanLink } from '@pancakeswap/uikit'
 import truncateHash from '@pancakeswap/utils/truncateHash'
 import { getBlockExploreLink } from 'utils'
 import { Vote } from 'state/types'
@@ -27,9 +27,7 @@ const VoteRow: React.FC<React.PropsWithChildren<VoteRowProps>> = ({ vote, isVote
     <Row>
       <AddressColumn>
         <Flex alignItems="center">
-          <LinkExternal isBscScan href={getBlockExploreLink(vote.voter, 'address')}>
-            {truncateHash(vote.voter)}
-          </LinkExternal>
+          <ScanLink href={getBlockExploreLink(vote.voter, 'address')}>{truncateHash(vote.voter)}</ScanLink>
           {isVoter && <VotedTag mr="4px" />}
         </Flex>
       </AddressColumn>

--- a/apps/web/src/views/Voting/components/Proposal/VoteRow.tsx
+++ b/apps/web/src/views/Voting/components/Proposal/VoteRow.tsx
@@ -2,6 +2,7 @@ import { Flex, LinkExternal, Text, Farm as FarmUI, ScanLink } from '@pancakeswap
 import truncateHash from '@pancakeswap/utils/truncateHash'
 import { getBlockExploreLink } from 'utils'
 import { Vote } from 'state/types'
+import { ChainId } from '@pancakeswap/sdk'
 import { IPFS_GATEWAY } from '../../config'
 import TextEllipsis from '../TextEllipsis'
 import Row, { AddressColumn, ChoiceColumn, VotingPowerColumn } from './Row'
@@ -27,7 +28,9 @@ const VoteRow: React.FC<React.PropsWithChildren<VoteRowProps>> = ({ vote, isVote
     <Row>
       <AddressColumn>
         <Flex alignItems="center">
-          <ScanLink href={getBlockExploreLink(vote.voter, 'address')}>{truncateHash(vote.voter)}</ScanLink>
+          <ScanLink chainId={ChainId.BSC} href={getBlockExploreLink(vote.voter, 'address')}>
+            {truncateHash(vote.voter)}
+          </ScanLink>
           {isVoter && <VotedTag mr="4px" />}
         </Flex>
       </AddressColumn>

--- a/packages/uikit/src/components/Link/LinkExternal.tsx
+++ b/packages/uikit/src/components/Link/LinkExternal.tsx
@@ -2,24 +2,16 @@ import React from "react";
 import Link from "./Link";
 import { LinkProps } from "./types";
 import OpenNewIcon from "../Svg/Icons/OpenNew";
-import BscScanIcon from "../Svg/Icons/BscScan";
-import AptosIcon from "../Svg/Icons/Aptos";
 
 const LinkExternal: React.FC<React.PropsWithChildren<LinkProps>> = ({
   children,
-  isBscScan = false,
-  isAptosScan = false,
   showExternalIcon = true,
   ...props
 }) => {
   return (
     <Link external {...props}>
       {children}
-      {isBscScan && <BscScanIcon color={props.color ? props.color : "primary"} ml="4px" />}
-      {isAptosScan && <AptosIcon width="18" height="18" color={props.color ? props.color : "primary"} ml="4px" />}
-      {!isBscScan && !isAptosScan && showExternalIcon && (
-        <OpenNewIcon color={props.color ? props.color : "primary"} ml="4px" />
-      )}
+      {showExternalIcon && <OpenNewIcon color={props.color ? props.color : "primary"} ml="4px" />}
     </Link>
   );
 };

--- a/packages/uikit/src/components/Link/ScanLink.tsx
+++ b/packages/uikit/src/components/Link/ScanLink.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useMemo } from "react";
+import { ChainId } from "@pancakeswap/sdk";
 import Link from "./Link";
 import OpenNewIcon from "../Svg/Icons/OpenNew";
 import BscScanIcon from "../Svg/Icons/BscScan";
@@ -6,12 +7,12 @@ import { LinkProps } from "./types";
 
 interface ScanLinkProps extends Omit<LinkProps, "external" | "showExternalIcon"> {
   icon?: ReactElement;
-  chainId?: number;
+  chainId?: ChainId;
 }
 
-const icons: { [key: number]: ReactElement } = {
-  56: <BscScanIcon />,
-  97: <BscScanIcon />,
+const icons: { [key in ChainId]?: ReactElement } = {
+  [ChainId.BSC]: <BscScanIcon />,
+  [ChainId.BSC_TESTNET]: <BscScanIcon />,
 };
 
 const ScanLink: React.FC<React.PropsWithChildren<ScanLinkProps>> = ({ children, icon, chainId, ...props }) => {

--- a/packages/uikit/src/components/Link/ScanLink.tsx
+++ b/packages/uikit/src/components/Link/ScanLink.tsx
@@ -20,15 +20,19 @@ const ScanLink: React.FC<React.PropsWithChildren<ScanLinkProps>> = ({ children, 
     if (chainId && icons[chainId]) return icons[chainId];
     return <OpenNewIcon />;
   }, [icon, chainId]);
-  return (
-    <Link external {...props}>
-      {children}
-      {React.isValidElement(iconToShow) &&
-        React.cloneElement(iconToShow, {
+  const iconElement = useMemo(() => {
+    return React.isValidElement(iconToShow)
+      ? React.cloneElement(iconToShow, {
           // @ts-ignore
           color: props.color ? props.color : "primary",
           ml: "4px",
-        })}
+        })
+      : null;
+  }, [iconToShow, props.color]);
+  return (
+    <Link external {...props}>
+      {children}
+      {iconElement}
     </Link>
   );
 };

--- a/packages/uikit/src/components/Link/ScanLink.tsx
+++ b/packages/uikit/src/components/Link/ScanLink.tsx
@@ -1,0 +1,27 @@
+import React, { useMemo } from "react";
+import Link from "./Link";
+import OpenNewIcon from "../Svg/Icons/OpenNew";
+import BscScanIcon from "../Svg/Icons/BscScan";
+import AptosIcon from "../Svg/Icons/Aptos";
+import { LinkProps } from "./types";
+
+interface ScanLinkProps extends Omit<LinkProps, "external" | "showExternalIcon"> {
+  forceChain?: "BSC" | "APTOS" | string;
+}
+
+const ScanLink: React.FC<React.PropsWithChildren<ScanLinkProps>> = ({ children, forceChain, ...props }) => {
+  const { href } = props;
+  const isBscScan = useMemo(() => (forceChain || href)?.toLowerCase()?.includes("bsc"), [forceChain, href]);
+  const isAptosScan = useMemo(() => (forceChain || href)?.toLowerCase()?.includes("aptos"), [forceChain, href]);
+
+  return (
+    <Link external {...props}>
+      {children}
+      {isBscScan && <BscScanIcon color={props.color ? props.color : "primary"} ml="4px" />}
+      {isAptosScan && <AptosIcon width="18" height="18" color={props.color ? props.color : "primary"} ml="4px" />}
+      {!isBscScan && !isAptosScan && <OpenNewIcon color={props.color ? props.color : "primary"} ml="4px" />}
+    </Link>
+  );
+};
+
+export default ScanLink;

--- a/packages/uikit/src/components/Link/ScanLink.tsx
+++ b/packages/uikit/src/components/Link/ScanLink.tsx
@@ -1,25 +1,34 @@
-import React, { useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import Link from "./Link";
 import OpenNewIcon from "../Svg/Icons/OpenNew";
 import BscScanIcon from "../Svg/Icons/BscScan";
-import AptosIcon from "../Svg/Icons/Aptos";
 import { LinkProps } from "./types";
 
 interface ScanLinkProps extends Omit<LinkProps, "external" | "showExternalIcon"> {
-  forceChain?: "BSC" | "APTOS" | string;
+  icon?: ReactElement;
+  chainId?: number;
 }
 
-const ScanLink: React.FC<React.PropsWithChildren<ScanLinkProps>> = ({ children, forceChain, ...props }) => {
-  const { href } = props;
-  const isBscScan = useMemo(() => (forceChain || href)?.toLowerCase()?.includes("bsc"), [forceChain, href]);
-  const isAptosScan = useMemo(() => (forceChain || href)?.toLowerCase()?.includes("aptos"), [forceChain, href]);
+const icons: { [key: number]: ReactElement } = {
+  56: <BscScanIcon />,
+  97: <BscScanIcon />,
+};
 
+const ScanLink: React.FC<React.PropsWithChildren<ScanLinkProps>> = ({ children, icon, chainId, ...props }) => {
+  const iconToShow = useMemo(() => {
+    if (icon) return icon;
+    if (chainId && icons[chainId]) return icons[chainId];
+    return <OpenNewIcon />;
+  }, [icon, chainId]);
   return (
     <Link external {...props}>
       {children}
-      {isBscScan && <BscScanIcon color={props.color ? props.color : "primary"} ml="4px" />}
-      {isAptosScan && <AptosIcon width="18" height="18" color={props.color ? props.color : "primary"} ml="4px" />}
-      {!isBscScan && !isAptosScan && <OpenNewIcon color={props.color ? props.color : "primary"} ml="4px" />}
+      {React.isValidElement(iconToShow) &&
+        React.cloneElement(iconToShow, {
+          // @ts-ignore
+          color: props.color ? props.color : "primary",
+          ml: "4px",
+        })}
     </Link>
   );
 };

--- a/packages/uikit/src/components/Link/index.tsx
+++ b/packages/uikit/src/components/Link/index.tsx
@@ -1,3 +1,4 @@
 export { default as Link } from "./Link";
 export { default as LinkExternal } from "./LinkExternal";
+export { default as ScanLink } from "./ScanLink";
 export type { LinkProps } from "./types";

--- a/packages/uikit/src/components/Link/types.ts
+++ b/packages/uikit/src/components/Link/types.ts
@@ -3,7 +3,5 @@ import { TextProps } from "../Text";
 
 export interface LinkProps extends TextProps, AnchorHTMLAttributes<HTMLAnchorElement> {
   external?: boolean;
-  isBscScan?: boolean;
-  isAptosScan?: boolean;
   showExternalIcon?: boolean;
 }

--- a/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "@pancakeswap/localization";
 import styled from "styled-components";
 import { Flex } from "../../../../components/Box";
 import { LinkExternal } from "../../../../components/Link";
+import ScanLink from "../../../../components/Link/ScanLink";
 import { Skeleton } from "../../../../components/Skeleton";
 import { Text } from "../../../../components/Text";
 import { HelpIcon } from "../../../../components/Svg";
@@ -29,6 +30,10 @@ const Wrapper = styled.div`
 `;
 
 const StyledLinkExternal = styled(LinkExternal)`
+  font-weight: 400;
+`;
+
+const StyledScanLink = styled(ScanLink)`
   font-weight: 400;
 `;
 
@@ -120,9 +125,7 @@ export const DetailsSection: React.FC<React.PropsWithChildren<ExpandableSectionP
       )}
       {scanAddressLink && (
         <Flex mb="2px" justifyContent={alignLinksToRight ? "flex-end" : "flex-start"}>
-          <StyledLinkExternal isBscScan href={scanAddressLink}>
-            {t("View Contract")}
-          </StyledLinkExternal>
+          <StyledScanLink href={scanAddressLink}>{t("View Contract")}</StyledScanLink>
         </Flex>
       )}
     </Wrapper>

--- a/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmCard/DetailsSection.tsx
@@ -1,3 +1,4 @@
+import { ReactElement } from "react";
 import { useTranslation } from "@pancakeswap/localization";
 import styled from "styled-components";
 import { Flex } from "../../../../components/Box";
@@ -10,7 +11,7 @@ import { useTooltip } from "../../../../hooks/useTooltip";
 import { FarmMultiplierInfo } from "../FarmMultiplierInfo";
 
 export interface ExpandableSectionProps {
-  scanAddressLink?: string;
+  scanAddress?: { link: string; chainId?: number; icon?: ReactElement };
   infoAddress?: string;
   removed?: boolean;
   totalValueFormatted?: string;
@@ -45,7 +46,7 @@ const StyledText = styled(Text)`
 `;
 
 export const DetailsSection: React.FC<React.PropsWithChildren<ExpandableSectionProps>> = ({
-  scanAddressLink,
+  scanAddress,
   infoAddress,
   removed,
   totalValueLabel,
@@ -123,9 +124,11 @@ export const DetailsSection: React.FC<React.PropsWithChildren<ExpandableSectionP
           <StyledLinkExternal href={infoAddress}>{t("See Pair Info")}</StyledLinkExternal>
         </Flex>
       )}
-      {scanAddressLink && (
+      {scanAddress && (
         <Flex mb="2px" justifyContent={alignLinksToRight ? "flex-end" : "flex-start"}>
-          <StyledScanLink href={scanAddressLink}>{t("View Contract")}</StyledScanLink>
+          <StyledScanLink icon={scanAddress.icon} chainId={scanAddress.chainId} href={scanAddress.link}>
+            {t("View Contract")}
+          </StyledScanLink>
         </Flex>
       )}
     </Wrapper>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 84416c1</samp>

### Summary
🌐🔄🆕

<!--
1.  🌐 - This emoji represents the concept of multiple chains and explorers, as well as the import of the `ChainId` enum and the use of the `multiChainId` variable.
2.  🔄 - This emoji represents the concept of swap transactions, as well as the import and use of the `getSwapType` and `getSwapDirection` functions.
3.  🆕 - This emoji represents the concept of adding support for a new feature or version, as well as the display of V3 swap transactions in the `TransactionsTable` component.
-->
Added multi-chain and V3 swap support to `TransactionsTable` components. Updated `InfoTables/TransactionsTable.tsx` and `V3Info/components/TransactionsTable/index.tsx` to use the appropriate chain and swap data.

> _We're sailing on the multi-chain, aye, `ChainId` is our guide_
> _We'll show you all the swaps we've made, no matter where they hide_
> _On the count of three, we'll pull the code, and make the table shine_
> _With `getSwapType` and `getSwapDirection`, we'll sort them by design_

### Walkthrough
* Import `ChainId` enum from `@pancakeswap/sdk` to check chain ID of transactions ([link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-b4efa43ba158074a7bdb8bd1a86424fbcb4093fef553a8a8ff99c25b1c3f9cbeR4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dR12))
* Use `multiChainId[chainName]` variable instead of hardcoded value for `isBscScan` prop of `LinkExternal` components, to support different chains and explorers ([link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-b4efa43ba158074a7bdb8bd1a86424fbcb4093fef553a8a8ff99c25b1c3f9cbeL112-R116), [link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-b4efa43ba158074a7bdb8bd1a86424fbcb4093fef553a8a8ff99c25b1c3f9cbeL137-R144), [link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL108-R109), [link](https://github.com/pancakeswap/pancake-frontend/pull/7292/files?diff=unified&w=0#diff-f4f80e2c099ecb4b767dc73e8b23fa11390c8fb4432ecb20051fe499d321865dL128-R129))


