### PR TITLE
perf: Memoize cake approval status to not create bignumber each render

### DIFF
--- a/apps/web/src/hooks/useCakeApprovalStatus.ts
+++ b/apps/web/src/hooks/useCakeApprovalStatus.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
 import { getCakeContract } from 'utils/contractHelpers'
 import { useAccount, useContractRead } from 'wagmi'
@@ -16,11 +17,14 @@ export const useCakeApprovalStatus = (spender) => {
     watch: true,
   })
 
-  return {
-    isVaultApproved: data > 0,
-    allowance: new BigNumber(data?.toString()),
-    setLastUpdated: refetch,
-  }
+  return useMemo(
+    () => ({
+      isVaultApproved: data > 0,
+      allowance: new BigNumber(data?.toString()),
+      setLastUpdated: refetch,
+    }),
+    [data, refetch],
+  )
 }
 
 export default useCakeApprovalStatus


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cf7955c</samp>

### Summary
🚀🧠🍰

<!--
1.  🚀 This emoji conveys the idea of speed, performance, and optimization, which are the main goals of the pull request.
2.  🧠 This emoji suggests intelligence, logic, and memory, which are the concepts involved in using `useMemo` to memoize the return value of the hook.
3.  🍰 This emoji is a reference to the name of the hook and the project, and adds some fun and flavor to the message.
-->
Optimizes the `useCakeApprovalStatus` hook by memoizing its return value with `useMemo` in `apps/web/src/hooks/useCakeApprovalStatus.ts`. This improves performance and reduces unnecessary updates.

> _Sing, O Muse, of the clever coder who refined_
> _The useCakeApprovalStatus hook, a wondrous tool_
> _That with useMemo he adorned, like Hephaestus divine_
> _Crafting golden ornaments for Hera's royal stool_

### Walkthrough
*  Memoize the return value of the `useCakeApprovalStatus` hook to improve performance and avoid unnecessary re-renders ([link](https://github.com/pancakeswap/pancake-frontend/pull/7612/files?diff=unified&w=0#diff-06bacd9571909a8c0c9c5dbf7768925db865a70beb632b651e866a9b0b48b743L19-R27))
* Import the `useMemo` hook from React to use it in the `useCakeApprovalStatus` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7612/files?diff=unified&w=0#diff-06bacd9571909a8c0c9c5dbf7768925db865a70beb632b651e866a9b0b48b743R1))


