### PR TITLE
feat(Aptos): Network Switch add Arbitrum

### DIFF
--- a/apps/aptos/components/NetworkSwitcher.tsx
+++ b/apps/aptos/components/NetworkSwitcher.tsx
@@ -13,6 +13,7 @@ const evmChains = [
   { id: 1, name: 'Ethereum', chainName: 'eth' },
   { id: 324, name: 'zkSync Era', chainName: 'zkSync' },
   { id: 1101, name: 'Polygon zkEVM', chainName: 'polygonZkEVM' },
+  { id: 42161, name: 'Arbitrum One', chainName: 'arb' },
 ]
 
 const NetworkSelect = () => {


### PR DESCRIPTION
![Screenshot 2023-08-11 at 1 17 13 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/d47cc7a6-4bbd-4a12-8522-1e60b3cb9eb7)





<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 16fede3</samp>

### Summary
🌐🚀🆕

<!--
1.  🌐 - This emoji represents the network or internet, and can be used to indicate a change related to the network switcher component or the evmChains array.
2.  🚀 - This emoji represents a rocket or launch, and can be used to indicate a change related to a scaling solution or a new feature that improves performance or user experience.
3.  🆕 - This emoji represents something new or added, and can be used to indicate a change that introduces a new option or functionality to the app.
-->
Added support for Arbitrum One network in the network switcher component. Updated `evmChains` array in `NetworkSwitcher.tsx` with the new option.

> _`evmChains` expands_
> _Arbitrum One joins the list_
> _Layer two in fall_

### Walkthrough
* Add a new network option for Arbitrum One to the network switcher component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7526/files?diff=unified&w=0#diff-3ff81a954673aa998f9490c76adc346de7fb57b7b526e9bcddbc9cd7cc12af6cR16))


