### PR TITLE
chore: set zksync default list

### DIFF
--- a/apps/web/src/components/SearchModal/ManageLists.tsx
+++ b/apps/web/src/components/SearchModal/ManageLists.tsx
@@ -14,7 +14,7 @@ import {
 } from '@pancakeswap/uikit'
 import { TokenList, Version } from '@pancakeswap/token-lists'
 import Card from 'components/Card'
-import { BSC_URLS, ETH_URLS, POLYGON_ZKEVM_URLS, UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
+import { BSC_URLS, ETH_URLS, POLYGON_ZKEVM_URLS, UNSUPPORTED_LIST_URLS, ZKSYNC_URLS } from 'config/constants/lists'
 import { useAtomValue } from 'jotai'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useListState } from 'state/lists/lists'
@@ -209,7 +209,8 @@ function ManageLists({
           return (
             (chainId === ChainId.ETHEREUM && ETH_URLS.includes(listUrl)) ||
             (chainId === ChainId.BSC && BSC_URLS.includes(listUrl)) ||
-            (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(listUrl))
+            (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(listUrl)) ||
+            (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(listUrl))
           )
         }
 

--- a/apps/web/src/components/SearchModal/ManageLists.tsx
+++ b/apps/web/src/components/SearchModal/ManageLists.tsx
@@ -1,33 +1,32 @@
 import { useTranslation } from '@pancakeswap/localization'
+import { TokenList, Version } from '@pancakeswap/token-lists'
 import {
+  acceptListUpdate,
+  disableList,
+  enableList,
+  removeList,
+  useFetchListCallback,
+} from '@pancakeswap/token-lists/react'
+import {
+  AutoColumn,
   Button,
   CheckmarkIcon,
   CogIcon,
+  Column,
   Input,
   LinkExternal,
   ListLogo,
   Text,
   Toggle,
   useTooltip,
-  AutoColumn,
-  Column,
 } from '@pancakeswap/uikit'
-import { TokenList, Version } from '@pancakeswap/token-lists'
+import uriToHttp from '@pancakeswap/utils/uriToHttp'
 import Card from 'components/Card'
-import { BSC_URLS, ETH_URLS, POLYGON_ZKEVM_URLS, UNSUPPORTED_LIST_URLS, ZKSYNC_URLS } from 'config/constants/lists'
+import { MULTI_CHAIN_LIST_URLS, UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
 import { useAtomValue } from 'jotai'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useListState } from 'state/lists/lists'
 import styled from 'styled-components'
-import {
-  useFetchListCallback,
-  acceptListUpdate,
-  disableList,
-  enableList,
-  removeList,
-} from '@pancakeswap/token-lists/react'
-import uriToHttp from '@pancakeswap/utils/uriToHttp'
-import { ChainId } from '@pancakeswap/sdk'
 
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { selectorByUrlsAtom, useActiveListUrls, useAllLists, useIsListActive } from '../../state/lists/hooks'
@@ -206,12 +205,7 @@ function ManageLists({
         const isValid = Boolean(lists[listUrl].current) && !UNSUPPORTED_LIST_URLS.includes(listUrl)
 
         if (isValid) {
-          return (
-            (chainId === ChainId.ETHEREUM && ETH_URLS.includes(listUrl)) ||
-            (chainId === ChainId.BSC && BSC_URLS.includes(listUrl)) ||
-            (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(listUrl)) ||
-            (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(listUrl))
-          )
+          return MULTI_CHAIN_LIST_URLS[chainId]?.includes(listUrl)
         }
 
         return false

--- a/apps/web/src/config/constants/lists.ts
+++ b/apps/web/src/config/constants/lists.ts
@@ -1,6 +1,7 @@
 export const PANCAKE_EXTENDED = 'https://tokens.pancakeswap.finance/pancakeswap-extended.json'
 export const COINGECKO = 'https://tokens.pancakeswap.finance/coingecko.json'
 export const PANCAKE_ETH_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-eth-default.json'
+export const PANCAKE_ZKSYNC_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-zksync-default.json'
 export const PANCAKE_POLYGON_ZKEVM_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-polygon-zkevm-default.json'
 export const PANCAKE_ETH_MM = 'https://tokens.pancakeswap.finance/pancakeswap-eth-mm.json'
 export const PANCAKE_BSC_MM = 'https://tokens.pancakeswap.finance/pancakeswap-bnb-mm.json'
@@ -10,6 +11,7 @@ export const CMC = 'https://tokens.pancakeswap.finance/cmc.json'
 export const ETH_URLS = [PANCAKE_ETH_DEFAULT, PANCAKE_ETH_MM, COINGECKO_ETH]
 export const BSC_URLS = [PANCAKE_EXTENDED, CMC, COINGECKO, PANCAKE_BSC_MM]
 export const POLYGON_ZKEVM_URLS = [PANCAKE_POLYGON_ZKEVM_DEFAULT]
+export const ZKSYNC_URLS = [PANCAKE_ZKSYNC_DEFAULT]
 
 // List of official tokens list
 export const OFFICIAL_LISTS = [PANCAKE_EXTENDED, PANCAKE_ETH_DEFAULT]
@@ -21,6 +23,7 @@ export const WARNING_LIST_URLS: string[] = []
 export const DEFAULT_LIST_OF_LISTS: string[] = [
   ...BSC_URLS,
   ...ETH_URLS,
+  ...ZKSYNC_URLS,
   ...POLYGON_ZKEVM_URLS,
   ...UNSUPPORTED_LIST_URLS, // need to load unsupported tokens as well
   ...WARNING_LIST_URLS,
@@ -31,5 +34,7 @@ export const DEFAULT_ACTIVE_LIST_URLS: string[] = [
   PANCAKE_EXTENDED,
   PANCAKE_ETH_DEFAULT,
   PANCAKE_ETH_MM,
+  PANCAKE_BSC_MM,
+  PANCAKE_ETH_DEFAULT,
   PANCAKE_POLYGON_ZKEVM_DEFAULT,
 ]

--- a/apps/web/src/config/constants/lists.ts
+++ b/apps/web/src/config/constants/lists.ts
@@ -1,3 +1,5 @@
+import { ChainId } from '@pancakeswap/sdk'
+
 export const PANCAKE_EXTENDED = 'https://tokens.pancakeswap.finance/pancakeswap-extended.json'
 export const COINGECKO = 'https://tokens.pancakeswap.finance/coingecko.json'
 export const PANCAKE_ETH_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-eth-default.json'
@@ -38,3 +40,10 @@ export const DEFAULT_ACTIVE_LIST_URLS: string[] = [
   PANCAKE_ETH_DEFAULT,
   PANCAKE_POLYGON_ZKEVM_DEFAULT,
 ]
+
+export const MULTI_CHAIN_LIST_URLS: { [chainId: number]: string[] } = {
+  [ChainId.BSC]: BSC_URLS,
+  [ChainId.ETHEREUM]: ETH_URLS,
+  [ChainId.ZKSYNC]: ZKSYNC_URLS,
+  [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_URLS,
+}

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -7,6 +7,7 @@ import {
   UNSUPPORTED_LIST_URLS,
   WARNING_LIST_URLS,
   ETH_URLS,
+  ZKSYNC_URLS,
   POLYGON_ZKEVM_URLS,
   BSC_URLS,
 } from 'config/constants/lists'
@@ -210,7 +211,8 @@ export function useAllLists(): {
         (_, url) =>
           (chainId === ChainId.ETHEREUM && ETH_URLS.includes(url)) ||
           (chainId === ChainId.BSC && BSC_URLS.includes(url)) ||
-          (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(url)),
+          (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(url)) ||
+          (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(url)),
       ),
     [chainId, urls],
   )
@@ -242,7 +244,9 @@ export function useActiveListUrls(): string[] | undefined {
       urls.filter(
         (url) =>
           (chainId === ChainId.ETHEREUM && ETH_URLS.includes(url)) ||
-          (chainId === ChainId.BSC && BSC_URLS.includes(url)),
+          (chainId === ChainId.BSC && BSC_URLS.includes(url)) ||
+          (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(url)) ||
+          (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(url)),
       ),
     [urls, chainId],
   )

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -6,10 +6,7 @@ import {
   OFFICIAL_LISTS,
   UNSUPPORTED_LIST_URLS,
   WARNING_LIST_URLS,
-  ETH_URLS,
-  ZKSYNC_URLS,
-  POLYGON_ZKEVM_URLS,
-  BSC_URLS,
+  MULTI_CHAIN_LIST_URLS,
 } from 'config/constants/lists'
 import { atom, useAtomValue } from 'jotai'
 import mapValues from 'lodash/mapValues'
@@ -204,18 +201,7 @@ export function useAllLists(): {
 
   const urls = useAtomValue(selectorByUrlsAtom)
 
-  return useMemo(
-    () =>
-      _pickBy(
-        urls,
-        (_, url) =>
-          (chainId === ChainId.ETHEREUM && ETH_URLS.includes(url)) ||
-          (chainId === ChainId.BSC && BSC_URLS.includes(url)) ||
-          (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(url)) ||
-          (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(url)),
-      ),
-    [chainId, urls],
-  )
+  return useMemo(() => _pickBy(urls, (_, url) => MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)), [chainId, urls])
 }
 
 function combineMaps(map1: TokenAddressMap, map2: TokenAddressMap): TokenAddressMap {
@@ -239,17 +225,7 @@ export function useActiveListUrls(): string[] | undefined {
   const { chainId } = useActiveChainId()
   const urls = useAtomValue(activeListUrlsAtom)
 
-  return useMemo(
-    () =>
-      urls.filter(
-        (url) =>
-          (chainId === ChainId.ETHEREUM && ETH_URLS.includes(url)) ||
-          (chainId === ChainId.BSC && BSC_URLS.includes(url)) ||
-          (chainId === ChainId.POLYGON_ZKEVM && POLYGON_ZKEVM_URLS.includes(url)) ||
-          (chainId === ChainId.ZKSYNC && ZKSYNC_URLS.includes(url)),
-      ),
-    [urls, chainId],
-  )
+  return useMemo(() => urls.filter((url) => MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)), [urls, chainId])
 }
 
 export function useInactiveListUrls() {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e522dfc</samp>

### Summary
🔄🌐🆕

<!--
1.  🔄 - This emoji signifies swapping or exchanging, which is one of the main features of the update. Users can now swap across different chains and access more tokens.
2.  🌐 - This emoji represents the global or cross-chain aspect of the update. Users can now connect to different networks and use different token lists, such as zkSync, BSC, and ETH.
3.  🆕 - This emoji indicates something new or updated, which is the case for the default token lists. Users can now see more options and choices for their tokens.
-->
Added zkSync token lists and updated default lists for cross-chain swaps. This improves the app's compatibility and functionality with different tokens and networks.

> _`zkSync` your tokens to the list of doom_
> _Swap across the chains in the darkened room_
> _`BSC` and `ETH` are the default ones_
> _But you can access more in the realm of the suns_

### Walkthrough
*  Add support for zkSync token lists ([link](https://github.com/pancakeswap/pancake-frontend/pull/7466/files?diff=unified&w=0#diff-9560b1a30bda8cc12c421b07b679e4dd58b888242ad19086c9e8e38c96709edcR4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7466/files?diff=unified&w=0#diff-9560b1a30bda8cc12c421b07b679e4dd58b888242ad19086c9e8e38c96709edcR14), [link](https://github.com/pancakeswap/pancake-frontend/pull/7466/files?diff=unified&w=0#diff-9560b1a30bda8cc12c421b07b679e4dd58b888242ad19086c9e8e38c96709edcR26))
* Add token lists for PancakeSwap on BSC and ETH ([link](https://github.com/pancakeswap/pancake-frontend/pull/7466/files?diff=unified&w=0#diff-9560b1a30bda8cc12c421b07b679e4dd58b888242ad19086c9e8e38c96709edcR37-R38))


