### PR TITLE
feat: Customized v3 pool fallbacks and tvl references

### DIFF
--- a/.changeset/stupid-walls-cheer.md
+++ b/.changeset/stupid-walls-cheer.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': minor
+---
+
+Add support for building v3 pool fetcher with customized fallbacks and source of pool tvl references

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/README.md
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/README.md
@@ -1,0 +1,52 @@
+# Pool Providers
+
+## V3 Pool Providers
+
+### How to setup a customized v3 pool provider?
+
+1. Define v3 pool on-chain fetcher with customized tvl references
+
+Pool tvl references are necessary for us to pick the candidate pools to participate the route calculation.
+
+Sometimes the service from the graph might be unstable so you may want to use your own source of pool tvl references.
+
+```typescript
+import { v3PoolsOnChainProviderFactory } from '@pancakeswap/smart-router/evm'
+
+// For the detailed params type definition pls refer to `GetV3CandidatePoolsParams`
+const getV3PoolsWithCustomizedTvlReferences = v3PoolsOnChainProviderFactory((params) => {
+  // Get pools tvl references based on input/output currencies
+  // or currency pairs specified by the function caller
+  const { currencyA, currencyB, pairs } = params
+
+  // For the return type pls refer to `V3PoolTvlReference` exported by the smart router
+  // NOTE: the return type should be a promise
+  return getTvlReferencesFromOwnSource(currencyA, currencyB, pairs)
+})
+```
+
+2. Build v3 pool fetcher with customized fallbacks
+
+In case your customized v3 pool fetcher suffers downtime, you can specify several fallback fetchers to guarantee the reliability of your service.
+
+```typescript
+import {
+  createGetV3CandidatePoolsWithFallbacks,
+  getV3PoolsWithTvlFromOnChainFallback,
+} from '@pancakeswap/smart-router/evm'
+
+const getV3CandidatePools = createGetV3CandidatePoolsWithFallbacks(
+  // Use your customized v3 pool fetcher by default
+  getV3PoolsWithCustomizedTvlReferences,
+  {
+    fallbacks: [getV3PoolsWithTvlFromOnChainFallback],
+
+    // In millisecond
+    // Will try fallback fetcher if the default doesn't respond in 2s
+    fallbackTimeout: 2000,
+  },
+)
+
+// For the detailed params type definition pls refer to `GetV3CandidatePoolsParams`
+const v3Pools = await getV3CandidatePools(params)
+```

--- a/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
+++ b/packages/smart-router/evm/v3-router/providers/poolProviders/getV3CandidatePools.ts
@@ -9,7 +9,7 @@ import { getPairCombinations } from '../../functions'
 import { v3PoolTvlSelector } from './poolTvlSelectors'
 import { getV3PoolsWithoutTicksOnChain } from './onChainPoolProviders'
 
