### PR TITLE
chore: Update Perpetual URL

### DIFF
--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -11,7 +11,7 @@ interface GetPerpetualUrlProps {
 export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualUrlProps) => {
   const perpChain = chainId === ChainId.ETHEREUM ? 'ethereum' : 'bnbchain'
   const version = chainId === ChainId.BSC ? 'v2/' : ''
-  return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(
+  return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/v2/${version}BTCUSD?theme=${perpTheme(
     isDark,
   )}&chain=${perpChain}`
 }

--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -19,11 +19,11 @@ const mapPerpChain = (chainId: ChainId): string => {
   }
 }
 
-const hasV2Chains: ChainId[] = [ChainId.BSC, ChainId.ARBITRUM_ONE]
+const supportV2Chains: ChainId[] = [ChainId.BSC, ChainId.ARBITRUM_ONE]
 
 export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualUrlProps) => {
   const perpChain = mapPerpChain(chainId)
-  const version = hasV2Chains.includes(chainId) ? 'v2/' : ''
+  const version = supportV2Chains.includes(chainId) ? 'v2/' : ''
   return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(
     isDark,
   )}&chain=${perpChain}`

--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -8,10 +8,23 @@ interface GetPerpetualUrlProps {
   isDark: boolean
 }
 
+const mapPerpChain = (chainId: ChainId): string => {
+  switch (chainId) {
+    case ChainId.ETHEREUM:
+      return 'ethereum'
+    case ChainId.ARBITRUM_ONE:
+      return 'arbitrum'
+    default:
+      return 'bnbchain'
+  }
+}
+
+const hasV2Chains: ChainId[] = [ChainId.BSC, ChainId.ARBITRUM_ONE]
+
 export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualUrlProps) => {
-  const perpChain = chainId === ChainId.ETHEREUM ? 'ethereum' : 'bnbchain'
-  const version = chainId === ChainId.BSC ? 'v2/' : ''
-  return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/v2/${version}BTCUSD?theme=${perpTheme(
+  const perpChain = mapPerpChain(chainId)
+  const version = hasV2Chains.includes(chainId) ? 'v2/' : ''
+  return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(
     isDark,
   )}&chain=${perpChain}`
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 81cd5ca</samp>

### Summary
🆙🌐📈

<!--
1.  🆙 - This emoji can represent the upgrade or update of the Perpetual Protocol integration, as well as the use of the new version of the UI.
2.  🌐 - This emoji can represent the web or URL aspect of the change, as well as the cross-chain compatibility of the Perpetual Protocol.
3.  📈 - This emoji can represent the futures or trading aspect of the change, as well as the potential for profit or growth.
-->
Updated `getPerpetualUrl` function to use `v2/` prefix for futures page. This reflects the new version of the Perpetual Protocol UI, which the PancakeSwap frontend integrates with.

> _`getPerpetualUrl`_
> _adds `v2/` to futures path_
> _snowy UI change_

### Walkthrough
*  Add `v2/` segment to futures URL path for Perpetual Protocol integration ([link](https://github.com/pancakeswap/pancake-frontend/pull/7677/files?diff=unified&w=0#diff-4c2d20aeaac9ab3c1c64428aaea6bb8f67d93af622de190e76242dc2b2717f5bL14-R14))


