### PR TITLE
chore(BuyCrypto): Only enable of support chains

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -17,7 +17,7 @@ import { ContextApi } from '@pancakeswap/localization'
 import { SUPPORTED_CHAIN_IDS as POOL_SUPPORTED_CHAINS } from '@pancakeswap/pools'
 import { nftsBaseUrl } from 'views/Nft/market/constants'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
-import { SUPPORT_FARMS, SUPPORT_ONLY_BSC } from 'config/constants/supportChains'
+import { SUPPORT_FARMS, SUPPORT_ONLY_BSC, SUPPORT_BUY_CRYPTO } from 'config/constants/supportChains'
 import { NewIconButton } from 'views/BuyCrypto/components/NewIcon'
 
 export type ConfigMenuDropDownItemsType = DropdownMenuItems & { hideSubNav?: boolean }
@@ -85,6 +85,7 @@ const config: (
           label: t('Buy Crypto'),
           LabelIcon: NewIconButton,
           href: '/buy-crypto',
+          supportChainIds: SUPPORT_BUY_CRYPTO,
           status: { text: t('New'), color: 'success' },
         },
       ].map((item) => addMenuItemSupported(item, chainId)),

--- a/apps/web/src/config/constants/supportChains.ts
+++ b/apps/web/src/config/constants/supportChains.ts
@@ -11,3 +11,4 @@ export const SUPPORT_FARMS = [
   ChainId.POLYGON_ZKEVM,
   ChainId.ZKSYNC,
 ]
+export const SUPPORT_BUY_CRYPTO = [ChainId.BSC, ChainId.ETHEREUM]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 76ff60c</samp>

### Summary
🆕💰🔗

<!--
1.  🆕 - This emoji represents the addition of a new constant and a new feature flag, which are both new features for the app.
2.  💰 - This emoji represents the buy crypto feature, which allows users to purchase cryptocurrencies with fiat currencies.
3.  🔗 - This emoji represents the chain filter, which restricts the buy crypto feature to certain networks or chains.
-->
Added a feature flag and a chain filter for the `Buy Crypto` menu option, to enable or disable it on different networks. The supported networks are defined in `SUPPORT_BUY_CRYPTO` in `config/constants/supportChains.ts`.

> _To buy crypto, you need a chain filter_
> _And a flag that can act as a tilter_
> _So they added `SUPPORT_BUY_CRYPTO`_
> _To the constants file, oh so simple_
> _And the menu option became nimbler_

### Walkthrough
*  Add `supportChainIds` property to `Buy Crypto` menu item to restrict it to BSC and Ethereum chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/7483/files?diff=unified&w=0#diff-e0daeed87867fc4fc6b0b1a9c2d52c9bfbd175cd1822e100f43300c4046484adR88))
*  Import `SUPPORT_BUY_CRYPTO` constant from `config/constants/supportChains.ts` to use in menu configuration ([link](https://github.com/pancakeswap/pancake-frontend/pull/7483/files?diff=unified&w=0#diff-e0daeed87867fc4fc6b0b1a9c2d52c9bfbd175cd1822e100f43300c4046484adL20-R20))
*  Define `SUPPORT_BUY_CRYPTO` constant as an array of chain IDs that support the buy crypto feature in `config/constants/supportChains.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7483/files?diff=unified&w=0#diff-d5561cd39967a71b1fe70cdb06abed66dd18633d9936a78951c0d6c30dbf905eR14))


