### PR TITLE
chore: Update tradingRewardTopTrades contract

### DIFF
--- a/apps/web/src/config/constants/contracts.ts
+++ b/apps/web/src/config/constants/contracts.ts
@@ -223,7 +223,7 @@ export default {
   },
   tradingRewardTopTrades: {
     1: '0x',
-    56: '0x549d484F493b778A5c70638E30Fc6Dc6B2Dcc4c0',
+    56: '0x41920b6A17CB73D1B60f4F41D82c35eD0a46fD71',
     97: '0x',
   },
 } as const satisfies Record<string, Record<number, `0x${string}`>>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6e4dc57</samp>

### Summary
🔄🌐🏆

<!--
1.  🔄 - This emoji signifies that something was updated or changed, which is the case for the contract address.
2.  🌐 - This emoji represents the Binance Smart Chain mainnet, which is the network where the change took place.
3.  🏆 - This emoji symbolizes the trading reward top trades feature, which is the functionality that was affected by the change.
-->
Updated the contract address for the trading reward top trades feature on the mainnet. This fixes the frontend display of the leaderboard in `apps/web/src/config/constants/contracts.ts`.

> _`TopTrades` contract_
> _Changed on Binance mainnet_
> _Autumn of rewards_

### Walkthrough
*  Update the contract address for the trading reward top trades on BSC mainnet ([link](https://github.com/pancakeswap/pancake-frontend/pull/7455/files?diff=unified&w=0#diff-6ccab19ffbec70686dc2221f7b79432ece4302c36067c91063d258209c09ec07L226-R226)) in `apps/web/src/config/constants/contracts.ts`. This allows the frontend to interact with the correct contract and display the leaderboard of the top traders.


