### PR TITLE
feat: Change ENV

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -84,6 +84,6 @@ export const QUOTING_API = `${process.env.NEXT_PUBLIC_QUOTING_API}/v0/quote`
 
 export const FARMS_API = 'https://farms-api.pancakeswap.com'
 
-export const MERCURYO_WIDGET_ID = process.env.MERCURYO_WIDGET_ID || '76ba4ff5-2686-4ed4-8666-fadb0d9a5888'
+export const MERCURYO_WIDGET_ID = process.env.NEXT_PUBLIC_MERCURYO_WIDGET_ID || '76ba4ff5-2686-4ed4-8666-fadb0d9a5888'
 
-export const MOONPAY_API_KEY = process.env.MOONPAY_LIVE_KEY || 'pk_test_1Ibe44lMglFVL8COOYO7SEKnIBrzrp54'
+export const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_LIVE_KEY || 'pk_test_1Ibe44lMglFVL8COOYO7SEKnIBrzrp54'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 552658a</samp>

### Summary
🌐🔑🛠️

<!--
1.  🌐 This emoji could represent the browser or the web, where the environment variables are now exposed.
2.  🔑 This emoji could represent the prefix or the key that is added to the environment variables to make them public.
3.  🛠️ This emoji could represent the Next.js framework or the tool that requires this change.
-->
Added `NEXT_PUBLIC_` prefix to Mercuryo and Moonpay widget environment variables in `endpoints.ts` to enable browser access. This is a Next.js compatibility fix.

> _`NEXT_PUBLIC_` prefix_
> _exposes env variables_
> _browser sees widgets_

### Walkthrough
*  Prefix Mercuryo and Moonpay widget environment variables with `NEXT_PUBLIC_` to make them accessible in the browser ([link](https://github.com/pancakeswap/pancake-frontend/pull/7585/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L87-R89)). This is required by the Next.js framework in `apps/web/src/config/constants/endpoints.ts`.


