### PR TITLE
feat: Arbitrum

### DIFF
--- a/.changeset/dry-waves-dress.md
+++ b/.changeset/dry-waves-dress.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/tokens': patch
+---
+
+Usd native USDC in Arbitrum

--- a/apis/routing/.dev.vars
+++ b/apis/routing/.dev.vars
@@ -3,4 +3,5 @@ GOERLI_NODE=https://eth-goerli.public.blastapi.io
 BSC_NODE=https://bsc-dataseed.binance.org
 BSC_TESTNET_NODE=https://data-seed-prebsc-2-s1.binance.org:8545
 POLYGON_ZKEVM_NODE=https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/
+ARBITRUM_ONE_NODE=https://arb1.arbitrum.io/rpc
 AXIOM_TOKEN=

--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -8,6 +8,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.ZKSYNC,
   ChainId.BSC_TESTNET,
   ChainId.GOERLI,
+  ChainId.ARBITRUM_ONE,
 ] as const
 
 export type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
@@ -21,4 +22,5 @@ export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
   [ChainId.LINEA_TESTNET]:
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
+  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-arbitrum/version/latest',
 }

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -57,6 +57,7 @@ export const v3SubgraphClients: Record<SupportedChainId, GraphQLClient> = {
   [ChainId.GOERLI]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.GOERLI], { fetch }),
   [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC], { fetch }),
   [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC_TESTNET], { fetch }),
