### PR TITLE
chore: Lower multicall for zkevm

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -59,7 +59,7 @@ export const PUBLIC_NODES = {
   [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
-    getNodeRealUrlV2(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+    // getNodeRealUrlV2(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
     ...POLYGON_ZKEVM_NODES,
   ],
   [ChainId.POLYGON_ZKEVM_TESTNET]: [

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -20,7 +20,7 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
       ),
       batch: {
         multicall: {
-          batchSize: 1024 * 200,
+          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 200,
         },
       },
     }),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 056c778</samp>

### Summary
🌐🚀🔧

<!--
1.  🌐 - This emoji represents the addition of support for a new network (Polygon ZK-EVM) to the PancakeSwap frontend, which is a global and cross-chain platform for decentralized exchange and yield farming.
2.  🚀 - This emoji represents the improvement of the performance and stability of the multicall requests on the Polygon ZK-EVM network, which is a fast and scalable network that uses zero-knowledge proofs to verify transactions.
3.  🔧 - This emoji represents the modification of the `batchSize` property of the `multicall` option in the `viewClients` function, which is a technical and configuration change that affects how the frontend interacts with the multicall contract.
-->
Reduced `batchSize` for multicall requests on Polygon ZK-EVM network in `viem.ts`. This improves performance and stability on the network with lower gas limit.

> _`batchSize` shrinks_
> _for Polygon ZK-EVM_
> _autumn leaves fall fast_

### Walkthrough
* Reduce the multicall batch size to 128 on Polygon ZK-EVM network to improve performance and stability ([link](https://github.com/pancakeswap/pancake-frontend/pull/7440/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL23-R23))


