### PR TITLE
feat: Show prices as in liquidity details page in increase page

### DIFF
--- a/apps/web/src/hooks/useTokenInverter.tsx
+++ b/apps/web/src/hooks/useTokenInverter.tsx
@@ -1,0 +1,27 @@
+import { Price, Token } from '@pancakeswap/swap-sdk-core'
+
+export const useTokenInverter = ({
+  priceLower,
+  priceUpper,
+  quote,
+  base,
+  invert,
+}: {
+  priceLower?: Price<Token, Token>
+  priceUpper?: Price<Token, Token>
+  quote?: Token
+  base?: Token
+  invert?: boolean
+}): {
+  priceLower?: Price<Token, Token>
+  priceUpper?: Price<Token, Token>
+  quote?: Token
+  base?: Token
+} => {
+  return {
+    priceUpper: invert ? priceLower?.invert() : priceUpper,
+    priceLower: invert ? priceUpper?.invert() : priceLower,
+    quote: invert ? base : quote,
+    base: invert ? quote : base,
+  }
+}

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Fraction, Percent, Price, Token } from '@pancakeswap/sdk'
+import { ChainId, Currency, CurrencyAmount, Fraction, Percent } from '@pancakeswap/sdk'
 import { isActiveV3Farm } from '@pancakeswap/farms'
 import {
   AutoColumn,
@@ -74,6 +74,7 @@ import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { hexToBigInt } from 'viem'
 import { getViemClients } from 'utils/viem'
 import isPoolTickInRange from 'utils/isPoolTickInRange'
+import { useTokenInverter } from 'hooks/useTokenInverter'
 
 export const BodyWrapper = styled(Card)`
   border-radius: 24px;
@@ -81,32 +82,6 @@ export const BodyWrapper = styled(Card)`
   width: 100%;
   z-index: 1;
 `
-
-const useInverter = ({
-  priceLower,
-  priceUpper,
-  quote,
-  base,
-  invert,
-}: {
-  priceLower?: Price<Token, Token>
-  priceUpper?: Price<Token, Token>
-  quote?: Token
-  base?: Token
-  invert?: boolean
-}): {
-  priceLower?: Price<Token, Token>
-  priceUpper?: Price<Token, Token>
-  quote?: Token
-  base?: Token
-} => {
-  return {
-    priceUpper: invert ? priceLower?.invert() : priceUpper,
-    priceLower: invert ? priceUpper?.invert() : priceLower,
-    quote: invert ? base : quote,
-    base: invert ? quote : base,
-  }
-}
 
 // function getRatio(
 //   lower: Price<Currency, Currency>,
@@ -201,7 +176,7 @@ export default function PoolPage() {
   const [manuallyInverted, setManuallyInverted] = useState(false)
 
   // handle manual inversion
-  const { priceLower, priceUpper, base } = useInverter({
+  const { priceLower, priceUpper, base } = useTokenInverter({
     priceLower: pricesFromPosition.priceLower,
     priceUpper: pricesFromPosition.priceUpper,
     quote: pricesFromPosition.quote,

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
@@ -11,11 +11,13 @@ import { ReactNode, useState, useCallback } from 'react'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 import { Bound } from 'config/constants/types'
 import Divider from 'components/Divider'
+import getPriceOrderingFromPositionForUI from 'hooks/v3/utils/getPriceOrderingFromPositionForUI'
 import { RangePriceSection } from 'components/RangePriceSection'
+import { RangeTag } from 'components/RangeTag'
 import { formatPrice } from 'utils/formatCurrencyAmount'
 import FormattedCurrencyAmount from 'components/Chart/FormattedCurrencyAmount/FormattedCurrencyAmount'
 
-import { RangeTag } from '../../../../../components/RangeTag'
+import { useTokenInverter } from 'hooks/useTokenInverter'
 import RateToggle from './RateToggle'
 
 export const PositionPreview = ({
@@ -39,6 +41,17 @@ export const PositionPreview = ({
   const currency0 = unwrappedToken(position.pool.token0)
   const currency1 = unwrappedToken(position.pool.token1)
 
+  const pricesFromPosition = getPriceOrderingFromPositionForUI(position)
+
+  // handle manual inversion
+  const { base } = useTokenInverter({
+    priceLower: pricesFromPosition.priceLower,
+    priceUpper: pricesFromPosition.priceUpper,
+    quote: pricesFromPosition.quote,
+    base: pricesFromPosition.base,
+    invert: false,
+  })
+
   // track which currency should be base
   const [baseCurrency, setBaseCurrency] = useState(
     baseCurrencyDefault
@@ -47,7 +60,7 @@ export const PositionPreview = ({
         : baseCurrencyDefault === currency1
         ? currency1
         : currency0
-      : currency0,
+      : unwrappedToken(base),
   )
 
   const sorted = baseCurrency === currency0


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at da0f6d2</samp>

### Summary
🎣🔄🏷️

<!--
1.  🎣 - This emoji represents the use of a custom hook, which is a common pattern in React to extract and reuse logic across components. The useTokenInverter hook is an example of this pattern, as it encapsulates the logic for inverting the position values and tokens based on a flag.
2.  🔄 - This emoji represents the inversion of the price range and the tokens, which is a feature that allows users to switch the perspective of their position and see it from the other side of the pool. The useTokenInverter hook and the position details page both implement this feature by flipping the priceLower, priceUpper, quote, and base properties of the position object.
3.  🏷️ - This emoji represents the display of the price and token information in the position preview component, which is a UI element that shows a summary of the position and its potential outcomes. The component was updated to use a new function and a hook to get the relevant data from the position object, and to show the ETH symbol instead of WETH when applicable.
-->
This pull request adds a new hook `useTokenInverter` to handle the inversion of price range and tokens in the liquidity position UI. It also updates the position details and preview components to use the hook and show the correct token symbols.

> _Oh, we're the coders of the sea, and we work with hooks and props_
> _We use `useTokenInverter` to flip the tokens and the price_
> _We heave and ho and pull the code, and we make the UI shine_
> _We show the ETH instead of WETH, and we do it all online_

### Walkthrough
*  Add a new custom hook `useTokenInverter` to handle the manual inversion of the price range and the tokens in the UI ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-418c65506d542672aa115b5980b38fdbe33c0e805a93b1636f0076dfb44a49e4R1-R27))
*  Use the `useTokenInverter` hook in the position details page (`pages/liquidity/[tokenId].tsx`) and remove the redundant `useInverter` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR77), [link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL85-L110), [link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL204-R179))
*  Log the inverted value in the position details page for debugging purposes ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR190))
*  Use the `getPriceOrderingFromPositionForUI` function and the `useTokenInverter` hook in the position preview component (`PositionPreview.tsx`) to get the correct price and token order ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-855ff4967fce38b55c660fd0a23d5093b024f95f1ce41fa5c94b3a705ed13cd3L14-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-855ff4967fce38b55c660fd0a23d5093b024f95f1ce41fa5c94b3a705ed13cd3R44-R54))
*  Use the `unwrappedToken` function in the position preview component to avoid showing the WETH symbol when the base token is ETH ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-855ff4967fce38b55c660fd0a23d5093b024f95f1ce41fa5c94b3a705ed13cd3L50-R63))
*  Update the import path of the `RangeTag` component as it was moved to a common folder ([link](https://github.com/pancakeswap/pancake-frontend/pull/7404/files?diff=unified&w=0#diff-855ff4967fce38b55c660fd0a23d5093b024f95f1ce41fa5c94b3a705ed13cd3L14-R20))


