### PR TITLE
feat: Add fallback configuration to v3 candidate pools

### DIFF
--- a/.changeset/silver-camels-pay.md
+++ b/.changeset/silver-camels-pay.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': minor
+---
+
+Add fallback configuration to v3 candidate pool fetcher

--- a/packages/smart-router/evm/utils/withFallback.ts
+++ b/packages/smart-router/evm/utils/withFallback.ts
@@ -1,6 +1,6 @@
 type AnyAsyncFunction = (...args: any[]) => Promise<any>
 
-interface AsyncCall<F extends AnyAsyncFunction> {
+export interface AsyncCall<F extends AnyAsyncFunction> {
   asyncFn: F
 
   // In millisecond


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a2bf633</samp>

### Summary
📝🏗️🚀

<!--
1.  📝 for adding a changeset file
2.  🏗️ for exporting an interface
3.  🚀 for enhancing a function
-->
This pull request improves the `@pancakeswap/smart-router` package by adding fallback configuration to the v3 candidate pool fetcher, which is a function that retrieves the best pools for swapping tokens on Uniswap v3. It also exports a helper interface and function from the `withFallback` utility module. The changes are documented in a changeset file.

> _To swap tokens on v3 with ease_
> _We need pools from different sources_
> _So we added fallback configuration_
> _And exported a helper function_
> _And imported the `AsyncCall` interface_

### Walkthrough
*  Add fallback configuration to v3 candidate pool fetcher ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-6a61ab09e1c3eb7fd93b880169e1ef96f6fd238c4b8ed3908915510b9a49759fR1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L6-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1R23-R28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L93-R155))
  - Document the minor update to the `@pancakeswap/smart-router` package in `.changeset/silver-camels-pay.md` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-6a61ab09e1c3eb7fd93b880169e1ef96f6fd238c4b8ed3908915510b9a49759fR1-R5))
  - Import the `AsyncCall` interface from the `withFallback` utility module in `getV3CandidatePools.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L6-R6))
  - Add optional parameters to the `Params` interface in `getV3CandidatePools.ts` to customize the fallback behavior ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1R23-R28))
  - Modify the `getV3CandidatePools` function in `getV3CandidatePools.ts` to use the fallback configuration and the default timeout value ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L93-R155))
* Export the `AsyncCall` interface and the `getV3PoolsWithTvlFromOnChain` function from their respective modules ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-ef3bd574e63cbd06e69c2fb2763bd36a956941f975c6fa8e0c93213028c8ac88L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L69-R75))
  - Export the `AsyncCall` interface from the `withFallback` utility module in `withFallback.ts` to use it in other modules ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-ef3bd574e63cbd06e69c2fb2763bd36a956941f975c6fa8e0c93213028c8ac88L3-R3))
  - Export the `getV3PoolsWithTvlFromOnChain` function from the `getV3CandidatePools` module in `getV3CandidatePools.ts` to use it in other modules ([link](https://github.com/pancakeswap/pancake-frontend/pull/7409/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L69-R75))


