### PR TITLE
feat: List unshETH

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -43,6 +43,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
+    pid: 70,
+    token0: bscTokens.unshETH,
+    token1: bscTokens.eth,
+    lpAddress: '0x3ccCef8d9D515eC7F59eb69aD06C22265cC95ea9',
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 69,
     token0: bscTokens.dar,
     token1: bscTokens.wbnb,

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -16,7 +16,7 @@ export const livePools: SerializedPool[] = [
   {
     sousId: 357,
     stakingToken: bscTokens.cake,
-    earningToken: bscTokens.unshETH,
+    earningToken: bscTokens.ush,
     contractAddress: '0x3408367d6d4F379e1dfb2bb61664c4833Ec3588c',
     poolCategory: PoolCategory.CORE,
     tokenPerBlock: '0.1157',

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,15 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 357,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.unshETH,
+    contractAddress: '0x3408367d6d4F379e1dfb2bb61664c4833Ec3588c',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.1157',
+    version: 3,
+  },
+  {
     sousId: 356,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.dck,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 07993b8</samp>

### Summary
🦄🍰🌾

<!--
1.  🦄 - This emoji represents Uniswap, the protocol that created the V3 liquidity pool mechanism and the unshETH token. It also suggests the idea of a unicorn, a rare and valuable creature in the crypto space.
2. 🍰 - This emoji represents CAKE, the native token of PancakeSwap, the platform that hosts the new farm and pool. It also suggests the idea of a sweet reward for staking and farming.
3. 🌾 - This emoji represents farming, the activity of providing liquidity and earning tokens. It also suggests the idea of harvesting and growing crops.
-->
This pull request adds support for a new farm and a new pool involving unshETH, a synthetic ETH token on Binance Smart Chain. It updates the files `packages/farms/constants/56.ts` and `packages/pools/src/constants/pools/56.ts` with the relevant parameters and contract addresses.

> _New farms and pools_
> _`unshETH` and `CAKE` reward_
> _Autumn harvest time_

### Walkthrough
* Add a new farm for unshETH-ETH LP on BSC with low fee and pid 70 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7515/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R46-R52))
* Add a new pool for staking CAKE and earning unshETH with sousId 357 and token per block 0.1157 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7515/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR17-R25))
* Use version 3 of `SousChef` contract for the new pool in `packages/pools/src/constants/pools/56.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7515/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR17-R25))


