### PR TITLE
perf: Use account instead of full web3 react hook

### DIFF
--- a/apps/web/src/hooks/v3/useDerivedV3BurnInfo.ts
+++ b/apps/web/src/hooks/v3/useDerivedV3BurnInfo.ts
@@ -1,11 +1,11 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency, CurrencyAmount, Percent } from '@pancakeswap/sdk'
 import { Position } from '@pancakeswap/v3-sdk'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { useToken } from 'hooks/Tokens'
 import { ReactNode, useMemo } from 'react'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 import { PositionDetails } from '@pancakeswap/farms'
+import { useAccount } from 'wagmi'
 import { usePool } from './usePools'
 import { useV3PositionFees } from './useV3PositionFees'
 
@@ -24,7 +24,7 @@ export function useDerivedV3BurnInfo(
   error?: ReactNode
 } {
   const { t } = useTranslation()
-  const { account } = useWeb3React()
+  const { address: account } = useAccount()
 
   const token0 = useToken(position?.token0)
   const token1 = useToken(position?.token1)

--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -9,7 +9,6 @@ import {
   TICK_SPACINGS,
   TickMath,
 } from '@pancakeswap/v3-sdk'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ReactNode, useMemo } from 'react'
 import { Field } from 'state/mint/actions'
 import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
@@ -19,6 +18,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Bound } from 'config/constants/types'
 import { MintState } from 'views/AddLiquidityV3/formViews/V3FormView/form/reducer'
 
+import { useAccount } from 'wagmi'
 import { tryParseTick } from './utils'
 import { usePool } from './usePools'
 import { getTickToPrice } from './utils/getTickToPrice'
@@ -57,7 +57,7 @@ export default function useV3DerivedInfo(
 } {
   const { t } = useTranslation()
 
-  const { account } = useWeb3React()
+  const { address: account } = useAccount()
 
   const { independentField, typedValue, leftRangeTypedValue, rightRangeTypedValue, startPriceTypedValue } = formState
 

--- a/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/StatusView.tsx
+++ b/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/StatusView.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useTooltip, useMatchBreakpoints, LinkExternal, HelpIcon, Flex } from '@pancakeswap/uikit'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useMemo } from 'react'
 import { useTranslation } from '@pancakeswap/localization'
+import { useAccount } from 'wagmi'
 import { BoostStatus } from '../../hooks/bCakeV3/useBoostStatus'
 import { useBCakeBoostLimitAndLockInfo } from '../../hooks/bCakeV3/useBCakeV3Info'
 
