### PR TITLE
fix: Wrong url when switching to v3 from v2 add liquidity

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -256,6 +256,18 @@ export function UniversalAddLiquidity({
           undefined,
           { shallow: true },
         )
+      } else {
+        router.replace(
+          {
+            pathname: router.pathname.replace('/v2', ''),
+            query: {
+              ...router.query,
+              currency: [currencyIdA, currencyIdB],
+            },
+          },
+          undefined,
+          { shallow: true },
+        )
       }
     },
     [currencyIdA, currencyIdB, router, setSelectorType],

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -900,7 +900,7 @@ export const RemoveLiquidityLayout = ({ currencyA, currencyB, children, pair }) 
     <Page>
       <AppBody>
         <AppHeader
-          backTo="/liquidity"
+          backTo={`/v2/pair/${currencyA?.address}/${currencyB?.address}`}
           title={t('Remove %assetA%-%assetB% Liquidity', {
             assetA: currencyA?.symbol ?? '',
             assetB: currencyB?.symbol ?? '',


### PR DESCRIPTION
To reproduce:

Go to existing v2 liquidity
Click add
Change type to v3 liquidity
See url construction is wrong

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a541bf0</samp>

### Summary
🔀🆙🔗

<!--
1.  🔀 This emoji represents the redirection of the user from one page to another based on the pair support. It can also imply the migration of liquidity from one version to another.
2.  🆙 This emoji represents the upgrade of the liquidity from v2 to v3, which is the main goal of the feature. It can also imply improvement or enhancement.
3.  🔗 This emoji represents the update of the link or the backTo prop of the AppHeader component. It can also imply connection or relation.
-->
The changes improve the user experience and navigation for adding and removing liquidity in v3. They redirect the user to the v3 add liquidity page if they select an unsupported v2 pair, and they link the user back to the v2 pair page when they remove liquidity from v2.

> _`v2` to `v3`_
> _migrating liquidity_
> _autumn leaves falling_

### Walkthrough
* Redirect the user to the v3 add liquidity page if they try to access the v2 page with a pair that is not supported by v2 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7700/files?diff=unified&w=0#diff-4b9d1d497762b8d67cf2e15af6da6f8cda35f6b3afee248bd96e6a7885825eefR259-R270))
* Update the backTo prop of the `AppHeader` component to link to the v2 pair page instead of the general liquidity page ([link](https://github.com/pancakeswap/pancake-frontend/pull/7700/files?diff=unified&w=0#diff-8db1969219b9eccaf2dced27a48414930c4153270fd11798082aae472b8626bfL903-R903))