+  [ChainId.ARBITRUM_ONE]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ARBITRUM_ONE], { fetch }),
 } as const
 
 export const v3SubgraphProvider: SubgraphProvider = ({ chainId = ChainId.BSC }: { chainId?: ChainId }) => {

--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -42,10 +42,7 @@ const NetworkSelect = ({ switchNetwork, chainId }) => {
       </Box>
       <UserMenuDivider />
       {chains
-        .filter(
-          (chain) =>
-            chain.id === ChainId.LINEA_TESTNET || !('testnet' in chain && chain.testnet) || chain.id === chainId,
-        )
+        .filter((chain) => !('testnet' in chain && chain.testnet) || chain.id === chainId)
         .map((chain) => (
           <UserMenuItem
             key={chain.id}

--- a/apps/web/src/config/chains.ts
+++ b/apps/web/src/config/chains.ts
@@ -10,7 +10,8 @@ import {
   polygonZkEvmTestnet as polygonZkEvmTestnet_,
   polygonZkEvm as polygonZkEvm_,
   lineaTestnet as lineaTestnet_,
-  // arbitrumGoerli,
+  arbitrum,
+  arbitrumGoerli,
   Chain,
 } from 'wagmi/chains'
 
@@ -113,6 +114,6 @@ export const CHAINS = [
   polygonZkEvm,
   polygonZkEvmTestnet,
   lineaTestnet,
-  // arbitrumGoerli,
-  // arbitrum,
+  arbitrumGoerli,
+  arbitrum,
 ]

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -50,7 +50,7 @@ export const INFO_CLIENT_WITH_CHAIN = {
   [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
   [ChainId.ZKSYNC]: ' https://api.studio.thegraph.com/query/45376/exchange-v2-zksync/version/latest',
   [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
-  [ChainId.ARBITRUM_ONE]: 'https://thegraph.com/hosted-service/subgraph/chef-jojo/exchange-v2-arb',
+  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
 }
 
 export const BLOCKS_CLIENT_WITH_CHAIN = {
@@ -67,7 +67,7 @@ export const V3_SUBGRAPH_URLS = {
   [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
   [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
   [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-  [ChainId.ARBITRUM_ONE]: 'https://thegraph.com/hosted-service/subgraph/chef-jojo/exchange-v3-arb',
+  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-arbitrum/version/latest',
   [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
   [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
   [ChainId.POLYGON_ZKEVM_TESTNET]: null,

--- a/apps/web/src/config/constants/lists.ts
+++ b/apps/web/src/config/constants/lists.ts
@@ -5,6 +5,7 @@ export const COINGECKO = 'https://tokens.pancakeswap.finance/coingecko.json'
 export const PANCAKE_ETH_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-eth-default.json'
 export const PANCAKE_ZKSYNC_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-zksync-default.json'
 export const PANCAKE_POLYGON_ZKEVM_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-polygon-zkevm-default.json'
+const PANCAKE_ARB_DEFAULT = 'https://tokens.pancakeswap.finance/pancakeswap-arbitrum-default.json'
 export const PANCAKE_ETH_MM = 'https://tokens.pancakeswap.finance/pancakeswap-eth-mm.json'
 export const PANCAKE_BSC_MM = 'https://tokens.pancakeswap.finance/pancakeswap-bnb-mm.json'
 export const COINGECKO_ETH = 'https://tokens.coingecko.com/uniswap/all.json'
@@ -13,6 +14,7 @@ export const CMC = 'https://tokens.pancakeswap.finance/cmc.json'
 export const ETH_URLS = [PANCAKE_ETH_DEFAULT, PANCAKE_ETH_MM, COINGECKO_ETH]
 export const BSC_URLS = [PANCAKE_EXTENDED, CMC, COINGECKO, PANCAKE_BSC_MM]
 export const POLYGON_ZKEVM_URLS = [PANCAKE_POLYGON_ZKEVM_DEFAULT]
+const ARBITRUM_URLS = [PANCAKE_ARB_DEFAULT]
 export const ZKSYNC_URLS = [PANCAKE_ZKSYNC_DEFAULT]
 
 // List of official tokens list
@@ -27,6 +29,7 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   ...ETH_URLS,
   ...ZKSYNC_URLS,
   ...POLYGON_ZKEVM_URLS,
+  ...ARBITRUM_URLS,
   ...UNSUPPORTED_LIST_URLS, // need to load unsupported tokens as well
   ...WARNING_LIST_URLS,
 ]
@@ -40,6 +43,7 @@ export const DEFAULT_ACTIVE_LIST_URLS: string[] = [
   PANCAKE_ETH_DEFAULT,
   PANCAKE_POLYGON_ZKEVM_DEFAULT,
   PANCAKE_ZKSYNC_DEFAULT,
+  PANCAKE_ARB_DEFAULT,
 ]
 
 export const MULTI_CHAIN_LIST_URLS: { [chainId: number]: string[] } = {
@@ -47,4 +51,5 @@ export const MULTI_CHAIN_LIST_URLS: { [chainId: number]: string[] } = {
   [ChainId.ETHEREUM]: ETH_URLS,
   [ChainId.ZKSYNC]: ZKSYNC_URLS,
   [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_URLS,
+  [ChainId.ARBITRUM_ONE]: ARBITRUM_URLS,
 }

--- a/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -212,7 +212,7 @@
     },
     {
       "name": "USD Coin",
-      "address": "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "symbol": "USDC",
       "decimals": 6,
       "chainId": 42161,

--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -11,9 +11,9 @@ import {
   BSC_TOKEN_WHITELIST,
   ETH_TOKEN_WHITELIST,
 } from 'config/constants/info'
-import { bsc, mainnet, polygonZkEvm, zkSync } from 'wagmi/chains'
+import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync } from 'wagmi/chains'
 
-export type MultiChainName = 'BSC' | 'ETH' | 'POLYGON_ZKEVM' | 'ZKSYNC'
+export type MultiChainName = 'BSC' | 'ETH' | 'POLYGON_ZKEVM' | 'ZKSYNC' | 'ARB'
 
 export type MultiChainNameExtend = MultiChainName | 'BSC_TESTNET' | 'ZKSYNC_TESTNET'
 
@@ -34,6 +34,7 @@ export const multiChainQueryMainToken: Record<MultiChainName, string> = {
   ETH: 'ETH',
   POLYGON_ZKEVM: 'ETH',
   ZKSYNC: 'ETH',
+  ARB: 'ARB',
 }
 
 export const multiChainBlocksClient: Record<MultiChainNameExtend, string> = {
@@ -43,6 +44,7 @@ export const multiChainBlocksClient: Record<MultiChainNameExtend, string> = {
   POLYGON_ZKEVM: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',
   ZKSYNC_TESTNET: 'https://api.studio.thegraph.com/query/45376/blocks-zksync-testnet/version/latest',
   ZKSYNC: BLOCKS_CLIENT_ZKSYNC,
+  ARB: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
 }
 
 export const multiChainStartTime = {
@@ -57,6 +59,7 @@ export const multiChainId: Record<MultiChainName, ChainId> = {
   ETH: ChainId.ETHEREUM,
   POLYGON_ZKEVM: ChainId.POLYGON_ZKEVM,
   ZKSYNC: ChainId.ZKSYNC,
+  ARB: ChainId.ARBITRUM_ONE,
 }
 
 export const multiChainPaths = {
@@ -64,6 +67,7 @@ export const multiChainPaths = {
   [ChainId.ETHEREUM]: '/eth',
   [ChainId.POLYGON_ZKEVM]: '/polygon-zkevm',
   [ChainId.ZKSYNC]: `/zksync`,
+  [ChainId.ARBITRUM_ONE]: `/arb`,
 }
 
 export const multiChainQueryClient = {
@@ -78,6 +82,7 @@ export const multiChainScan: Record<MultiChainName, string> = {
   ETH: mainnet.blockExplorers.etherscan.name,
   POLYGON_ZKEVM: polygonZkEvm.blockExplorers.default.name,
   ZKSYNC: zkSync.blockExplorers.default.name,
+  ARB: arbitrum.blockExplorers.default.name,
 }
 
 export const multiChainTokenBlackList: Record<MultiChainName, string[]> = {
@@ -85,6 +90,7 @@ export const multiChainTokenBlackList: Record<MultiChainName, string[]> = {
   ETH: ETH_TOKEN_BLACKLIST,
   POLYGON_ZKEVM: ['0x'],
   ZKSYNC: ['0x'],
+  ARB: ['0x'],
 }
 
 export const multiChainTokenWhiteList: Record<MultiChainName, string[]> = {
@@ -92,6 +98,7 @@ export const multiChainTokenWhiteList: Record<MultiChainName, string[]> = {
   ETH: ETH_TOKEN_WHITELIST,
   POLYGON_ZKEVM: [],
   ZKSYNC: [],
+  ARB: [],
 }
 
 export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNameExtend): GraphQLClient => {
@@ -100,11 +107,13 @@ export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNa
   return multiChainQueryClient[chainName]
 }
 
+// FIXME: this should be per chain
 export const subgraphTokenName = {
   '0x738d96caf7096659db4c1afbf1e1bdfd281f388c': 'Ankr Staked MATIC',
   '0x14016e85a25aeb13065688cafb43044c2ef86784': 'True USD Old',
 }
 
+// FIXME: this should be per chain
 export const subgraphTokenSymbol = {
   '0x14016e85a25aeb13065688cafb43044c2ef86784': 'TUSDOLD',
 }

--- a/packages/tokens/src/42161.ts
+++ b/packages/tokens/src/42161.ts
@@ -1,8 +1,11 @@
-import { ChainId, WETH9 } from '@pancakeswap/sdk'
+import { ChainId, ERC20Token, WETH9 } from '@pancakeswap/sdk'
 import { USDT, USDC } from './common'
 
 export const arbitrumTokens = {
   weth: WETH9[ChainId.ARBITRUM_ONE],
   usdt: USDT[ChainId.ARBITRUM_ONE],
   usdc: USDC[ChainId.ARBITRUM_ONE],
+  arb: new ERC20Token(ChainId.ARBITRUM_ONE, '0x912CE59144191C1204E64559FE8253a0e49E6548', 18, 'ARB', 'Arbitrum'),
+  gmx: new ERC20Token(ChainId.ARBITRUM_ONE, '0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a', 18, 'GMX', 'GMX'),
+  wbtc: new ERC20Token(ChainId.ARBITRUM_ONE, '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f', 8, 'WBTC', 'Wrapped BTC'),
 }

--- a/packages/tokens/src/common.ts
+++ b/packages/tokens/src/common.ts
@@ -188,7 +188,7 @@ export const USDC = {
   ),
   [ChainId.ARBITRUM_ONE]: new ERC20Token(
     ChainId.ARBITRUM_ONE,
-    '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+    '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
     6,
     'USDC',
     'USD Coin',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2973872</samp>

### Summary
🌐🚀🪙

<!--
1.  🌐 - This emoji represents the addition of a new network and its RPC node to the routing API and the web app. It also signifies the global and cross-chain nature of the Uniswap protocol.
2.  🚀 - This emoji represents the launch of the Arbitrum One network and its subgraphs, which enable faster and cheaper transactions for Uniswap users and liquidity providers. It also signifies the innovation and scalability of the Arbitrum technology.
3.  🪙 - This emoji represents the support for some ERC20 tokens on the Arbitrum One chain, which allow users to trade and swap a variety of assets on Uniswap. It also signifies the diversity and value of the token ecosystem.
-->
This pull request adds support for the Arbitrum One network to the routing API and the web app. It defines the chain ID, subgraph URL, tokens, and other constants for the Arbitrum One chain in various files. It also updates the subgraph URLs and creates GraphQL clients for the routing API to query the Uniswap V2 and V3 data on Arbitrum One.

> _Sing, O Muse, of the valiant developers who dared_
> _To extend the routing API and web app with skill and care_
> _To the swift and cunning Arbitrum One, a new chain of great renown_
> _Where Uniswap V2 and V3 exchanges flourish and abound_

### Walkthrough
*  Add support for the Arbitrum One chain to the web app and the routing API ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-e5605623b5c1ea9b8403a275bbc272f3650548f215f40c77171212c8f89dd890L6-L4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR11), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0R60), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-870705bc610c873933b2d04d9a57db54345cab8d9ad2af707454ac577b21f6e4L13-R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-870705bc610c873933b2d04d9a57db54345cab8d9ad2af707454ac577b21f6e4L116-R118), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L53-R53), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L70-R70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80L14-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R62), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R85), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R93), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R101), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8R8-R10))
  * Add a new environment variable `ARBITRUM_ONE_NODE` to store the URL of the Arbitrum One RPC node in the `.dev.vars` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-e5605623b5c1ea9b8403a275bbc272f3650548f215f40c77171212c8f89dd890L6-L4))
  * Add the `ChainId.ARBITRUM_ONE` value to the `SUPPORTED_CHAINS` array in the `constants.ts` file of the routing API, which defines the list of chains that the routing API supports ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR11))
  * Add a new entry to the `V3_SUBGRAPH_URLS` object in the `constants.ts` file of the routing API, which maps the `ChainId.ARBITRUM_ONE` to the URL of the hosted subgraph for the exchange V3 on Arbitrum One ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR25))
  * Add a new entry to the `v3SubgraphClients` object in the `provider.ts` file of the routing API, which creates a GraphQL client for the `ChainId.ARBITRUM_ONE` using the URL from the `V3_SUBGRAPH_URLS` object and the `fetch` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0R60))
  * Import the `arbitrum` and `arbitrumGoerli` objects from the `wagmi/chains` module in the `chains.ts` file of the web app, which define the chain configurations for the Arbitrum One and Arbitrum Goerli networks ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-870705bc610c873933b2d04d9a57db54345cab8d9ad2af707454ac577b21f6e4L13-R14))
  * Add the `arbitrumGoerli` and `arbitrum` objects to the `CHAINS` array in the `chains.ts` file of the web app, which defines the list of chains that the web app supports ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-870705bc610c873933b2d04d9a57db54345cab8d9ad2af707454ac577b21f6e4L116-R118))
  * Update the value of the `ChainId.ARBITRUM_ONE` key in the `INFO_CLIENT_WITH_CHAIN` object in the `endpoints.ts` file of the web app, which maps each chain ID to its corresponding Uniswap V2 subgraph URL, to the URL of the hosted subgraph for the exchange V2 on Arbitrum One ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L53-R53))
  * Update the value of the `ChainId.ARBITRUM_ONE` key in the `V3_SUBGRAPH_URLS` object in the `endpoints.ts` file of the web app, which maps each chain ID to its corresponding Uniswap V3 subgraph URL, to the URL of the hosted subgraph for the exchange V3 on Arbitrum One ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L70-R70))
  * Import the `ERC20Token` class from the `@pancakeswap/sdk` module in the `constant.ts` file of the web app, which defines the constants and types for the info state of the web app, and add the `ARB` value to the `MultiChainName` and `MultiChainNameExtend` types, which represent the names of the supported chains for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80L14-R16))
  * Add a new entry to the `multiChainQueryMainToken` object in the `constant.ts` file of the web app, which maps the `ARB` name to the `ARB` symbol, which is the native token of the Arbitrum One network, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R37))
  * Add a new entry to the `multiChainBlocksClient` object in the `constant.ts` file of the web app, which maps the `ARB` name to the URL of the hosted subgraph for the Arbitrum One blocks, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R47))
  * Add a new entry to the `multiChainId` object in the `constant.ts` file of the web app, which maps the `ARB` name to the `ChainId.ARBITRUM_ONE` value, which is the numeric identifier of the Arbitrum One network, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R62))
  * Add a new entry to the `multiChainPaths` object in the `constant.ts` file of the web app, which maps the `ChainId.ARBITRUM_ONE` to the `/arb` path, which is the URL segment for the Arbitrum One chain, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R70))
  * Add a new entry to the `multiChainScan` object in the `constant.ts` file of the web app, which maps the `ARB` name to the `arbitrum.blockExplorers.default.name` value, which is the name of the default block explorer for the Arbitrum One network, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R85))
  * Add a new entry to the `multiChainWhitelist` object in the `constant.ts` file of the web app, which maps the `ARB` name to an array containing the `0x` address, which is the address of the zero address token on the Arbitrum One network, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R93))
  * Add a new entry to the `multiChainBlacklist` object in the `constant.ts` file of the web app, which maps the `ARB` name to an empty array, which means that there are no blacklisted tokens on the Arbitrum One network, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R101))
  * Add comments to the `ETH_TOKEN_WHITELIST` and `ETH_TOKEN_BLACKLIST` objects in the `constant.ts` file of the web app, which suggest that these objects should be per chain, instead of using the same list for all chains, for the info state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R110), [link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R116))
  * Import the `ERC20Token` class from the `@pancakeswap/sdk` module in the `42161.ts` file of the tokens package, which defines the tokens for the Arbitrum One chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8L1-R1))
  * Add a new entry to the `arbitrumTokens` object in the `42161.ts` file of the tokens package, which exports the `arb`, `gmx`, and `wbtc` tokens, which are ERC20 tokens on the Arbitrum One chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7485/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8R8-R10))


