### PR TITLE
chore: list PENDLE farm on eth

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -49,6 +49,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 34,
+    lpAddress: Pool.getAddress(ethereumTokens.pendle, ethereumTokens.weth, FeeAmount.HIGH),
+    token0: ethereumTokens.pendle,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 33,
     lpAddress: Pool.getAddress(ethereumTokens.canto, ethereumTokens.weth, FeeAmount.HIGH),
     token0: ethereumTokens.canto,

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -240,4 +240,12 @@ export const ethereumTokens = {
     'Canto',
     'https://tusd.io/',
   ),
+  pendle: new ERC20Token(
+    ChainId.ETHEREUM,
+    '0x808507121B80c02388fAd14726482e061B8da827',
+    18,
+    'PENDLE',
+    'Pendle',
+    'https://www.pendle.finance/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d3f3772</samp>

### Summary
🌾🧙🌊

<!--
1.  🌾 - This emoji represents a farm or a field, and can be used to indicate the addition of a new farm to the liquidity pools. It also suggests the idea of harvesting or earning rewards from staking.
2.  🧙 - This emoji represents a wizard or a mage, and can be used to indicate the Pendle token and protocol, which involve some complex and innovative mechanisms for trading and hedging future yield. It also suggests the idea of magic or power, which the Pendle token holders have as governance participants.
3.  🌊 - This emoji represents a wave or water, and can be used to indicate the WETH token, which is a wrapped version of Ether, the native currency of the Ethereum network. It also suggests the idea of liquidity or fluidity, which are important aspects of the DeFi ecosystem.
-->
This pull request adds support for the Pendle token and the PENDLE/WETH farm on the Ethereum network. It updates the `ethereumTokens` and `farmsV3` data in `packages/tokens/src/1.ts` and `packages/farms/constants/1.ts` respectively.



### Walkthrough
*  Add new farm for PENDLE/WETH pair with high fee amount and reward rate ([link](https://github.com/pancakeswap/pancake-frontend/pull/7377/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R52-R58), packages/farms/constants/1.ts)