@@ -29,7 +29,7 @@ export const StatusView: React.FC<{
 }> = ({ status, boostedMultiplier, isFarmStaking }) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const { targetRef, tooltip, tooltipVisible } = useTooltip(<BoosterTooltip />, {
     placement: 'top',
     ...(isMobile && { hideTimeout: 1500 }),
@@ -77,7 +77,7 @@ export const StatusView: React.FC<{
 }
 
 const useBCakeMessage = (
-  account: `0x${string}`,
+  account: `0x${string}` | undefined,
   isFarmStaking: boolean,
   locked: boolean,
   isLockEnd: boolean,

--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBoostStatus.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBoostStatus.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import { useAccount } from 'wagmi'
 import { useIsBoostedPool, useBakeV3farmCanBoost } from './useBCakeV3Info'
 
 export enum BoostStatus {
@@ -10,7 +10,7 @@ export enum BoostStatus {
 }
 
 export const useBoostStatus = (pid: number, tokenId?: string) => {
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const { isBoosted, mutate } = useIsBoostedPool(tokenId)
   const { farmCanBoost } = useBakeV3farmCanBoost(pid)
   const status = useMemo(() => {

--- a/apps/web/src/views/Swap/V3Swap/containers/FormMain.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/FormMain.tsx
@@ -16,6 +16,7 @@ import { useCurrencyBalances } from 'state/wallet/hooks'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 import { currencyId } from 'utils/currencyId'
 
+import { useAccount } from 'wagmi'
 import { FormContainer } from '../components'
 import useWarningImport from '../../hooks/useWarningImport'
 import { RiskCheck } from './RiskCheck'
@@ -32,7 +33,7 @@ interface Props {
 }
 
 export function FormMain({ pricingAndSlippage, inputAmount, outputAmount, tradeLoading, swapCommitButton }: Props) {
-  const { account } = useWeb3React()
+  const { address: account } = useAccount()
   const { t } = useTranslation()
   const warningSwapHandler = useWarningImport()
   const {

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapInputError.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapInputError.ts
@@ -2,12 +2,12 @@ import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/sdk'
 import { SmartRouterTrade } from '@pancakeswap/smart-router/evm'
 import { useTranslation } from '@pancakeswap/localization'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
-import { useWeb3React } from '@pancakeswap/wagmi'
 
 import { isAddress } from 'utils'
 import { Field } from 'state/swap/actions'
 import { useSwapState } from 'state/swap/hooks'
 
+import { useAccount } from 'wagmi'
 import { useSlippageAdjustedAmounts } from './useSlippageAdjustedAmounts'
 
 interface Balances {
@@ -37,7 +37,7 @@ export function useSwapInputError(
   currencyBalances: Balances,
 ): string {
   const { t } = useTranslation()
-  const { account } = useWeb3React()
+  const { address: account } = useAccount()
   const { independentField, typedValue } = useSwapState()
   const inputCurrency = currencyBalances[Field.INPUT]?.currency
   const outputCurrency = currencyBalances[Field.OUTPUT]?.currency

--- a/apps/web/src/views/TradingReward/components/Leaderboard/MyRank.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/MyRank.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
 import { Card, Table, Th, Td, Box, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { useTranslation } from '@pancakeswap/localization'
 import { useUserTradeRank } from 'views/TradingReward/hooks/useUserTradeRank'
 import DesktopResult from 'views/TradingReward/components/Leaderboard/DesktopResult'
 import MobileResult from 'views/TradingReward/components/Leaderboard/MobileResult'
+import { useAccount } from 'wagmi'
 
 interface MyRankProps {
   campaignId: string
@@ -12,7 +12,7 @@ interface MyRankProps {
 
 const MyRank: React.FC<React.PropsWithChildren<MyRankProps>> = ({ campaignId }) => {
   const { t } = useTranslation()
-  const { account } = useWeb3React()
+  const { address: account } = useAccount()
   const { isDesktop } = useMatchBreakpoints()
   const { data: userRank, isFetching } = useUserTradeRank({ campaignId })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b57e483</samp>

### Summary
🪙🧹🛠️

<!--
1.  🪙 - This emoji represents the use of the `useAccount` hook, which simplifies the access to the user's account and chain id information. It also suggests the theme of cryptocurrency and web3, which are relevant to the project.
2.  🧹 - This emoji represents the removal of unused imports and the simplification of the code, which makes it cleaner and more readable. It also suggests the idea of refactoring and improving the code quality.
3.  🛠️ - This emoji represents the refactoring of the `StatusView.tsx` file, which handles the case of undefined account and displays a different UI accordingly. It also suggests the idea of fixing bugs and enhancing the user experience.
-->
Refactored several hooks and components to use `useAccount` hook from `wagmi` library to simplify web3 account access. Removed unused imports and handled undefined account cases. Affected files include `useDerivedV3BurnInfo.ts`, `useV3DerivedInfo.ts`, `StatusView.tsx`, `useBoostStatus.ts`, `FormMain.tsx`, `useSwapInputError.ts`, and `MyRank.tsx`.

> _Oh we're the wagmi crew and we know what to do_
> _We use `useAccount` hook to get the web3 info_
> _We don't need `useWeb3React` anymore, it's true_
> _So we'll refactor all the code and make it clean and new_

### Walkthrough
*  Replace `useWeb3React` hook with `useAccount` hook from `wagmi` to simplify code and avoid importing entire web3 context ([link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-fb827c87f73221da8bd6927d283ff67b2ec21e403f647fd937d488b65d2ae5e3L27-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-17478fda6073470e29ee11762c55326142e799cbe063d0c9ad51e22248a69698L60-R60), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-7cb53caa323b303423decd85daaa8f38294f56b748e0fe576b6c4d4f12a58a6cL32-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-168a0e522293e1e3abad64dd27ead7fb9c33743551241ed4cc93e076610d2697L13-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-e426210e288cb7f95ebbf5e3dfc81beb2d0a8d36d1a681465560b1f6c8e5d43dL35-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-90eea299b155dad5e69ea8463328b0c10374922728a1233b840d478b5c8b1a4cL40-R40), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-162db74c38bd881f81ea3cac99f47db4187271b391e0d9c51d9bfab08cd5ce43L15-R15))
* Remove unused import of `useWeb3React` from `@pancakeswap/wagmi` in various files ([link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-fb827c87f73221da8bd6927d283ff67b2ec21e403f647fd937d488b65d2ae5e3L4-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-17478fda6073470e29ee11762c55326142e799cbe063d0c9ad51e22248a69698L12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-7cb53caa323b303423decd85daaa8f38294f56b748e0fe576b6c4d4f12a58a6cL2-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-168a0e522293e1e3abad64dd27ead7fb9c33743551241ed4cc93e076610d2697L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-90eea299b155dad5e69ea8463328b0c10374922728a1233b840d478b5c8b1a4cL5))
* Add import of `useAccount` from `wagmi` in files where it is used to get user's account address ([link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-17478fda6073470e29ee11762c55326142e799cbe063d0c9ad51e22248a69698R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-e426210e288cb7f95ebbf5e3dfc81beb2d0a8d36d1a681465560b1f6c8e5d43dR19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-90eea299b155dad5e69ea8463328b0c10374922728a1233b840d478b5c8b1a4cR10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-162db74c38bd881f81ea3cac99f47db4187271b391e0d9c51d9bfab08cd5ce43L3-R7))
* Change type of `account` parameter in `useBCakeMessage` function to allow for undefined value in `StatusView.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7640/files?diff=unified&w=0#diff-7cb53caa323b303423decd85daaa8f38294f56b748e0fe576b6c4d4f12a58a6cL80-R80))


