### PR TITLE
fix: Remove liquidity v2 leaks state between lp's

### DIFF
--- a/apps/web/src/pages/v2/remove/[[...currency]].tsx
+++ b/apps/web/src/pages/v2/remove/[[...currency]].tsx
@@ -5,6 +5,7 @@ import { CHAIN_IDS } from 'utils/wagmi'
 import RemoveLiquidity, { RemoveLiquidityV2Layout } from 'views/RemoveLiquidity'
 import RemoveStableLiquidity, { RemoveLiquidityStableLayout } from 'views/RemoveLiquidity/RemoveStableLiquidity'
 import useStableConfig, { StableConfigContext } from 'views/Swap/hooks/useStableConfig'
+import RemoveLiquidityV2FormProvider from 'views/RemoveLiquidity/RemoveLiquidityV2FormProvider'
 
 const RemoveLiquidityPage = () => {
   const router = useRouter()
@@ -26,15 +27,19 @@ const RemoveLiquidityPage = () => {
   }
 
   return stableConfig.stableSwapConfig && Boolean(router.query.stable) ? (
-    <StableConfigContext.Provider value={stableConfig}>
-      <RemoveLiquidityStableLayout {...props}>
-        <RemoveStableLiquidity {...props} />
-      </RemoveLiquidityStableLayout>
-    </StableConfigContext.Provider>
+    <RemoveLiquidityV2FormProvider>
+      <StableConfigContext.Provider value={stableConfig}>
+        <RemoveLiquidityStableLayout {...props}>
+          <RemoveStableLiquidity {...props} />
+        </RemoveLiquidityStableLayout>
+      </StableConfigContext.Provider>
+    </RemoveLiquidityV2FormProvider>
   ) : (
-    <RemoveLiquidityV2Layout {...props}>
-      <RemoveLiquidity {...props} />
-    </RemoveLiquidityV2Layout>
+    <RemoveLiquidityV2FormProvider>
+      <RemoveLiquidityV2Layout {...props}>
+        <RemoveLiquidity {...props} />
+      </RemoveLiquidityV2Layout>
+    </RemoveLiquidityV2FormProvider>
   )
 }
 

--- a/apps/web/src/state/burn/hooks.ts
+++ b/apps/web/src/state/burn/hooks.ts
@@ -6,15 +6,10 @@ import useTotalSupply from 'hooks/useTotalSupply'
 
 import { useTranslation } from '@pancakeswap/localization'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
-import { useAtom, useAtomValue } from 'jotai'
-import { burnReducerAtom } from 'state/burn/reducer'
+import { useRemoveLiquidityV2FormDispatch, useRemoveLiquidityV2FormState } from 'state/burn/reducer'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useTokenBalances } from '../wallet/hooks'
 import { Field, typeInput } from './actions'
