### PR TITLE
fix(swap): optional warning

### DIFF
--- a/apps/web/src/utils/shouldShowSwapWarning.ts
+++ b/apps/web/src/utils/shouldShowSwapWarning.ts
@@ -1,13 +1,13 @@
 import { Token } from '@pancakeswap/sdk'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
 
-const shouldShowSwapWarning = (chainId: number, swapCurrency: Token) => {
+const shouldShowSwapWarning = (chainId: number, swapCurrency: Token): boolean => {
   if (SwapWarningTokens[chainId]) {
     const swapWarningTokens = Object.values(SwapWarningTokens[chainId])
     return swapWarningTokens.some((warningToken) => warningToken.equals(swapCurrency))
   }
 
-  return []
+  return false
 }
 
 export default shouldShowSwapWarning

--- a/apps/web/src/views/Swap/components/SwapWarningModal/index.tsx
+++ b/apps/web/src/views/Swap/components/SwapWarningModal/index.tsx
@@ -38,11 +38,11 @@ const SwapWarningModal: React.FC<React.PropsWithChildren<SwapWarningModalProps>>
   return (
     <StyledModalContainer minWidth="280px">
       <ModalHeader background={theme.colors.gradientCardHeader}>
-        <Heading p="12px 24px">{t('Notice for trading %symbol%', { symbol: SWAP_WARNING.symbol })}</Heading>
+        <Heading p="12px 24px">{t('Notice for trading %symbol%', { symbol: SWAP_WARNING?.symbol })}</Heading>
       </ModalHeader>
       <ModalBody p="24px">
         <MessageContainer variant="warning" mb="24px">
-          <Box>{SWAP_WARNING.component}</Box>
+          <Box>{SWAP_WARNING?.component}</Box>
         </MessageContainer>
         <Acknowledgement handleContinueClick={onDismiss} />
       </ModalBody>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 21fa218</samp>

### Summary
🐛🔧🚨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It conveys that the change addresses an issue that was causing errors or unexpected behavior in the application.
2.  🔧 - This emoji represents a tool or configuration change, which is a secondary aspect of the pull request. It conveys that the change modifies how the SWAP_WARNING object is accessed and handled, using a different syntax and logic than before.
3.  🚨 - This emoji represents a warning or alert, which is a tertiary aspect of the pull request. It conveys that the change affects the SwapWarningModal component, which is responsible for displaying important information to the user about potential risks or conditions of certain tokens.
-->
Fix swap warning modal crash by using optional chaining for `SWAP_WARNING` object. This prevents errors when accessing the warning message for certain tokens in `SwapWarningModal/index.tsx`.

> _`SWAP_WARNING` may_
> _be missing or null. Use_
> _optional chaining._

### Walkthrough
*  Prevent swap warning modal crash by using optional chaining operators to access SWAP_WARNING object ([link](https://github.com/pancakeswap/pancake-frontend/pull/7523/files?diff=unified&w=0#diff-653d590d8895f7c7d78b015cbfef2c729eab14e44a4fa7ac0ce5d6adc192505cL41-R45))


