### PR TITLE
chore: Update TUSD-USDD route

### DIFF
--- a/packages/smart-router/evm/constants/exchange.ts
+++ b/packages/smart-router/evm/constants/exchange.ts
@@ -105,6 +105,9 @@ export const ADDITIONAL_BASES: {
     // unshETH - USH
     [bscTokens.unshETH.address]: [bscTokens.ush],
     [bscTokens.ush.address]: [bscTokens.unshETH],
+
+    [bscTokens.tusd.address]: [bscTokens.usdd],
+    [bscTokens.usdd.address]: [bscTokens.tusd],
   },
   [ChainId.ETHEREUM]: {
     // alETH - ALCX

--- a/packages/smart-router/evm/v3-router/utils/getPoolSelectorConfig.ts
+++ b/packages/smart-router/evm/v3-router/utils/getPoolSelectorConfig.ts
@@ -22,6 +22,7 @@ function poolSelectorConfigFactory(
 
     const additionalConfigA = tokenPoolSelectorConfigMap[chainId]?.[currencyA?.wrapped?.address || '0x']
     const additionalConfigB = tokenPoolSelectorConfigMap[chainId]?.[currencyB?.wrapped?.address || '0x']
+
     return mergePoolSelectorConfig(
       mergePoolSelectorConfig(poolSelecorConfigMap[chainId], additionalConfigA),
       additionalConfigB,

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2642,4 +2642,12 @@ export const bscTokens = {
     'Pendle',
     'https://www.pendle.finance/',
   ),
+  usdd: new ERC20Token(
+    ChainId.BSC,
+    '0xd17479997F34dd9156Deef8F95A52D81D265be9c',
+    18,
+    'USDD',
+    'Decentralized USD',
+    'https://usdd.io/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 88e7057</samp>

### Summary
🔄📝🆕

<!--
1.  🔄 This emoji represents the exchange or swap action, which is the main feature of the `exchange.ts` file. It also implies that the change adds more options or flexibility for the users to swap between different tokens.
2.  📝 This emoji represents the writing or editing action, which is what adding an empty line to a file does. It also implies that the change is minor or cosmetic, and does not affect the functionality of the code.
3.  🆕 This emoji represents the new or added action, which is what adding a new token definition to the `56.ts` file does. It also implies that the change introduces something novel or innovative, and expands the scope or coverage of the code.
-->
This pull request adds support for two new stablecoins, TUSD and USDD, to the PancakeSwap exchange. It updates the `EXCHANGE_WHITELIST` constant in `exchange.ts` and the `bscTokens` object in `56.ts` with the new token pairs and information. It also adds an empty line to `getPoolSelectorConfig.ts` for readability.

> _`EXCHANGE_WHITELIST`_
> _New pairs of stablecoins_
> _Autumn harvest time_

### Walkthrough
*  Add two new stablecoin pairs to the exchange whitelist ([link](https://github.com/pancakeswap/pancake-frontend/pull/7367/files?diff=unified&w=0#diff-78ce9cd83b6e1807ee9752c395d004a76077b4df666c24beafa7932c76193b02R108-R110))
* Add USDD token definition to the Binance Smart Chain tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7367/files?diff=unified&w=0#diff-71ff5223fbd0d4df9a3c1d29ff72168019f58785ec79d2fae29f002d095f3bf4R2645-R2652))
* Add an empty line to `getPoolSelectorConfig.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7367/files?diff=unified&w=0#diff-c800b9eb9b2b6f36d34dd5053e945f9ccd61d9817b8d6e0d3a660466b70bd647R25))


