### PR TITLE
feat: Add More chains

### DIFF
--- a/apps/aptos/components/NetworkSwitcher.tsx
+++ b/apps/aptos/components/NetworkSwitcher.tsx
@@ -11,6 +11,8 @@ import { aptosLogoClass } from './Logo/CurrencyLogo.css'
 const evmChains = [
   { id: 56, name: 'BNB Smart Chain', chainName: 'bsc' },
   { id: 1, name: 'Ethereum', chainName: 'eth' },
+  { id: 324, name: 'zkSync Era', chainName: 'zkSync' },
+  { id: 1101, name: 'Polygon zkEVM', chainName: 'polygonZkEVM' },
 ]
 
 const NetworkSelect = () => {


### PR DESCRIPTION
Add zkSync Era and Polygon zkEVM networks
![Screenshot 2023-08-03 at 10 22 55 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/0d3bad75-0b2d-4509-a2f9-4f340a520010)




<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9abdbf0</samp>

### Summary
🔮🌐🚀

<!--
1.  🔮 - This emoji represents the futuristic and innovative nature of zero-knowledge proofs and scaling solutions, as well as the potential benefits they can bring to the Ethereum ecosystem and the app's users.
2.  🌐 - This emoji represents the network switcher component and the idea of connecting to different chains and layer 2 solutions within the app, as well as the interoperability and compatibility of the app with various scaling solutions.
3.  🚀 - This emoji represents the speed and efficiency of the scaling solutions, as well as the excitement and enthusiasm of the app's users and developers for exploring new possibilities and opportunities on Ethereum.
-->
Added support for zkSync Era and Polygon zkEVM networks in the `NetworkSwitcher` component. This lets users access the app's features on cheaper and faster scaling solutions.

> _`evmChains` expands_
> _zkSync and Polygon join_
> _autumn of scaling_

### Walkthrough
*  Add new network options for zkSync Era and Polygon zkEVM to the network switcher component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7480/files?diff=unified&w=0#diff-3ff81a954673aa998f9490c76adc346de7fb57b7b526e9bcddbc9cd7cc12af6cR14-R15))


