### PR TITLE
chore: fix linea banner details

### DIFF
--- a/apps/web/src/views/Home/components/Banners/LineaBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/LineaBanner.tsx
@@ -65,7 +65,7 @@ const BgWrapper = styled.div`
     > span:first-child {
       position: relative !important;
       right: 0px;
-      top: 20px;
+      top: 22px;
     }
   }
 `


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b21cdf</samp>

### Summary
🎨🖼️📱

<!--
1.  🎨 - This emoji is often used to indicate changes related to UI design, layout, or aesthetics. Increasing the `top` property of the `BgWrapper` is a design-related change that affects how the banner looks on the screen.
2.  🖼️ - This emoji is sometimes used to indicate changes related to images, graphics, or icons. Changing the `BgWrapper` also affects the background image of the banner, which is a graphical element of the UI.
3.  📱 - This emoji is commonly used to indicate changes related to responsiveness, compatibility, or adaptation for different devices or screen sizes. Adjusting the `top` property of the `BgWrapper` is a change that improves the responsiveness of the banner for different screen sizes.
-->
Adjusted the background image alignment of the `LineaBanner` component. Modified the `top` property of the `BgWrapper` styled component in `LineaBanner.tsx`.

> _`BgWrapper` shifts_
> _Aligning the image better_
> _A springtime refresh_

### Walkthrough
*  Increase the `top` property of the `BgWrapper` styled component to align the background image in the `LineaBanner` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7641/files?diff=unified&w=0#diff-335952fd034a2136987825398dfdbf3356c35cd0ab5f3a465a5b507bb9ee3882L68-R68))


