### PR TITLE
perf: Memoize token info data

### DIFF
--- a/apps/web/src/hooks/v3/usePairTokensPrice.ts
+++ b/apps/web/src/hooks/v3/usePairTokensPrice.ts
@@ -3,7 +3,7 @@ import { ChainId } from '@pancakeswap/sdk'
 import { PairDataTimeWindowEnum } from '@pancakeswap/uikit'
 import { useMemo } from 'react'
 
-export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTimeWindowEnum, chianId?: ChainId) => {
+export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTimeWindowEnum, chainId?: ChainId) => {
   const priceTimeWindow = useMemo(() => {
     switch (duration) {
       case PairDataTimeWindowEnum.DAY:
@@ -19,7 +19,7 @@ export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTime
     }
   }, [duration])
 
-  const pairPrice = usePairPriceChartTokenData(pairAddress?.toLowerCase(), priceTimeWindow, chianId)
+  const pairPrice = usePairPriceChartTokenData(pairAddress?.toLowerCase(), priceTimeWindow, chainId)
 
   const pairPriceData: { time: Date; value: number }[] = useMemo(() => {
     return pairPrice?.data?.map((d) => ({
@@ -28,10 +28,13 @@ export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTime
     }))
   }, [pairPrice])
 
-  return {
-    pairPriceData,
-    maxPrice: pairPrice?.maxPrice,
-    minPrice: pairPrice?.minPrice,
-    averagePrice: pairPrice?.averagePrice,
-  }
+  return useMemo(
+    () => ({
+      pairPriceData,
+      maxPrice: pairPrice?.maxPrice,
+      minPrice: pairPrice?.minPrice,
+      averagePrice: pairPrice?.averagePrice,
+    }),
+    [pairPriceData, pairPrice],
+  )
 }

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -53,7 +53,7 @@ export const useProtocolChartData = (): ChartDayData[] | undefined => {
     () => fetchChartData(v3InfoClients[chainId]),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return chartData?.data ?? []
+  return useMemo(() => chartData?.data ?? [], [chartData])
 }
 
 export const useProtocolData = (): ProtocolData | undefined => {
@@ -77,7 +77,7 @@ export const useProtocolTransactionData = (): Transaction[] | undefined => {
     () => fetchTopTransactions(v3InfoClients[chainId]),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return data?.filter((d) => d.amountUSD > 0) ?? []
+  return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
 }
 
 export const useTokenPriceChartData = (
@@ -117,33 +117,37 @@ export const usePairPriceChartTokenData = (
 ): { data: PriceChartEntry[] | undefined; maxPrice?: number; minPrice?: number; averagePrice?: number } => {
   const chainName = useChainNameByQuery()
   const chainId = targetChainId || multiChainId[chainName]
-  const utcCurrentTime = dayjs()
-  const startTimestamp = utcCurrentTime
-    .subtract(1, duration ?? 'day')
-    .startOf('hour')
-    .unix()
 
   const { data } = useSWRImmutable(
     chainId &&
       address &&
       address !== 'undefined' && [`v3/info/token/pairPriceChartToken/${address}/${duration}`, targetChainId ?? chainId],
-    () =>
-      fetchPairPriceChartTokenData(
+    async () => {
+      const utcCurrentTime = dayjs()
+      const startTimestamp = utcCurrentTime
+        .subtract(1, duration ?? 'day')
+        .startOf('hour')
+        .unix()
+      return fetchPairPriceChartTokenData(
         address,
         DURATION_INTERVAL[duration ?? 'day'],
         startTimestamp,
         v3Clients[targetChainId ?? chainId],
         multiChainName[targetChainId ?? chainId],
         SUBGRAPH_START_BLOCK[chainId],
-      ),
+      )
+    },
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return {
-    data: data?.data ?? [],
-    maxPrice: data?.maxPrice,
-    minPrice: data?.minPrice,
-    averagePrice: data?.averagePrice,
-  }
+  return useMemo(
+    () => ({
+      data: data?.data ?? [],
+      maxPrice: data?.maxPrice,
+      minPrice: data?.minPrice,
+      averagePrice: data?.averagePrice,
+    }),
+    [data],
+  )
 }
 
 export async function fetchTopTokens(dataClient: GraphQLClient, blocks: Block[]) {
@@ -202,7 +206,7 @@ export const useTokensData = (addresses: string[], targetChainId?: ChainId): Tok
       ),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return data?.data ? Object.values(data?.data) : undefined
+  return useMemo(() => (data?.data ? Object.values(data?.data) : undefined), [data])
 }
 
 export const useTokenData = (address: string): TokenData | undefined => {
@@ -288,7 +292,7 @@ export const useTokenTransactions = (address: string): Transaction[] | undefined
     () => fetchTokenTransactions(address, v3InfoClients[chainId]),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return data?.data?.filter((d) => d.amountUSD > 0)
+  return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
 }
 
 export async function fetchTopPools(dataClient: GraphQLClient, chainId: ChainId, blocks: Block[]) {
@@ -348,7 +352,7 @@ export const usePoolsData = (addresses: string[]): PoolData[] | undefined => {
       ),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return data?.data ? Object.values(data.data) : undefined
+  return useMemo(() => (data?.data ? Object.values(data.data) : undefined), [data])
 }
 
 export const usePoolData = (address: string): PoolData | undefined => {
@@ -382,7 +386,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
     () => fetchPoolTransactions(address, v3InfoClients[chainId]),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )
-  return data?.data?.filter((d) => d.amountUSD > 0) ?? undefined
+  return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
 }
 
 export const usePoolChartData = (address: string): PoolChartEntry[] | undefined => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aee4188</samp>

### Summary
🐛🚀🧹

<!--
1.  🐛 - This emoji is often used to indicate bug fixes or typos, so it could represent the correction of the hook parameter.
2.  🚀 - This emoji is commonly used to signify performance improvements or optimizations, so it could represent the use of `useMemo` and the refactoring of `useSWR` callbacks.
3.  🧹 - This emoji is sometimes used to indicate code cleanup or refactoring, so it could represent the improved readability and consistency of the hook return values.
-->
Improved the performance and readability of some hooks related to V3 pair tokens price and info. Fixed a typo in `usePairTokensPrice` hook and refactored some `useSWR` callbacks to use `useMemo` and `async/await`.

> _`useMemo` saves time_
> _hooks return values refined_
> _autumn leaves fall fast_

### Walkthrough
*  Fix typo in `chainId` parameter of `usePairTokensPrice` hook and its callers ([link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-11c632dad7ad8c4c8fea0b8983fb21411f1fa15a4f1f314a86520c3d10f16a15L6-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-11c632dad7ad8c4c8fea0b8983fb21411f1fa15a4f1f314a86520c3d10f16a15L22-R22))
*  Wrap return values of various hooks in `useMemo` to improve performance and avoid unnecessary re-rendering ([link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-11c632dad7ad8c4c8fea0b8983fb21411f1fa15a4f1f314a86520c3d10f16a15L31-R39), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L56-R56), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L80-R80), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L138-R150), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L205-R209), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L291-R295), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L351-R355), [link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L385-R389))
*  Move `startTimestamp` calculation from `usePairPriceChartTokenData` hook to `useSWR` callback to avoid re-computing it on every render ([link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L120-L124))
*  Make `useSWR` callback for `usePairPriceChartTokenData` hook `async` and use `await` syntax for readability ([link](https://github.com/pancakeswap/pancake-frontend/pull/7619/files?diff=unified&w=0#diff-0e25f35a054e136faf680211a1d5776d2a4bd5b1ded2ccb46a2f20e26fd847a0L130-R131))


