### PR TITLE
chore: zksync token list turn up default

### DIFF
--- a/apps/web/src/config/constants/lists.ts
+++ b/apps/web/src/config/constants/lists.ts
@@ -39,6 +39,7 @@ export const DEFAULT_ACTIVE_LIST_URLS: string[] = [
   PANCAKE_BSC_MM,
   PANCAKE_ETH_DEFAULT,
   PANCAKE_POLYGON_ZKEVM_DEFAULT,
+  PANCAKE_ZKSYNC_DEFAULT,
 ]
 
 export const MULTI_CHAIN_LIST_URLS: { [chainId: number]: string[] } = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a2780a</samp>

### Summary
🥞🌉🌀

<!--
1.  🥞 - This emoji represents PancakeSwap, the project that is making the change and the platform that hosts the token list. It is also a fitting symbol for the name of the project and the theme of the frontend.
2.  🌉 - This emoji represents the bridge feature, which is the main functionality that the change enables. It also conveys the idea of connecting two different chains or networks, which is what the zkSync bridge does.
3.  🌀 - This emoji represents zkSync, the technology that powers the bridge and allows for fast and cheap transfers using zkRollups. It also suggests the concept of scaling and layer 2 solutions, which are relevant for the bridge.
-->
Added support for the zkSync bridge feature in the frontend. Updated `lists.ts` to include the default token list for the bridge.

> _`PANCAKE_ZKSYNC_DEFAULT`_
> _A bridge of tokens_
> _Cutting through winter's frost_

### Walkthrough
*  Add the default token list URL for the zkSync bridge feature to the list of token lists ([link](https://github.com/pancakeswap/pancake-frontend/pull/7469/files?diff=unified&w=0#diff-9560b1a30bda8cc12c421b07b679e4dd58b888242ad19086c9e8e38c96709edcR42))