-interface Params {
+export type GetV3CandidatePoolsParams = {
   currencyA?: Currency
   currencyB?: Currency
 
@@ -20,7 +20,9 @@ interface Params {
 
   // Only use this param if we want to specify pairs we want to get
   pairs?: [Currency, Currency][]
+}
 
+type DefaultParams = GetV3CandidatePoolsParams & {
   // In millisecond
   fallbackTimeout?: number
   subgraphFallback?: boolean
@@ -28,7 +30,7 @@ interface Params {
   staticFallback?: boolean
 }
 
-interface V3PoolTvlReference extends Pick<V3PoolWithTvl, 'address'> {
+export interface V3PoolTvlReference extends Pick<V3PoolWithTvl, 'address'> {
   tvlUSD: bigint | string
 }
 
@@ -42,7 +44,7 @@ const getV3PoolTvl = memoize(
 
 // Get pools from onchain and use the tvl data from subgraph as reference
 // The reason we do this is the data from subgraph might delay
-const v3PoolsOnChainProviderFactory = <P extends Params = Params>(
+export const v3PoolsOnChainProviderFactory = <P extends GetV3CandidatePoolsParams = GetV3CandidatePoolsParams>(
   tvlReferenceProvider: (params: P) => Promise<V3PoolTvlReference[]>,
 ) => {
   return async function getV3PoolsWithTvlFromOnChain(params: P): Promise<V3PoolWithTvl[]> {
@@ -72,7 +74,7 @@ const v3PoolsOnChainProviderFactory = <P extends Params = Params>(
   }
 }
 
-export const getV3PoolsWithTvlFromOnChain = v3PoolsOnChainProviderFactory((params: Params) => {
+export const getV3PoolsWithTvlFromOnChain = v3PoolsOnChainProviderFactory((params: GetV3CandidatePoolsParams) => {
   const { currencyA, currencyB, pairs: providedPairs, subgraphProvider } = params
   const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
   return getV3PoolSubgraph({ provider: subgraphProvider, pairs })
@@ -80,7 +82,7 @@ export const getV3PoolsWithTvlFromOnChain = v3PoolsOnChainProviderFactory((param
 
 const createFallbackTvlRefGetter = () => {
   const cache = new Map<ChainId, V3PoolTvlReference[]>()
-  return async (params: Params) => {
+  return async (params: GetV3CandidatePoolsParams) => {
     const { currencyA } = params
     if (!currencyA?.chainId) {
       throw new Error(`Cannot get tvl references at chain ${currencyA?.chainId}`)
@@ -99,60 +101,73 @@ const createFallbackTvlRefGetter = () => {
 export const getV3PoolsWithTvlFromOnChainFallback = v3PoolsOnChainProviderFactory(createFallbackTvlRefGetter())
 
 export const getV3PoolsWithTvlFromOnChainStaticFallback = v3PoolsOnChainProviderFactory<
-  Omit<Params, 'subgraphProvider' | 'onChainProvider'>
+  Omit<GetV3CandidatePoolsParams, 'subgraphProvider' | 'onChainProvider'>
 >(() => Promise.resolve([]))
 
-export async function getV3CandidatePools(params: Params) {
-  const {
-    currencyA,
-    currencyB,
-    pairs: providedPairs,
-    subgraphProvider,
-    subgraphFallback = true,
-    subgraphCacheFallback = true,
-    staticFallback = true,
-    fallbackTimeout: timeout = 3000,
-  } = params
-  const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
+type GetV3CandidatePools = (params: GetV3CandidatePoolsParams) => Promise<V3PoolWithTvl[]>
 
-  const calls: AsyncCall<() => Promise<V3PoolWithTvl[]>>[] = [
-    // Try get pools from on chain and ref tvl by subgraph
-    {
-      asyncFn: () => getV3PoolsWithTvlFromOnChain(params),
+type V3PoolsWithFallbackFactoryOptions = {
+  // Order matters for fallbacks
+  fallbacks?: GetV3CandidatePools[]
+
+  // In millisecond
+  fallbackTimeout?: number
+}
+
+export function createGetV3CandidatePoolsWithFallbacks(
+  defaultGetV3Pools: GetV3CandidatePools,
+  options?: V3PoolsWithFallbackFactoryOptions,
+) {
+  const { fallbacks = [], fallbackTimeout: timeout = 3000 } = options || {}
+
+  return async function getV3Pools(params: GetV3CandidatePoolsParams) {
+    const { currencyA, currencyB } = params
+    const calls: AsyncCall<(params: GetV3CandidatePoolsParams) => Promise<V3PoolWithTvl[]>>[] = [
+      defaultGetV3Pools,
+      ...fallbacks,
+    ].map((asyncFn) => ({
+      asyncFn,
       timeout,
-    },
-  ]
+    }))
+    const getV3PoolsWithFallback = withFallback(calls)
+    const pools = await getV3PoolsWithFallback(params)
+    return v3PoolTvlSelector(currencyA, currencyB, pools)
+  }
+}
 
+export async function getV3CandidatePools(params: DefaultParams) {
+  const {
+    subgraphCacheFallback = true,
+    subgraphFallback = true,
+    staticFallback = true,
+    fallbackTimeout,
+    ...rest
+  } = params
+
+  const fallbacks: GetV3CandidatePools[] = []
+  // Fallback to get pools from on chain and ref tvl by subgraph cache
   if (subgraphCacheFallback) {
-    calls.push(
-      // Fallback to get pools from on chain and ref tvl by subgraph cache
-      {
-        asyncFn: () => getV3PoolsWithTvlFromOnChainFallback(params),
-        timeout,
-      },
-    )
+    fallbacks.push(getV3PoolsWithTvlFromOnChainFallback)
   }
 
+  // Fallback to get all pools info from subgraph
   if (subgraphFallback) {
-    calls.push(
-      // Fallback to get all pools info from subgraph
-      {
-        asyncFn: () => getV3PoolSubgraph({ provider: subgraphProvider, pairs }),
-        timeout,
-      },
-    )
+    fallbacks.push(async (p) => {
+      const { currencyA, currencyB, pairs: providedPairs, subgraphProvider } = p
+      const pairs = providedPairs || getPairCombinations(currencyA, currencyB)
+      return getV3PoolSubgraph({ provider: subgraphProvider, pairs })
+    })
   }
 
+  // Fallback to get pools from on chain and static ref
   if (staticFallback) {
-    calls.push(
-      // Fallback to get pools from on chain and static ref
-      {
-        asyncFn: () => getV3PoolsWithTvlFromOnChainStaticFallback(params),
-      },
-    )
+    fallbacks.push(getV3PoolsWithTvlFromOnChainStaticFallback)
   }
 
-  const getPools = withFallback(calls)
-  const pools = await getPools()
-  return v3PoolTvlSelector(currencyA, currencyB, pools)
+  // Deafult try get pools from on chain and ref tvl by subgraph
+  const getV3PoolsWithFallback = createGetV3CandidatePoolsWithFallbacks(getV3PoolsWithTvlFromOnChain, {
+    fallbacks,
+    fallbackTimeout,
+  })
+  return getV3PoolsWithFallback(rest)
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad41eab</samp>

### Summary
🎁📝♻️

<!--
1.  🎁 - This emoji represents a new feature or enhancement, which is appropriate for the addition of the v3 pool fetcher with customized fallbacks and source of pool tvl references. This is a useful feature for developers who want to integrate the smart router with different v3 pool data providers or fallback strategies.
2. 📝 - This emoji represents a documentation update, which is suitable for the addition of the README file that explains how to use the new feature. This is helpful for users who want to learn more about the v3 pool provider options and how to customize them.
3. ♻️ - This emoji represents a code refactoring or improvement, which is relevant for the code changes that simplify and modularize the v3 pool fetching logic. This is beneficial for the code quality and maintainability, as well as for the reusability of some types and functions.
-->
This pull request improves the `@pancakeswap/smart-router` package by adding more flexibility and reliability to the v3 pool fetching logic. It refactors the `getV3CandidatePools` function and exports some types and helper functions. It also adds a changeset file and a README file to document the changes and usage.

> _To update the smart router package_
> _We added a changeset to track it_
> _We also wrote a README_
> _To show how to use `poolProviders`_
> _And refactored the code for `v3PoolsOnChainProviderFactory`_

### Walkthrough
*  Add a changeset file to document the minor update of the `@pancakeswap/smart-router` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-0287435c2d258ec2b5815c526eeeeaf70042f8be2d84d6ca08acd4a3b35b48e5R1-R5))
*  Export new types and functions from `getV3CandidatePools.ts` to support customized v3 pool fetchers ([link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L12-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L23-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L31-R33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L45-R47))
*  Refactor `getV3CandidatePools` function to use `createGetV3CandidatePoolsWithFallbacks` function, which allows users to specify their own fallback v3 pool fetchers ([link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L102-R166))
*  Update default and fallback v3 pool fetchers to use the `GetV3CandidatePoolsParams` type instead of the `Params` type ([link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L75-R77), [link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-fa32b8286269fa2eec559aad9b5bb720b82b1435d77d45c3992d04a0cee540d1L83-R85))
*  Add a README file to explain how to setup a customized v3 pool provider using the exported functions from `getV3CandidatePools.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7646/files?diff=unified&w=0#diff-9e4aaf3d4f24ce46b175b7d023572b8b5640d3913b40aa10ef8f556dc287ccd9R1-R52))


