### PR TITLE
fix(Trading Reward): Pagination

### DIFF
--- a/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
@@ -133,7 +133,7 @@ const Leaderboard: React.FC<React.PropsWithChildren<LeaderboardProps>> = ({ camp
                 endTime: timeFormat(locale, campaignLeaderBoardList?.campaignClaimTime),
               })}
             </Text>
-            {index === 1 && (
+            {index === 1 || !currentLeaderBoard ? (
               <PaginationButton
                 showMaxPageText
                 currentPage={currentLeaderBoard ? campaignPage - 1 : campaignPage}
@@ -142,7 +142,7 @@ const Leaderboard: React.FC<React.PropsWithChildren<LeaderboardProps>> = ({ camp
                   setCampaignPage(currentLeaderBoard ? page + 1 : page)
                 }}
               />
-            )}
+            ) : null}
           </>
         )}
         {campaignLeaderBoardList.campaignStart > 0 && (

--- a/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
@@ -136,9 +136,11 @@ const Leaderboard: React.FC<React.PropsWithChildren<LeaderboardProps>> = ({ camp
             {index === 1 && (
               <PaginationButton
                 showMaxPageText
-                currentPage={campaignPage}
-                maxPage={campaignMaxPage}
-                setCurrentPage={setCampaignPage}
+                currentPage={currentLeaderBoard ? campaignPage - 1 : campaignPage}
+                maxPage={currentLeaderBoard ? campaignMaxPage - 1 : campaignMaxPage}
+                setCurrentPage={(page) => {
+                  setCampaignPage(currentLeaderBoard ? page + 1 : page)
+                }}
               />
             )}
           </>

--- a/apps/web/src/views/TradingReward/components/RewardsBreakdown/index.tsx
+++ b/apps/web/src/views/TradingReward/components/RewardsBreakdown/index.tsx
@@ -54,7 +54,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
   })
 
   const sortData = useMemo(() => data.sort((a, b) => Number(b.campaignId) - Number(a.campaignId)), [data])
-  const currentList = useMemo(() => sortData.find((i) => i.campaignClaimTime >= Date.now() / 1000), [sortData])
+  const currentList = useMemo(() => sortData.find((i) => i.campaignClaimTime < Date.now() / 1000), [sortData])
 
   useEffect(() => {
     if (sortData.length > 0) {
@@ -75,25 +75,26 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
   }, [currentPage, sortData])
 
   useEffect(() => {
-    const getActivitySlice = () => {
-      if (currentList?.campaignId) {
-        if (index === 0) {
-          setCurrentPage(1)
-          setList(currentList)
-        } else {
-          setCurrentPage(2)
-          sliceData()
-        }
-      } else {
-        setIndex(1)
-        sliceData()
-      }
-    }
-
     if (sortData.length > 0) {
-      getActivitySlice()
+      sliceData()
     }
-  }, [index, currentPage, sortData, currentList, sliceData])
+  }, [sliceData, sortData])
+
+  const handlePagination = (page: number) => {
+    if (!isFetching) {
+      setCurrentPage(currentList ? page + 1 : page)
+    }
+  }
+
+  const handleIndex = (pageIndex: number) => {
+    if (pageIndex === 0) {
+      setCurrentPage(1)
+      setList(currentList)
+    } else {
+      setCurrentPage(2)
+    }
+    setIndex(pageIndex)
+  }
 
   return (
     <Flex
@@ -108,7 +109,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
       </Text>
       {currentList && (
         <Box width="350px" margin="auto auto 16px auto">
-          <ButtonMenu activeIndex={index} onItemClick={setIndex} fullWidth scale="sm" variant="subtle">
+          <ButtonMenu activeIndex={index} onItemClick={handleIndex} fullWidth scale="sm" variant="subtle">
             <ButtonMenuItem>{t('Current Round')}</ButtonMenuItem>
             <ButtonMenuItem>{t('Previous Rounds')}</ButtonMenuItem>
           </ButtonMenu>
@@ -129,7 +130,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
             showMaxPageText
             currentPage={currentList ? currentPage - 1 : currentPage}
             maxPage={currentList ? maxPage - 1 : maxPage}
-            setCurrentPage={setCurrentPage}
+            setCurrentPage={handlePagination}
           />
         </Box>
       )}

--- a/apps/web/src/views/TradingReward/components/RewardsBreakdown/index.tsx
+++ b/apps/web/src/views/TradingReward/components/RewardsBreakdown/index.tsx
@@ -54,7 +54,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
   })
 
   const sortData = useMemo(() => data.sort((a, b) => Number(b.campaignId) - Number(a.campaignId)), [data])
-  const currentList = useMemo(() => sortData.find((i) => i.campaignClaimTime < Date.now() / 1000), [sortData])
+  const currentList = useMemo(() => sortData.find((i) => i.campaignClaimTime >= Date.now() / 1000), [sortData])
 
   useEffect(() => {
     if (sortData.length > 0) {
@@ -124,7 +124,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
           })}
         </Text>
       )}
-      {index === 1 && list?.pairs?.length && (
+      {index === 1 || !currentList ? (
         <Box mb="-16px">
           <PaginationButton
             showMaxPageText
@@ -133,7 +133,7 @@ const RewardsBreakdown: React.FC<React.PropsWithChildren<RewardsBreakdownProps>>
             setCurrentPage={handlePagination}
           />
         </Box>
-      )}
+      ) : null}
       <Card mt="40px">
         {isDesktop ? (
           <DesktopView list={list} isFetching={isFetching} />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d400f4b</samp>

### Summary
🐛🔄📊

<!--
1.  🐛 - This emoji represents a bug fix, which is the main goal of the first change and part of the second change.
2.  🔄 - This emoji represents a refactoring or improvement of existing code, which is the main goal of the second change and part of the first change.
3.  📊 - This emoji represents a data or UI component, which is relevant to both changes since they affect the leaderboard and the rewards breakdown components.
-->
This pull request improves the pagination logic and UI for the `RewardsBreakdown` and `Leaderboard` components in the trading reward view. It also fixes some bugs related to rendering the pagination button when switching between rounds.

> _Pagination fixed_
> _`useEffect` refactored_
> _Autumn of bugs ends_

### Walkthrough
*  Fix pagination bugs and improve consistency in leaderboard and rewards breakdown components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-94382753793192a4edd427aba2521b380c88958dbcc9821b7f456a923c67847aL136-R145), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L78-R98), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L111-R112), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L126-R127), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L132-R136))
  - Remove unnecessary function and dependency in `useEffect` hook in `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L78-R98))
  - Add `handlePagination` function to check fetching status before setting current page in both components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L78-R98), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L132-R136))
  - Add `handleIndex` function to set current page and list state based on index value in `RewardsBreakdown` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L111-R112))
  - Modify rendering condition and page numbers for `PaginationButton` component in both components to account for current or previous round data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-94382753793192a4edd427aba2521b380c88958dbcc9821b7f456a923c67847aL136-R145), [link](https://github.com/pancakeswap/pancake-frontend/pull/7488/files?diff=unified&w=0#diff-84dcb226924a4df52e63f545677d1d57610612105558abb2c22e78aa35cc8a13L126-R127))


