### PR TITLE
chore: bsctestnet whitelist

### DIFF
--- a/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -123,8 +123,8 @@
       "logoURI": "https://pancakeswap.finance/images/tokens/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82.png"
     },
     {
-      "name": "Mock BUSD Token",
-      "symbol": "BUSD",
+      "name": "Test BUSD Token",
+      "symbol": "tBUSD",
       "address": "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
       "chainId": 97,
       "decimals": 18,
@@ -304,7 +304,7 @@
       "address": "0x64544969ed7EBf5f083679233325356EbE738930",
       "chainId": 97,
       "decimals": 18,
-      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdt.png"
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdc.png"
     },
     {
       "name": "DAI Token",

--- a/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -123,7 +123,7 @@
       "logoURI": "https://pancakeswap.finance/images/tokens/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82.png"
     },
     {
-      "name": "BUSD Token",
+      "name": "Mock BUSD Token",
       "symbol": "BUSD",
       "address": "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
       "chainId": 97,
@@ -289,6 +289,54 @@
       "chainId": 1,
       "decimals": 8,
       "logoURI": "https://tokens.pancakeswap.finance/images/symbol/wbtc.png"
+    },
+    {
+      "name": "BUSD Token",
+      "symbol": "BUSD",
+      "address": "0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/busd.png"
+    },
+    {
+      "name": "USD Coin",
+      "symbol": "USDT",
+      "address": "0x64544969ed7EBf5f083679233325356EbE738930",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdt.png"
+    },
+    {
+      "name": "DAI Token",
+      "symbol": "DAI",
+      "address": "0xEC5dCb5Dbf4B114C9d0F65BcCAb49EC54F6A0867",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/dai.png"
+    },
+    {
+      "name": "Tether USD",
+      "symbol": "USDT",
+      "address": "0x337610d27c682E347C9cD60BD4b3b107C9d34dDd",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdt.png"
+    },
+    {
+      "name": "BTCB Token",
+      "symbol": "BTCB",
+      "address": "0x6ce8dA28E2f864420840cF74474eFf5fD80E65B8",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://tokens.pancakeswap.finance/images/symbol/wbtc.png"
+    },
+    {
+      "name": "Ethereum Token",
+      "symbol": "ETH",
+      "address": "0xd66c6B4F0be8CE5b39D52E0Fd1344c389929B378",
+      "chainId": 97,
+      "decimals": 18,
+      "logoURI": "https://pancakeswap.finance/images/tokens/0x2170Ed0880ac9A755fd29B2688956BD959F933F8.png"
     }
   ]
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d4d3e6</samp>

### Summary
🔄🧪🏷️

<!--
1.  🔄 This emoji can be used to indicate that something was updated or changed, such as the token list for the testnet.
2.  🧪 This emoji can be used to indicate that something relates to testing or experimentation, such as the mock and pegged tokens on the testnet.
3.  🏷️ This emoji can be used to indicate that something was renamed or labeled, such as the `BUSD` token on the mainnet.
-->
Added testnet tokens and renamed `BUSD` on mainnet in `pancake-default.tokenlist.json`. This improves the testing and clarity of the token list for the PancakeSwap web app.

> _Sing, O Muse, of the skillful coder who updated the token list_
> _For the PancakeSwap testnet, where many mock and pegged tokens exist_
> _He renamed the `BUSD` token on the mainnet, to avoid the strife_
> _Of traders who might confuse it with the real one, and lose their gifts_

### Walkthrough
* Change the name of the BUSD token on the BSC mainnet to "Mock BUSD Token" to avoid confusion with the real BUSD token ([link](https://github.com/pancakeswap/pancake-frontend/pull/7532/files?diff=unified&w=0#diff-55ee773d94e57d4fe20f6463bc02307f5d9747933c77b517fa31a90375d2af7eL126-R126))
* Add six pegged tokens to the token list for the PancakeSwap testnet: BUSD, USDT, DAI, USDT, BTCB, and ETH ([link](https://github.com/pancakeswap/pancake-frontend/pull/7532/files?diff=unified&w=0#diff-55ee773d94e57d4fe20f6463bc02307f5d9747933c77b517fa31a90375d2af7eR292-R339))


