### PR TITLE
chore: Add batch on zkevm

### DIFF
--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -12,6 +12,12 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
         (PUBLIC_NODES[cur.id] as string[]).map((url) =>
           http(url, {
             timeout: 15_000,
+            batch:
+              cur.id === ChainId.POLYGON_ZKEVM
+                ? {
+                    batchSize: 2,
+                  }
+                : false,
           }),
         ),
         {
@@ -20,7 +26,7 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
       ),
       batch: {
         multicall: {
-          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 200,
+          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 256 : 1024 * 200,
         },
       },
     }),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 48c1a2f</samp>

### Summary
🚀💰🔧

<!--
1.  🚀 - This emoji represents the performance improvement of the requests to the blockchain, as the batching options are adjusted to reduce the number of requests and the latency.
2.  💰 - This emoji represents the cost reduction of the requests to the blockchain, as the batching options are adjusted to minimize the gas fees and the network congestion.
3.  🔧 - This emoji represents the configuration change of the `viewClients` object, as the batching options are modified based on the chain ID.
-->
Optimize blockchain requests for different chains. Change the `viemClients` batching options in `apps/web/src/utils/viem.ts` based on the chain ID.

> _Sing, O Muse, of the cunning coder who tweaked the batching options_
> _Of the `viewClients` object, that wondrous tool of blockchain queries,_
> _To suit the different chain IDs, each with its own demands and costs,_
> _Especially the `POLYGON_ZKEVM`, that new and swift testnet of magic._

### Walkthrough
*  Add and modify `batch` and `multicall` options for `viemClients` to adjust request batching for zkEVM testnet ([link](https://github.com/pancakeswap/pancake-frontend/pull/7441/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cR15-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/7441/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL23-R29))


