### PR TITLE
fix: Invalid apr for arb pool

### DIFF
--- a/apps/web/src/state/pools/index.ts
+++ b/apps/web/src/state/pools/index.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js'
 import keyBy from 'lodash/keyBy'
 import orderBy from 'lodash/orderBy'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { bscTokens, arbitrumTokens } from '@pancakeswap/tokens'
+import { bscTokens, arbitrumTokens, CAKE } from '@pancakeswap/tokens'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import { fetchTokenUSDValue } from '@pancakeswap/utils/llamaPrice'
 import { getFarmsPrices } from '@pancakeswap/farms/farmPrices'
@@ -228,9 +228,14 @@ export const fetchPoolsPublicDataAsync = (chainId: number) => async (dispatch, g
       const earningTokenAddress = isAddress(pool.earningToken.address)
       let earningTokenPrice = earningTokenAddress ? prices[earningTokenAddress] : 0
       if (earningTokenAddress && !prices[earningTokenAddress] && !isPoolFinished) {
-        // eslint-disable-next-line no-await-in-loop
-        const result = await fetchTokenUSDValue(chainId, [earningTokenAddress])
-        earningTokenPrice = result.get(earningTokenAddress) || 0
+        if (earningTokenAddress === CAKE[chainId].address) {
+          // eslint-disable-next-line no-await-in-loop
+          earningTokenPrice = parseFloat(await getCakePriceFromOracle())
+        } else {
+          // eslint-disable-next-line no-await-in-loop
+          const result = await fetchTokenUSDValue(chainId, [earningTokenAddress])
+          earningTokenPrice = result.get(earningTokenAddress) || 0
+        }
       }
       const totalStaked = getBalanceNumber(new BigNumber(totalStaking.totalStaked), pool.stakingToken.decimals)
       const apr = !isPoolFinished


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b29e9a</samp>

### Summary
🍰📈🔮

<!--
1.  🍰 - This emoji represents the CAKE token, which is the main focus of this pull request. It also conveys a sense of reward and sweetness, which is fitting for a token that is used to distribute rewards to liquidity providers.
2.  📈 - This emoji represents the improvement in accuracy and reliability of the earning token price calculation, which can benefit users who want to know how much they are earning from their pools. It also suggests a positive trend and growth, which is desirable for any token or project.
3.  🔮 - This emoji represents the oracle, which is the new source of price data for the CAKE token. It also conveys a sense of magic and mystery, which can appeal to users who are curious about how the oracle works and how it provides accurate and timely information.
-->
Improve earning token price accuracy for CAKE pools. Use oracle price for `CAKE` token instead of llamaPrice API in `state/pools/index.ts`.

> _Oh we are the coders of the `CAKE` pool_
> _And we work to make our earnings cool_
> _We import the `CAKE` token from the oracle_
> _And we heave away on the count of three_

### Walkthrough
* Import CAKE token from tokens package to check earning token of pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/7679/files?diff=unified&w=0#diff-054edc51cf96fdb1806d9e5ff731fbdf0a6036340b7c86156d44505c83a8018eL6-R6))
* Use getCakePriceFromOracle function to fetch CAKE price from oracle instead of llamaPrice API ([link](https://github.com/pancakeswap/pancake-frontend/pull/7679/files?diff=unified&w=0#diff-054edc51cf96fdb1806d9e5ff731fbdf0a6036340b7c86156d44505c83a8018eL231-R238))


