### PR TITLE
fix: Missing farming translation

### DIFF
--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -155,7 +155,7 @@ export default function PoolListPage() {
                   <>
                     {p.isStaked && (
                       <Tag outline variant="warning" mr="8px">
-                        Farming
+                        {t('Farming')}
                       </Tag>
                     )}
                     <RangeTag removed={removed} outOfRange={outOfRange} />

--- a/apps/web/src/views/Migration/components/v3/Step4.tsx
+++ b/apps/web/src/views/Migration/components/v3/Step4.tsx
@@ -80,7 +80,7 @@ export function Step4() {
                     <>
                       {p.isStaked && (
                         <Tag outline variant="warning" mr="8px">
-                          Farming
+                          {t('Farming')}
                         </Tag>
                       )}
                       <RangeTag removed={removed} outOfRange={outOfRange} />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aaaea57</samp>

### Summary
🌐🚜🔄

<!--
1.  🌐 - This emoji represents the concept of i18n or globalization, as it shows a globe with different regions. It can be used to indicate that the text has been made translatable or that the app supports multiple languages.
2.  🚜 - This emoji represents the concept of farming, as it shows a tractor that is used for agricultural work. It can be used to indicate that the text relates to the farming feature or that the user can stake their liquidity in a farm.
3.  🔄 - This emoji represents the concept of migration, as it shows two arrows forming a circle. It can be used to indicate that the text relates to the migration feature or that the user can move their liquidity from v2 to v3.
-->
Added i18n support for the `Farming` text in the `Tag` component used in the `liquidity` and `Migration` views. This allows the text to be translated into different languages based on the user's preference or locale.

> _`t` wraps `Farming`_
> _translating for v3 migration_
> _autumn harvest time_

### Walkthrough
*  Enable i18n support for the `Farming` text in the `Tag` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7607/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL158-R158),[link](https://github.com/pancakeswap/pancake-frontend/pull/7607/files?diff=unified&w=0#diff-dea3c61bb864b14e2254e9ac25e8377d95fbdc778797b6cbeb204e80f8ec21bcL83-R83))


