### PR TITLE
fix: buy crypto small changes

### DIFF
--- a/apps/web/src/components/Card/index.tsx
+++ b/apps/web/src/components/Card/index.tsx
@@ -30,7 +30,8 @@ export const LightGreyCard = styled(Card)`
 
 export const CryptoCard = styled(Card)<{ isClicked: boolean; isDisabled: boolean }>`
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
-  background-color: ${({ theme, isClicked }) => (isClicked ? theme.colors.input : 'transparent')};
+  background-color: ${({ theme, isClicked }) =>
+    isClicked ? theme.colors.input : theme.isDark ? theme.colors.backgroundAlt : theme.colors.background};
   transition: height 0.4s ease-in-out, background-color 0.1s ease-in-out;
   overflow: hidden;
   &:hover {

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -13,7 +13,12 @@ import {
 } from '@pancakeswap/uikit'
 import { LoadingDot } from '@pancakeswap/uikit/src/widgets/Liquidity'
 import { CommitButton } from 'components/CommitButton'
-import { MERCURYO_WIDGET_ID, MOONPAY_SIGN_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
+import {
+  MERCURYO_WIDGET_ID,
+  MERCURYO_WIDGET_URL,
+  MOONPAY_SIGN_URL,
+  ONRAMP_API_BASE_URL,
+} from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import Script from 'next/script'
 import { Dispatch, ReactNode, SetStateAction, memo, useCallback, useEffect, useState } from 'react'
@@ -109,7 +114,7 @@ const fetchMoonPaySignedUrl = async (
   try {
     const baseCurrency = `${inputCurrency.toLowerCase()}${moonapyCurrencyChainidentifier[chainId]}`
 
-    const res = await fetch(`${MOONPAY_SIGN_URL}/generate-moonpay-sig`, {
+    const res = await fetch(`${ONRAMP_API_BASE_URL}/generate-moonpay-sig`, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
@@ -124,6 +129,7 @@ const fetchMoonPaySignedUrl = async (
         theme: isDark ? 'dark' : 'light',
         showOnlyCurrencies: supportedTokenMap[chainId].moonPayTokens,
         walletAddress: account,
+        isTestEnv: true,
       }),
     })
     const result: FetchResponse = await res.json()
@@ -333,7 +339,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
         )}
       </ModalWrapper>
       <Script
-        src="https://widget.mercuryo.io/embed.2.0.js"
+        src={MERCURYO_WIDGET_URL}
         onLoad={() => {
           setScriptOnLoad(true)
         }}

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -208,9 +208,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
     onDismiss?.()
     setModalView(CryptoFormView.Input)
     try {
-      const moonpayCustomerResponse = await fetch(
-        `https://pcs-on-ramp-api.com/checkItem?searchAddress=${account.address}`,
-      )
+      const moonpayCustomerResponse = await fetch(`${ONRAMP_API_BASE_URL}/checkItem?searchAddress=${account.address}`)
       const moonpayCustomerResult = await moonpayCustomerResponse.json()
       onIsNewCustomer(!moonpayCustomerResult.found)
     } catch (err) {
@@ -269,7 +267,6 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
   useEffect(() => {
     if (provider === ONRAMP_PROVIDERS.Mercuryo) {
       if (sig && window?.mercuryoWidget) {
-        console.log(MERCURYO_WIDGET_ID, MERCURYO_WIDGET_URL)
         const transactonId = generateRandomString(20)
         // @ts-ignore
         const MC_WIDGET = window?.mercuryoWidget

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -269,6 +269,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
   useEffect(() => {
     if (provider === ONRAMP_PROVIDERS.Mercuryo) {
       if (sig && window?.mercuryoWidget) {
+        console.log(MERCURYO_WIDGET_ID, MERCURYO_WIDGET_URL)
         const transactonId = generateRandomString(20)
         // @ts-ignore
         const MC_WIDGET = window?.mercuryoWidget

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -130,7 +130,7 @@ const fetchMoonPaySignedUrl = async (
         theme: isDark ? 'dark' : 'light',
         showOnlyCurrencies: supportedTokenMap[chainId].moonPayTokens,
         walletAddress: account,
-        isTestEnv: true,
+        isTestEnv: window.location.origin.includes('https') ? 'false' : 'true',
       }),
     })
     const result: FetchResponse = await res.json()

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -13,12 +13,7 @@ import {
 } from '@pancakeswap/uikit'
 import { LoadingDot } from '@pancakeswap/uikit/src/widgets/Liquidity'
 import { CommitButton } from 'components/CommitButton'
-import {
-  MERCURYO_WIDGET_ID,
-  MERCURYO_WIDGET_URL,
-  MOONPAY_SIGN_URL,
-  ONRAMP_API_BASE_URL,
-} from 'config/constants/endpoints'
+import { MERCURYO_WIDGET_ID, MERCURYO_WIDGET_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import Script from 'next/script'
 import { Dispatch, ReactNode, SetStateAction, memo, useCallback, useEffect, useState } from 'react'
@@ -35,6 +30,7 @@ import {
 import { CryptoFormView } from 'views/BuyCrypto/types'
 import { ErrorText } from 'views/Swap/components/styleds'
 import { useAccount } from 'wagmi'
+import crypto from 'crypto'
 
 export const StyledIframe = styled.iframe<{ isDark: boolean }>`
   height: 90%;
@@ -90,6 +86,11 @@ interface FiatOnRampProps {
 
 interface FetchResponse {
   urlWithSignature: string
+}
+
+function generateRandomString(length) {
+  const randomBytes = crypto.randomBytes(length)
+  return randomBytes.toString('hex') // 'hex' encoding converts bytes to a hexadecimal string
 }
 
 const LoadingBuffer = () => {
@@ -268,6 +269,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
   useEffect(() => {
     if (provider === ONRAMP_PROVIDERS.Mercuryo) {
       if (sig && window?.mercuryoWidget) {
+        const transactonId = generateRandomString(20)
         // @ts-ignore
         const MC_WIDGET = window?.mercuryoWidget
         MC_WIDGET.run({
@@ -284,6 +286,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
           address: account.address,
           signature: sig,
           network: chainIdToNetwork[chainId],
+          merchantTransactionId: `${account.address}_${transactonId}`,
           host: document.getElementById('mercuryo-widget'),
           theme: theme.isDark ? 'PCS_dark' : 'PCS_light',
         })

--- a/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
+++ b/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
@@ -30,6 +30,7 @@ import { useDomainNameForAddress } from 'hooks/useDomain'
 import { isMobile } from 'react-device-detect'
 import { useState } from 'react'
 import InternalLink from 'components/Links'
+import { SUPPORT_BUY_CRYPTO } from 'config/constants/supportChains'
 import CakeBenefitsCard from './CakeBenefitsCard'
 
 const COLORS = {
@@ -90,6 +91,9 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
     },
   )
 
+  const showBscEntryPoint = Number(bnbBalance?.data?.value) === 0 && SUPPORT_BUY_CRYPTO.includes(chainId)
+  const showNativeEntryPoint = Number(nativeBalance?.data?.value) === 0 && SUPPORT_BUY_CRYPTO.includes(chainId)
+
   return (
     <>
       <Text color="secondary" fontSize="12px" textTransform="uppercase" fontWeight="bold" mb="8px">
@@ -99,7 +103,7 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
         <CopyAddress tooltipMessage={t('Copied')} account={account} />
         {domainName ? <Text color="textSubtle">{domainName}</Text> : null}
       </FlexGap>
-      {hasLowNativeBalance && (
+      {hasLowNativeBalance && SUPPORT_BUY_CRYPTO.includes(chainId) && (
         <Message variant="warning" mb="24px">
           <Box>
             <Text fontWeight="bold">
@@ -137,7 +141,25 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
             {!nativeBalance.isFetched ? (
               <Skeleton height="22px" width="60px" />
             ) : (
-              nativeBalance && <Text>{formatBigInt(nativeBalance?.data?.value ?? 0n, 6)}</Text>
+              <Flex>
+                <Text
+                  color={showNativeEntryPoint ? 'warning' : 'text'}
+                  fontWeight={showNativeEntryPoint ? 'bold' : 'normal'}
+                >
+                  {formatBigInt(nativeBalance?.data?.value ?? 0n, 6)}
+                </Text>
+                {showNativeEntryPoint ? (
+                  <TooltipText
+                    ref={buyCryptoTargetRef}
+                    onClick={() => setMobileTooltipShow(false)}
+                    display="flex"
+                    style={{ justifyContent: 'center' }}
+                  >
+                    <InfoFilledIcon pl="2px" fill="#000" color="#D67E0A" width="22px" />
+                  </TooltipText>
+                ) : null}
+                {buyCryptoTooltipVisible && (!isMobile || mobileTooltipShow) && buyCryptoTooltip}
+              </Flex>
             )}
           </Flex>
           {wNativeBalance && wNativeBalance.gt(0) && (
@@ -176,21 +198,21 @@ const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss 
             ) : (
               <Flex alignItems="center" justifyContent="center">
                 <Text
-                  fontWeight={Number(bnbBalance?.data?.value) === 0 ? 'bold' : 'normal'}
-                  color={Number(bnbBalance?.data?.value) === 0 ? 'warning' : 'normal'}
+                  fontWeight={showBscEntryPoint ? 'bold' : 'normal'}
+                  color={showBscEntryPoint ? 'warning' : 'normal'}
                 >
                   {formatBigInt(bnbBalance?.data?.value ?? 0n, 6)}
                 </Text>
-                <TooltipText
-                  ref={buyCryptoTargetRef}
-                  onClick={() => setMobileTooltipShow(false)}
-                  display="flex"
-                  style={{ justifyContent: 'center' }}
-                >
-                  {Number(bnbBalance?.data?.value) === 0 ? (
+                {showBscEntryPoint ? (
+                  <TooltipText
+                    ref={buyCryptoTargetRef}
+                    onClick={() => setMobileTooltipShow(false)}
+                    display="flex"
+                    style={{ justifyContent: 'center' }}
+                  >
                     <InfoFilledIcon pl="2px" fill="#000" color="#D67E0A" width="22px" />
-                  ) : null}
-                </TooltipText>
+                  </TooltipText>
+                ) : null}
                 {buyCryptoTooltipVisible && (!isMobile || mobileTooltipShow) && buyCryptoTooltip}
               </Flex>
             )}

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -91,5 +91,8 @@ export const MERCURYO_WIDGET_ID = process.env.NEXT_PUBLIC_MERCURYO_WIDGET_ID || 
 
 export const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_LIVE_KEY || 'pk_test_1Ibe44lMglFVL8COOYO7SEKnIBrzrp54'
 
+// no need for extra public env
 export const MERCURYO_WIDGET_URL =
-  process.env.NEXT_PUBLIC_MERCURYO_WIDGET_URL || 'https://sandbox-widget.mrcr.io/embed.2.0.js'
+  typeof window !== 'undefined' && window.location.origin.includes('https')
+    ? 'https://widget.mercuryo.io/embed.2.0.js'
+    : 'https://sandbox-widget.mrcr.io/embed.2.0.js'

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -88,6 +88,9 @@ export const QUOTING_API = `${process.env.NEXT_PUBLIC_QUOTING_API}/v0/quote`
 
 export const FARMS_API = 'https://farms-api.pancakeswap.com'
 
-export const MERCURYO_WIDGET_ID = process.env.NEXT_PUBLIC_MERCURYO_WIDGET_ID || '76ba4ff5-2686-4ed4-8666-fadb0d9a5888'
+export const MERCURYO_WIDGET_ID = process.env.NEXT_PUBLIC_MERCURYO_WIDGET_ID || '64d1f9f9-85ee-4558-8168-1dc0e7057ce6'
 
 export const MOONPAY_API_KEY = process.env.NEXT_PUBLIC_MOONPAY_LIVE_KEY || 'pk_test_1Ibe44lMglFVL8COOYO7SEKnIBrzrp54'
+
+export const MERCURYO_WIDGET_URL =
+  process.env.NEXT_PUBLIC_MERCURYO_WIDGET_URL || 'https://sandbox-widget.mrcr.io/embed.2.0.js'

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -13,7 +13,6 @@ export const SNAPSHOT_HUB_API = `${SNAPSHOT_BASE_URL}/api/message`
 export const GRAPH_API_POTTERY = 'https://api.thegraph.com/subgraphs/name/pancakeswap/pottery'
 export const ONRAMP_API_BASE_URL = 'https://pcs-on-ramp-api.com'
 export const MOONPAY_BASE_URL = 'https://api.moonpay.com'
-export const MOONPAY_SIGN_URL = 'https://pcs-on-ramp-api.com'
 /**
  * V1 will be deprecated but is still used to claim old rounds
  */

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -11,7 +11,7 @@ export const API_NFT = 'https://nft.pancakeswap.com/api/v1'
 export const SNAPSHOT_API = `${SNAPSHOT_BASE_URL}/graphql`
 export const SNAPSHOT_HUB_API = `${SNAPSHOT_BASE_URL}/api/message`
 export const GRAPH_API_POTTERY = 'https://api.thegraph.com/subgraphs/name/pancakeswap/pottery'
-export const ONRAMP_API_BASE_URL = 'https://pcs-onramp-api.com'
+export const ONRAMP_API_BASE_URL = 'https://pcs-on-ramp-api.com'
 export const MOONPAY_BASE_URL = 'https://api.moonpay.com'
 export const MOONPAY_SIGN_URL = 'https://pcs-on-ramp-api.com'
 /**

--- a/apps/web/src/views/BuyCrypto/components/AccordianDropdown/AccordianItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordianDropdown/AccordianItem.tsx
@@ -108,7 +108,7 @@ function AccordionItem({
             >
               <Flex alignItems="center" justifyContent="center">
                 <Text ml="4px" fontSize="14px" color="textSubtle">
-                  Quote not available
+                  {t('Quote not available')}
                 </Text>
                 <InfoIcon color="textSubtle" pl="4px" pt="2px" />
               </Flex>

--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -23,10 +23,11 @@ const usePriceQuotes = () => {
     async (combinedData: ProviderQoute[], isNew: boolean) => {
       let sortedFilteredQuotes = combinedData
       try {
-        if (userIp) {
+        // skip for now
+        if (!userIp) {
           const providerAvailabilities = await fetchProviderAvailabilities({ userIp })
           sortedFilteredQuotes = combinedData.filter((quote: ProviderQoute) => {
-            return true
+            return providerAvailabilities[quote.provider]
           })
         }
         if (!isNew) {

--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -23,8 +23,7 @@ const usePriceQuotes = () => {
     async (combinedData: ProviderQoute[], isNew: boolean) => {
       let sortedFilteredQuotes = combinedData
       try {
-        // skip for now
-        if (!userIp) {
+        if (userIp) {
           const providerAvailabilities = await fetchProviderAvailabilities({ userIp })
           sortedFilteredQuotes = combinedData.filter((quote: ProviderQoute) => {
             return providerAvailabilities[quote.provider]

--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -26,7 +26,7 @@ const usePriceQuotes = () => {
         if (userIp) {
           const providerAvailabilities = await fetchProviderAvailabilities({ userIp })
           sortedFilteredQuotes = combinedData.filter((quote: ProviderQoute) => {
-            return providerAvailabilities[quote.provider]
+            return true
           })
         }
         if (!isNew) {

--- a/apps/web/src/views/BuyCrypto/hooks/useProviderAvailability.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/useProviderAvailability.ts
@@ -1,4 +1,4 @@
-import { MOONPAY_SIGN_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
+import { ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 
 // will cleanup urls later
 export async function fetchMoonpayAvailability(userIp: string): Promise<Response> {
@@ -27,7 +27,7 @@ export async function fetchMercuryoAvailability(userIp: string): Promise<Respons
 
 export async function fetchProviderAvailabilities(payload): Promise<{ [provider: string]: boolean }> {
   // Fetch data from endpoint 1
-  const response = await fetch(`${MOONPAY_SIGN_URL}/fetch-provider-availability`, {
+  const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-provider-availability`, {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/apps/web/src/views/BuyCrypto/hooks/useProviderAvailability.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/useProviderAvailability.ts
@@ -1,30 +1,5 @@
 import { ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 
-// will cleanup urls later
-export async function fetchMoonpayAvailability(userIp: string): Promise<Response> {
-  // Fetch data from endpoint 1
-  const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-moonpay-availability?userIp=${userIp}`, {
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  })
-  const result = response.json()
-  return result
-}
-
-export async function fetchMercuryoAvailability(userIp: string): Promise<Response> {
-  // Fetch data from endpoint 2
-  const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-mercuryo-availability?userIp=${userIp}`, {
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  })
-  const result = response.json()
-  return result
-}
-
 export async function fetchProviderAvailabilities(payload): Promise<{ [provider: string]: boolean }> {
   // Fetch data from endpoint 1
   const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-provider-availability`, {

--- a/apps/web/src/views/BuyCrypto/hooks/useProviderQuotes.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/useProviderQuotes.ts
@@ -1,20 +1,5 @@
-import { MOONPAY_API_KEY, MOONPAY_BASE_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
+import { ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 import { ProviderQoute } from '../types'
-
-export async function fetchMoonpayQuote(baseAmount: number, currencyCode: string, outputCurrency: string) {
-  // Fetch data from endpoint 1
-  const response = await fetch(
-    `${MOONPAY_BASE_URL}/v3/currencies/${outputCurrency.toLowerCase()}/buy_quote/?apiKey=${MOONPAY_API_KEY}&baseCurrencyAmount=${baseAmount}&&baseCurrencyCode=${currencyCode.toLowerCase()}`,
-    {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-    },
-  )
-  const result = response.json()
-  return result
-}
 
 export async function fetchProviderQuotes(payload): Promise<ProviderQoute[]> {
   // Fetch data from endpoint 1
@@ -28,18 +13,4 @@ export async function fetchProviderQuotes(payload): Promise<ProviderQoute[]> {
   })
   const result = await response.json()
   return result.result
-}
-
-export async function fetchMercuryoQuote(payload: any) {
-  // Fetch data from endpoint 2
-  const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-mercuryo-quote`, {
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify(payload),
-  })
-  const result = await response.json()
-  return result.result.result
 }

--- a/apps/web/src/views/BuyCrypto/hooks/useProviderQuotes.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/useProviderQuotes.ts
@@ -1,4 +1,4 @@
-import { MOONPAY_API_KEY, MOONPAY_BASE_URL, MOONPAY_SIGN_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
+import { MOONPAY_API_KEY, MOONPAY_BASE_URL, ONRAMP_API_BASE_URL } from 'config/constants/endpoints'
 import { ProviderQoute } from '../types'
 
 export async function fetchMoonpayQuote(baseAmount: number, currencyCode: string, outputCurrency: string) {
@@ -18,7 +18,7 @@ export async function fetchMoonpayQuote(baseAmount: number, currencyCode: string
 
 export async function fetchProviderQuotes(payload): Promise<ProviderQoute[]> {
   // Fetch data from endpoint 1
-  const response = await fetch(`${MOONPAY_SIGN_URL}/fetch-provider-quotes`, {
+  const response = await fetch(`${ONRAMP_API_BASE_URL}/fetch-provider-quotes`, {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2669,5 +2669,6 @@
   "Linea is LIVE!": "Linea is LIVE!",
   "PancakeSwap Now Live on Linea!": "PancakeSwap Now Live on Linea!",
   "Swap and Provide Liquidity on Linea now": "Swap and Provide Liquidity on Linea now",
-  "day": "day"
+  "day": "day",
+  "Quote not available": "Quote not available"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ad1c1a</samp>

### Summary
🎨🔧⚠️

<!--
1.  🎨 - This emoji represents the change in the `CryptoCard` component's appearance and theme.
2.  🔧 - This emoji represents the refactoring and improvement of the code related to the fiat on-ramp modal and the widget URLs.
3.  ⚠️ - This emoji represents the addition of warning icons and tooltips for the buy crypto feature in the `WalletInfo` component.
-->
This pull request adds support for Mercuryo as a fiat on-ramp provider and improves the UI and code quality of the buy crypto feature. It refactors the `FiatOnRampModal` component to use constants for the widget and API URLs, updates the `WalletInfo` component to show warnings and tooltips for buying BNB or the native token, and changes the background color of the `CryptoCard` component based on the theme and the click state.

> _`CryptoCard` shines in the dark, a beacon of the brave_
> _`FiatOnRampModal` opens the gate, to the crypto world we crave_
> _`WalletInfo` warns us of the risks, but we don't fear the chains_
> _We buy the tokens with our clicks, we are the Mercuryo reigns_

### Walkthrough
*  Improve the contrast and visibility of the `CryptoCard` component in dark mode by using a different background color depending on the theme and the click state ([link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-44ba08619785c9500e8a2cb2dd4f1711ac4cc76654e97e0f890392043c8ddcf9L33-R34))
*  Configure the widget URL and the API base URL for MoonPay and Mercuryo from a single source and use different values for different environments by importing the `MERCURYO_WIDGET_URL`, `MERCURYO_WIDGET_ID`, and `ONRAMP_API_BASE_URL` constants from the `endpoints` file and using them in the `FiatOnRampModal` and the `WalletInfo` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L16-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L112-R117), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905R132), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L336-R342), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-667fa9ffb5f38ba848d89c70e2b060c60ce67fee0185391f612eb425169911beR33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L91-R96))
*  Send a `isTestEnv` parameter to the API when fetching the MoonPay signed URL to allow the API to use different keys and endpoints for testing and production environments ([link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905R132))
*  Show a warning icon and a tooltip for buying BNB or the native token of the current chain using MoonPay or Mercuryo in the `WalletInfo` component if the user has zero balance and the current chain supports the buy crypto feature, and use a warning color and font weight for the balance display in that case ([link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-667fa9ffb5f38ba848d89c70e2b060c60ce67fee0185391f612eb425169911beR94-R96), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-667fa9ffb5f38ba848d89c70e2b060c60ce67fee0185391f612eb425169911beL102-R106), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-667fa9ffb5f38ba848d89c70e2b060c60ce67fee0185391f612eb425169911beL140-R162), [link](https://github.com/pancakeswap/pancake-frontend/pull/7666/files?diff=unified&w=0#diff-667fa9ffb5f38ba848d89c70e2b060c60ce67fee0185391f612eb425169911beL179-R215))


