### PR TITLE
feat: Return to liquidity detail page instead of overview after increase liquidity

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -242,11 +242,11 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
 
   const handleDismissConfirmation = useCallback(() => {
     // if there was a tx hash, we want to clear the input
-    if (txHash) {
+    if (txHash && tokenId) {
       onFieldAInput('')
-      router.push('/liquidity')
+      router.push(`/liquidity/${tokenId}`)
     }
-  }, [onFieldAInput, router, txHash])
+  }, [onFieldAInput, router, txHash, tokenId])
 
   const pendingText = `Supplying ${
     !depositADisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale) : ''
@@ -338,7 +338,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
                   maxAmount={maxAmounts[Field.CURRENCY_A]}
                   onMax={() => onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '')}
                   onPercentInput={(percent) =>
-                    onFieldAInput(maxAmounts[Field.CURRENCY_A]?.multiply(new Percent(percent, 100)).toExact() ?? '')
+                    onFieldAInput(maxAmounts?.[Field.CURRENCY_A]?.multiply(new Percent(percent, 100))?.toExact() ?? '')
                   }
                   value={formattedAmounts[Field.CURRENCY_A]}
                   onUserInput={onFieldAInput}
@@ -357,7 +357,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
                   maxAmount={maxAmounts[Field.CURRENCY_B]}
                   onMax={() => onFieldBInput(maxAmounts[Field.CURRENCY_B]?.toExact() ?? '')}
                   onPercentInput={(percent) =>
-                    onFieldBInput(maxAmounts[Field.CURRENCY_B]?.multiply(new Percent(percent, 100)).toExact() ?? '')
+                    onFieldBInput(maxAmounts[Field.CURRENCY_B]?.multiply(new Percent(percent, 100))?.toExact() ?? '')
                   }
                   value={formattedAmounts[Field.CURRENCY_B]}
                   onUserInput={onFieldBInput}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9290396</samp>

### Summary
🚀🛡️🌊

<!--
1.  🚀 - This emoji represents the improvement in user experience, as the user is now redirected to a more relevant page after supplying liquidity.
2.  🛡️ - This emoji represents the improvement in code robustness, as the optional chaining operators prevent errors from occurring when the `maxAmounts` object is not fully populated.
3.  🌊 - This emoji represents the increase liquidity feature itself, as liquidity is often associated with water or waves.
-->
Improve UX and code robustness of `IncreaseLiquidityV3` component. Redirect user to position page and handle missing `maxAmounts` object.

> _To improve the liquidity feature_
> _This pull request makes some changes neater_
> _It redirects the user_
> _To the position, sir_
> _And adds `?.` to the `onPercentInput` meter_

### Walkthrough
*  Redirect user to position page after supplying liquidity ([link](https://github.com/pancakeswap/pancake-frontend/pull/7493/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL245-R249))
*  Prevent errors when `maxAmounts` object is undefined or missing properties ([link](https://github.com/pancakeswap/pancake-frontend/pull/7493/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL341-R341), [link](https://github.com/pancakeswap/pancake-frontend/pull/7493/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL360-R360))