-
-export function useBurnState() {
-  return useAtomValue(burnReducerAtom)
-}
 
 export function useDerivedBurnInfo(
   currencyA: Currency | undefined,
@@ -36,7 +31,7 @@ export function useDerivedBurnInfo(
 } {
   const { account, chainId } = useAccountActiveChain()
 
-  const { independentField, typedValue } = useBurnState()
+  const { independentField, typedValue } = useRemoveLiquidityV2FormState()
 
   const { t } = useTranslation()
 
@@ -180,7 +175,7 @@ export function useDerivedBurnInfo(
 export function useBurnActionHandlers(): {
   onUserInput: (field: Field, typedValue: string) => void
 } {
-  const [, dispatch] = useAtom(burnReducerAtom)
+  const dispatch = useRemoveLiquidityV2FormDispatch()
 
   const onUserInput = useCallback(
     (field: Field, typedValue: string) => {

--- a/apps/web/src/state/burn/reducer.ts
+++ b/apps/web/src/state/burn/reducer.ts
@@ -1,5 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit'
 import { atomWithReducer } from 'jotai/utils'
+import { createContext, useContext } from 'react'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { Field, typeInput } from './actions'
 
 export interface BurnState {
@@ -22,4 +24,20 @@ const reducer = createReducer<BurnState>(initialState, (builder) =>
   }),
 )
 
-export const burnReducerAtom = atomWithReducer(initialState, reducer)
+export const createFormAtom = () => atomWithReducer(initialState, reducer)
+
+const RemoveLiquidityV2AtomContext = createContext({
+  formAtom: createFormAtom(),
+})
+
+export const RemoveLiquidityV2AtomProvider = RemoveLiquidityV2AtomContext.Provider
+
+export function useRemoveLiquidityV2FormState() {
+  const ctx = useContext(RemoveLiquidityV2AtomContext)
+  return useAtomValue(ctx.formAtom)
+}
+
+export function useRemoveLiquidityV2FormDispatch() {
+  const ctx = useContext(RemoveLiquidityV2AtomContext)
+  return useSetAtom(ctx.formAtom)
+}

--- a/apps/web/src/views/Migration/components/v3/Step2.tsx
+++ b/apps/web/src/views/Migration/components/v3/Step2.tsx
@@ -22,6 +22,7 @@ import RemoveStableLiquidity from 'views/RemoveLiquidity/RemoveStableLiquidity'
 import useStableConfig, { StableConfigContext, useLPTokensWithBalanceByAccount } from 'views/Swap/hooks/useStableConfig'
 import { useAccount } from 'wagmi'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import RemoveLiquidityV2FormProvider from 'views/RemoveLiquidity/RemoveLiquidityV2FormProvider'
 
 export const STABLE_LP_TO_MIGRATE = [
   '0x36842F8fb99D55477C0Da638aF5ceb6bBf86aA98', // USDT-BUSD
@@ -104,14 +105,14 @@ export function Step2() {
             <Image src="/images/decorations/liquidity.png" width={174} height={184} alt="liquidity-image" />
           </AtomBox>
         ) : (
-          <>
+          <RemoveLiquidityV2FormProvider>
             {allV2PairsWithLiquidity?.map((pair) => (
               <LpCard key={pair.liquidityToken.address} pair={pair} />
             ))}
             {stablePairs?.map((pair) => (
               <StableLpCard key={pair.liquidityToken.address} pair={pair} />
             ))}
-          </>
+          </RemoveLiquidityV2FormProvider>
         )}
       </AtomBox>
     </AppBody>

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV2FormProvider.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV2FormProvider.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react'
+import { createFormAtom, RemoveLiquidityV2AtomProvider } from 'state/burn/reducer'
+
+export default function RemoveLiquidityV2FormProvider({ children }: { children: React.ReactNode }) {
+  const formAtom = useMemo(() => createFormAtom(), [])
+
+  return (
+    <RemoveLiquidityV2AtomProvider
+      value={{
+        formAtom,
+      }}
+    >
+      {children}
+    </RemoveLiquidityV2AtomProvider>
+  )
+}

--- a/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/hooks/useStableDerivedBurnInfo.ts
+++ b/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/hooks/useStableDerivedBurnInfo.ts
@@ -3,7 +3,6 @@ import { Currency, CurrencyAmount, Percent, Token } from '@pancakeswap/sdk'
 import { useTranslation } from '@pancakeswap/localization'
 import { Field } from 'state/burn/actions'
 import { useTokenBalances } from 'state/wallet/hooks'
-import { useBurnState } from 'state/burn/hooks'
 import { StablePair, useStablePair } from 'views/AddLiquidity/AddStableLiquidity/hooks/useStableLPDerivedMintInfo'
 import { StableConfigContext } from 'views/Swap/hooks/useStableConfig'
 import useSWR from 'swr'
@@ -11,6 +10,7 @@ import { useContext, useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { Address } from 'viem'
 import { useInfoStableSwapContract } from 'hooks/useContract'
+import { useRemoveLiquidityV2FormState } from 'state/burn/reducer'
 
 export function useGetRemovedTokenAmounts({ lpAmount }: { lpAmount: string }) {
   const { stableSwapInfoContract, stableSwapConfig } = useContext(StableConfigContext)
@@ -68,7 +68,7 @@ export function useStableDerivedBurnInfo(
 } {
   const { address: account } = useAccount()
 
-  const { independentField, typedValue } = useBurnState()
+  const { independentField, typedValue } = useRemoveLiquidityV2FormState()
 
   const { t } = useTranslation()
 

--- a/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
@@ -29,30 +29,31 @@ import { useStableSwapNativeHelperContract } from 'hooks/useContract'
 import { useUserSlippage } from '@pancakeswap/utils/user'
 import { Hash } from 'viem'
 
-import { LightGreyCard } from '../../../components/Card'
-import ConnectWalletButton from '../../../components/ConnectWalletButton'
-import CurrencyInputPanel from '../../../components/CurrencyInputPanel'
-import { RowBetween } from '../../../components/Layout/Row'
-import { CurrencyLogo } from '../../../components/Logo'
-import useActiveWeb3React from '../../../hooks/useActiveWeb3React'
+import { LightGreyCard } from 'components/Card'
+import { RowBetween } from 'components/Layout/Row'
 
-import StyledInternalLink from '../../../components/Links'
-import Dots from '../../../components/Loader/Dots'
-import { ApprovalState, useApproveCallback } from '../../../hooks/useApproveCallback'
-import { useBurnActionHandlers, useBurnState } from '../../../state/burn/hooks'
-import { useTransactionAdder } from '../../../state/transactions/hooks'
-import { calculateGasMargin } from '../../../utils'
-import { currencyId } from '../../../utils/currencyId'
-import { calculateSlippageAmount } from '../../../utils/exchange'
+import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
+import { useBurnActionHandlers } from 'state/burn/hooks'
+import { useTransactionAdder } from 'state/transactions/hooks'
+import { calculateGasMargin } from 'utils'
+import { currencyId } from 'utils/currencyId'
+import { calculateSlippageAmount } from 'utils/exchange'
 
-import { Field } from '../../../state/burn/actions'
-import { useGasPrice } from '../../../state/user/hooks'
+import { Field } from 'state/burn/actions'
+import { useGasPrice } from 'state/user/hooks'
+import { isUserRejected, logError } from 'utils/sentry'
+import { CommonBasesType } from 'components/SearchModal/types'
+import { SettingsMode } from 'components/Menu/GlobalSettings/types'
+import { useRemoveLiquidityV2FormState } from 'state/burn/reducer'
 import ConfirmLiquidityModal from '../../Swap/components/ConfirmRemoveLiquidityModal'
-import { isUserRejected, logError } from '../../../utils/sentry'
-import { CommonBasesType } from '../../../components/SearchModal/types'
 import { useStableDerivedBurnInfo } from './hooks/useStableDerivedBurnInfo'
 import SettingsModal from '../../../components/Menu/GlobalSettings/SettingsModal'
-import { SettingsMode } from '../../../components/Menu/GlobalSettings/types'
+import Dots from '../../../components/Loader/Dots'
+import StyledInternalLink from '../../../components/Links'
+import useActiveWeb3React from '../../../hooks/useActiveWeb3React'
+import { CurrencyLogo } from '../../../components/Logo'
+import CurrencyInputPanel from '../../../components/CurrencyInputPanel'
+import ConnectWalletButton from '../../../components/ConnectWalletButton'
 import { RemoveLiquidityLayout } from '..'
 
 const BorderCard = styled.div`
@@ -74,7 +75,7 @@ export default function RemoveStableLiquidity({ currencyA, currencyB, currencyId
   const gasPrice = useGasPrice()
 
   // burn state
-  const { independentField, typedValue } = useBurnState()
+  const { independentField, typedValue } = useRemoveLiquidityV2FormState()
 
   const nativeHelperContract = useStableSwapNativeHelperContract()
 

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -40,36 +40,37 @@ import { formattedCurrencyAmount } from 'components/Chart/FormattedCurrencyAmoun
 import { splitSignature } from 'utils/splitSignature'
 import { Hash } from 'viem'
 
-import CurrencyInputPanel from '../../components/CurrencyInputPanel'
-import { MinimalPositionCard } from '../../components/PositionCard'
-import { AppHeader, AppBody } from '../../components/App'
-import { RowBetween } from '../../components/Layout/Row'
-import ConnectWalletButton from '../../components/ConnectWalletButton'
-import { LightGreyCard } from '../../components/Card'
+import { MinimalPositionCard } from 'components/PositionCard'
+import { RowBetween } from 'components/Layout/Row'
+import { LightGreyCard } from 'components/Card'
 
-import { CurrencyLogo } from '../../components/Logo'
-import useActiveWeb3React from '../../hooks/useActiveWeb3React'
-import { usePairContract, useZapContract } from '../../hooks/useContract'
-import useTransactionDeadline from '../../hooks/useTransactionDeadline'
+import { usePairContract, useZapContract } from 'hooks/useContract'
 
-import { useTransactionAdder } from '../../state/transactions/hooks'
-import StyledInternalLink from '../../components/Links'
-import { calculateGasMargin } from '../../utils'
-import { calculateSlippageAmount, useRouterContract } from '../../utils/exchange'
-import { currencyId } from '../../utils/currencyId'
-import { useApproveCallback, ApprovalState } from '../../hooks/useApproveCallback'
-import Dots from '../../components/Loader/Dots'
-import { useBurnActionHandlers, useDerivedBurnInfo, useBurnState } from '../../state/burn/hooks'
+import { useTransactionAdder } from 'state/transactions/hooks'
+import { calculateGasMargin } from 'utils'
+import { calculateSlippageAmount, useRouterContract } from 'utils/exchange'
+import { currencyId } from 'utils/currencyId'
+import { useApproveCallback, ApprovalState } from 'hooks/useApproveCallback'
+import { useBurnActionHandlers, useDerivedBurnInfo } from 'state/burn/hooks'
 
-import { Field } from '../../state/burn/actions'
-import { useGasPrice } from '../../state/user/hooks'
+import { Field } from 'state/burn/actions'
+import { useGasPrice } from 'state/user/hooks'
+import { isUserRejected, logError } from 'utils/sentry'
+import { CommonBasesType } from 'components/SearchModal/types'
+import { SettingsMode } from 'components/Menu/GlobalSettings/types'
+import { useRemoveLiquidityV2FormState } from 'state/burn/reducer'
 import Page from '../Page'
 import ConfirmLiquidityModal from '../Swap/components/ConfirmRemoveLiquidityModal'
-import { isUserRejected, logError } from '../../utils/sentry'
 import { formatAmount } from '../../utils/formatInfoNumbers'
-import { CommonBasesType } from '../../components/SearchModal/types'
 import SettingsModal from '../../components/Menu/GlobalSettings/SettingsModal'
-import { SettingsMode } from '../../components/Menu/GlobalSettings/types'
+import Dots from '../../components/Loader/Dots'
+import StyledInternalLink from '../../components/Links'
+import useTransactionDeadline from '../../hooks/useTransactionDeadline'
+import useActiveWeb3React from '../../hooks/useActiveWeb3React'
+import { CurrencyLogo } from '../../components/Logo'
+import ConnectWalletButton from '../../components/ConnectWalletButton'
+import { AppHeader, AppBody } from '../../components/App'
+import CurrencyInputPanel from '../../components/CurrencyInputPanel'
 
 const BorderCard = styled.div`
   border: solid 1px ${({ theme }) => theme.colors.cardBorder};
@@ -93,7 +94,7 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
   const gasPrice = useGasPrice()
 
   // burn state
-  const { independentField, typedValue } = useBurnState()
+  const { independentField, typedValue } = useRemoveLiquidityV2FormState()
   const [removalCheckedA, setRemovalCheckedA] = useState(true)
   const [removalCheckedB, setRemovalCheckedB] = useState(true)
   const { pair, parsedAmounts, error, tokenToReceive, estimateZapOutAmount } = useDerivedBurnInfo(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 16a193f</samp>

### Summary
📝🔥🚀

<!--
1.  📝 - This emoji represents the creation of a new file and component, as well as the refactoring of the state management and the import paths.
2.  🔥 - This emoji represents the removal of liquidity from v2 pools, as well as the burn feature and the use of the burnReducerAtom.
3.  🚀 - This emoji represents the improvement of code readability and consistency, as well as the migration feature and the use of the useMemo hook.
-->
This pull request refactors the remove liquidity feature to use `jotai` atoms instead of `redux` reducers for state management. It also introduces new components, hooks, and aliases to improve code readability and consistency. The changes affect the files `apps/web/src/pages/v2/remove/[[...currency]].tsx`, `apps/web/src/state/burn/*`, `apps/web/src/views/Migration/components/v3/Step2.tsx`, and `apps/web/src/views/RemoveLiquidity/*`.

> _`Jotai` atoms burn the old state_
> _`Redux` reducers fade away_
> _We unleash the power of the form_
> _With `RemoveLiquidityV2FormProvider`_

### Walkthrough
*  Refactor the burn state management to use jotai atoms instead of redux reducers ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-944dffd9f652d8d364be640609dd2b43d483bb0b93beb933dd2a017b568e4db0R8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-06f3d6ee8b177160754ec854c6b2be248dd7585828458c951c70bfa10cd9d4e7L39-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-06f3d6ee8b177160754ec854c6b2be248dd7585828458c951c70bfa10cd9d4e7L183-R178), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-ad426e762a251d47e77ffbd0aaee9e40c0320dfb42aad01419af64fe2542d988R3-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-ad426e762a251d47e77ffbd0aaee9e40c0320dfb42aad01419af64fe2542d988L25-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-71534283807f31add563b41c2eff1a47849a95e9dbaca00948648e3642394d9eR1-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbL6), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbR13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbL71-R71), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-8db1969219b9eccaf2dced27a48414930c4153270fd11798082aae472b8626bfL96-R97))
  * Create and export a new component `RemoveLiquidityV2FormProvider` that uses the `useMemo` hook to create a new form atom and passes it to the `RemoveLiquidityV2AtomProvider` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-71534283807f31add563b41c2eff1a47849a95e9dbaca00948648e3642394d9eR1-R16))
  * Wrap the `RemoveLiquidity` and `RemoveStableLiquidity` components with the `RemoveLiquidityV2FormProvider` component in the `remove/[[...currency]].tsx` and `v3/Step2.tsx` files to provide them with the form state and dispatch functions from the atom ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-944dffd9f652d8d364be640609dd2b43d483bb0b93beb933dd2a017b568e4db0L29-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d497a46f17ed29ab779158404be2b91d4474126b721b8f867cbefefc92819d4cL107-R108), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d497a46f17ed29ab779158404be2b91d4474126b721b8f867cbefefc92819d4cL114-R115))
  * Replace the `useBurnState` hook with the `useRemoveLiquidityV2FormState` hook in the `hooks.ts`, `RemoveLiquidity/index.tsx`, and `RemoveStableLiquidity/hooks/useStableDerivedBurnInfo.ts` files to access the form state from the atom ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-06f3d6ee8b177160754ec854c6b2be248dd7585828458c951c70bfa10cd9d4e7L39-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbR13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbL71-R71), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-8db1969219b9eccaf2dced27a48414930c4153270fd11798082aae472b8626bfL96-R97))
  * Replace the `useAtom` hook with the `useRemoveLiquidityV2FormDispatch` hook in the `hooks.ts` file to access the setAtom function from the atom ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-06f3d6ee8b177160754ec854c6b2be248dd7585828458c951c70bfa10cd9d4e7L183-R178))
  * Export a function that creates a new atom with the initial state and reducer instead of a single atom in the `reducer.ts` file to allow each component that uses the atom to have its own instance of the atom and avoid conflicts ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-ad426e762a251d47e77ffbd0aaee9e40c0320dfb42aad01419af64fe2542d988L25-R43))
  * Create and export a new context, provider, and hooks for the form atom in the `reducer.ts` file to provide a convenient way for the components to access the form state and dispatch from the atom ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-ad426e762a251d47e77ffbd0aaee9e40c0320dfb42aad01419af64fe2542d988L25-R43))
  * Import the `createContext`, `useContext`, `useAtomValue`, and `useSetAtom` functions from the `react` and `jotai` libraries in the `reducer.ts` file to create and access the jotai atom for the form state and dispatch ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-ad426e762a251d47e77ffbd0aaee9e40c0320dfb42aad01419af64fe2542d988R3-R4))
  * Remove the import of the `useBurnState` hook from the `RemoveStableLiquidity/hooks/useStableDerivedBurnInfo.ts` file to avoid using the old hook that returns the form state from the redux reducer ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-d5fd73c73580a4983adec60f49306678da99e19200e2745402d30ed575071dbbL6))
* Update the import paths of several modules and components to use the alias `@pancakeswap` instead of the relative paths in the `hooks.ts`, `RemoveLiquidity/index.tsx`, and `RemoveStableLiquidity/index.tsx` files to improve the readability and consistency of the import statements ([link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-06f3d6ee8b177160754ec854c6b2be248dd7585828458c951c70bfa10cd9d4e7L9-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-854579da9e3ac0c6fbb5a4370c31c81d548968ce351e69cf3b421bfdaccc58dbL32-R56), [link](https://github.com/pancakeswap/pancake-frontend/pull/7591/files?diff=unified&w=0#diff-8db1969219b9eccaf2dced27a48414930c4153270fd11798082aae472b8626bfL43-R73))


