### PR TITLE
fix: Pool expected roi shows old value when it is smaller than 0.00

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/Overview/BalanceRow.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/Overview/BalanceRow.tsx
@@ -19,7 +19,7 @@ const DiffBalance: React.FC<React.PropsWithChildren<DiffBalancePropsType>> = ({
   unit,
   prefix,
 }) => {
-  if (isUndefinedOrNull(newValue) || !value || value === newValue || _toNumber(newValue) === 0) {
+  if (isUndefinedOrNull(newValue) || isUndefinedOrNull(value) || _toNumber(value) === _toNumber(newValue)) {
     return <BalanceWithLoading bold fontSize="16px" value={value} decimals={decimals} unit={unit} prefix={prefix} />
   }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c7556c4</samp>

### Summary
🔄🚀🧐

<!--
1.  🔄 This emoji means "repeat" or "update", and it can be used to indicate that the condition for rendering the component was simplified or changed as part of a refactoring task.
2.  🚀 This emoji means "rocket" or "launch", and it can be used to indicate that the change improved the performance or speed of the code by avoiding unnecessary re-rendering or potential bugs.
3.  🧐 This emoji means "monocle face" or "inspect", and it can be used to indicate that the change improved the readability or clarity of the code by using helper functions or consistent formatting.
-->
Simplified the rendering logic of `BalanceWithLoading` component in `BalanceRow.tsx` to avoid re-rendering and bugs. Refactored the code for performance and readability.

> _`BalanceWithLoading`_
> _Simplified condition - ah!_
> _Spring cleaning the code_

### Walkthrough
*  Simplify the condition for rendering the `BalanceWithLoading` component to avoid unnecessary re-rendering and potential bugs ([link](https://github.com/pancakeswap/pancake-frontend/pull/7427/files?diff=unified&w=0#diff-03c3af2f9650e5a0850278536e4af79b97fe2c612ded19f8881d36257bd1b18aL22-R22))


