### PR TITLE
feat: Only show v1 farm in BSC

### DIFF
--- a/apps/web/src/views/Farms/Farms.tsx
+++ b/apps/web/src/views/Farms/Farms.tsx
@@ -484,7 +484,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
             </LabelWrapper>
           </FilterContainer>
         </ControlContainer>
-        {isInactive && (
+        {isInactive && chainId === ChainId.BSC && (
           <FinishedTextContainer>
             <Text fontSize={['16px', null, '20px']} color="failure" pr="4px">
               {t("Don't see the farm you are staking?")}

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -567,7 +567,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
             </LabelWrapper>
           </FilterContainer>
         </ControlContainer>
-        {isInactive && (
+        {isInactive && chainId === ChainId.BSC && (
           <FinishedTextContainer>
             <Text fontSize={['16px', null, '20px']} color="failure" pr="4px">
               {t("Don't see the farm you are staking?")}


### PR DESCRIPTION
Seem V1 Farm only support BSC chain.
So that we can show it only when chain is BSC.
![Screenshot 2023-08-17 at 11 28 01 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/9d586d30-0dd1-4834-bd04-2fe81a70a011)


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at baaf390</samp>

### Summary
🐛🌐🆕

<!--
1.  🐛 - This emoji represents a bug fix, since the previous behavior of showing the "Finished" text for active farms on other chains was incorrect and misleading.
2.  🌐 - This emoji represents a cross-chain feature, since the change affects how the Farms view displays farms that are available on different chains, such as Ethereum and Polygon.
3.  🆕 - This emoji represents a new feature, since the change applies to the FarmsV3 view, which is a new version of the Farms view that has not been released yet.
-->
Added chainId check to `Farms` and `FarmsV3` views to prevent showing incorrect "Finished" text for cross-chain farms. This improves the user experience and accuracy of the farm status.

> _`Farms` and `FarmsV3`_
> _show "Finished" text with care_
> _autumn harvest time_

### Walkthrough
*  Add a chainId check to prevent showing "Finished" text for active farms on other chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/7578/files?diff=unified&w=0#diff-99cc199074209bdf8fe96c89eb7c76ae1e7f5858c67da50acb14f5a8361ba52dL487-R487), [link](https://github.com/pancakeswap/pancake-frontend/pull/7578/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fL570-R570))


