### PR TITLE
chore(farms): Api more timeout

### DIFF
--- a/apis/farms/src/v3.ts
+++ b/apis/farms/src/v3.ts
@@ -258,7 +258,7 @@ const handler_ = async (req: Request, event: FetchEvent) => {
     }
 
     const resultTimeout = await Promise.race([
-      timeout(15),
+      timeout(20),
       fetchLiquidityFromSubgraph(chainId, address, masterChefV3Address, tick, sqrtPriceX96),
     ])
 

--- a/apis/farms/src/v3.ts
+++ b/apis/farms/src/v3.ts
@@ -209,7 +209,7 @@ const handler_ = async (req: Request, event: FetchEvent) => {
 
   if (kvCache) {
     // 5 mins
-    if (new Date().getTime() > new Date(kvCache.updatedAt).getTime() + 1000 * 60 * 5) {
+    if (new Date().getTime() < new Date(kvCache.updatedAt).getTime() + 1000 * 60 * 5) {
       return json(
         {
           tvl: {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9cacd56</samp>

### Summary
🕑🚀🌾

<!--
1.  🕑 - This emoji represents the increase in the timeout value, as it is related to time and clocks. It can also suggest that the subgraph query might take longer than expected, or that the user might have to wait a bit more for the data to load.
2.  🚀 - This emoji represents the improvement in the performance and reliability of the farms page, as it is related to speed and launch. It can also suggest that the pull request was a positive and impactful change for the user experience and the app functionality.
3.  🌾 - This emoji represents the farms page, as it is related to agriculture and harvesting. It can also suggest that the pull request was focused on this specific feature of the app, and that it might affect the liquidity and rewards of the farms.
-->
Increased the timeout value for fetching liquidity data from the subgraph in `v3.ts`. This improves the farms page performance and reliability.

> _`Promise.race` waits_
> _More seconds for subgraph_
> _Winter data slow_

### Walkthrough
* Increase the timeout value for fetching liquidity data from the subgraph to 20 seconds ([link](https://github.com/pancakeswap/pancake-frontend/pull/7553/files?diff=unified&w=0#diff-0e56562b1a287487ad933f04eb8867f8afbccfc461716cc24e9ddad41d614126L261-R261)). This improves the performance and reliability of the farms page by avoiding potential errors due to slow responses from the subgraph. The change affects the `apis/farms/src/v3.ts` file, which contains the logic for querying the subgraph and calculating the liquidity values for each farm.


