### PR TITLE
fix(Pool): Lock CAKE Modal

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/Overview/BalanceRow.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/Overview/BalanceRow.tsx
@@ -19,7 +19,12 @@ const DiffBalance: React.FC<React.PropsWithChildren<DiffBalancePropsType>> = ({
   unit,
   prefix,
 }) => {
-  if (isUndefinedOrNull(newValue) || isUndefinedOrNull(value) || _toNumber(value) === _toNumber(newValue)) {
+  if (
+    isUndefinedOrNull(newValue) ||
+    isUndefinedOrNull(value) ||
+    _toNumber(value) === _toNumber(newValue) ||
+    _toNumber(newValue) === 0
+  ) {
     return <BalanceWithLoading bold fontSize="16px" value={value} decimals={decimals} unit={unit} prefix={prefix} />
   }
 

--- a/apps/web/src/views/Pools/components/LockedPool/Common/Overview/index.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/Overview/index.tsx
@@ -12,7 +12,7 @@ import TextRow from './TextRow'
 import BalanceRow from './BalanceRow'
 import DateRow from './DateRow'
 import formatRoi from '../../utils/formatRoi'
-import formateICake from '../../utils/formatICake'
+import formatICake from '../../utils/formatICake'
 import { OverviewPropsType } from '../../types'
 import CalculatorButton from '../../Buttons/CalculatorButton'
 
@@ -53,14 +53,14 @@ const Overview: React.FC<React.PropsWithChildren<OverviewPropsType>> = ({
     : addSeconds(now, duration)
 
   const formattediCake = useMemo(() => {
-    return formateICake({ lockedAmount, duration, ceiling }) || 0
+    return formatICake({ lockedAmount, duration, ceiling }) || 0
   }, [lockedAmount, duration, ceiling])
 
   const newFormattediCake = useMemo(() => {
     const amount = Number(newLockedAmount) ? newLockedAmount : lockedAmount
     const lockDuration = Number(newDuration) ? newDuration : duration
 
-    return formateICake({ lockedAmount: amount, duration: lockDuration, ceiling }) || 0
+    return formatICake({ lockedAmount: amount, duration: lockDuration, ceiling }) || 0
   }, [lockedAmount, newLockedAmount, duration, newDuration, ceiling])
 
   return (

--- a/apps/web/src/views/Pools/components/LockedPool/Common/Overview/index.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/Overview/index.tsx
@@ -12,7 +12,7 @@ import TextRow from './TextRow'
 import BalanceRow from './BalanceRow'
 import DateRow from './DateRow'
 import formatRoi from '../../utils/formatRoi'
-import formatiCake from '../../utils/formatICake'
+import formateICake from '../../utils/formatICake'
 import { OverviewPropsType } from '../../types'
 import CalculatorButton from '../../Buttons/CalculatorButton'
 
@@ -53,14 +53,14 @@ const Overview: React.FC<React.PropsWithChildren<OverviewPropsType>> = ({
     : addSeconds(now, duration)
 
   const formattediCake = useMemo(() => {
-    return formatiCake({ lockedAmount, duration, ceiling })
+    return formateICake({ lockedAmount, duration, ceiling }) || 0
   }, [lockedAmount, duration, ceiling])
 
   const newFormattediCake = useMemo(() => {
     const amount = Number(newLockedAmount) ? newLockedAmount : lockedAmount
     const lockDuration = Number(newDuration) ? newDuration : duration
 
-    return formatiCake({ lockedAmount: amount, duration: lockDuration, ceiling })
+    return formateICake({ lockedAmount: amount, duration: lockDuration, ceiling }) || 0
   }, [lockedAmount, newLockedAmount, duration, newDuration, ceiling])
 
   return (

--- a/apps/web/src/views/Pools/components/LockedPool/utils/formatICake.ts
+++ b/apps/web/src/views/Pools/components/LockedPool/utils/formatICake.ts
@@ -6,7 +6,7 @@ interface FormatiCake {
   ceiling: BigNumber
 }
 
-export default function formatiCake({ lockedAmount, duration, ceiling }: FormatiCake) {
+export default function formateICake({ lockedAmount, duration, ceiling }: FormatiCake) {
   const durationAsBn = new BigNumber(duration)
   if (durationAsBn.gte(ceiling)) {
     return new BigNumber(lockedAmount).toNumber()

--- a/apps/web/src/views/Pools/components/LockedPool/utils/formatICake.ts
+++ b/apps/web/src/views/Pools/components/LockedPool/utils/formatICake.ts
@@ -6,7 +6,7 @@ interface FormatiCake {
   ceiling: BigNumber
 }
 
-export default function formateICake({ lockedAmount, duration, ceiling }: FormatiCake) {
+export default function formatICake({ lockedAmount, duration, ceiling }: FormatiCake) {
   const durationAsBn = new BigNumber(duration)
   if (durationAsBn.gte(ceiling)) {
     return new BigNumber(lockedAmount).toNumber()


### PR DESCRIPTION
Before
![before-lock-cake](https://github.com/pancakeswap/pancake-frontend/assets/98292246/d7f5c390-a16f-417e-ab1d-4ef658da81f5)


After
![after-lock-cake](https://github.com/pancakeswap/pancake-frontend/assets/98292246/a1922985-0268-44e5-905e-d5e5f25a5dbd)





<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ccf8cae</samp>

### Summary
🛑🔄🐛

<!--
1.  🛑 - This emoji can represent the condition to stop showing a negative percentage change when the balance is zero, as it implies a halt or a block.
2.  🔄 - This emoji can represent the renaming of the formatiCake function, as it implies a change or a refresh.
3.  🐛 - This emoji can represent the fixing of a typo and the addition of fallback values, as it implies a bug fix or a improvement.
-->
This pull request fixes some UI issues and typos related to the Locked Pool feature of the Pools view. It improves the display of iCake balances, percentages, and formatting.

> _`iCake` balance change_
> _Avoid negative percent_
> _Fall is for fixing_

### Walkthrough
* Fix a typo and add fallback values for displaying iCake balance and percentage change in the overview component of locked pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-90fd304187666e0084537c21fc9c79495aa1bb6365ddb6efb727b6c0b740018eL15-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-90fd304187666e0084537c21fc9c79495aa1bb6365ddb6efb727b6c0b740018eL56-R56), [link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-90fd304187666e0084537c21fc9c79495aa1bb6365ddb6efb727b6c0b740018eL63-R63))
* Rename the `formatiCake` function to `formateICake` in `formatICake.ts` and update the import statements accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-53e8193da4532395804f7f9ae098b004ae843d864979b91902930da73c607ad1L9-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-03c3af2f9650e5a0850278536e4af79b97fe2c612ded19f8881d36257bd1b18aL22-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-90fd304187666e0084537c21fc9c79495aa1bb6365ddb6efb727b6c0b740018eL15-R15))
* Add a condition to avoid showing a negative percentage change when the balance becomes zero in the balance row component of locked pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7594/files?diff=unified&w=0#diff-03c3af2f9650e5a0850278536e4af79b97fe2c612ded19f8881d36257bd1b18aL22-R27))


