### PR TITLE
chore: list cyber farm on bsc

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -43,6 +43,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
+    pid: 71,
+    token0: bscTokens.cyber,
+    token1: bscTokens.wbnb,
+    lpAddress: '0x846BD025527c8427809E11D0B0a9cE50F149D5d5',
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 70,
     token0: bscTokens.unshETH,
     token1: bscTokens.eth,

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2690,4 +2690,12 @@ export const bscTokens = {
     'DexCheck',
     'https://dexcheck.ai/',
   ),
+  cyber: new ERC20Token(
+    ChainId.BSC,
+    '0x14778860E937f509e651192a90589dE711Fb88a9',
+    18,
+    'CYBER',
+    'CyberConnect',
+    'https://cyberconnect.me/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at adb0bb4</samp>

### Summary
🚜🌐🚀

<!--
1.  🚜 - This emoji represents the farm concept, as farms are where users can stake their liquidity tokens and earn rewards. The tractor emoji suggests the idea of cultivating and harvesting crops, which is analogous to providing and withdrawing liquidity.
2.  🌐 - This emoji represents the network concept, as the changes are specific to the BSC network, which is one of the supported chains by PancakeSwap. The globe emoji suggests the idea of a global and interconnected network, which is relevant to the BSC network and the CyberConnect platform.
3.  🚀 - This emoji represents the token concept, as the changes introduce a new token to the PancakeSwap frontend. The rocket emoji suggests the idea of a new and exciting project, which is relevant to the CYBER token and the CyberConnect platform.
-->
This pull request adds support for the CYBER token and its liquidity pool on the PancakeSwap frontend. It updates the `farmsV3` and `bscTokens` arrays in `packages/farms/constants/56.ts` and `packages/tokens/src/56.ts` respectively with the configuration and information of the CYBER-WBNB pair and the CYBER token.

> _Adding `CYBER` farm_
> _PancakeSwap on BSC network_
> _Autumn of social_

### Walkthrough
*  Add support for the CYBER token and the CYBER-WBNB farm on the BSC network
  * Add a new token definition for the CYBER token with its address, decimals, symbol, name, and logo URL ([link](https://github.com/pancakeswap/pancake-frontend/pull/7598/files?diff=unified&w=0#diff-71ff5223fbd0d4df9a3c1d29ff72168019f58785ec79d2fae29f002d095f3bf4R2693-R2700))
  * Add a new farm for the CYBER-WBNB pair with its pid, feeAmount, and lpAddress ([link](https://github.com/pancakeswap/pancake-frontend/pull/7598/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R46-R52))


