### PR TITLE
chore: Add nodereal zkevm

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -58,7 +58,10 @@ export const PUBLIC_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
-  [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_NODES,
+  [ChainId.POLYGON_ZKEVM]: [
+    getNodeRealUrlV2(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+    ...POLYGON_ZKEVM_NODES,
+  ],
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     ...polygonZkEvmTestnet.rpcUrls.public.http,
     'https://polygon-zkevm-testnet.rpc.thirdweb.com',

--- a/apps/web/src/utils/nodeReal.ts
+++ b/apps/web/src/utils/nodeReal.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@pancakeswap/sdk'
+
 export const getNodeRealUrl = (networkName: string) => {
   let host = null
 
@@ -31,19 +33,24 @@ export const getNodeRealUrlV2 = (chainId: number, key?: string) => {
   let host = null
 
   switch (chainId) {
-    case 1:
+    case ChainId.ETHEREUM:
       if (key) {
         host = `eth-mainnet.nodereal.io/v1/${key}`
       }
       break
-    case 5:
+    case ChainId.GOERLI:
       if (key) {
         host = `eth-goerli.nodereal.io/v1/${key}`
       }
       break
-    case 56:
+    case ChainId.BSC:
       if (key) {
         host = `bsc-mainnet.nodereal.io/v1/${key}`
+      }
+      break
+    case ChainId.POLYGON_ZKEVM:
+      if (key) {
+        host = `open-platform.nodereal.io/${key}/polygon-zkevm-rpc`
       }
       break
     default:


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f87356c</samp>

### Summary
🌐🔗🚀

<!--
1.  🌐 - This emoji represents the addition of a new node URL for the Polygon ZK-EVM chain, which is a global network that connects different blockchains.
2.  🔗 - This emoji represents the update of the `getNodeRealUrlV2` function to use the `ChainId` enum and support the Polygon ZK-EVM chain, which is a way of linking different chains and identifying them by their unique IDs.
3.  🚀 - This emoji represents the integration of the Polygon ZK-EVM chain into the PancakeSwap frontend, which is a fast and scalable solution for decentralized applications.
-->
This pull request adds support for the Polygon ZK-EVM chain to the PancakeSwap frontend by updating the node URL configuration and the `getNodeRealUrlV2` function. It also uses the `ChainId` enum to improve code readability and consistency.

> _We're breaking the boundaries of the EVM_
> _With `getNodeRealUrlV2` we unleash the ZK_
> _We're integrating the Polygon chain_
> _With `ChainId` we make our code more sane_

### Walkthrough
*  Integrate Polygon ZK-EVM chain into the frontend by:
  - Adding a new node URL for the chain in `nodes.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7348/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL61-R64))
  - Updating the `getNodeRealUrlV2` function in `nodeReal.ts` to handle the chain's host and path format ([link](https://github.com/pancakeswap/pancake-frontend/pull/7348/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94L34-R55))
* Refactor the `getNodeRealUrlV2` function to use the `ChainId` enum from the `@pancakeswap/sdk` package instead of hard-coded numbers for consistency ([link](https://github.com/pancakeswap/pancake-frontend/pull/7348/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94R1-R2))


