### PR TITLE
chore: Graceful upgrade routing api

### DIFF
--- a/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
@@ -89,7 +89,7 @@ const createFallbackTvlRefGetter = () => {
     if (cached) {
       return cached
     }
-    const res = await fetch(`https://routing-api.pancakeswap.com/v0/v3-pools-tvl/${currencyA.chainId}`)
+    const res = await fetch(`https://routing-api-v2.pancakeswap.com/v0/v3-pools-tvl/${currencyA.chainId}`)
     const refs: V3PoolTvlReference[] = await res.json()
     cache.set(currencyA.chainId, refs)
     return refs


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bb521dc</samp>

### Summary
🚀🔄🔒

<!--
1.  🚀 - This emoji can be used to indicate that the change was a performance improvement or a speed boost for the V3 router.
2.  🔄 - This emoji can be used to indicate that the change was a switch or a replacement of one API endpoint with another.
3.  🔒 - This emoji can be used to indicate that the change was related to the TVL metric, which measures the amount of liquidity locked in the V3 pools.
-->
Updated the `getV3CandidatePools` function to use the new routing-api-v2 endpoint for fetching V3 pool TVL. This was part of a pull request to optimize the V3 router logic and UI.

> _`createFallbackTvlRefGetter`_
> _Faster and more reliable_
> _Using routing-api-v2_

### Walkthrough
* Updated the function to fetch TVL of V3 pools from routing-api-v2 endpoint ([link](https://github.com/pancakeswap/pancake-frontend/pull/7548/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L92-R92))


