### PR TITLE
fix(Blog): Image url

### DIFF
--- a/apps/blog/types.ts
+++ b/apps/blog/types.ts
@@ -40,7 +40,7 @@ export interface ResponseArticleDataType {
       data: CategoriesType[]
     }
     image: {
-      data: ArticleImageType[]
+      data: ArticleImageType
     }
     newsOutBoundLink: string
     newsFromPlatform: string

--- a/apps/blog/utils/transformArticle.ts
+++ b/apps/blog/utils/transformArticle.ts
@@ -32,7 +32,7 @@ export const transformArticle = (article: ResponseArticleDataType): ArticleDataT
     description: article?.attributes?.description ?? '',
     newsFromPlatform: article?.attributes?.newsFromPlatform ?? '',
     newsOutBoundLink: article?.attributes?.newsOutBoundLink ?? '',
-    imgUrl: article?.attributes?.image?.data?.[0]?.attributes?.url ?? '',
+    imgUrl: article.attributes.image.data.attributes.url ?? '',
     categories: article.attributes?.categories?.data?.map((i) => i.attributes.name),
   }
 }

--- a/apps/blog/utils/transformArticle.ts
+++ b/apps/blog/utils/transformArticle.ts
@@ -32,7 +32,7 @@ export const transformArticle = (article: ResponseArticleDataType): ArticleDataT
     description: article?.attributes?.description ?? '',
     newsFromPlatform: article?.attributes?.newsFromPlatform ?? '',
     newsOutBoundLink: article?.attributes?.newsOutBoundLink ?? '',
-    imgUrl: article.attributes.image.data.attributes.url ?? '',
+    imgUrl: article?.attributes?.image?.data?.attributes?.url ?? '',
     categories: article.attributes?.categories?.data?.map((i) => i.attributes.name),
   }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b1adf09</samp>

### Summary
🐛🔄📝

<!--
1.  🐛 - This emoji represents a bug fix, since the previous interface and function were not correctly handling the CMS API response data and could cause errors or unexpected behavior.
2.  🔄 - This emoji represents a refactor, since the change in the interface and function improves the code quality and readability without altering the functionality or output.
3.  📝 - This emoji represents a documentation update, since the change in the interface and function clarifies the expected data structure and type of the `image` property.
-->
Fixed the type and transformation of article images in the blog app. Changed the `image` property of the `ResponseArticleDataType` interface and the `imgUrl` property of the `transformArticle` function to match the CMS API response.

> _`image` is not array_
> _one `ArticleImageType` per article_
> _fall leaves no errors_

### Walkthrough
*  Simplify the image data structure for articles ([link](https://github.com/pancakeswap/pancake-frontend/pull/7475/files?diff=unified&w=0#diff-be86497777a3b318bd86840a83b8e55239456255e2cb4a24e33da363cb90304cL43-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/7475/files?diff=unified&w=0#diff-dd5151d886e1c520d3df4db0026868c1ebe300ced3a0997af9c61043b7e9f448L35-R35))


