### PR TITLE
fix: Tooltip not visible when hover in modals

### DIFF
--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -129,7 +129,7 @@
     "framer-motion": "10.11.2",
     "lightweight-charts": "^4.0.1",
     "lodash": "^4.17.20",
-    "react-popper": "^2.2.5",
+    "react-popper": "^2.3.0",
     "styled-system": "^5.1.5",
     "tslib": "^2.2.0"
   },

--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -122,7 +122,11 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
           <LazyMotion features={isMobile ? DomMax : DomAnimation}>
             <AnimatePresence>
               {isOpen && (
-                <DismissableLayer role="dialog" disableOutsidePointerEvents onEscapeKeyDown={handleOverlayDismiss}>
+                <DismissableLayer
+                  role="dialog"
+                  disableOutsidePointerEvents={false}
+                  onEscapeKeyDown={handleOverlayDismiss}
+                >
                   <StyledModalWrapper
                     ref={animationRef}
                     onAnimationStart={() => animationHandler(animationRef.current)}

--- a/packages/uikit/src/widgets/Modal/ModalV2.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalV2.tsx
@@ -43,7 +43,7 @@ export function ModalV2({
   onDismiss,
   closeOnOverlayClick,
   children,
-  disableOutsidePointerEvents = true,
+  disableOutsidePointerEvents = false,
   ...props
 }: ModalV2Props & BoxProps & { disableOutsidePointerEvents?: boolean }) {
   const animationRef = useRef<HTMLDivElement>(null);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,7 +829,7 @@ importers:
         version: 18.2.0
       '@types/react-datepicker':
         specifier: ^4.4.1
-        version: 4.4.1(react@18.2.0)
+        version: 4.4.1(react-dom@18.2.0)(react@18.2.0)
       '@types/react-dom':
         specifier: ^18.0.6
         version: 18.2.1
@@ -1484,8 +1484,8 @@ importers:
         specifier: ^4.17.20
         version: 4.17.21
       react-popper:
-        specifier: ^2.2.5
-        version: 2.2.5(@popperjs/core@2.11.2)(react@18.2.0)
+        specifier: ^2.3.0
+        version: 2.3.0(@popperjs/core@2.11.2)(react-dom@18.2.0)(react@18.2.0)
       styled-system:
         specifier: ^5.1.5
         version: 5.1.5
@@ -10175,15 +10175,16 @@ packages:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
     dev: true
 
-  /@types/react-datepicker@4.4.1(react@18.2.0):
+  /@types/react-datepicker@4.4.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-M8+hzwj+bpuwxC82z35NxkD3sqMl/vVXTs6xjPAsYqjucVXFpY1DK6ETKgICZE7YpuPYpf2OYF2OVZ5E7R42rA==}
     dependencies:
       '@popperjs/core': 2.11.2
       '@types/react': 18.2.0
       date-fns: 2.29.3
-      react-popper: 2.2.5(@popperjs/core@2.11.2)(react@18.2.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.2)(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
       - react
+      - react-dom
     dev: true
 
   /@types/react-dom@18.2.1:
@@ -22642,7 +22643,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-onclickoutside: 6.12.1(react-dom@18.2.0)(react@18.2.0)
-      react-popper: 2.2.5(@popperjs/core@2.11.2)(react@18.2.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.2)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
   /react-device-detect@2.1.2(react-dom@17.0.2)(react@18.2.0):
@@ -22818,14 +22819,16 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-popper@2.2.5(@popperjs/core@2.11.2)(react@18.2.0):
-    resolution: {integrity: sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==}
+  /react-popper@2.3.0(@popperjs/core@2.11.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
       '@popperjs/core': ^2.0.0
-      react: ^16.8.0 || ^17
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
     dependencies:
       '@popperjs/core': 2.11.2
       react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.0
       warning: 4.0.3
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cde93f4</samp>

### Summary
🆙🖱️🐛

<!--
1.  🆙 - This emoji represents the update of the dependency version of `react-popper` in the `package.json` file. It conveys the idea of upgrading or improving something.
2.  🖱️ - This emoji represents the modification of the `disableOutsidePointerEvents` prop in the `DismissableLayer` and `ModalV2` components. It conveys the idea of enabling or allowing mouse or pointer events or interactions.
3.  🐛 - This emoji represents the update of the `react-popper` dependency and its peer dependencies in the `pnpm-lock.yaml` file. It conveys the idea of fixing or resolving bugs or issues.
-->
This pull request updates the `react-popper` dependency and its usage in the `uikit` package. It also enables the user to interact with elements outside the modal components when they are open.

> _To improve the modal and popper_
> _We updated the `react-popper`_
> _We set a prop to false_
> _To let the user cross_
> _The modal without any stopper_

### Walkthrough
*  Update `react-popper` dependency version to `2.3.0` in `packages/uikit/package.json` and `pnpm-lock.yaml` to use the latest features and bug fixes of the library ([link](https://github.com/pancakeswap/pancake-frontend/pull/7463/files?diff=unified&w=0#diff-cb0a1990ba52670ab2c56f831e950ca6447a9ca43ab7028565a66d0defd034d6L132-R132), [link](https://github.com/pancakeswap/pancake-frontend/pull/7463/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1487-R1488), [link](https://github.com/pancakeswap/pancake-frontend/pull/7463/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL22821-R22830))
*  Allow user interaction with elements outside the modal when it is open by setting `disableOutsidePointerEvents` prop to `false` in `DismissableLayer` and `ModalV2` components in `packages/uikit/src/widgets/Modal` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7463/files?diff=unified&w=0#diff-2b429321cef5fdd2a3dce2c632c0b1f2b7ed743b9ee800a3e6a3b879e72a4cf4L125-R129), [link](https://github.com/pancakeswap/pancake-frontend/pull/7463/files?diff=unified&w=0#diff-efa53f9c8d53afeec870fb307cd027975042427aed54a610efa6e2cd05ffe232L46-R46))


