### PR TITLE
fix: Finished pools apr modal still available

### DIFF
--- a/packages/uikit/src/widgets/Pool/Apr.tsx
+++ b/packages/uikit/src/widgets/Pool/Apr.tsx
@@ -1,4 +1,5 @@
-import styled from "styled-components";
+import { useCallback, useMemo } from "react";
+import styled, { css } from "styled-components";
 import { useTranslation } from "@pancakeswap/localization";
 import BigNumber from "bignumber.js";
 import { BIG_ZERO } from "@pancakeswap/utils/bigNumber";
@@ -15,10 +16,15 @@ import {
 } from "../../components";
 import { useModal } from "../Modal";
 
-const AprLabelContainer = styled(Flex)`
-  &:hover {
-    opacity: 0.5;
-  }
+const AprLabelContainer = styled(Flex)<{ enableHover: boolean }>`
+  ${({ enableHover }) =>
+    enableHover
+      ? css`
+          &:hover {
+            opacity: 0.5;
+          }
+        `
+      : null}
 `;
 
 interface AprProps<T> extends FlexProps {
@@ -56,9 +62,15 @@ export function Apr<T>({
   } = pool;
   const { t } = useTranslation();
 
-  const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO;
+  const stakingTokenBalance = useMemo(
+    () => (userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO),
+    [userData]
+  );
 
-  const apyModalLink = stakingToken?.address ? `/swap?outputCurrency=${stakingToken.address}` : "/swap";
+  const apyModalLink = useMemo(
+    () => (stakingToken?.address ? `/swap?outputCurrency=${stakingToken.address}` : "/swap"),
+    [stakingToken]
+  );
 
   const [onPresentApyModal] = useModal(
     <RoiCalculatorModal
@@ -77,22 +89,25 @@ export function Apr<T>({
     />
   );
 
-  const openRoiModal = (event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
-    onPresentApyModal();
-  };
+  const openRoiModal = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      event.stopPropagation();
+      onPresentApyModal();
+    },
+    [onPresentApyModal]
+  );
 
   const isValidate = apr !== undefined && !Number.isNaN(apr);
 
   return (
-    <AprLabelContainer alignItems="center" justifyContent="flex-start" {...props}>
+    <AprLabelContainer enableHover={!isFinished} alignItems="center" justifyContent="flex-start" {...props}>
       {isValidate || isFinished ? (
         <>
           {shouldShowApr ? (
             <>
               <BalanceWithLoading
                 onClick={(event) => {
-                  if (!showIcon) return;
+                  if (!showIcon || isFinished) return;
                   openRoiModal(event);
                 }}
                 fontSize={fontSize}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8515af6</samp>

### Summary
🚀💅🚫

<!--
1.  🚀 - This emoji conveys the idea of speed, performance, and efficiency, which are some of the benefits of using React hooks and conditional logic. It also suggests that the `Apr` component is now more responsive and dynamic.
2.  💅 - This emoji represents the use of styled-components, a popular library for styling React components with CSS-in-JS. It implies that the `Apr` component has a more consistent and elegant appearance, and that the code is more modular and maintainable.
3.  🚫 - This emoji indicates that something has been disabled or removed, in this case the hover effect and the ROI modal for finished pools. It suggests that the `Apr` component is now more user-friendly and avoids unnecessary or confusing interactions.
-->
Refactored the `Apr` component to make it faster and more user-friendly. Removed unnecessary features for finished pools.

> _Sing, O Muse, of the skillful coder who enhanced the `Apr` component_
> _With hooks and styles and logic, he made it swift and elegant_
> _No more the hovering effect or modal would distract the user_
> _But like the wise Athena, he disabled them for pools that were over_

### Walkthrough
*  Optimize the performance and avoid unnecessary re-rendering of the `Apr` component by using `useCallback` and `useMemo` hooks and passing a `enableHover` prop to the `AprLabelContainer` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L1-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L18-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L59-R73), [link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L80-R103))
* Prevent opening the ROI modal when the pool is finished by checking the `isFinished` prop in the `onClick` handler of the `BalanceWithLoading` component and passing it to the `AprLabelContainer` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L80-R103), [link](https://github.com/pancakeswap/pancake-frontend/pull/7603/files?diff=unified&w=0#diff-4bf5a17fe5dd2d5d9a617aa06dd88f88065022a7bd5d01c49b3a09aff2c651b1L95-R110))


