### PR TITLE
fix: Scroll to hash id

### DIFF
--- a/apps/web/src/hooks/useScrollToHash.ts
+++ b/apps/web/src/hooks/useScrollToHash.ts
@@ -1,24 +1,22 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { getHashFromRouter } from 'utils/getHashFromRouter'
-import useAccountActiveChain from 'hooks/useAccountActiveChain'
 
 const useScrollToHash = (isFetching: boolean, enabled: boolean) => {
   const router = useRouter()
-  const { account } = useAccountActiveChain()
   const [initialScrollDone, setInitialScrollDone] = useState(false)
 
   useEffect(() => {
-    if (account && enabled && !isFetching && router.isReady && !initialScrollDone) {
-      const hashFromRouter = getHashFromRouter(router)?.[0]
+    if (enabled && !isFetching && router.isReady && !initialScrollDone) {
+      const hashFromRouter = getHashFromRouter(router)?.[0].replace('#', '')
       if (hashFromRouter !== null && hashFromRouter !== '') {
         const elementToScroll = document.getElementById(hashFromRouter)
         if (elementToScroll && window) {
           const scrollAfter = setTimeout(() => {
-            const elementToScrollNewPosition = document.getElementById(hashFromRouter)
-            if (elementToScrollNewPosition) {
+            const currentElementToScroll = document.getElementById(hashFromRouter)
+            if (currentElementToScroll) {
               window.scrollTo({
-                top: elementToScrollNewPosition.offsetTop,
+                top: currentElementToScroll.offsetTop,
               })
               setInitialScrollDone(true)
             }
@@ -30,7 +28,7 @@ const useScrollToHash = (isFetching: boolean, enabled: boolean) => {
       }
     }
     return undefined
-  }, [router, isFetching, initialScrollDone, enabled, account])
+  }, [router, isFetching, initialScrollDone, enabled])
 }
 
 export default useScrollToHash


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc02a94</samp>

### Summary
🚀🧹🔧

<!--
1.  🚀 - This emoji could represent the improvement in performance and efficiency that the simplification of the hook brings.
2.  🧹 - This emoji could represent the cleaning up of the code and the removal of unnecessary clutter and complexity.
3.  🔧 - This emoji could represent the refactoring and fixing of the hook to make it more reliable and maintainable.
-->
Refactored a hook that handles scrolling to hash links in the web app. Removed unnecessary code from `useScrollToHash.ts`.

> _We'll scroll to the hash with a flick of the wrist_
> _We don't need no `deps` or `ref` to assist_
> _We've simplified the hook and we've cleaned up the code_
> _So heave away, me hearties, and lighten the load_

### Walkthrough
*  Remove unused hook and simplify hash handling in `useScrollToHash` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7357/files?diff=unified&w=0#diff-ce45d8fafd58bd15eddbaa31418fcc31fcab1c635b644a88c8050c2a724d2ca7L4-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/7357/files?diff=unified&w=0#diff-ce45d8fafd58bd15eddbaa31418fcc31fcab1c635b644a88c8050c2a724d2ca7L33-R30))


