### PR TITLE
chore: fix zkevm token logo path

### DIFF
--- a/packages/uikit/src/components/CurrencyLogo/utils.ts
+++ b/packages/uikit/src/components/CurrencyLogo/utils.ts
@@ -36,7 +36,7 @@ export const getTokenLogoURLByAddress = memoize(
 const chainName: { [key: number]: string } = {
   [ChainId.BSC]: "",
   [ChainId.ETHEREUM]: "eth",
-  [ChainId.POLYGON_ZKEVM]: "polygonzkevm",
+  [ChainId.POLYGON_ZKEVM]: "polygon-zkevm",
   [ChainId.ARBITRUM_ONE]: "arb",
 };
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b60c40</samp>

### Summary
🐛🖼️🔗

<!--
1.  🐛 - This emoji represents a bug fix, as the change was made to correct a problem with the logo display.
2.  🖼️ - This emoji represents an image or logo, as the change was related to the currency logo URL.
3.  🔗 - This emoji represents a link or connection, as the change was related to the chain ID and name that identify the Polygon ZK-EVM chain.
-->
Fixed logo display for Polygon ZK-EVM chain by correcting the value of `polygonzkevm` in `utils.ts`.

> _`polygonzkevm` wrong_
> _Logo URL needs a dash_
> _Fixed in the fall_

### Walkthrough
* Fix logo URL for Polygon ZK-EVM chain by changing `polygonzkevm` to `polygon-zkevm` in `utils.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7419/files?diff=unified&w=0#diff-7deb472f34cafe26dd54d7936b6e694673570a38a9cc6694b511062b1e8b01d9L39-R39))


