### PR TITLE
feat: Add useShowOnceAirdropModal hook

### DIFF
--- a/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
@@ -138,7 +138,7 @@ const V3AirdropModal: React.FC<V3AirdropModalProps> = ({ data, onDismiss }) => {
                 <Image src="/images/nfts/v3-part1.jpg" />
               </Box>
               <Button
-                mt="24px"
+                m="12px 0"
                 disabled={isLoading}
                 onClick={handleClick}
                 endIcon={isLoading ? <AutoRenewIcon spin color="currentColor" /> : undefined}
@@ -170,7 +170,7 @@ const V3AirdropModal: React.FC<V3AirdropModalProps> = ({ data, onDismiss }) => {
                 <Image src="/images/nfts/v3-part2.jpg" />
               </Box>
               <Button
-                mt="24px"
+                m="12px 0"
                 disabled={isLoading}
                 onClick={handleClick}
                 endIcon={isLoading ? <AutoRenewIcon spin color="currentColor" /> : undefined}

--- a/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
@@ -137,6 +137,14 @@ const V3AirdropModal: React.FC<V3AirdropModalProps> = ({ data, onDismiss }) => {
               <Box>
                 <Image src="/images/nfts/v3-part1.jpg" />
               </Box>
+              <Button
+                mt="24px"
+                disabled={isLoading}
+                onClick={handleClick}
+                endIcon={isLoading ? <AutoRenewIcon spin color="currentColor" /> : undefined}
+              >
+                {isLoading ? <Dots>{t('Claiming')}</Dots> : t('Claim now')}
+              </Button>
               <Text textAlign="center" bold>
                 {t('Part 1')}
               </Text>
@@ -161,6 +169,14 @@ const V3AirdropModal: React.FC<V3AirdropModalProps> = ({ data, onDismiss }) => {
               <Box>
                 <Image src="/images/nfts/v3-part2.jpg" />
               </Box>
+              <Button
+                mt="24px"
+                disabled={isLoading}
+                onClick={handleClick}
+                endIcon={isLoading ? <AutoRenewIcon spin color="currentColor" /> : undefined}
+              >
+                {isLoading ? <Dots>{t('Claiming')}</Dots> : t('Claim now')}
+              </Button>
               <Text textAlign="center" bold>
                 {t('Part 2')}
               </Text>
@@ -184,14 +200,6 @@ const V3AirdropModal: React.FC<V3AirdropModalProps> = ({ data, onDismiss }) => {
         <Text textAlign="center" bold color="secondary" mt="24px">
           {textDisplay()}
         </Text>
-        <Button
-          mt="24px"
-          disabled={isLoading}
-          onClick={handleClick}
-          endIcon={isLoading ? <AutoRenewIcon spin color="currentColor" /> : undefined}
-        >
-          {isLoading ? <Dots>{t('Claiming')}</Dots> : t('Claim now')}
-        </Button>
       </Flex>
     </Modal>
   )

--- a/apps/web/src/components/GlobalCheckClaimStatus/hooks/useAirdropModalStatus.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/hooks/useAirdropModalStatus.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react'
+import { useAccount } from 'wagmi'
+import { useV3AirdropContract } from 'hooks/useContract'
+import useSWRImmutable from 'swr/immutable'
+import { FetchStatus } from 'config/constants/types'
+import useSWR from 'swr'
+
+interface AirdropModalStatus {
+  shouldShowModal: boolean
+  v3WhitelistAddress: any
+}
+
+const GITHUB_ENDPOINT = 'https://raw.githubusercontent.com/pancakeswap/airdrop-v3-users/master'
+
+const useAirdropModalStatus = (): AirdropModalStatus => {
+  const { address: account } = useAccount()
+  const v3Airdrop = useV3AirdropContract()
+
+  const { data: isAccountClaimed, status: accountClaimedStatus } = useSWR(
+    account && [account, '/airdrop-claimed'],
+    async () => v3Airdrop.read.isClaimed([account]),
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      revalidateOnReconnect: false,
+    },
+  )
+
+  const { data: v3WhitelistAddress } = useSWRImmutable(
+    !isAccountClaimed && accountClaimedStatus === FetchStatus.Fetched && '/airdrop-whitelist-json',
+    async () => (await fetch(`${GITHUB_ENDPOINT}/forFE.json`)).json(),
+  )
+
+  const shouldShowModal = useMemo(() => {
+    return (
+      accountClaimedStatus === FetchStatus.Fetched && !isAccountClaimed && v3WhitelistAddress?.[account?.toLowerCase()]
+    )
+  }, [account, accountClaimedStatus, isAccountClaimed, v3WhitelistAddress])
+
+  return {
+    shouldShowModal,
+    v3WhitelistAddress,
+  }
+}
+
+export default useAirdropModalStatus

--- a/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
@@ -65,7 +65,6 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
       showOnceAirdropModal
     ) {
       setShow(true)
-      setShowOnceAirdropModal(false)
     } else {
       setShow(false)
     }
@@ -81,10 +80,18 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
     v3WhitelistAddress,
   ])
 
