### PR TITLE
chore: Show minutes countdown

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -68,9 +68,13 @@ function AccordionItem({
     () => isNewCustomer && quote.provider === 'MoonPay' && Date.now() / 1000 < MOONPAY_CAMPAIGN_END_TIME,
     [isNewCustomer, quote.provider],
   )
-  const { days, hours } = useMemo(
-    () => isCampaignEligible && quote && getTimePeriods(MOONPAY_CAMPAIGN_END_TIME - Date.now() / 1000),
+  const campaignTimeLeft = useMemo(
+    () => (isCampaignEligible && quote ? getTimePeriods(MOONPAY_CAMPAIGN_END_TIME - Date.now() / 1000) : undefined),
     [isCampaignEligible, quote],
+  )
+  const isCampaignLastHour = useMemo(
+    () => campaignTimeLeft && campaignTimeLeft.days === 0 && campaignTimeLeft.hours === 0,
+    [campaignTimeLeft],
   )
 
   const toggleVisibility = useCallback(() => {
@@ -171,10 +175,15 @@ function AccordionItem({
               <Flex>
                 <Image src={pocketWatch} alt="pocket-watch" height={30} width={30} />
                 <Text marginLeft="14px" fontSize="15px" color="#D67E0B">
-                  {t('No provider fees. Ends in %days% days and %hours% hours.', {
-                    days,
-                    hours,
-                  })}
+                  {t('No provider fees.')}{' '}
+                  {isCampaignLastHour
+                    ? t('Ends in %minutes% minutes.', {
+                        minutes: campaignTimeLeft?.minutes,
+                      })
+                    : t('Ends in %days% days and %hours% hours.', {
+                        days: campaignTimeLeft?.days,
+                        hours: campaignTimeLeft?.hours,
+                      })}
                 </Text>
               </Flex>
             </Box>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2638,7 +2638,6 @@
   "Arbitrum One is LIVE!": "Arbitrum One is LIVE!",
   "PancakeSwap Now Live on Arbitrum One": "PancakeSwap Now Live on Arbitrum One",
   "Swap and Provide Liquidity Now": "Swap and Provide Liquidity Now",
-  "No provider fees. Ends in %days% days and %hours% hours.": "No provider fees. Ends in %days% days and %hours% hours.",
   "Why do i receive different USDC tokens on Arbitrum?": "Why do i receive different USDC tokens on Arbitrum?",
   "In the case of Arbitrum, there's a bridged version of USDC known as USDC.e that has been bridged from Ethereum to Arbitrum, and native USDC, known as USDC. Depending on providers, we support both USDC.e and USDC. Please check your wallet balances for both tokens": "In the case of Arbitrum, there's a bridged version of USDC known as USDC.e that has been bridged from Ethereum to Arbitrum, and native USDC, known as USDC. Depending on providers, we support both USDC.e and USDC. Please check your wallet balances for both tokens",
   "%token1%'s exchange rate is determined by the value accrued vs %token0%. As you receive rewards, your amount of %token1% will not change.": "%token1%'s exchange rate is determined by the value accrued vs %token0%. As you receive rewards, your amount of %token1% will not change.",
@@ -2670,5 +2669,8 @@
   "PancakeSwap Now Live on Linea!": "PancakeSwap Now Live on Linea!",
   "Swap and Provide Liquidity on Linea now": "Swap and Provide Liquidity on Linea now",
   "day": "day",
-  "Quote not available": "Quote not available"
+  "Quote not available": "Quote not available",
+  "No provider fees.": "No provider fees.",
+  "Ends in %minutes% minutes.": "Ends in %minutes% minutes.",
+  "Ends in %days% days and %hours% hours.": "Ends in %days% days and %hours% hours."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d66ccfc</samp>

### Summary
🌖🕒🗑️

<!--
1.  🌖 - This emoji represents the MoonPay campaign and the logic to show the remaining time for it. It is also a reference to the moon phase that is closest to the end of the campaign (waning gibbous).
2.  🕒 - This emoji represents the addition of variables and logic to format the time left for the campaign and the lottery countdown. It also suggests the idea of time passing and counting down.
3.  🗑️ - This emoji represents the removal of some translation keys that are no longer needed for the lottery countdown messages. It also implies cleaning up and simplifying the code.
-->
Added a feature to show the remaining time for the MoonPay campaign in the Buy Crypto view. Updated the translations for the lottery countdown messages.

> _`MoonPay` campaign_
> _Counting down the time left_
> _Autumn leaves falling_

### Walkthrough
*  Introduce variables to store and check the remaining time for the MoonPay campaign in `AccordionItem.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7704/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L71-R78))
*  Update the conditional rendering of the time left message in `AccordionItem.tsx` to use the new variables and show minutes or days and hours accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/7704/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L174-R186))
*  Remove the unused translation key for the time left message with days and hours in `translations.json` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7704/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2641))
*  Add translation keys for the no provider fees message and the time left messages with minutes or days and hours in `translations.json` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7704/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2673-R2675))


