### PR TITLE
feat: Add testnet subgraph

### DIFF
--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -9,6 +9,8 @@ export const SUPPORTED_CHAINS = [
   ChainId.BSC_TESTNET,
   ChainId.GOERLI,
   ChainId.ARBITRUM_ONE,
+  ChainId.SCROLL_SEPOLIA,
+  ChainId.BASE_TESTNET,
 ] as const
 
 export type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
@@ -20,6 +22,8 @@ export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
   [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
   [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
   [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
+  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
+  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
   [ChainId.LINEA_TESTNET]:
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
   [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -76,9 +76,9 @@ export const V3_SUBGRAPH_URLS = {
   [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync-testnet/version/latest',
   [ChainId.LINEA_TESTNET]:
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-  [ChainId.BASE_TESTNET]: null,
+  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
   [ChainId.OPBNB_TESTNET]: null,
-  [ChainId.SCROLL_SEPOLIA]: null,
+  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
 } satisfies Record<ChainId, string | null>
 
 export const TRADING_REWARD_API = 'https://pancake-trading-fee-rebate-api.pancakeswap.com/api/v1'

--- a/apps/web/src/state/swap/fetch/fetchDerivedPriceData.ts
+++ b/apps/web/src/state/swap/fetch/fetchDerivedPriceData.ts
@@ -55,8 +55,12 @@ const SWAP_INFO_BY_CHAIN = {
     v3: V3_SUBGRAPH_URLS[ChainId.LINEA_TESTNET],
   },
   [ChainId.OPBNB_TESTNET]: {},
-  [ChainId.BASE_TESTNET]: {},
-  [ChainId.SCROLL_SEPOLIA]: {},
+  [ChainId.BASE_TESTNET]: {
+    v3: V3_SUBGRAPH_URLS[ChainId.BASE_TESTNET],
+  },
+  [ChainId.SCROLL_SEPOLIA]: {
+    v3: V3_SUBGRAPH_URLS[ChainId.SCROLL_SEPOLIA],
+  },
 } satisfies Record<ChainId, Partial<ProtocolEndpoint>>
 
 export const getTokenBestTvlProtocol = async (tokenAddress: string, chainId: ChainId): Promise<Protocol | null> => {

--- a/apps/web/src/utils/graphql.ts
+++ b/apps/web/src/utils/graphql.ts
@@ -44,6 +44,8 @@ export const v3Clients = {
   [ChainId.ZKSYNC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ZKSYNC]),
   [ChainId.ZKSYNC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ZKSYNC_TESTNET]),
   [ChainId.LINEA_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.LINEA_TESTNET]),
+  [ChainId.BASE_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BASE_TESTNET]),
+  [ChainId.SCROLL_SEPOLIA]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.SCROLL_SEPOLIA]),
 }
 
 export const v3InfoClients = { ...v3Clients, [ChainId.BSC]: new GraphQLClient(V3_BSC_INFO_CLIENT) }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb0d31a</samp>

### Summary
🌐🔄🚀

<!--
1.  🌐 - This emoji represents the addition of new subgraph URLs for the testnets, which are web-based endpoints that provide access to the V3 protocol data.
2.  🔄 - This emoji represents the update of the `SWAP_INFO_BY_CHAIN` constant, which enables the app to use the V3 protocol for swapping tokens on the testnets.
3.  🚀 - This emoji represents the creation of new GraphQL clients for the testnets, which allow the app to query the V3 subgraphs and display the relevant information to the users.
-->
This pull request adds support for the V3 protocol on two new testnets, Scroll Sepolia and Base Testnet, to the app. It updates the `V3_SUBGRAPH_URLS`, `SUPPORTED_CHAINS`, and `SWAP_INFO_BY_CHAIN` constants, and the `v3Clients` function, with the relevant chain IDs and subgraph URLs.

> _We're breaking the chains of the old protocols_
> _We're summoning the subgraphs from the depths of the web_
> _We're routing the swaps with the power of GraphQL_
> _We're testing the limits on Scroll Sepolia and Base Testnet_

### Walkthrough
*  Add support for Scroll and Base testnets to the app ([link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR12-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR25-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L79-R81), [link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-dfa0d43a8db000e0c6466316afa72d83e8ce626238b0960dae8ecdf2de43bfc3L58-R63), [link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-9a18c7fa948e0139245c60f3160a24972b35b6960387ac74cbf7b4d9da9e26a5R47-R48))
  * Add new chain IDs and subgraph URLs for Scroll and Base testnets to `SUPPORTED_CHAINS` and `V3_SUBGRAPH_URLS` constants in `apis/routing/src/constants.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR12-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aR25-R26))
  * Update `V3_SUBGRAPH_URLS` constant in `apps/web/src/config/constants/endpoints.ts` to use the new subgraph URLs for Scroll and Base testnets ([link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L79-R81))
  * Update `SWAP_INFO_BY_CHAIN` constant in `apis/routing/src/constants.ts` to use the V3 protocol for Scroll and Base testnets ([link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-dfa0d43a8db000e0c6466316afa72d83e8ce626238b0960dae8ecdf2de43bfc3L58-R63))
  * Add new GraphQL clients for Scroll and Base testnets to the `v3Clients` function in `apps/web/src/utils/graphql.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7622/files?diff=unified&w=0#diff-9a18c7fa948e0139245c60f3160a24972b35b6960387ac74cbf7b4d9da9e26a5R47-R48))


