### PR TITLE
chore: Add arb node

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -23,7 +23,10 @@ export const SERVER_NODES = {
     getNodeRealUrlV2(ChainId.GOERLI, process.env.SERVER_NODE_REAL_API_GOERLI),
     'https://eth-goerli.public.blastapi.io',
   ].filter(Boolean),
-  [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
+  [ChainId.ARBITRUM_ONE]: [
+    getNodeRealUrlV2(ChainId.ARBITRUM_ONE, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+    ...arbitrum.rpcUrls.public.http,
+  ],
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_NODES,
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
@@ -56,7 +59,10 @@ export const PUBLIC_NODES = {
     getNodeRealUrlV2(ChainId.GOERLI, process.env.NEXT_PUBLIC_NODE_REAL_API_GOERLI),
     'https://eth-goerli.public.blastapi.io',
   ].filter(Boolean),
-  [ChainId.ARBITRUM_ONE]: arbitrum.rpcUrls.public.http,
+  [ChainId.ARBITRUM_ONE]: [
+    getNodeRealUrlV2(ChainId.ARBITRUM_ONE, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH),
+    ...arbitrum.rpcUrls.public.http,
+  ],
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
     ...POLYGON_ZKEVM_NODES,

--- a/apps/web/src/utils/nodeReal.ts
+++ b/apps/web/src/utils/nodeReal.ts
@@ -53,6 +53,11 @@ export const getNodeRealUrlV2 = (chainId: number, key?: string) => {
         host = `open-platform.nodereal.io/${key}/polygon-zkevm-rpc`
       }
       break
+    case ChainId.ARBITRUM_ONE:
+      if (key) {
+        host = `open-platform.nodereal.io/${key}/arbitrum-nitro`
+      }
+      break
     default:
       host = null
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1313bf8</samp>

### Summary
🌐🚀🔧

<!--
1.  🌐 - This emoji represents the addition of a new node URL for the Arbitrum One network, which is a layer 2 scaling solution for Ethereum that enables fast and low-cost transactions. The globe emoji suggests the idea of connecting to a different network or layer, as well as the global reach and accessibility of Arbitrum One.
2.  🚀 - This emoji represents the improvement of the reliability and performance of the web app when interacting with the Arbitrum One chain, which is a desirable outcome for users and developers. The rocket emoji suggests the idea of speed, efficiency, and innovation, as well as the excitement and potential of layer 2 scaling solutions.
3.  🔧 - This emoji represents the addition of a case for the Arbitrum One network in the `getNodeRealUrlV2` function, which is a technical change that enables the new node URL to work properly. The wrench emoji suggests the idea of fixing, adjusting, or configuring something, as well as the skill and expertise involved in coding and development.
-->
Added a new node URL for the Arbitrum One network in `apps/web/src/config/nodes.ts` and updated the `getNodeRealUrlV2` function in `apps/web/src/utils/nodeReal.ts` to support it. This is to improve the web app's compatibility and performance with the Arbitrum One chain.

> _New node URL_
> _For Arbitrum One network_
> _`getNodeRealUrlV2`_

### Walkthrough
* Add a new node URL for the Arbitrum One network to improve web app reliability and performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/7571/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL26-R29), [link](https://github.com/pancakeswap/pancake-frontend/pull/7571/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94R56-R60))
  - Use the `getNodeRealUrlV2` function in `nodeReal.ts` to return a node URL based on the environment variable `NEXT_PUBLIC_NODE_REAL_API_ETH` and the host `open-platform.nodereal.io` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7571/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94R56-R60))
  - Add a case for the Arbitrum One network in the `getNodeRealUrlV2` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7571/files?diff=unified&w=0#diff-bb3c63d785380b9b32453c5badb6a4a1422845ccd7d67fdff5c625be3efc5a94R56-R60))
  - Update the `nodes.ts` config file to include the new node URL for the Arbitrum One network ([link](https://github.com/pancakeswap/pancake-frontend/pull/7571/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL26-R29))


