### PR TITLE
chore: bCake v3 UI QA details

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -260,8 +260,8 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
     return <Text fontSize="14px">0%</Text>
   }
 
-  if (!displayApr) {
-    return <Skeleton height={24} width={80} />
+  if (!displayApr || true) {
+    return <Skeleton height={24} width={80} style={{ borderRadius: '12px' }} />
   }
 
   return (

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -260,7 +260,7 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
     return <Text fontSize="14px">0%</Text>
   }
 
-  if (!displayApr || true) {
+  if (!displayApr) {
     return <Skeleton height={24} width={80} style={{ borderRadius: '12px' }} />
   }
 

--- a/packages/uikit/src/components/Skeleton/types.ts
+++ b/packages/uikit/src/components/Skeleton/types.ts
@@ -18,6 +18,7 @@ export interface SkeletonProps extends SpaceProps, LayoutProps, BorderRadiusProp
   animation?: Animation;
   variant?: Variant;
   isDark?: boolean;
+  style?: React.CSSProperties;
 }
 
 export interface SkeletonV2Props extends SpaceProps, LayoutProps, BorderRadiusProps {
@@ -27,4 +28,5 @@ export interface SkeletonV2Props extends SpaceProps, LayoutProps, BorderRadiusPr
   wrapperProps?: SpaceProps & LayoutProps;
   skeletonTop?: string;
   skeletonLeft?: string;
+  style?: React.CSSProperties;
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c448cc2</samp>

### Summary
🎨🔄⏳

<!--
1.  🎨 - This emoji represents the addition of a style prop to customize the appearance of the Skeleton component. It is often used for changes related to UI design or aesthetics.
2.  🔄 - This emoji represents the addition of a style prop to both Skeleton and SkeletonV2 components, which are similar but have different implementations. It is often used for changes related to refactoring or updating code.
3.  ⏳ - This emoji represents the use of Skeleton components to display loading indicators while data is fetching. It is often used for changes related to performance or optimization.
-->
This pull request enhances the `Skeleton` and `SkeletonV2` components with a `style` prop for custom styling. It also applies this prop to the `FarmV3ApyButton` component to improve the UI consistency.

> _`Skeleton` gets style_
> _Customize the loading shape_
> _Winter of waiting_

### Walkthrough
*  Add style prop to Skeleton and SkeletonV2 components to allow custom CSS properties ([link](https://github.com/pancakeswap/pancake-frontend/pull/7346/files?diff=unified&w=0#diff-3bc05c2575de676bf923711170ed09a0ea051c9931865e44dbc963b395427d7dR21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7346/files?diff=unified&w=0#diff-3bc05c2575de676bf923711170ed09a0ea051c9931865e44dbc963b395427d7dR31))
*  Apply style prop to Skeleton component in FarmV3ApyButton to set border radius to 12px ([link](https://github.com/pancakeswap/pancake-frontend/pull/7346/files?diff=unified&w=0#diff-fda14e0d4e6e6151bd888953d6a631472fc742a475793fb2e13b847929fd9dc0L263-R264))