+  const handleCloseModal = () => {
+    if (showOnceAirdropModal) {
+      setShowOnceAirdropModal(!showOnceAirdropModal)
+    }
+    setShow(false)
+  }
+
   return (
-    <ModalV2 isOpen={show} onDismiss={() => setShow(false)} closeOnOverlayClick>
+    <ModalV2 isOpen={show} onDismiss={() => handleCloseModal()} closeOnOverlayClick>
       <V3AirdropModal
         data={account ? (v3WhitelistAddress?.[account.toLowerCase()] as WhitelistType) : (null as WhitelistType)}
+        onDismiss={handleCloseModal}
       />
     </ModalV2>
   )

--- a/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
@@ -2,14 +2,11 @@ import { useEffect, useState } from 'react'
 import { ChainId } from '@pancakeswap/sdk'
 import { ModalV2 } from '@pancakeswap/uikit'
 import { useAccount } from 'wagmi'
-import { useV3AirdropContract } from 'hooks/useContract'
 import { useRouter } from 'next/router'
-import useSWRImmutable from 'swr/immutable'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import { FetchStatus } from 'config/constants/types'
-import useSWR from 'swr'
 import { useShowOnceAirdropModal } from 'hooks/useShowOnceAirdropModal'
 import V3AirdropModal, { WhitelistType } from './V3AirdropModal'
