### PR TITLE
fix: Wrong v2 token order on pair detail page causes incorrect balance displayed

### DIFF
--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -252,7 +252,6 @@ export default function PoolListPage() {
         />
         <Body>
           {mainSection}
-
           {selectedTypeIndex === FILTER.V2 ? <FindOtherLP /> : null}
         </Body>
         <CardFooter style={{ textAlign: 'center' }}>

--- a/apps/web/src/pages/v2/pair/[[...currency]].tsx
+++ b/apps/web/src/pages/v2/pair/[[...currency]].tsx
@@ -63,8 +63,8 @@ export default function PoolV2Page() {
   const [token0Deposited, token1Deposited] = useTokensDeposited({ pair, userPoolBalance, totalPoolTokens })
 
   const totalUSDValue = useTotalUSDValue({
-    currency0: baseCurrency,
-    currency1: currencyB,
+    currency0: pair?.token0,
+    currency1: pair?.token1,
     token0Deposited,
     token1Deposited,
   })
@@ -97,9 +97,9 @@ export default function PoolV2Page() {
         <AppHeader
           title={
             <Flex justifyContent="center" alignItems="center">
-              <DoubleCurrencyLogo size={24} currency0={baseCurrency} currency1={currencyB} />
+              <DoubleCurrencyLogo size={24} currency0={pair?.token0} currency1={pair?.token1} />
               <Heading as="h2" ml="8px">
-                {baseCurrency?.symbol}-{currencyB?.symbol} LP
+                {pair?.token0?.symbol}-{pair?.token1?.symbol} LP
               </Heading>
             </Flex>
           }
@@ -108,17 +108,22 @@ export default function PoolV2Page() {
           buttons={
             !isMobile && (
               <>
-                <NextLinkFromReactRouter to={`/v2/add/${currencyIdA}/${currencyIdB}`}>
-                  <Button width="100%">{t('Add')}</Button>
+                <NextLinkFromReactRouter to={`/v2/add/${pair?.token0.address}/${pair?.token1.address}`}>
+                  <Button width="100%" disabled={!pair}>
+                    {t('Add')}
+                  </Button>
                 </NextLinkFromReactRouter>
-                <NextLinkFromReactRouter to={`/v2/remove/${currencyIdA}/${currencyIdB}`} style={{ margin: '0px 8px' }}>
-                  <Button variant="secondary" width="100%">
+                <NextLinkFromReactRouter
+                  to={`/v2/remove/${pair?.token0.address}/${pair?.token1.address}`}
+                  style={{ margin: '0px 8px' }}
+                >
+                  <Button variant="secondary" width="100%" disabled={!pair}>
                     {t('Remove')}
                   </Button>
                 </NextLinkFromReactRouter>
                 {isFarmExistActiveForPair === 'notexist' && (
                   <NextLinkFromReactRouter to={`/v2/migrate/${pair?.liquidityToken?.address}`}>
-                    <Button variant="secondary" width="100%">
+                    <Button variant="secondary" width="100%" disabled={!pair}>
                       {t('Migrate')}
                     </Button>
                   </NextLinkFromReactRouter>
@@ -130,19 +135,19 @@ export default function PoolV2Page() {
         <CardBody>
           {isMobile && (
             <>
-              <NextLinkFromReactRouter to={`/v2/add/${currencyIdA}/${currencyIdB}`}>
-                <Button width="100%" mb="8px">
+              <NextLinkFromReactRouter to={`/v2/add/${pair?.token0.address}/${pair?.token1.address}`}>
+                <Button width="100%" mb="8px" disabled={!pair}>
                   {t('Add')}
                 </Button>
               </NextLinkFromReactRouter>
-              <NextLinkFromReactRouter to={`/v2/remove/${currencyIdA}/${currencyIdB}`}>
-                <Button variant="secondary" width="100%" mb="8px">
+              <NextLinkFromReactRouter to={`/v2/remove/${pair?.token0.address}/${pair?.token1.address}`}>
+                <Button variant="secondary" width="100%" mb="8px" disabled={!pair}>
                   {t('Remove')}
                 </Button>
               </NextLinkFromReactRouter>
               {isFarmExistActiveForPair === 'notexist' && (
                 <NextLinkFromReactRouter to={`/v2/migrate/${pair.liquidityToken.address}`}>
-                  <Button variant="secondary" width="100%" mb="8px">
+                  <Button variant="secondary" width="100%" mb="8px" disabled={!pair}>
                     {t('Migrate')}
                   </Button>
                 </NextLinkFromReactRouter>
@@ -167,9 +172,9 @@ export default function PoolV2Page() {
                 <LightGreyCard mr="4px">
                   <AutoRow justifyContent="space-between" mb="8px">
                     <Flex>
-                      <CurrencyLogo currency={baseCurrency} />
+                      <CurrencyLogo currency={pair?.token0} />
                       <Text small color="textSubtle" id="remove-liquidity-tokenb-symbol" ml="4px">
-                        {baseCurrency?.symbol}
+                        {pair?.token0?.symbol}
                       </Text>
                     </Flex>
                     <Flex justifyContent="center">
@@ -178,9 +183,9 @@ export default function PoolV2Page() {
                   </AutoRow>
                   <AutoRow justifyContent="space-between" mb="8px">
                     <Flex>
-                      <CurrencyLogo currency={currencyB} />
+                      <CurrencyLogo currency={pair?.token1} />
                       <Text small color="textSubtle" id="remove-liquidity-tokenb-symbol" ml="4px">
-                        {currencyB?.symbol}
+                        {pair?.token1?.symbol}
                       </Text>
                     </Flex>
                     <Flex justifyContent="center">

--- a/apps/web/src/views/PoolFinder/index.tsx
+++ b/apps/web/src/views/PoolFinder/index.tsx
@@ -15,19 +15,19 @@ import { BIG_INT_ZERO } from 'config/constants/exchange'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { AppBody, AppHeader } from '../../components/App'
-import { LightCard } from '../../components/Card'
-import Row from '../../components/Layout/Row'
-import Dots from '../../components/Loader/Dots'
-import { CurrencyLogo } from '../../components/Logo'
-import { MinimalPositionCard } from '../../components/PositionCard'
-import CurrencySearchModal from '../../components/SearchModal/CurrencySearchModal'
-import { PairState, useV2Pair } from '../../hooks/usePairs'
-import { usePairAdder } from '../../state/user/hooks'
-import { useTokenBalance } from '../../state/wallet/hooks'
-import { currencyId } from '../../utils/currencyId'
+import { LightCard } from 'components/Card'
+import { MinimalPositionCard } from 'components/PositionCard'
+import { PairState, useV2Pair } from 'hooks/usePairs'
+import { usePairAdder } from 'state/user/hooks'
+import { useTokenBalance } from 'state/wallet/hooks'
+import { currencyId } from 'utils/currencyId'
+import { CommonBasesType } from 'components/SearchModal/types'
 import Page from '../Page'
-import { CommonBasesType } from '../../components/SearchModal/types'
+import CurrencySearchModal from '../../components/SearchModal/CurrencySearchModal'
+import { CurrencyLogo } from '../../components/Logo'
+import Dots from '../../components/Loader/Dots'
+import Row from '../../components/Layout/Row'
+import { AppBody, AppHeader } from '../../components/App'
 
 enum Fields {
   TOKEN0 = 0,
@@ -151,7 +151,7 @@ export default function PoolFinder() {
                   <MinimalPositionCard pair={pair} />
                   <Button
                     as={NextLinkFromReactRouter}
-                    to={`/v2/pair/${currencyId(currency0)}/${currencyId(currency1)}`}
+                    to={`/v2/pair/${pair.token0.address}/${pair.token1.address}`}
                     variant="secondary"
                     width="100%"
                   >


### PR DESCRIPTION
To reproduce

Go to https://pancakeswap.finance/find 
Try v2 pair that account have with opposite pair order
Click manage pair button
See token balances flipped and incorrect amount shown

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a4aaf68</samp>

### Summary
🗑️♻️🛠️

<!--
1.  🗑️ for removing an empty code block.
2.  ♻️ for refactoring the liquidity page to use the `pair` object.
3.  🛠️ for fixing a broken link and improving the code style.
-->
This pull request refactors the liquidity and pair pages to use a common `pair` object that contains the relevant data for each pair. It also improves the code style, fixes a broken link, and removes an unused code block.

> _Oh we're the coders of the sea, and we work with `pair` objects_
> _We refactor and we style, and we fix the broken links_
> _Heave away, me hearties, heave away with care_
> _For we're the coders of the sea, and we use the `pair` objects_

### Walkthrough
*  Refactor the liquidity page to use the `pair` object as the source of truth instead of individual currency variables ([link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L66-R67), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L100-R102), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L111-R120), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L121-R126), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L133-R144), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L145-R150), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L170-R177), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-95970649a9114012ead9ae731edf12ce24f2427902f909cbc2c4774a886b3830L181-R188), [link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-4ac24b4c5590c024f5d8470f3a0dfff1b4fe839f1452cc942dd494d286497c0cL154-R154))
* Remove an empty code block from the `apps/web/src/pages/liquidity/index.tsx` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL255))
* Update the import statements in the `apps/web/src/views/PoolFinder/index.tsx` file to use relative paths and reorder them by type and alphabetically ([link](https://github.com/pancakeswap/pancake-frontend/pull/7306/files?diff=unified&w=0#diff-4ac24b4c5590c024f5d8470f3a0dfff1b4fe839f1452cc942dd494d286497c0cL18-R30))


