### PR TITLE
fix: update mercuryo widget

### DIFF
--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -13,7 +13,7 @@ import {
 } from '@pancakeswap/uikit'
 import { LoadingDot } from '@pancakeswap/uikit/src/widgets/Liquidity'
 import { CommitButton } from 'components/CommitButton'
-import { MOONPAY_SIGN_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
+import { MERCURYO_WIDGET_ID, MOONPAY_SIGN_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import Script from 'next/script'
 import { Dispatch, ReactNode, SetStateAction, memo, useCallback, useEffect, useState } from 'react'
@@ -265,7 +265,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
         // @ts-ignore
         const MC_WIDGET = window?.mercuryoWidget
         MC_WIDGET.run({
-          widgetId: '3b8eed96-f637-4c90-9e4f-661fc326223b',
+          widgetId: MERCURYO_WIDGET_ID,
           fiatCurrency: outputCurrency.toUpperCase(),
           currency: inputCurrency.toUpperCase(),
           fiatAmount: amount,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6f95100</samp>

### Summary
🎨♻️🔧

<!--
1.  🎨 - This emoji can be used to indicate that the code was improved in terms of style, formatting, or structure, without changing its functionality or behavior.
2.  ♻️ - This emoji can be used to indicate that the code was refactored, meaning that it was reorganized or simplified to make it more efficient or easier to understand, without changing its functionality or behavior.
3.  🔧 - This emoji can be used to indicate that the code was modified to fix or improve a minor issue, such as a bug, a typo, or a configuration setting, without changing its functionality or behavior.
-->
Refactored Mercuryo widget integration in `FiatOnRampModal.tsx` to use a constant for the widget ID.

> _We summon the widget of doom_
> _With a constant ID we consume_
> _No more hard-coded strings_
> _We unleash the Mercuryo wings_

### Walkthrough
*  Import and use `MERCURYO_WIDGET_ID` constant for Mercuryo widget ID ([link](https://github.com/pancakeswap/pancake-frontend/pull/7582/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L16-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7582/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L268-R268))


