### PR TITLE
chore: zksync banner adjustment

### DIFF
--- a/apps/web/src/views/Home/components/Banners/ZksyncBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/ZksyncBanner.tsx
@@ -50,6 +50,7 @@ const Title = styled.div`
   line-height: 98%;
   padding-right: 80px;
   margin-bottom: 20px;
+  color: ${({ theme }) => theme.colors.white};
 
   ${({ theme }) => theme.mediaQueries.lg} {
     font-size: 32px;
@@ -120,7 +121,7 @@ export const ZksyncBanner = () => {
             >
               <StyledButtonLeft scale={['xs', 'sm', 'md']} style={{ borderRadius: isMobile && '20px' }}>
                 <Text bold fontSize={['12px', '16px']} mr="4px">
-                  {isMobile ? t('CTA') : t('Get Started')}
+                  {isMobile ? t('Start Now') : t('Get Started')}
                 </Text>
                 <OpenNewIcon color="white" />
               </StyledButtonLeft>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2612,6 +2612,5 @@
   "Round #%round%  |  %startTime% - %endTime%": "Round #%round%  |  %startTime% - %endTime%",
   "Swap and Provide Liquidity on zkSync Era Now": "Swap and Provide Liquidity on zkSync Era Now",
   "PancakeSwap Now Live on zkSync Era!": "PancakeSwap Now Live on zkSync Era!",
-  "Zksync Lormips LIVE!": "Zksync Lormips LIVE!",
-  "CTA": "CTA"
+  "Zksync Lormips LIVE!": "Zksync Lormips LIVE!"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 182d11c</samp>

### Summary
🗑️🎨📱

<!--
1.  🗑️ - This emoji conveys the idea of deleting or removing something, which is what the change does to the translation key "CTA".
2.  🎨 - This emoji conveys the idea of improving the appearance or design of something, which is what the change does to the zkSync banner color.
3.  📱 - This emoji conveys the idea of adapting or optimizing something for mobile devices, which is what the change does to the zkSync button text.
-->
This pull request enhances the zkSync banner on the home page and removes an unused translation key. It makes the banner more appealing and responsive for mobile users and cleans up the `translations.json` file.

> _`CTA` key gone_
> _zkSync banner shines brighter_
> _Spring cleaning the code_

### Walkthrough
*  Add white color to banner title for better contrast and visibility ([link](https://github.com/pancakeswap/pancake-frontend/pull/7434/files?diff=unified&w=0#diff-96c8c592cb95cdeee4b804c7ef0446a64d589ec8dbd9dd9fc93826c5da873dcbR53))
*  Change button text to "Start Now" for mobile devices and remove unused translation key ([link](https://github.com/pancakeswap/pancake-frontend/pull/7434/files?diff=unified&w=0#diff-96c8c592cb95cdeee4b804c7ef0446a64d589ec8dbd9dd9fc93826c5da873dcbL123-R124), [link](https://github.com/pancakeswap/pancake-frontend/pull/7434/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2615-R2615))


