### PR TITLE
fix: Ifo disclaimer modal closed by overlay click

### DIFF
--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -28,7 +28,7 @@ const Menu = (props) => {
   const { pathname } = useRouter()
   const [onUSCitizenModalPresent] = useModal(
     <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
-    true,
+    false,
     false,
     'usCitizenConfirmModal',
   )

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -20,7 +20,7 @@ const Congratulations = () => {
 
   return (
     <>
-      <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} closeOnOverlayClick onDismiss={() => setIsOpen(false)}>
+      <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
         <USCitizenConfirmModal title={t('PancakeSwap Affiliate Program')} id={IdType.AFFILIATE_PROGRAM} />
       </ModalV2>
       <Flex flexDirection="column" padding={['24px', '24px', '24px', '24px', '80px 24px']}>

--- a/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualApolloXCampaignBanner.tsx
@@ -154,7 +154,7 @@ const PerpetualBanner = () => {
   const perpetualUrl = useMemo(() => getPerpetualUrl({ chainId, languageCode: code, isDark }), [chainId, code, isDark])
   const [onUSCitizenModalPresent] = useModal(
     <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
-    true,
+    false,
     false,
     'usCitizenConfirmModal',
   )

--- a/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualBanner.tsx
@@ -57,7 +57,7 @@ const PerpetualBanner = () => {
   const headerRef = useRef<HTMLDivElement>(null)
   const [onUSCitizenModalPresent] = useModal(
     <USCitizenConfirmModal title={t('PancakeSwap Perpetuals')} id={IdType.PERPETUALS} />,
-    true,
+    false,
     false,
     'usCitizenConfirmModal',
   )

--- a/apps/web/src/views/Ifos/index.tsx
+++ b/apps/web/src/views/Ifos/index.tsx
@@ -17,7 +17,7 @@ export const IfoPageLayout = ({ children }) => {
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.IFO)
   const [onUSCitizenModalPresent] = useModal(
     <USCitizenConfirmModal title={t('PancakeSwap IFOs')} id={IdType.IFO} />,
-    true,
+    false,
     false,
     'usCitizenConfirmModal',
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f3b4539</samp>

### Summary
🙅‍♂️🔒🚀

<!--
1.  🙅‍♂️ - This emoji can represent the idea of rejecting or denying something, which is what the `autoFocus` parameter set to `false` does for the `USCitizenConfirmModal`. It can also convey a sense of frustration or annoyance, which is what the users might feel if they encounter the modal too often or unexpectedly.
2.  🔒 - This emoji can represent the idea of locking or securing something, which is what the `closeOnOverlayClick` parameter set to `false` does for the `Congratulations` modal. It can also convey a sense of importance or urgency, which is what the site might want to communicate to the users about the `USCitizenConfirmModal`.
3.  🚀 - This emoji can represent the idea of launching or boosting something, which is what the `PerpetualBanner` and the `IfoPageLayout` components do for the site's features. It can also convey a sense of excitement or opportunity, which is what the site might want to attract the users with.
-->
This pull request disables the automatic opening of the `USCitizenConfirmModal` for several components that use the `useModal` hook. This improves the user experience and avoids annoying pop-ups that might discourage users from exploring the site.

> _`USCitizenConfirmModal`_
> _No more auto-focus_
> _Let users explore the site_

### Walkthrough
*  Disable automatic opening of `USCitizenConfirmModal` on various pages to improve user experience ([link](https://github.com/pancakeswap/pancake-frontend/pull/7329/files?diff=unified&w=0#diff-128603fbd7fa98404a4bc03c4d7e4d2a80c1d222b84e0606b851e459a75a3793L31-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/7329/files?diff=unified&w=0#diff-a0c4a81cbfb69f07ce0d2c2fb718d01b4430a42e3ec8ed49521d9dc3bfe34c9eL157-R158), [link](https://github.com/pancakeswap/pancake-frontend/pull/7329/files?diff=unified&w=0#diff-e468011e07f3d7556d4740492ead9d03c9a7a56b30bf10c2923e8febdcce7cf0L60-R61), [link](https://github.com/pancakeswap/pancake-frontend/pull/7329/files?diff=unified&w=0#diff-26eb4184f85a5f26b10f9d47b441a9a444db1de130d037d7e6ec91d578f26be7L20-R21))
*  Prevent closing of `Congratulations` modal by clicking outside to ensure user confirmation of eligibility for affiliate program ([link](https://github.com/pancakeswap/pancake-frontend/pull/7329/files?diff=unified&w=0#diff-a9dbefb1fbe66e6a6021569ef44f6903854ae58cd74af8fd0c77b080a5edceafL23-R23))


