### PR TITLE
perf: Memoize farm ui widgets

### DIFF
--- a/packages/uikit/src/widgets/Farm/components/DepositModal/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/DepositModal/index.tsx
@@ -97,20 +97,27 @@ const DepositModal: React.FC<React.PropsWithChildren<DepositModalProps>> = ({
     return false;
   }, [allowance, decimals, val]);
 
-  const lpTokensToStake = new BigNumber(val);
+  const lpTokensToStake = useMemo(() => new BigNumber(val), [val]);
   const fullBalanceNumber = useMemo(() => new BigNumber(fullBalance), [fullBalance]);
 
-  const usdToStake = lpTokensToStake.times(lpPrice);
+  const usdToStake = useMemo(() => lpTokensToStake.times(lpPrice), [lpTokensToStake, lpPrice]);
 
-  const interestBreakdown = getInterestBreakdown({
-    principalInUSD: !lpTokensToStake.isNaN() ? usdToStake.toNumber() : 0,
-    apr,
-    earningTokenPrice: cakePrice.toNumber(),
-  });
+  const interestBreakdown = useMemo(
+    () =>
+      getInterestBreakdown({
+        principalInUSD: !lpTokensToStake.isNaN() ? usdToStake.toNumber() : 0,
+        apr,
+        earningTokenPrice: cakePrice.toNumber(),
+      }),
+    [lpTokensToStake, usdToStake, cakePrice, apr]
+  );
 
-  const annualRoi = cakePrice.times(interestBreakdown[3]);
-  const annualRoiAsNumber = annualRoi.toNumber();
-  const formattedAnnualRoi = formatNumber(annualRoiAsNumber, annualRoi.gt(10000) ? 0 : 2, annualRoi.gt(10000) ? 0 : 2);
+  const annualRoi = useMemo(() => cakePrice.times(interestBreakdown[3]), [cakePrice, interestBreakdown]);
+  const annualRoiAsNumber = useMemo(() => annualRoi.toNumber(), [annualRoi]);
+  const formattedAnnualRoi = useMemo(
+    () => formatNumber(annualRoiAsNumber, annualRoi.gt(10000) ? 0 : 2, annualRoi.gt(10000) ? 0 : 2),
+    [annualRoiAsNumber, annualRoi]
+  );
 
   const handleChange = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {

--- a/packages/uikit/src/widgets/Farm/components/FarmApyButton/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmApyButton/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import styled from "styled-components";
 import { Flex } from "../../../../components/Box";
 import { CalculateIcon } from "../../../../components/Svg";
@@ -24,10 +25,13 @@ export const FarmApyButton: React.FC<React.PropsWithChildren<FarmApyButtonProps>
   handleClickButton,
   children,
 }) => {
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (hideButton) return;
-    handleClickButton(event);
-  };
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (hideButton) return;
+      handleClickButton(event);
+    },
+    [hideButton, handleClickButton]
+  );
 
   return (
     <Flex flexDirection="column" alignItems="flex-start">

--- a/packages/uikit/src/widgets/Farm/components/FarmTable/FarmTokenInfo.tsx
+++ b/packages/uikit/src/widgets/Farm/components/FarmTable/FarmTokenInfo.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import styled from "styled-components";
 import { useTranslation } from "@pancakeswap/localization";
 import { Text } from "../../../../components/Text";
@@ -32,7 +33,7 @@ const Farm: React.FunctionComponent<React.PropsWithChildren<FarmTableFarmTokenIn
 }) => {
   const { t } = useTranslation();
 
-  const handleRenderFarming = (): JSX.Element => {
+  const handleRenderFarming = useMemo(() => {
     if (isStaking) {
       return (
         <Text color="secondary" fontSize="12px" bold textTransform="uppercase">
@@ -41,7 +42,7 @@ const Farm: React.FunctionComponent<React.PropsWithChildren<FarmTableFarmTokenIn
       );
     }
     return <></>;
-  };
+  }, [t, isStaking]);
 
   if (!isReady) {
     return (
@@ -59,7 +60,7 @@ const Farm: React.FunctionComponent<React.PropsWithChildren<FarmTableFarmTokenIn
     <Container>
       <TokenWrapper>{children}</TokenWrapper>
       <div>
-        {handleRenderFarming()}
+        {handleRenderFarming}
         <Text bold>{label}</Text>
       </div>
     </Container>

--- a/packages/uikit/src/widgets/Farm/components/WithdrawModal/index.tsx
+++ b/packages/uikit/src/widgets/Farm/components/WithdrawModal/index.tsx
@@ -39,7 +39,7 @@ const WithdrawModal: React.FC<React.PropsWithChildren<WithdrawModalProps>> = ({
     return getFullDisplayBalance(max, decimals);
   }, [max, decimals]);
 
-  const valNumber = new BigNumber(val);
+  const valNumber = useMemo(() => new BigNumber(val), [val]);
   const fullBalanceNumber = useMemo(() => new BigNumber(fullBalance), [fullBalance]);
 
   const handleChange = useCallback(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bae0dcf</samp>

### Summary
🚀🧠🧹

<!--
1.  🚀 - This emoji represents the improved performance and speed of the components after using `useMemo` and `useCallback` hooks.
2.  🧠 - This emoji represents the memoization technique that is used to avoid unnecessary calculations and re-rendering of the components based on the input values and props.
3.  🧹 - This emoji represents the refactoring and cleaning of the code to make it more readable and maintainable.
-->
The pull request optimizes the performance and readability of some components in the `Farm` widget by using `useMemo` and `useCallback` hooks to memoize values and functions that depend on props or state. The files affected are `FarmApyButton/index.tsx`, `FarmTokenInfo.tsx`, `DepositModal/index.tsx`, and `WithdrawModal/index.tsx`.

> _Oh, we're the merry coders of the `CAKE` farm_
> _We use `useMemo` and `useCallback` to keep our code fast and warm_
> _We don't waste our renders on the changing props_
> _We memoize our values and our elements with hooks_

### Walkthrough
*  Refactor `DepositModal` component to use `useMemo` hooks for performance optimization ([link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-0267f104b678d2406ffec0ff504c09b1b67fe2d1b56be3af89bd94f9a983dcb9L100-R120))
*  Wrap `handleClick` function in `FarmApyButton` component with `useCallback` hook to memoize it and avoid unnecessary re-rendering of the `Button` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-6194a746711452105c467e324a904ad235f2fc272570d10237cc04a076f37a1aR1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-6194a746711452105c467e324a904ad235f2fc272570d10237cc04a076f37a1aL27-R34))
*  Memoize `handleRenderFarming` function in `FarmTokenInfo` component with `useMemo` hook and invoke it as a JSX element ([link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-0bfaabc6f2889e6872889f4fd1e924e34b4aa3fac12b2d0843fd993ad454aef1R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-0bfaabc6f2889e6872889f4fd1e924e34b4aa3fac12b2d0843fd993ad454aef1L35-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-0bfaabc6f2889e6872889f4fd1e924e34b4aa3fac12b2d0843fd993ad454aef1L44-R45), [link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-0bfaabc6f2889e6872889f4fd1e924e34b4aa3fac12b2d0843fd993ad454aef1L62-R63))
*  Memoize `valNumber` variable in `WithdrawModal` component with `useMemo` hook to avoid creating a new `BigNumber` instance on every render ([link](https://github.com/pancakeswap/pancake-frontend/pull/7330/files?diff=unified&w=0#diff-9e9a6ef009860713c26dd119cf99ae2a16832392182cf8bf9eb369e0acfff8b4L42-R42))


