### PR TITLE
fix: Decimal error in pool cake usd price

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/BalanceField.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/BalanceField.tsx
@@ -18,7 +18,7 @@ interface PropsType {
   lockedAmount: string
   stakingMax: BigNumber
   setLockedAmount: Dispatch<SetStateAction<string>>
-  usedValueStaked: number | undefined
+  usdValueStaked: number | undefined
   stakingTokenBalance: BigNumber
   needApprove: boolean
 }
@@ -30,7 +30,7 @@ const BalanceField: React.FC<React.PropsWithChildren<PropsType>> = ({
   lockedAmount,
   stakingMax,
   setLockedAmount,
-  usedValueStaked,
+  usdValueStaked,
   stakingTokenBalance,
   needApprove,
 }) => {
@@ -85,7 +85,7 @@ const BalanceField: React.FC<React.PropsWithChildren<PropsType>> = ({
         isWarning={userNotEnoughCake || needApprove}
         value={lockedAmount}
         onUserInput={handleStakeInputChange}
-        currencyValue={`~${usedValueStaked || 0} USD`}
+        currencyValue={`~${usdValueStaked || 0} USD`}
         decimals={stakingDecimals}
       />
       {needApprove && !userNotEnoughCake ? (

--- a/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/LockedModalBody.tsx
@@ -39,8 +39,9 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
   const { t } = useTranslation()
   const ceiling = useIfoCeiling()
   const { avgLockDurationsInSeconds } = useAvgLockDuration()
-  const { duration, setDuration, pendingTx, handleConfirmClick } = useLockedPool({
+  const { usdValueStaked, duration, setDuration, pendingTx, handleConfirmClick } = useLockedPool({
     stakingToken,
+    stakingTokenPrice,
     onDismiss,
     lockedAmount,
     prepConfirmArg,
@@ -131,7 +132,7 @@ const LockedModalBody: React.FC<React.PropsWithChildren<LockedModalBodyPropsType
           openCalculator={_noop}
           duration={duration}
           lockedAmount={lockedAmount?.toNumber()}
-          usdValueStaked={stakingTokenPrice}
+          usdValueStaked={usdValueStaked}
           showLockWarning
           ceiling={ceiling}
         />

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/AddAmountModal.tsx
@@ -79,12 +79,19 @@ const AddAmountModal: React.FC<React.PropsWithChildren<AddAmountModalProps>> = (
     [currentLockedAmount, lockedAmountAsBigNumber],
   )
 
-  const totalLockedAmount: number = useMemo(() => getBalanceNumber(totalLockedAmountBN), [totalLockedAmountBN])
+  const totalLockedAmount: number = useMemo(
+    () => getBalanceNumber(totalLockedAmountBN, stakingToken.decimals),
+    [totalLockedAmountBN, stakingToken.decimals],
+  )
 
   const currentLockedAmountAsBalance = useMemo(() => getBalanceAmount(currentLockedAmount), [currentLockedAmount])
 
   const usdValueStaked = useMemo(
-    () => getBalanceNumber(lockedAmountAsBigNumber.multipliedBy(stakingTokenPrice), stakingToken.decimals),
+    () =>
+      getBalanceNumber(
+        getDecimalAmount(lockedAmountAsBigNumber, stakingToken.decimals).multipliedBy(stakingTokenPrice),
+        stakingToken.decimals,
+      ),
     [lockedAmountAsBigNumber, stakingTokenPrice, stakingToken.decimals],
   )
 
@@ -151,7 +158,7 @@ const AddAmountModal: React.FC<React.PropsWithChildren<AddAmountModalProps>> = (
             stakingSymbol={stakingToken.symbol}
             stakingDecimals={stakingToken.decimals}
             lockedAmount={lockedAmount}
-            usedValueStaked={usdValueStaked}
+            usdValueStaked={usdValueStaked}
             stakingMax={currentBalance}
             setLockedAmount={setLockedAmount}
             stakingTokenBalance={stakingTokenBalance}

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/ExtendDurationModal.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import BigNumber from 'bignumber.js'
 import { useIfoCeiling } from 'state/pools/hooks'
 
-import { getBalanceAmount, getBalanceNumber } from '@pancakeswap/utils/formatBalance'
+import { getBalanceAmount, getBalanceNumber, getDecimalAmount } from '@pancakeswap/utils/formatBalance'
 import StaticAmount from '../Common/StaticAmount'
 import LockedBodyModal from '../Common/LockedModalBody'
 import Overview from '../Common/Overview'
@@ -33,7 +33,11 @@ const ExtendDurationModal: React.FC<ExtendDurationModal> = ({
   const { t } = useTranslation()
 
   const usdValueStaked = useMemo(
-    () => getBalanceNumber(new BigNumber(currentLockedAmount).multipliedBy(stakingTokenPrice), stakingToken.decimals),
+    () =>
+      getBalanceNumber(
+        getDecimalAmount(new BigNumber(currentLockedAmount), stakingToken.decimals).multipliedBy(stakingTokenPrice),
+        stakingToken.decimals,
+      ),
     [currentLockedAmount, stakingTokenPrice, stakingToken.decimals],
   )
 

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
@@ -31,7 +31,11 @@ const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = (
   }, [customLockAmount])
 
   const usdValueStaked = useMemo(
-    () => getBalanceNumber(new BigNumber(lockedAmount).multipliedBy(stakingTokenPrice), stakingToken.decimals),
+    () =>
+      getBalanceNumber(
+        getDecimalAmount(new BigNumber(lockedAmount), stakingToken.decimals).multipliedBy(stakingTokenPrice),
+        stakingToken.decimals,
+      ),
     [lockedAmount, stakingTokenPrice, stakingToken.decimals],
   )
 
@@ -50,7 +54,7 @@ const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = (
             stakingSymbol={stakingToken.symbol}
             stakingDecimals={stakingToken.decimals}
             lockedAmount={lockedAmount}
-            usedValueStaked={usdValueStaked}
+            usdValueStaked={usdValueStaked}
             stakingMax={currentBalance}
             setLockedAmount={setLockedAmount}
             stakingTokenBalance={stakingTokenBalance}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f40f79</samp>

### Summary
🐛📝💵

<!--
1.  🐛 - This emoji represents a bug fix, which is a common type of change in software development. It indicates that the change fixed an error or a problem in the code or functionality of the application.
2.  📝 - This emoji represents a rename or a refactor, which is another common type of change in software development. It indicates that the change improved the readability, consistency, or clarity of the code or the variables, without altering the functionality or logic.
3.  💵 - This emoji represents a currency or a money-related change, which is a specific type of change in this context. It indicates that the change involved the USD value of the staked or locked tokens, which is an important aspect of the application's features and user interface.
-->
Fixed bugs and improved readability in the locked pools feature. Renamed some props and variables to reflect the USD value of staked and locked tokens in different modals and components. Used a common function to handle different decimals in the staking tokens.

> _We stake our tokens in the pools of doom_
> _We face the bugs that lurk in the code_
> _We fix the calculations with `usdValueStaked`_
> _We rename the props to make them clear_

### Walkthrough
*  Rename `usedValueStaked` prop to `usdValueStaked` in `BalanceField` component and its parent components to clarify its meaning ([link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-b17e08ba0f1b649394dbb6eb6fd437d28f264eda6f3af3138184756a9899a329L21-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-b17e08ba0f1b649394dbb6eb6fd437d28f264eda6f3af3138184756a9899a329L33-R33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-b17e08ba0f1b649394dbb6eb6fd437d28f264eda6f3af3138184756a9899a329L88-R88), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-231dfeadfe125708f9959bee67c3bbe95011f59335a6fca677f17e311a4f666eL154-R161), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-1402eab437397b1660231d29413da2566d0cbb92cc3b523b0168f45830660be8L53-R57))
*  Use `getDecimalAmount` function to convert staking token amounts to decimal values with correct decimals before calculating `usdValueStaked` in `AddAmountModal`, `ExtendDurationModal`, and `LockedStakeModal` components to ensure accuracy ([link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-231dfeadfe125708f9959bee67c3bbe95011f59335a6fca677f17e311a4f666eL82-R94), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-0dd6b4ba95f1c45edd2a2f7b2861c95865159c821d06361daf1edbf96bbf2148L10-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-0dd6b4ba95f1c45edd2a2f7b2861c95865159c821d06361daf1edbf96bbf2148L36-R40), [link](https://github.com/pancakeswap/pancake-frontend/pull/7426/files?diff=unified&w=0#diff-1402eab437397b1660231d29413da2566d0cbb92cc3b523b0168f45830660be8L34-R38))


