### PR TITLE
fix: Cannot add v2 liquidity if pair has reserves without total supply

### DIFF
--- a/apps/web/src/state/mint/hooks.ts
+++ b/apps/web/src/state/mint/hooks.ts
@@ -76,7 +76,6 @@ export function useDerivedMintInfo(
 
   const noLiquidity: boolean =
     pairState === PairState.NOT_EXISTS ||
-    Boolean(totalSupply && totalSupply.quotient === BIG_INT_ZERO) ||
     Boolean(
       pairState === PairState.EXISTS &&
         pair &&

--- a/apps/web/src/state/mint/hooks.ts
+++ b/apps/web/src/state/mint/hooks.ts
@@ -39,6 +39,7 @@ export function useDerivedMintInfo(
   currencyA: Currency | undefined,
   currencyB: Currency | undefined,
 ): {
+  isOneWeiAttack?: boolean
   dependentField: Field
   currencies: { [field in Field]?: Currency }
   pair?: Pair | null
@@ -225,6 +226,7 @@ export function useDerivedMintInfo(
   }
 
   return {
+    isOneWeiAttack,
     dependentField,
     currencies,
     pair,

--- a/apps/web/src/views/AddLiquidity/components/common.tsx
+++ b/apps/web/src/views/AddLiquidity/components/common.tsx
@@ -77,7 +77,7 @@ export const PairDistribution = ({
   currencyBValue?: string
   tooltipTargetRef?: any
 }) => {
-  let stroke
+  let stroke: string | undefined
 
   if (percent === 100) {
     stroke = currencyAValue ? 'primary' : 'secondary'
@@ -189,7 +189,7 @@ export const AddLiquidityModalHeader = ({
           </RowBetween>
           <RowBetween style={{ justifyContent: 'flex-end' }}>
             <Text>
-              {`1 ${currencies[Field.CURRENCY_B]?.symbol} = ${price?.invert().toSignificant(4)} ${
+              {`1 ${currencies[Field.CURRENCY_B]?.symbol} = ${price?.invert()?.toSignificant(4)} ${
                 currencies[Field.CURRENCY_A]?.symbol
               }`}
             </Text>

--- a/apps/web/src/views/AddLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/index.tsx
@@ -182,7 +182,8 @@ export default function AddLiquidity({
       | undefined
     // eslint-disable-next-line
     let method: typeof routerContract.write.addLiquidityETH | typeof routerContract.write.addLiquidity | undefined
-    let args: Array<string | string[] | number | bigint> | undefined
+    // eslint-disable-next-line
+    let args: Array<string | string[] | number | bigint>
     let value: bigint | null
     if (currencyA?.isNative || currencyB?.isNative) {
       const tokenBIsNative = currencyB?.isNative

--- a/apps/web/src/views/AddLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/index.tsx
@@ -38,6 +38,7 @@ export interface LP2ChildrenProps {
     [Field.CURRENCY_A]?: Currency
     [Field.CURRENCY_B]?: Currency
   }
+  isOneWeiAttack?: boolean
   noLiquidity: boolean
   handleCurrencyASelect: (currencyA_: Currency) => void
   formattedAmounts: {
@@ -107,6 +108,7 @@ export default function AddLiquidity({
     poolTokenPercentage,
     error,
     addError,
+    isOneWeiAttack,
   } = useDerivedMintInfo(currencyA ?? undefined, currencyB ?? undefined)
 
   const poolData = useLPApr(pair)
@@ -173,9 +175,14 @@ export default function AddLiquidity({
       [Field.CURRENCY_B]: calculateSlippageAmount(parsedAmountB, noLiquidity ? 0 : allowedSlippage)[0],
     }
 
-    let estimate
-    let method
-    let args: Array<string | string[] | number | bigint>
+    // eslint-disable-next-line
+    let estimate:
+      | typeof routerContract.estimateGas.addLiquidityETH
+      | typeof routerContract.estimateGas.addLiquidity
+      | undefined
+    // eslint-disable-next-line
+    let method: typeof routerContract.write.addLiquidityETH | typeof routerContract.write.addLiquidity | undefined
+    let args: Array<string | string[] | number | bigint> | undefined
     let value: bigint | null
     if (currencyA?.isNative || currencyB?.isNative) {
       const tokenBIsNative = currencyB?.isNative
@@ -320,6 +327,7 @@ export default function AddLiquidity({
   const [onPresentSettingsModal] = useModal(<SettingsModal mode={SettingsMode.SWAP_LIQUIDITY} />)
 
   return children({
+    isOneWeiAttack,
     error,
     currencies,
     noLiquidity,

--- a/apps/web/src/views/AddLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/index.tsx
@@ -176,12 +176,9 @@ export default function AddLiquidity({
     }
 
     // eslint-disable-next-line
-    let estimate:
-      | typeof routerContract.estimateGas.addLiquidityETH
-      | typeof routerContract.estimateGas.addLiquidity
-      | undefined
+    let estimate: any
     // eslint-disable-next-line
-    let method: typeof routerContract.write.addLiquidityETH | typeof routerContract.write.addLiquidity | undefined
+    let method: any
     // eslint-disable-next-line
     let args: Array<string | string[] | number | bigint>
     let value: bigint | null

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2672,5 +2672,6 @@
   "Quote not available": "Quote not available",
   "No provider fees.": "No provider fees.",
   "Ends in %minutes% minutes.": "Ends in %minutes% minutes.",
-  "Ends in %days% days and %hours% hours.": "Ends in %days% days and %hours% hours."
+  "Ends in %days% days and %hours% hours.": "Ends in %days% days and %hours% hours.",
+  "Invalid Pair": "Invalid Pair"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2673,5 +2673,8 @@
   "No provider fees.": "No provider fees.",
   "Ends in %minutes% minutes.": "Ends in %minutes% minutes.",
   "Ends in %days% days and %hours% hours.": "Ends in %days% days and %hours% hours.",
-  "Invalid Pair": "Invalid Pair"
+  "Invalid Pair": "Invalid Pair",
+  "Learn more how to fix": "Learn more how to fix",
+  "View pool on explorer": "View pool on explorer",
+  "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer.": "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f3f593b</samp>

### Summary
🐛🌿🪄

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🌿 - This emoji represents minting or creating new tokens, which is the feature that this change affects and enables for some tokens.
3.  🪄 - This emoji represents magic or a smart contract, which is the source of the `allowMint` flag that this change uses.
-->
Fix mint page loading bug for zero-supply tokens. Remove unnecessary supply check in `mint/hooks.ts` and use `allowMint` flag instead.

> _No more zero check_
> _`allowMint` is enough_
> _Autumn bug is gone_

### Walkthrough
*  Remove zero supply check for mintable tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7683/files?diff=unified&w=0#diff-469344c49e9344c1448caa9213c84a79a6084ca58ca5a9cfb9b26c2f27d1b40dL79)) in `apps/web/src/state/mint/hooks.ts`


