### PR TITLE
fix: Sentry issue

### DIFF
--- a/apps/web/src/utils/shouldShowSwapWarning.ts
+++ b/apps/web/src/utils/shouldShowSwapWarning.ts
@@ -2,8 +2,12 @@ import { Token } from '@pancakeswap/sdk'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
 
 const shouldShowSwapWarning = (chainId: number, swapCurrency: Token) => {
-  const swapWarningTokens = Object.values(SwapWarningTokens[chainId])
-  return swapWarningTokens.some((warningToken) => warningToken.equals(swapCurrency))
+  if (SwapWarningTokens[chainId]) {
+    const swapWarningTokens = Object.values(SwapWarningTokens[chainId])
+    return swapWarningTokens.some((warningToken) => warningToken.equals(swapCurrency))
+  }
+
+  return []
 }
 
 export default shouldShowSwapWarning

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/QualifiedPreview.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/QualifiedPreview.tsx
@@ -81,7 +81,7 @@ const QualifiedPreview: React.FC<React.PropsWithChildren<QualifiedPreviewProps>>
   const additionalAmount = useMemo(() => {
     const totalMapCap =
       tradingFeeArr?.map((fee) => fee.maxCap).reduce((a, b) => new BigNumber(a).plus(b).toNumber(), 0) ?? 0
-    return new BigNumber(totalMapCap).minus(currentUserCampaignInfo.totalEstimateRewardUSD).toNumber()
+    return new BigNumber(totalMapCap).minus(currentUserCampaignInfo.totalEstimateRewardUSD).toNumber() ?? 0
   }, [currentUserCampaignInfo, tradingFeeArr])
 
   // MAX REWARD CAP


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 215ff42</samp>

### Summary
🛠️🧮🔄

<!--
1.  🛠️ - This emoji can be used to represent the `shouldShowSwapWarning` function change, as it is a bug fix or improvement that prevents a potential error from occurring.
2.  🧮 - This emoji can be used to represent the `getRemainingCap` function change, as it is a change related to calculations or numbers that affects the display of the remaining cap.
3.  🔄 - This emoji can be used to represent the overall changes, as they are both related to swapping or exchanging tokens and involve some logic or data manipulation.
-->
Fixed potential errors and edge cases in `shouldShowSwapWarning` and `getRemainingCap` functions. These functions are used to display warnings and rewards for swapping and trading on the PancakeSwap platform.

> _`shouldShowSwapWarning`_
> _checks `chainId` property_
> _no error in fall_

### Walkthrough
*  Prevent potential errors when checking swap warning tokens by validating the `chainId` property and returning an empty array if not found ([link](https://github.com/pancakeswap/pancake-frontend/pull/7520/files?diff=unified&w=0#diff-f014b65b3767b692adf67cc7a18c62f34ec13f8fe39ee8561ff1a7fdfcfd2395L5-R10))
*  Add fallback value of 0 for remaining cap calculation in trading reward preview to avoid incorrect display or calculation failure ([link](https://github.com/pancakeswap/pancake-frontend/pull/7520/files?diff=unified&w=0#diff-45202aaffe794f426a403905acca14f5ebfc81c9530ff7beb396f4638249d6fdL84-R84))