+import useAirdropModalStatus from './hooks/useAirdropModalStatus'
 
 interface GlobalCheckClaimStatusProps {
   excludeLocations: string[]
@@ -32,53 +29,21 @@ const GlobalCheckClaimStatus: React.FC<React.PropsWithChildren<GlobalCheckClaimS
  *
  * TODO: Put global checks in redux or make a generic area to house global checks
  */
-const GITHUB_ENDPOINT = 'https://raw.githubusercontent.com/pancakeswap/airdrop-v3-users/master'
 
 const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusProps>> = ({ excludeLocations }) => {
   const { address: account } = useAccount()
   const { pathname } = useRouter()
-  const v3Airdrop = useV3AirdropContract()
   const [show, setShow] = useState(false)
+  const { shouldShowModal, v3WhitelistAddress } = useAirdropModalStatus()
   const [showOnceAirdropModal, setShowOnceAirdropModal] = useShowOnceAirdropModal()
 
-  const { data: isAccountClaimed, status: accountClaimedStatus } = useSWR(
-    account && [account, '/airdrop-claimed'],
-    async () => v3Airdrop.read.isClaimed([account]),
-    {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-    },
-  )
-
-  const { data: v3WhitelistAddress } = useSWRImmutable(
-    !isAccountClaimed && accountClaimedStatus === FetchStatus.Fetched && '/airdrop-whitelist-json',
-    async () => (await fetch(`${GITHUB_ENDPOINT}/forFE.json`)).json(),
-  )
-
   useEffect(() => {
-    if (
-      accountClaimedStatus === FetchStatus.Fetched &&
-      !isAccountClaimed &&
-      v3WhitelistAddress?.[account?.toLowerCase()] &&
-      !excludeLocations.some((location) => pathname.includes(location)) &&
-      showOnceAirdropModal
-    ) {
+    if (shouldShowModal && !excludeLocations.some((location) => pathname.includes(location)) && showOnceAirdropModal) {
       setShow(true)
     } else {
       setShow(false)
     }
-  }, [
-    account,
-    accountClaimedStatus,
-    excludeLocations,
-    isAccountClaimed,
-    pathname,
-    setShow,
-    setShowOnceAirdropModal,
-    showOnceAirdropModal,
-    v3WhitelistAddress,
-  ])
+  }, [account, excludeLocations, pathname, setShow, shouldShowModal, showOnceAirdropModal, v3WhitelistAddress])
 
   const handleCloseModal = () => {
     if (showOnceAirdropModal) {

--- a/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
@@ -8,6 +8,7 @@ import useSWRImmutable from 'swr/immutable'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { FetchStatus } from 'config/constants/types'
 import useSWR from 'swr'
+import { useShowOnceAirdropModal } from 'hooks/useShowOnceAirdropModal'
 import V3AirdropModal, { WhitelistType } from './V3AirdropModal'
 
 interface GlobalCheckClaimStatusProps {
@@ -38,6 +39,7 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
   const { pathname } = useRouter()
   const v3Airdrop = useV3AirdropContract()
   const [show, setShow] = useState(false)
+  const [showOnceAirdropModal, setShowOnceAirdropModal] = useShowOnceAirdropModal()
 
   const { data: isAccountClaimed, status: accountClaimedStatus } = useSWR(
     account && [account, '/airdrop-claimed'],
@@ -59,13 +61,25 @@ const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusP
       accountClaimedStatus === FetchStatus.Fetched &&
       !isAccountClaimed &&
       v3WhitelistAddress?.[account?.toLowerCase()] &&
-      !excludeLocations.some((location) => pathname.includes(location))
+      !excludeLocations.some((location) => pathname.includes(location)) &&
+      showOnceAirdropModal
     ) {
       setShow(true)
+      setShowOnceAirdropModal(false)
     } else {
       setShow(false)
     }
-  }, [account, accountClaimedStatus, excludeLocations, isAccountClaimed, pathname, setShow, v3WhitelistAddress])
+  }, [
+    account,
+    accountClaimedStatus,
+    excludeLocations,
+    isAccountClaimed,
+    pathname,
+    setShow,
+    setShowOnceAirdropModal,
+    showOnceAirdropModal,
+    v3WhitelistAddress,
+  ])
 
   return (
     <ModalV2 isOpen={show} onDismiss={() => setShow(false)} closeOnOverlayClick>

--- a/apps/web/src/components/Menu/UserMenu/ClaimYourNFT.tsx
+++ b/apps/web/src/components/Menu/UserMenu/ClaimYourNFT.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from '@pancakeswap/localization'
+import styled from 'styled-components'
+import { Flex, UserMenuItem } from '@pancakeswap/uikit'
+import { useShowOnceAirdropModal } from 'hooks/useShowOnceAirdropModal'
+
+const Dot = styled.div`
+  background-color: ${({ theme }) => theme.colors.success};
+  border-radius: 50%;
+  height: 8px;
+  width: 8px;
+`
+
+const ClaimYourNFT = () => {
+  const { t } = useTranslation()
+  const [_, setShowOnceAirdropModal] = useShowOnceAirdropModal()
+
+  return (
+    <UserMenuItem as="button" onClick={() => setShowOnceAirdropModal(true)}>
+      <Flex alignItems="center" justifyContent="space-between" width="100%">
+        {t('Claim Your NFT')}
+        <Dot />
+      </Flex>
+    </UserMenuItem>
+  )
+}
+
+export default ClaimYourNFT

--- a/apps/web/src/components/Menu/UserMenu/index.tsx
+++ b/apps/web/src/components/Menu/UserMenu/index.tsx
@@ -21,9 +21,11 @@ import { useProfile } from 'state/profile/hooks'
 import { usePendingTransactions } from 'state/transactions/hooks'
 import { useAccount } from 'wagmi'
 import { useDomainNameForAddress } from 'hooks/useDomain'
+import useAirdropModalStatus from 'components/GlobalCheckClaimStatus/hooks/useAirdropModalStatus'
 import ProfileUserMenuItem from './ProfileUserMenuItem'
 import WalletModal, { WalletView } from './WalletModal'
 import WalletUserMenuItem from './WalletUserMenuItem'
+import ClaimYourNFT from './ClaimYourNFT'
 
 const UserMenuItems = () => {
   const { t } = useTranslation()
@@ -32,6 +34,8 @@ const UserMenuItems = () => {
   const { address: account } = useAccount()
   const { hasPendingTransactions } = usePendingTransactions()
   const { isInitialized, isLoading, profile } = useProfile()
+  const { shouldShowModal } = useAirdropModalStatus()
+
   const [onPresentWalletModal] = useModal(<WalletModal initialView={WalletView.WALLET_INFO} />)
   const [onPresentTransactionModal] = useModal(<WalletModal initialView={WalletView.TRANSACTIONS} />)
   const [onPresentWrongNetworkModal] = useModal(<WalletModal initialView={WalletView.WRONG_NETWORK} />)
@@ -56,6 +60,7 @@ const UserMenuItems = () => {
       <NextLink href={`/profile/${account?.toLowerCase()}`} passHref>
         <UserMenuItem disabled={isWrongNetwork || chainId !== ChainId.BSC}>{t('Your NFTs')}</UserMenuItem>
       </NextLink>
+      {shouldShowModal && <ClaimYourNFT />}
       <ProfileUserMenuItem
         isLoading={isLoading}
         hasProfile={hasProfile}

--- a/apps/web/src/hooks/useShowOnceAirdropModal.ts
+++ b/apps/web/src/hooks/useShowOnceAirdropModal.ts
@@ -1,0 +1,9 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+const airdropModal = atomWithStorage('pcs:v3-airdrop-modal', true)
+
+export function useShowOnceAirdropModal() {
+  return useAtom(airdropModal)
+}

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2612,5 +2612,6 @@
   "Round #%round%  |  %startTime% - %endTime%": "Round #%round%  |  %startTime% - %endTime%",
   "Swap and Provide Liquidity on zkSync Era Now": "Swap and Provide Liquidity on zkSync Era Now",
   "PancakeSwap Now Live on zkSync Era!": "PancakeSwap Now Live on zkSync Era!",
-  "Zksync Lormips LIVE!": "Zksync Lormips LIVE!"
+  "Zksync Lormips LIVE!": "Zksync Lormips LIVE!",
+  "Claim Your NFT": "Claim Your NFT"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15f9786</samp>

### Summary
🆕🎁💸

<!--
1.  🆕 for creating a new file and hook
2.  🎁 for adding a feature to show the airdrop modal once
3.  💸 for adding a feature to claim the airdrop tokens from the modal
-->
This pull request adds a feature to show and claim the V3 airdrop tokens from a modal that appears only once per user. It uses a new hook `useShowOnceAirdropModal` and a state atom stored in the local storage to control the modal visibility. It also modifies the `V3AirdropModal` component and the `GlobalCheckClaimStatus` component to implement the feature.

> _Claim your airdrop, don't let it slip away_
> _`useShowOnceAirdropModal` to seize the day_
> _No more check status, just press the button_
> _V3 tokens are yours, unleash the dragon_

### Walkthrough
*  Add useShowOnceAirdropModal hook to store and update the boolean value of showOnceAirdropModal state in local storage ([link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-7a40cdeac99b90af10d6cf3800dace39a3c6513f060e53b575f318845060a738R1-R9))
*  Use showOnceAirdropModal and setShowOnceAirdropModal variables to control the visibility of V3AirdropModal component based on user interaction and claim status ([link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L62-R82))
*  Add claim button to V3AirdropModal component that allows the user to claim their V3 airdrop tokens and shows the loading icon while the transaction is pending ([link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-7f798474c360a1c059fda314f3b04cdaf9b6a3a9cd6f780faff8efaec5331ccbR140-R147), [link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-7f798474c360a1c059fda314f3b04cdaf9b6a3a9cd6f780faff8efaec5331ccbR172-R179))
*  Remove check status button from V3AirdropModal component as it is no longer needed ([link](https://github.com/pancakeswap/pancake-frontend/pull/7428/files?diff=unified&w=0#diff-7f798474c360a1c059fda314f3b04cdaf9b6a3a9cd6f780faff8efaec5331ccbL187-L194))


