### PR TITLE
fix(wagmi): Blocto keep connection after disconnect

### DIFF
--- a/.changeset/empty-trees-boil.md
+++ b/.changeset/empty-trees-boil.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/wagmi': patch
+---
+
+Fix blocto keep connection after disconnect

--- a/packages/wagmi/connectors/blocto/blocto.ts
+++ b/packages/wagmi/connectors/blocto/blocto.ts
@@ -108,17 +108,10 @@ export class BloctoConnector extends Connector<EthereumProviderInterface, { defa
   }
 
   async isAuthorized(): Promise<boolean> {
-    try {
-      const provider = await this.getProvider()
-      if (!provider) throw new ConnectorNotFoundError()
-      const accounts = await provider.request({
-        method: 'eth_requestAccounts',
-      })
-      const account = accounts[0]
-      return !!account
-    } catch {
-      return false
-    }
+    const walletName = this.storage?.getItem('wallet')
+    const connected = Boolean(this.storage?.getItem('connected'))
+    const isConnect = walletName === 'blocto' && connected
+    return Promise.resolve(isConnect)
   }
 
   async getWalletClient({ chainId }: { chainId?: number } = {}): Promise<WalletClient> {
@@ -177,6 +170,9 @@ export class BloctoConnector extends Connector<EthereumProviderInterface, { defa
 
   async disconnect() {
     const provider = await this.getProvider()
+    if (provider) {
+      await provider.request({ method: 'wallet_disconnect' })
+    }
     if (!provider?.removeListener) return
 
     provider.removeListener('accountsChanged', this.onAccountsChanged)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c4f969</samp>

### Summary
🐛🧹📦

<!--
1.  🐛 - This emoji represents a bug fix, which is suitable for the change that fixes the disconnect issue with the Blocto wallet.
2.  🧹 - This emoji represents a cleanup or refactoring, which is suitable for the change that simplifies the authorization check for the Blocto wallet.
3.  📦 - This emoji represents a package update, which is suitable for the change that updates the changeset file for the `@pancakeswap/wagmi` package.
-->
This pull request fixes the Blocto wallet integration for the `@pancakeswap/wagmi` package by simplifying the authorization check and resolving the disconnect issue. It also updates the changeset file to reflect the patch update.

> _`BloctoConnector`_
> _Simpler and more reliable_
> _A patch for wagmi_

### Walkthrough
*  Simplify and fix Blocto wallet authorization and deactivation logic in `BloctoConnector` class (`packages/wagmi/connectors/blocto/blocto.ts`) ([link](https://github.com/pancakeswap/pancake-frontend/pull/7587/files?diff=unified&w=0#diff-5f2b801de6e04d1ec70fa4748127d12ca4e9541c8b724af91a0842ae82abe4e6L111-R114), [link](https://github.com/pancakeswap/pancake-frontend/pull/7587/files?diff=unified&w=0#diff-5f2b801de6e04d1ec70fa4748127d12ca4e9541c8b724af91a0842ae82abe4e6R173-R175))
* Update changeset file to indicate patch update for `@pancakeswap/wagmi` package and summarize the fix (`.changeset/empty-trees-boil.md`) ([link](https://github.com/pancakeswap/pancake-frontend/pull/7587/files?diff=unified&w=0#diff-48dfae5eb0c6d9e4305c424aa216b987a4200ba831d6c342f9d4525e41c975ddR1-R5))


