### PR TITLE
feat: Hide Your shares percentage when totalSupplyAt is zero

### DIFF
--- a/apps/web/src/views/Pools/components/RevenueSharing/BenefitsModal/RevenueSharing.tsx
+++ b/apps/web/src/views/Pools/components/RevenueSharing/BenefitsModal/RevenueSharing.tsx
@@ -44,6 +44,8 @@ const RevenueSharing: React.FunctionComponent<React.PropsWithChildren<RevenueSha
     [balanceOfAt, totalSupplyAt],
   )
 
+  const showYourSharePercentage = useMemo(() => new BigNumber(totalSupplyAt).gt(0), [totalSupplyAt])
+
   const availableCake = useMemo(() => getBalanceAmount(new BigNumber(availableClaim)).toNumber(), [availableClaim])
   const availableCakeUsdValue = useMemo(
     () => new BigNumber(availableCake).times(cakePriceBusd).toNumber(),
@@ -103,17 +105,21 @@ const RevenueSharing: React.FunctionComponent<React.PropsWithChildren<RevenueSha
                   ) : (
                     <Balance display="inline-block" bold value={yourShare} decimals={2} />
                   )}
-                  {yourSharePercentage <= 0.01 ? (
-                    <Text as="span" ml="4px">{`(< 0.01%)`}</Text>
-                  ) : (
-                    <Balance
-                      display="inline-block"
-                      prefix="("
-                      unit="%)"
-                      ml="4px"
-                      value={yourSharePercentage}
-                      decimals={2}
-                    />
+                  {showYourSharePercentage && (
+                    <>
+                      {yourSharePercentage <= 0.01 ? (
+                        <Text as="span" ml="4px">{`(< 0.01%)`}</Text>
+                      ) : (
+                        <Balance
+                          display="inline-block"
+                          prefix="("
+                          unit="%)"
+                          ml="4px"
+                          value={yourSharePercentage}
+                          decimals={2}
+                        />
+                      )}
+                    </>
                   )}
                 </>
               )}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f99026</samp>

### Summary
📈💰🔢

<!--
1.  📈 This emoji conveys the idea of growth, increase, or improvement, which is related to the feature of showing the user's share of the revenue pool.
2.  💰 This emoji represents money, wealth, or income, which is related to the concept of revenue sharing and the user's share of the pool.
3.  🔢 This emoji signifies numbers, calculations, or percentages, which is related to the variable `showYourSharePercentage` and the rendering of the percentage in the UI.
-->
Added a feature to show the user's share of the revenue pool in `RevenueSharing.tsx`. This allows the user to see how much they can earn from staking in the selected block.

> _There once was a feature so cool_
> _That showed users their share of the pool_
> _With `showYourSharePercentage`_
> _They could see their advantage_
> _In `RevenueSharing.tsx` as a rule_

### Walkthrough
*  Add a new variable `showYourSharePercentage` to determine whether to display the user's share percentage of the revenue pool ([link](https://github.com/pancakeswap/pancake-frontend/pull/7481/files?diff=unified&w=0#diff-ef7b1d229df78ae89f93e8d7f045f911939aadda3e30011ee766554f4728ba49R47-R48))
*  Update the conditional rendering of the user's share percentage to check the `showYourSharePercentage` variable and handle values less than 0.01% ([link](https://github.com/pancakeswap/pancake-frontend/pull/7481/files?diff=unified&w=0#diff-ef7b1d229df78ae89f93e8d7f045f911939aadda3e30011ee766554f4728ba49L106-R122))


