### PR TITLE
chore: update subgraph endpoint for arb

### DIFF
--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -22,5 +22,5 @@ export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
   [ChainId.LINEA_TESTNET]:
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-arbitrum/version/latest',
+  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
 }

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -67,7 +67,7 @@ export const V3_SUBGRAPH_URLS = {
   [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
   [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
   [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-arbitrum/version/latest',
+  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
   [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
   [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
   [ChainId.POLYGON_ZKEVM_TESTNET]: null,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e02e5de</samp>

### Summary
🚀🔄🛠️

<!--
1.  🚀 This emoji represents the improvement in reliability and performance of the subgraph queries for the exchange v3 features on Arbitrum One. It conveys a sense of speed, launch, and progress.
2.  🔄 This emoji represents the update of the subgraph URL in the web app config file to match the change in the routing API. It conveys a sense of synchronization, alignment, and refresh.
3.  🛠️ This emoji represents the maintenance and bug fixing aspect of the changes. It conveys a sense of repair, improvement, and quality.
-->
Updated the subgraph URL for Arbitrum One to use the official endpoint from The Graph in both the `routing` API and the web app. This improves the subgraph query reliability and performance for the exchange v3 features on Arbitrum One.

> _`subgraph` URL changed_
> _Arbitrum One more reliable_
> _Autumn leaves fall fast_

### Walkthrough
*  Update subgraph URL for Arbitrum One chain to use official endpoint ([link](https://github.com/pancakeswap/pancake-frontend/pull/7537/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aL25-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7537/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L70-R70))


