### PR TITLE
fix: Invalid routing on zksync era

### DIFF
--- a/packages/smart-router/evm/constants/multicall.ts
+++ b/packages/smart-router/evm/constants/multicall.ts
@@ -65,7 +65,20 @@ export const BATCH_MULTICALL_CONFIGS: ChainMap<BatchMulticallConfigs> = {
       multicallChunk: 1,
     },
   },
-  [ChainId.ZKSYNC]: DEFAULT,
+  [ChainId.ZKSYNC]: {
+    defaultConfig: {
+      multicallChunk: 50,
+      gasLimitOverride: 1_000_000,
+    },
+    gasErrorFailureOverride: {
+      gasLimitOverride: 1_000_000,
+      multicallChunk: 40,
+    },
+    successRateFailureOverrides: {
+      gasLimitOverride: 1_000_000,
+      multicallChunk: 45,
+    },
+  },
   [ChainId.ZKSYNC_TESTNET]: DEFAULT,
   [ChainId.LINEA]: DEFAULT,
   [ChainId.LINEA_TESTNET]: DEFAULT,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b315085</samp>

### Summary
🚀🛠️🍰

<!--
1.  🚀 - This emoji can represent the improvement in performance and reliability of the batch multicall feature, as well as the support for the ZKSync chain, which are both features that can enhance the user experience and scalability of the PancakeSwap frontend.
2.  🛠️ - This emoji can represent the custom configuration and the override of the default values, which are both technical adjustments that require some fine-tuning and testing to ensure the optimal functionality of the batch multicall feature on the ZKSync chain.
3.  🍰 - This emoji can represent the PancakeSwap frontend itself, which is the main product and brand of the project, and which uses the batch multicall feature to display various data and information to the users. The emoji can also suggest the idea of layering, which is relevant for the ZKSync chain as a layer 2 solution.
-->
Add custom batch multicall configuration for the ZKSync chain in `multicall.ts`. This improves the performance and reliability of the batch multicall feature on the layer 2 scaling solution.

> _`ZKSync` config_
> _Tweaking gas and chunks for_
> _Batch multicall_

### Walkthrough
* Add custom configuration for ZKSync chain in `BATCH_MULTICALL_CONFIGS` object to improve batch multicall performance and reliability ([link](https://github.com/pancakeswap/pancake-frontend/pull/7684/files?diff=unified&w=0#diff-811cce7aeac21c9b1e6aceba276b6f1c541076dbf4722a255a0c1c7c40b9c3ccL68-R81))


