### PR TITLE
chore: Update polygon zkevm rpc node

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -2,6 +2,12 @@ import { ChainId } from '@pancakeswap/sdk'
 import { arbitrum, polygonZkEvm, zkSync, zkSyncTestnet, polygonZkEvmTestnet, arbitrumGoerli } from 'wagmi/chains'
 import { getNodeRealUrlV2 } from 'utils/nodeReal'
 
+const POLYGON_ZKEVM_NODES = [
+  'https://magical-dark-flower.zkevm-mainnet.quiknode.pro/db439a06298d58c68c72d8cb74b1629d638705f1',
+  'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
+  ...polygonZkEvm.rpcUrls.public.http,
+]
+
 export const SERVER_NODES = {
   [ChainId.BSC]: [
     process.env.NEXT_PUBLIC_NODE_PRODUCTION,
@@ -20,10 +26,7 @@ export const SERVER_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
-  [ChainId.POLYGON_ZKEVM]: [
-    'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
-    ...polygonZkEvm.rpcUrls.public.http,
-  ],
+  [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_NODES,
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     'https://polygon-zkevm-testnet.rpc.thirdweb.com',
     ...polygonZkEvmTestnet.rpcUrls.public.http,
@@ -56,10 +59,7 @@ export const PUBLIC_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
-  [ChainId.POLYGON_ZKEVM]: [
-    'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
-    ...polygonZkEvm.rpcUrls.public.http,
-  ],
+  [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_NODES,
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     'https://polygon-zkevm-testnet.rpc.thirdweb.com',
     ...polygonZkEvmTestnet.rpcUrls.public.http,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ce39c8</samp>

### Summary
🌐🧮🛠️

<!--
1.  🌐 - This emoji represents the web app's connection to the Polygon ZK-EVM network, which is enabled by the new constant and the updated objects.
2.  🧮 - This emoji represents the ZK-EVM technology that powers the Polygon network, and the web app's ability to interact with smart contracts deployed on it.
3.  🛠️ - This emoji represents the improvement of the code quality and readability for the web app's source code, which makes it easier to maintain and extend.
-->
Added a constant for Polygon ZK-EVM RPC URLs and refactored `nodes.ts` to use it. This simplifies the web app's configuration for the Polygon ZK-EVM network.

> _To connect to Polygon ZK-EVM_
> _We used inline arrays, what a gem_
> _But to make it more neat_
> _We defined a constant_
> _And replaced them with `POLYGON_ZKEVM_NODES` then_

### Walkthrough
*  Add a constant `POLYGON_ZKEVM_NODES` that contains RPC URLs for the Polygon ZK-EVM mainnet in `nodes.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7297/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecR5-R10))
*  Use `POLYGON_ZKEVM_NODES` instead of inline arrays for the server-side rendering (SSR) and client-side rendering (CSR) of the web app in `nodes.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7297/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL23-R29), [link](https://github.com/pancakeswap/pancake-frontend/pull/7297/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL59-R62))


