### PR TITLE
chore: Add v3 gas estimation on zkrollup chains

### DIFF
--- a/packages/smart-router/evm/constants/gasModel/v3.ts
+++ b/packages/smart-router/evm/constants/gasModel/v3.ts
@@ -9,6 +9,10 @@ export const BASE_SWAP_COST_V3 = (id: ChainId): bigint => {
     case ChainId.BSC_TESTNET:
     case ChainId.ETHEREUM:
     case ChainId.GOERLI:
+    case ChainId.ZKSYNC:
+    case ChainId.ZKSYNC_TESTNET:
+    case ChainId.POLYGON_ZKEVM:
+    case ChainId.POLYGON_ZKEVM_TESTNET:
       return 2000n
     default:
       return 0n
@@ -20,6 +24,10 @@ export const COST_PER_INIT_TICK = (id: ChainId): bigint => {
     case ChainId.BSC_TESTNET:
     case ChainId.ETHEREUM:
     case ChainId.GOERLI:
+    case ChainId.ZKSYNC:
+    case ChainId.ZKSYNC_TESTNET:
+    case ChainId.POLYGON_ZKEVM:
+    case ChainId.POLYGON_ZKEVM_TESTNET:
       return 31000n
     default:
       return 0n
@@ -32,6 +40,10 @@ export const COST_PER_HOP_V3 = (id: ChainId): bigint => {
     case ChainId.BSC_TESTNET:
     case ChainId.ETHEREUM:
     case ChainId.GOERLI:
+    case ChainId.ZKSYNC:
+    case ChainId.ZKSYNC_TESTNET:
+    case ChainId.POLYGON_ZKEVM:
+    case ChainId.POLYGON_ZKEVM_TESTNET:
       return 80000n
     default:
       return 0n


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9c0c7c5</samp>

### Summary
🦄🌐⛽

<!--
1.  🦄 - This emoji represents Uniswap V3, the protocol that the smart router interacts with to execute swaps on different chains.
2.  🌐 - This emoji represents the cross-chain functionality of the smart router, which can find the optimal swap route across multiple L2 and L1 chains, such as ZKSync and Polygon ZK-EVM.
3.  ⛽ - This emoji represents the gas model constants, which are used to estimate the gas costs and fees of each swap route and compare them to find the best one.
-->
This pull request adds support for ZKSync and Polygon ZK-EVM chains to the smart router's gas model for Uniswap V3 swaps. This improves cross-chain and cross-protocol liquidity and efficiency for users.

> _To swap tokens with speed and low fees_
> _You can use the smart router with ease_
> _It supports ZKSync and Polygon_
> _With updated gas constants on_
> _The Uniswap V3 protocols and chains_

### Walkthrough
*  Add support for ZKSync and Polygon ZK-EVM chains in smart router ([link](https://github.com/pancakeswap/pancake-frontend/pull/7458/files?diff=unified&w=0#diff-547db0075f559af065060c380ed030a74d1c823c7062ee7e8926f73abeb3c24aR12-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/7458/files?diff=unified&w=0#diff-547db0075f559af065060c380ed030a74d1c823c7062ee7e8926f73abeb3c24aR27-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/7458/files?diff=unified&w=0#diff-547db0075f559af065060c380ed030a74d1c823c7062ee7e8926f73abeb3c24aR43-R46))


