### PR TITLE
fix: Axl finished pool

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -139,6 +139,15 @@ export const livePools: SerializedPool[] = [
 // known finished pools
 const finishedPools = [
   {
+    sousId: 345,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.axl,
+    contractAddress: '0x0592c701fE5DE53d534AFBaf3A11A8F1bbEE9E91',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.05173',
+    version: 3,
+  },
+  {
     sousId: 343,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.edu,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cbdb1a3</samp>

### Summary
🍰🎸🏁

<!--
1.  🍰 - This emoji represents the CAKE token, which is the staking token for the new pool. It also conveys the idea of earning rewards or having a sweet deal.
2.  🎸 - This emoji represents the AXL token, which is the earning token for the new pool. It also conveys the idea of music, rock, or entertainment, which are related to the AXL project.
3.  🏁 - This emoji represents the finished pool, which is no longer active or accepting new stakers. It also conveys the idea of completion, finality, or achievement.
-->
Add a new finished pool for CAKE-AXL to `packages/pools/src/constants/pools/56.ts`. This pool allows users to view their past earnings and unstake their tokens.

> _`finishedPools` grows_
> _CAKE staked for AXL tokens_
> _Autumn harvest time_

### Walkthrough
*  Add a new finished pool for CAKE-AXL ([link](https://github.com/pancakeswap/pancake-frontend/pull/7602/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR142-R150))


