### PR TITLE
fix: Liquidity urls not correctly constructed

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/StableV3Selector.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/StableV3Selector.tsx
@@ -35,12 +35,17 @@ export function StableV3Selector({
 
   const { isLoading, isError, largestUsageFeeTier, distributions } = useFeeTierDistribution(currencyA, currencyB)
 
-  const pools = usePools([
-    [currencyA, currencyB, FeeAmount.LOWEST],
-    [currencyA, currencyB, FeeAmount.LOW],
-    [currencyA, currencyB, FeeAmount.MEDIUM],
-    [currencyA, currencyB, FeeAmount.HIGH],
-  ])
+  const pools = usePools(
+    useMemo(
+      () => [
+        [currencyA, currencyB, FeeAmount.LOWEST],
+        [currencyA, currencyB, FeeAmount.LOW],
+        [currencyA, currencyB, FeeAmount.MEDIUM],
+        [currencyA, currencyB, FeeAmount.HIGH],
+      ],
+      [currencyA, currencyB],
+    ),
+  )
 
   const poolsByFeeTier: Record<FeeAmount, PoolState> = useMemo(
     () =>

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/FeeSelector.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/FeeSelector.tsx
@@ -43,7 +43,7 @@ export default function FeeSelector({
     if (currencyA && currencyB) {
       const [tokenA, tokenB] = [currencyA.wrapped, currencyB.wrapped]
       const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
-      return farmV3Config?.length > 0 && farmV3Config.find((f) => f.token.equals(token0) && f.quoteToken.equals(token1))
+      return farmV3Config?.find((f) => f.token.equals(token0) && f.quoteToken.equals(token1))
     }
     return null
   }, [currencyA, currencyB, farmV3Config])
@@ -57,12 +57,17 @@ export default function FeeSelector({
 
   const [showOptions, setShowOptions] = useState(false)
   // get pool data on-chain for latest states
-  const pools = usePools([
-    [currencyA, currencyB, FeeAmount.LOWEST],
-    [currencyA, currencyB, FeeAmount.LOW],
-    [currencyA, currencyB, FeeAmount.MEDIUM],
-    [currencyA, currencyB, FeeAmount.HIGH],
-  ])
+  const pools = usePools(
+    useMemo(
+      () => [
+        [currencyA, currencyB, FeeAmount.LOWEST],
+        [currencyA, currencyB, FeeAmount.LOW],
+        [currencyA, currencyB, FeeAmount.MEDIUM],
+        [currencyA, currencyB, FeeAmount.HIGH],
+      ],
+      [currencyA, currencyB],
+    ),
+  )
 
   const poolsByFeeTier: Record<FeeAmount, PoolState> = useMemo(
     () =>

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -251,6 +251,18 @@ export function UniversalAddLiquidity({
     [currencyIdA, currencyIdB, router, setSelectorType],
   )
 
+  const handleSelectV2 = useCallback(() => {
+    setSelectorType(SELECTOR_TYPE.V2)
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: router.query,
+      },
+      `/v2/add/${currencyIdA}/${currencyIdB}`,
+      { shallow: true },
+    )
+  }, [currencyIdA, currencyIdB, router, setSelectorType])
+
   useEffect(() => {
     if (preferredFeeAmount && !feeAmountFromUrl && selectorType === SELECTOR_TYPE.V3) {
       handleFeePoolSelect({ type: selectorType, feeAmount: preferredFeeAmount })
@@ -312,7 +324,7 @@ export function UniversalAddLiquidity({
                   currencyB={quoteCurrency ?? undefined}
                   handleFeePoolSelect={handleFeePoolSelect}
                   feeAmount={feeAmount}
-                  handleSelectV2={() => setSelectorType(SELECTOR_TYPE.V2)}
+                  handleSelectV2={handleSelectV2}
                 />
               )}
             </DynamicSection>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f48929a</samp>

### Summary
🧮🔥🔄

<!--
1.  🧮 - This emoji represents the use of `useMemo` to perform calculations and memoize the result, which is appropriate for the first change.
2.  🔥 - This emoji represents the removal of unnecessary code or logic, which is appropriate for the second change.
3.  🔄 - This emoji represents the switching or toggling between different interfaces or options, which is appropriate for the third change.
-->
Added a feature to switch between V2 and V3 liquidity interfaces and improved the performance and readability of the V3 stable pool components. Simplified the logic for finding the farm config for the selected fee tier in `FeeSelector.tsx` and `PriceRangeSelector.tsx`.

> _To optimize the pool rendering_
> _The `usePools` hook was memoing_
> _The `farmV3Config` checks were dropped_
> _The logic for finding farms was cropped_
> _And a feature for V2 switching was adding_

### Walkthrough
*  Memoize pool parameters with `useMemo` to improve performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-fb7858ccec9af7a3f95ee2118d6f2f2c77a4d4c1fe99cb50fa214461012c6f7cL38-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-bd4c88a7d543807cc6b62bb9b9bc6c5a9009495d15d00ed8343634f70feb850fL60-R70))
*  Remove redundant `length` check for `farmV3Config` array ([link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-bd4c88a7d543807cc6b62bb9b9bc6c5a9009495d15d00ed8343634f70feb850fL46-R46))
*  Add `handleSelectV2` callback to switch to V2 liquidity interface ([link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefR254-R265), [link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefL315-R327))
*  Pass `handleSelectV2` prop to `StableV3Selector` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7600/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefL315-R327))


