### PR TITLE
chore: Remove quicknode rpc endpoint

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -3,7 +3,6 @@ import { arbitrum, polygonZkEvm, zkSync, zkSyncTestnet, polygonZkEvmTestnet, arb
 import { getNodeRealUrlV2 } from 'utils/nodeReal'
 
 const POLYGON_ZKEVM_NODES = [
-  'https://magical-dark-flower.zkevm-mainnet.quiknode.pro/db439a06298d58c68c72d8cb74b1629d638705f1',
   'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
   ...polygonZkEvm.rpcUrls.public.http,
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e295425</samp>

### Summary
🛠️🧠🔄

<!--
1.  🛠️ - This emoji represents fixing a bug or an issue, which is the main goal of this change.
2.  🧠 - This emoji represents intelligence or smartness, which is related to the concept of zero-knowledge proofs and the ZK-EVM network.
3.  🔄 - This emoji represents changing or updating something, which is what this change does to the list of RPC URLs.
-->
Remove an incompatible ZK-EVM mainnet node from `nodes.ts`. This improves transaction reliability on the new network.

> _ZK-EVM mainnet_
> _Remove one node from `RPC_URLS`_
> _Fall is for pruning_

### Walkthrough
* Remove one ZK-EVM mainnet node from RPC URLs to fix transaction failures ([link](https://github.com/pancakeswap/pancake-frontend/pull/7298/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL6))


