### PR TITLE
chore: MM linked pool doc adjustment

### DIFF
--- a/apps/web/src/views/Swap/MMLinkPools/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/SwapModalFooter.tsx
@@ -155,7 +155,7 @@ export default function SwapModalFooter({
                     </Text>
                     :{' '}
                     {t(
-                      'PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.',
+                      'PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% - 0.25% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.',
                     )}
                   </Text>
                 </>

--- a/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
@@ -114,7 +114,11 @@ export const TradeSummary = memo(function TradeSummary({
                       style={{ display: 'inline' }}
                       ml="4px"
                       external
-                      href="https://docs.pancakeswap.finance/products/pancakeswap-exchange/faq#what-will-be-the-trading-fee-breakdown-for-v3-exchange"
+                      href={
+                        isMM
+                          ? 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/market-maker-integration'
+                          : 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/faq#what-will-be-the-trading-fee-breakdown-for-v3-exchange'
+                      }
                     >
                       {t('Fee Breakdown and Tokenomics')}
                     </Link>
@@ -125,7 +129,7 @@ export const TradeSummary = memo(function TradeSummary({
                     </Text>
                     :{' '}
                     {t(
-                      'PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.',
+                      'PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% - 0.25% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.',
                     )}
                   </Text>
                 </>

--- a/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
@@ -116,7 +116,7 @@ export const TradeSummary = memo(function TradeSummary({
                       external
                       href={
                         isMM
-                          ? 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/market-maker-integration'
+                          ? 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/market-maker-integration#fees'
                           : 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/faq#what-will-be-the-trading-fee-breakdown-for-v3-exchange'
                       }
                     >

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2143,7 +2143,7 @@
   "MM": "MM",
   "Amount of Liquidity to Remove": "Amount of Liquidity to Remove",
   "No slippage against quote from market maker": "No slippage against quote from market maker",
-  "PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.": "PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.",
+  "PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% - 0.25% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.": "PancakeSwap does not charge any fees for trades. However, the market makers charge an implied fee of 0.05% - 0.25% (non-stablecoin) / 0.01% (stablecoin) factored into the quotes provided by them.",
   "Trading Fee": "Trading Fee",
   "MM Linked Pool": "MM Linked Pool",
   "Trade through the market makers if they provide better deal": "Trade through the market makers if they provide better deal",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4a60802</samp>

### Summary
🔄🌐🔗

<!--
1.  🔄 for the first change, since it relates to swapping and changing the fee range.
2. 🌐 for the second change, since it relates to translation and localization.
3. 🔗 for the third change, since it relates to adding and modifying external links.
-->
This pull request adds support for variable fees and different external links for market maker trades in the Swap view. It also updates the English translation file to match the new text strings.

> _Swap fees vary now_
> _`TradeSummary` shows more links_
> _Autumn of changes_

### Walkthrough
*  Add conditional logic to external link for fee breakdown and tokenomics documentation based on market maker pool usage ([link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-65730801b841c0fd17e97ac2609066b79fd2875585af9babde2b88f1481348e0L117-R121))
*  Update implied fee range text for non-stablecoin trades from market makers to reflect variable fee structure ([link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-dc8ab52f9b39decdc3a1fdd10c09bf1a419f8930b40dcba6e978cfa8841d9d41L158-R158), [link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-65730801b841c0fd17e97ac2609066b79fd2875585af9babde2b88f1481348e0L128-R132), [link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2146-R2146))
*  Modify `TradeSummary` component to display updated fee information in both `SwapModalFooter` and `AdvancedSwapDetails` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-dc8ab52f9b39decdc3a1fdd10c09bf1a419f8930b40dcba6e978cfa8841d9d41L158-R158), [link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-65730801b841c0fd17e97ac2609066b79fd2875585af9babde2b88f1481348e0L117-R121), [link](https://github.com/pancakeswap/pancake-frontend/pull/7324/files?diff=unified&w=0#diff-65730801b841c0fd17e97ac2609066b79fd2875585af9babde2b88f1481348e0L128-R132))


