### PR TITLE
chore(Farm): Only show booster msg on booster farms

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
@@ -123,7 +123,7 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
             </Text>
           </Flex>
         )}
-        {!account && (
+        {!account && farm.boosted && (
           <Box mt="24px" mb="16px">
             <StatusView status={boostStatus} />
           </Box>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ee79464</samp>

### Summary
🚀🔒🌾

<!--
1.  🚀 - This emoji represents the boost feature, which increases the APR of some farms when staking CAKE. It also conveys a sense of speed and excitement, which are positive emotions for users who want to earn more rewards.
2.  🔒 - This emoji represents the condition of being connected to a wallet, which is required to stake CAKE and access the boost feature. It also conveys a sense of security and trust, which are important aspects of using a decentralized platform.
3.  🌾 - This emoji represents the farms, which are the main source of earning rewards on the platform. It also conveys a sense of growth and abundance, which are desirable outcomes for users who want to increase their wealth.
-->
Added a boost indicator for some farms and fixed a condition for showing it. The file `FarmV3Card.tsx` was updated to only render the `StatusView` component for boosted farms when the user is connected.

> _Boosted farms show `StatusView`_
> _But only when user stakes CAKE_
> _Autumn harvest awaits_

### Walkthrough
*  Modify the condition for rendering the `StatusView` component to check if the farm is boosted and the user is not connected ([link](https://github.com/pancakeswap/pancake-frontend/pull/7314/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdL126-R126))



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/9ad9e49a-a494-45ec-bde5-4d0ec05b2b70)


After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/5bf41afd-08aa-4757-85f1-3b0cb2e77839)
