### PR TITLE
chore: list WLD farm on eth

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -49,6 +49,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 35,
+    lpAddress: Pool.getAddress(ethereumTokens.wld, ethereumTokens.weth, FeeAmount.HIGH),
+    token0: ethereumTokens.wld,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 34,
     lpAddress: Pool.getAddress(ethereumTokens.pendle, ethereumTokens.weth, FeeAmount.HIGH),
     token0: ethereumTokens.pendle,

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -248,4 +248,12 @@ export const ethereumTokens = {
     'Pendle',
     'https://www.pendle.finance/',
   ),
+  wld: new ERC20Token(
+    ChainId.ETHEREUM,
+    '0x163f8C2467924be0ae7B5347228CABF260318753',
+    18,
+    'WLD',
+    'Worldcoin',
+    'https://worldcoin.org/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c9874e5</samp>

### Summary
🌾🌐💸

<!--
1.  🌾 - This emoji represents farming, which is a common term for earning rewards by providing liquidity to a pool. It also suggests the idea of harvesting, which is another term for claiming the rewards. This emoji could be used to indicate the addition of a new farm or the modification of an existing one.
2.  🌐 - This emoji represents the world, which is a reference to the Worldcoin token and its website. It also suggests the idea of global or universal, which could be part of the token's vision or use case. This emoji could be used to indicate the addition of a new token or the modification of an existing one that has a global or universal theme.
3.  💸 - This emoji represents money or fees, which are relevant to the Uniswap V3 pool that uses the high fee tier of 0.3%. It also suggests the idea of profit or reward, which could be the motivation for providing liquidity to the pool or using the token. This emoji could be used to indicate the addition or modification of a pool or a token that has a high fee or reward potential.
-->
This pull request adds support for a new farm and a new token on the Ethereum network. It defines the WLD token in `packages/tokens/src/1.ts` and the WLD/WETH farm in `packages/farms/constants/1.ts`.

> _New farm for `WLD`_
> _High fees on Uniswap V3_
> _Harvest in autumn_

### Walkthrough
*  Add a new farm for WLD/WETH pair on Uniswap V3 with high fees ([link](https://github.com/pancakeswap/pancake-frontend/pull/7413/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R52-R58))
* Add a new token definition for WLD, the Worldcoin token, to ethereumTokens object in `packages/tokens/src/1.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7413/files?diff=unified&w=0#diff-5f81da2a1b12c306423ba81c127abdc5f541a950a6079e7b4c1d65de467a214eR251-R258))


