### PR TITLE
revert: Hook useCakePrice & useBNBPrice 

### DIFF
--- a/apps/web/src/hooks/useBNBPrice.ts
+++ b/apps/web/src/hooks/useBNBPrice.ts
@@ -5,17 +5,19 @@ import { chainlinkOracleABI } from 'config/abi/chainlinkOracle'
 import contracts from 'config/constants/contracts'
 import { publicClient } from 'utils/wagmi'
 import { formatUnits } from 'viem'
-import { FAST_INTERVAL } from 'config/constants'
-import { useQuery } from '@tanstack/react-query'
+import { useContractRead } from 'wagmi'
 
 // for migration to bignumber.js to avoid breaking changes
 export const useBNBPrice = () => {
-  const { data } = useQuery<BigNumber, Error>({
-    queryKey: ['bnbPrice'],
-    queryFn: async () => new BigNumber(await getBNBPriceFromOracle()),
-    staleTime: FAST_INTERVAL,
-    refetchInterval: FAST_INTERVAL,
+  const { data } = useContractRead({
+    abi: chainlinkOracleABI,
+    address: contracts.chainlinkOracleBNB[ChainId.BSC],
+    functionName: 'latestAnswer',
+    chainId: ChainId.BSC,
+    watch: true,
+    select: (d) => new BigNumber(formatUnits(d, 8)),
   })
+
   return data ?? BIG_ZERO
 }
 

--- a/apps/web/src/hooks/useCakePrice.ts
+++ b/apps/web/src/hooks/useCakePrice.ts
@@ -5,17 +5,19 @@ import { chainlinkOracleABI } from 'config/abi/chainlinkOracle'
 import contracts from 'config/constants/contracts'
 import { publicClient } from 'utils/wagmi'
 import { formatUnits } from 'viem'
-import { FAST_INTERVAL } from 'config/constants'
-import { useQuery } from '@tanstack/react-query'
+import { useContractRead } from 'wagmi'
 
 // for migration to bignumber.js to avoid breaking changes
 export const useCakePrice = () => {
-  const { data } = useQuery<BigNumber, Error>({
-    queryKey: ['cakePrice'],
-    queryFn: async () => new BigNumber(await getCakePriceFromOracle()),
-    staleTime: FAST_INTERVAL,
-    refetchInterval: FAST_INTERVAL,
+  const { data } = useContractRead({
+    abi: chainlinkOracleABI,
+    address: contracts.chainlinkOracleCAKE[ChainId.BSC],
+    functionName: 'latestAnswer',
+    chainId: ChainId.BSC,
+    watch: true,
+    select: (d) => new BigNumber(formatUnits(d, 8)),
   })
+
   return data ?? BIG_ZERO
 }
 


### PR DESCRIPTION
Found out in this [PR](https://github.com/pancakeswap/pancake-frontend/pull/7527/files)
`useBNBPrice`  &  `useCakePrice` return `0`


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad107b8</samp>

### Summary
🔧🗑️🔄

<!--
1.  🔧 - This emoji represents a refactor or a configuration change, which is what the `useCakePrice` hook underwent when it switched from using `useQuery` to `useContractRead`.
2.  🗑️ - This emoji represents a removal or a deletion, which is what happened to the `getCakePriceFromOracle` function, which was no longer needed and was deleted from the codebase.
3.  🔄 - This emoji represents a migration or an update, which is what the codebase did when it moved from using ethers.js to bignumber.js for handling big numbers.
-->
Refactored `useCakePrice` hook to use `useContractRead` and removed deprecated function. This was part of the migration to bignumber.js.

> _`useCakePrice` hook_
> _refactored with `useContractRead`_
> _simpler and cleaner_

### Walkthrough
* Refactor `useCakePrice` hook to use `useContractRead` instead of `useQuery` and remove deprecated `getCakePriceFromOracle` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7563/files?diff=unified&w=0#diff-73f150d33a2313d6ecd8ddaaedd9ec90bdb9e0b2d63b79c219434f284d132acfL8-R20))
* Update `useCakePrice` hook to return a bignumber.js instance instead of a ethers.js BigNumber ([link](https://github.com/pancakeswap/pancake-frontend/pull/7563/files?diff=unified&w=0#diff-73f150d33a2313d6ecd8ddaaedd9ec90bdb9e0b2d63b79c219434f284d132acfL8-R20))


