### PR TITLE
chore: update banner wording

### DIFF
--- a/apps/web/src/views/Home/components/Banners/ZksyncBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/ZksyncBanner.tsx
@@ -86,7 +86,7 @@ export const ZksyncBanner = () => {
   const { t } = useTranslation()
   const { isMobile, isDesktop } = useMatchBreakpoints()
 
-  const title = isDesktop ? t('PancakeSwap Now Live on zkSync Era!') : t('Zksync Lormips LIVE!')
+  const title = isDesktop ? t('PancakeSwap Now Live on zkSync Era!') : t('Zksync is LIVE!')
 
   return (
     <S.Wrapper

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2612,7 +2612,7 @@
   "Round #%round%  |  %startTime% - %endTime%": "Round #%round%  |  %startTime% - %endTime%",
   "Swap and Provide Liquidity on zkSync Era Now": "Swap and Provide Liquidity on zkSync Era Now",
   "PancakeSwap Now Live on zkSync Era!": "PancakeSwap Now Live on zkSync Era!",
-  "Zksync Lormips LIVE!": "Zksync Lormips LIVE!",
+  "Zksync is LIVE!": "Zksync is LIVE!",
   "Claim Your NFT": "Claim Your NFT",
   "View Benefits": "View Benefits",
   "locked benefits": "locked benefits",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3445d77</samp>

### Summary
📱✏️🗑️

<!--
1.  📱 - This emoji represents the mobile device or screen size that motivated the change to the title of the ZksyncBanner component. It also suggests that the change improves the user experience and accessibility of the component on smaller screens.
2.  ✏️ - This emoji represents the editing or rewriting of the title text to make it shorter, clearer, and more grammatically correct. It also suggests that the change improves the communication and readability of the component.
3.  🗑️ - This emoji represents the deletion or removal of the old translation key that was no longer used after the change to the title text. It also suggests that the change improves the code quality and maintainability of the component.
-->
Shortened and fixed the title of the `ZksyncBanner` component for mobile devices and updated the corresponding translation key in `translations.json`.

> _`ZksyncBanner` changed_
> _Shorter title for mobile_
> _Winter is clearer_

### Walkthrough
* Shorten the title of the ZksyncBanner component for mobile devices and fix grammar ([link](https://github.com/pancakeswap/pancake-frontend/pull/7468/files?diff=unified&w=0#diff-96c8c592cb95cdeee4b804c7ef0446a64d589ec8dbd9dd9fc93826c5da873dcbL89-R89))
* Update the translation key for the ZksyncBanner title in `translations.json` and remove the unused old key ([link](https://github.com/pancakeswap/pancake-frontend/pull/7468/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2615-R2615))


