### PR TITLE
fix: Handle wrapped token info on swap detail modal

### DIFF
--- a/apps/web/src/views/Swap/MMLinkPools/components/TransactionConfirmSwapContent.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/TransactionConfirmSwapContent.tsx
@@ -81,6 +81,7 @@ const TransactionConfirmSwapContent = ({
       <SwapModalHeader
         inputAmount={trade.inputAmount}
         outputAmount={trade.outputAmount}
+        currencyBalances={currencyBalances}
         tradeType={trade.tradeType}
         priceImpactWithoutFee={priceImpactWithoutFee}
         allowedSlippage={<MMSlippageTolerance />}
@@ -93,6 +94,7 @@ const TransactionConfirmSwapContent = ({
     ) : null
   }, [
     priceImpactWithoutFee,
+    currencyBalances,
     onAcceptChanges,
     recipient,
     showAcceptChanges,

--- a/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
@@ -85,6 +85,7 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
         <SwapModalHeader
           inputAmount={trade.inputAmount}
           outputAmount={trade.outputAmount}
+          currencyBalances={currencyBalances}
           tradeType={trade.tradeType}
           priceImpactWithoutFee={priceImpactWithoutFee}
           allowedSlippage={allowedSlippage}
@@ -97,6 +98,7 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
       ) : null
     }, [
       priceImpactWithoutFee,
+      currencyBalances,
       allowedSlippage,
       onAcceptChanges,
       recipient,

--- a/apps/web/src/views/Swap/components/SwapModalHeader.tsx
+++ b/apps/web/src/views/Swap/components/SwapModalHeader.tsx
@@ -14,6 +14,7 @@ export default function SwapModalHeader({
   inputAmount,
   outputAmount,
   tradeType,
+  currencyBalances,
   priceImpactWithoutFee,
   slippageAdjustedAmounts,
   isEnoughInputBalance,
@@ -24,6 +25,10 @@ export default function SwapModalHeader({
 }: {
   inputAmount: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>
+  currencyBalances: {
+    INPUT?: CurrencyAmount<Currency>
+    OUTPUT?: CurrencyAmount<Currency>
+  }
   tradeType: TradeType
   priceImpactWithoutFee?: Percent
   slippageAdjustedAmounts: { [field in Field]?: CurrencyAmount<Currency> }
@@ -74,7 +79,11 @@ export default function SwapModalHeader({
     <AutoColumn gap="md">
       <RowBetween align="flex-end">
         <RowFixed gap="4px">
-          <CurrencyLogo currency={inputAmount.currency} size="24px" style={{ marginRight: '12px' }} />
+          <CurrencyLogo
+            currency={currencyBalances.INPUT?.currency ?? inputAmount.currency}
+            size="24px"
+            style={{ marginRight: '12px' }}
+          />
           <TruncatedText fontSize="24px" color={inputTextColor}>
             {formatAmount(inputAmount, 6)}
           </TruncatedText>
@@ -90,7 +99,7 @@ export default function SwapModalHeader({
       </RowFixed>
       <RowBetween align="flex-end">
         <RowFixed gap="4px">
-          <CurrencyLogo currency={outputAmount.currency} size="24px" />
+          <CurrencyLogo currency={currencyBalances.OUTPUT?.currency ?? outputAmount.currency} size="24px" />
           <TruncatedText
             fontSize="24px"
             color={


### PR DESCRIPTION
Use wrapped token info currency instead of trade to get the correct token logo

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7f979e3</samp>

### Summary
🔄📊🎨

<!--
1.  🔄 - This emoji represents the swapping functionality of the modal, as well as the fact that the component can handle different types of tokens, such as wrapped ones.
2.  📊 - This emoji represents the balance information that is displayed in the modal header, as well as the improved accuracy and clarity of the amounts.
3.  🎨 - This emoji represents the visual design and layout of the modal header, as well as the use of logos and symbols to identify the currencies.
-->
This pull request fixes the display of currency logos and balances in the swap modal header when swapping wrapped tokens. It adds a new prop `currencyBalances` to the `SwapModalHeader` component and passes it from the swap confirmation modal.

> _When swapping some tokens that wrap_
> _Like WBNB on the app_
> _We need to display_
> _The balances the right way_
> _So we pass `currencyBalances` to the `SwapModalHeader` prop_

### Walkthrough
*  Pass and use `currencyBalances` prop in `SwapModalHeader` component to handle wrapped tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aR17), [link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aR28-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aL77-R86), [link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aL93-R102), [link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7R88), [link](https://github.com/pancakeswap/pancake-frontend/pull/7635/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7R101))


