### PR TITLE
chore: Add zksync era support to routing api

### DIFF
--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -5,11 +5,12 @@ export const SUPPORTED_CHAINS = [
   ChainId.BSC,
   ChainId.LINEA_TESTNET,
   ChainId.POLYGON_ZKEVM,
+  ChainId.ZKSYNC,
   ChainId.BSC_TESTNET,
   ChainId.GOERLI,
 ] as const
 
-type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
+export type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
 
 export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
@@ -17,6 +18,7 @@ export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
   [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
   [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
+  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
   [ChainId.LINEA_TESTNET]:
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
 }

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -4,7 +4,7 @@ import { createPublicClient, http } from 'viem'
 import { bsc, bscTestnet, goerli, mainnet } from 'viem/chains'
 import { GraphQLClient } from 'graphql-request'
 
-import { V3_SUBGRAPH_URLS } from './constants'
+import { V3_SUBGRAPH_URLS, SupportedChainId } from './constants'
 
 const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE]
 requireCheck.forEach((node) => {
@@ -49,13 +49,16 @@ export const viemProviders: OnChainProvider = ({ chainId }: { chainId?: ChainId 
   }
 }
 
-export const v3SubgraphClients = {
+export const v3SubgraphClients: Record<SupportedChainId, GraphQLClient> = {
   [ChainId.ETHEREUM]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ETHEREUM], { fetch }),
+  [ChainId.POLYGON_ZKEVM]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.POLYGON_ZKEVM], { fetch }),
+  [ChainId.ZKSYNC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ZKSYNC], { fetch }),
+  [ChainId.LINEA_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.LINEA_TESTNET], { fetch }),
   [ChainId.GOERLI]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.GOERLI], { fetch }),
   [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC], { fetch }),
   [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC_TESTNET], { fetch }),
-}
+} as const
 
 export const v3SubgraphProvider: SubgraphProvider = ({ chainId = ChainId.BSC }: { chainId?: ChainId }) => {
-  return v3SubgraphClients[chainId] || v3SubgraphClients[ChainId.BSC]
+  return v3SubgraphClients[chainId as SupportedChainId] || v3SubgraphClients[ChainId.BSC]
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1de92b5</samp>

### Summary
🌐🛣️📊

<!--
1.  🌐 - This emoji can be used to represent the addition of support for new chains or networks, as it suggests expanding the scope or reach of the project.
2.  🛣️ - This emoji can be used to represent the update of the routing API, as it suggests improving the navigation or direction of the project.
3.  📊 - This emoji can be used to represent the update of the subgraph provider, as it suggests enhancing the data or analysis of the project.
-->
Added support for two new Layer 2 chains, Polygon ZK-EVM and ZKSync, in the routing API. Modified `constants.ts` and `provider.ts` in the `apis/routing` module to handle the new chain IDs and subgraph URLs.

> _Oh we're the brave developers of the routing API_
> _We support the chains that make the transactions fly_
> _Heave away, me lads and lasses, heave away with `ZKSync`_
> _And don't forget the `Polygon ZK-EVM` in the mix_

### Walkthrough
*  Add support for ZKSync chain and subgraph ([link](https://github.com/pancakeswap/pancake-frontend/pull/7432/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aL8-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7432/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7432/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L7-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7432/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L52-R63))


