### PR TITLE
fix: farm cake price oracle chain id

### DIFF
--- a/packages/farms/src/fetchFarmsV3.ts
+++ b/packages/farms/src/fetchFarmsV3.ts
@@ -1,4 +1,4 @@
-import { ERC20Token, Currency } from '@pancakeswap/sdk'
+import { ERC20Token, Currency, ChainId } from '@pancakeswap/sdk'
 import { CAKE } from '@pancakeswap/tokens'
 import { tickToPrice } from '@pancakeswap/v3-sdk'
 import { Address, PublicClient, formatUnits } from 'viem'
@@ -38,7 +38,7 @@ export async function farmV3FetchFarms({
 }) {
   const [poolInfos, cakePrice, v3PoolData] = await Promise.all([
     fetchPoolInfos(farms, chainId, provider, masterChefAddress),
-    provider({ chainId })
+    provider({ chainId: ChainId.BSC })
       .readContract({
         abi: chainlinkAbi,
         address: '0xB6064eD41d4f67e353768aA239cA86f4F73665a1',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b7d2ee</samp>

### Summary
🍰🔗🌐

<!--
1.  🍰 - This emoji represents the CAKE token and the main focus of the code update.
2.  🔗 - This emoji represents the Chainlink oracle and the use of its price feed for CAKE.
3.  🌐 - This emoji represents the network switch and the use of the `ChainId` enum.
-->
Updated farms fetching logic to use ChainId enum and Chainlink oracle for CAKE price. This enhances cross-chain compatibility and data quality.

> _We defy the chaos of the chains_
> _We invoke the `ChainId` of the BSC_
> _We trust the oracle of the Link_
> _We claim the true price of the CAKE_

### Walkthrough
*  Import `ChainId` enum from `@pancakeswap/sdk` to use it for fetching CAKE price from Chainlink oracle ([link](https://github.com/pancakeswap/pancake-frontend/pull/7327/files?diff=unified&w=0#diff-d3babe079368d69111b752814a4382eb279623a4c5bdb0b8b4cc40fb1d1a603bL1-R1))
*  Replace `chainId` parameter with `ChainId.BSC` in `provider` function call to ensure CAKE price is always fetched from BSC network ([link](https://github.com/pancakeswap/pancake-frontend/pull/7327/files?diff=unified&w=0#diff-d3babe079368d69111b752814a4382eb279623a4c5bdb0b8b4cc40fb1d1a603bL41-R41))


