### PR TITLE
chore: Add missing subgraphs for routing api

### DIFF
--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -58,6 +58,9 @@ export const v3SubgraphClients: Record<SupportedChainId, GraphQLClient> = {
   [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC], { fetch }),
   [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC_TESTNET], { fetch }),
   [ChainId.ARBITRUM_ONE]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ARBITRUM_ONE], { fetch }),
+  [ChainId.LINEA]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.LINEA], { fetch }),
+  [ChainId.SCROLL_SEPOLIA]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.SCROLL_SEPOLIA], { fetch }),
+  [ChainId.BASE_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BASE_TESTNET], { fetch }),
 } as const
 
 export const v3SubgraphProvider: SubgraphProvider = ({ chainId = ChainId.BSC }: { chainId?: ChainId }) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e4c0aa2</samp>

### Summary
🚀🍰🔗

<!--
1.  🚀 - This emoji represents the launch of the new chains and the excitement of expanding the routing provider's capabilities.
2.  🍰 - This emoji represents the PancakeSwap brand and the delicious rewards that users can earn by swapping and providing liquidity on the new chains.
3.  🔗 - This emoji represents the connection and integration of the new chains with the existing ones, as well as the interoperability and compatibility of the routing provider.
-->
Added support for new V3 chains in `provider.ts`. This allows the routing provider to query the subgraphs for the Linea, Scroll Sepolia, and Base Testnet chains.

> _`v3SubgraphClients`_
> _Add new chains for pancakes_
> _Autumn harvest time_

### Walkthrough
*  Add GraphQL clients for new chains to support V3 routing ([link](https://github.com/pancakeswap/pancake-frontend/pull/7672/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0R61-R63))


