### PR TITLE
fix: Lp shows active tag when loading

### DIFF
--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -158,7 +158,7 @@ export default function PoolListPage() {
                         Farming
                       </Tag>
                     )}
-                    <RangeTag removed={removed} outOfRange={outOfRange} />
+                    {token0Symbol && token1Symbol ? <RangeTag removed={removed} outOfRange={outOfRange} /> : null}
                   </>
                 }
                 subtitle={subtitle}

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -366,7 +366,7 @@ function Remove({ tokenId }: { tokenId: bigint }) {
                   {t('Farming')}
                 </Tag>
               )}
-              <RangeTag removed={removed} outOfRange={outOfRange} />
+              {liquidityValue0 && liquidityValue1 ? <RangeTag removed={removed} outOfRange={outOfRange} /> : null}
             </Flex>
           </AutoRow>
           <Text fontSize="12px" color="secondary" bold textTransform="uppercase" mb="4px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 911ce82</samp>

### Summary
🐛🌐🎨

<!--
1.  🐛 This emoji represents a bug fix, which is the main purpose of this change. The `undefined-undefined` range was a bug that was caused by rendering the component before the data was available.
2.  🌐 This emoji represents a web-related change, which is the domain of this change. The liquidity page UI is part of the web interface of the Uniswap app, and the change affects how the page is displayed to the user.
3.  🎨 This emoji represents a design or UI-related change, which is the secondary aspect of this change. The conditional rendering of the `RangeTag` component improves the aesthetics and usability of the liquidity page UI, by avoiding showing an incorrect or meaningless range to the user.
-->
Fix range tag rendering on liquidity page. Only show `RangeTag` component when token symbols are available.

> _`RangeTag` appears_
> _only when symbols are known_
> _no more undefined_

### Walkthrough
*  Add conditional rendering of `RangeTag` component to avoid showing undefined symbols ([link](https://github.com/pancakeswap/pancake-frontend/pull/7608/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL161-R161))


