### PR TITLE
chore: revert zkevm node order

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -59,8 +59,8 @@ export const PUBLIC_NODES = {
   [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
-    getNodeRealUrlV2(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
     ...POLYGON_ZKEVM_NODES,
+    getNodeRealUrlV2(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
   ],
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     ...polygonZkEvmTestnet.rpcUrls.public.http,

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -20,7 +20,7 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
       ),
       batch: {
         multicall: {
-          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 200,
+          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 64 : 1024 * 200,
         },
       },
     }),

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -20,7 +20,7 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
       ),
       batch: {
         multicall: {
-          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 64 : 1024 * 200,
+          batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 200,
         },
       },
     }),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 78fd6ef</samp>

### Summary
🔀📉🛠️

<!--
1.  🔀 - This emoji represents the reordering of the array of RPC URLs, as it suggests a shuffling or switching of elements.
2.  📉 - This emoji represents the reduction of the batch size, as it suggests a decrease or a lower value.
3.  🛠️ - This emoji represents the bug fixing and performance improvement, as it suggests a repair or a solution.
-->
The pull request improves the web app's compatibility and performance on the Polygon ZK-EVM chain by adjusting the RPC node order in `nodes.ts` and the multicall batch size in `viem.ts`.

> _`Polygon ZK-EVM`_
> _Adjusting nodes and batches_
> _Winter of bug fixes_

### Walkthrough
* Reduce multicall batch size for Polygon ZK-EVM chain to avoid gas limit errors ([link](https://github.com/pancakeswap/pancake-frontend/pull/7450/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL23-R23))
* Reorder RPC URLs for Polygon ZK-EVM chain to use node real API as fallback option ([link](https://github.com/pancakeswap/pancake-frontend/pull/7450/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL62-R63))


