### PR TITLE
fix: WOM farm config

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -51,8 +51,8 @@ export const farmsV3 = defineFarmV3Configs([
   {
     pid: 36,
     lpAddress: Pool.getAddress(ethereumTokens.wom, ethereumTokens.usdt, FeeAmount.HIGH),
-    token0: ethereumTokens.usdt,
-    token1: ethereumTokens.wom,
+    token0: ethereumTokens.wom,
+    token1: ethereumTokens.usdt,
     feeAmount: FeeAmount.HIGH,
   },
   {

--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -50,8 +50,8 @@ export const farmsV3 = defineFarmV3Configs([
   // Keep those farms on top
   {
     pid: 36,
-    lpAddress: Pool.getAddress(ethereumTokens.wom, ethereumTokens.weth, FeeAmount.HIGH),
-    token0: ethereumTokens.weth,
+    lpAddress: Pool.getAddress(ethereumTokens.wom, ethereumTokens.usdt, FeeAmount.HIGH),
+    token0: ethereumTokens.usdt,
     token1: ethereumTokens.wom,
     feeAmount: FeeAmount.HIGH,
   },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa7ce3c</samp>

### Summary
🔄🇺🇸🚀

<!--
1.  🔄 - This emoji represents the swapping or changing of the pool address and the tokens for the farm with pid 36.
2.  🇺🇸 - This emoji represents the USDT token, which is a stablecoin pegged to the US dollar and is widely used in DeFi.
3.  🚀 - This emoji represents the potential boost or improvement of the farm's performance or yield by using a more liquid and less volatile pair.
-->
Updated the configuration of the WOM farm to use WOM/USDT pair on Uniswap V3. This file `packages/farms/constants/1.ts` contains the farm settings for Uniswap V3 pools.

> _`farmsV3` array_
> _WOM leaves ETH for USDT_
> _Autumn migration_

### Walkthrough
*  Update the farm configuration for WOM/USDT pair on Uniswap V3 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7490/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8L53-R54))


