### PR TITLE
chore: Always shows minutes in countdown

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -72,10 +72,6 @@ function AccordionItem({
     () => (isCampaignEligible && quote ? getTimePeriods(MOONPAY_CAMPAIGN_END_TIME - Date.now() / 1000) : undefined),
     [isCampaignEligible, quote],
   )
-  const isCampaignLastHour = useMemo(
-    () => campaignTimeLeft && campaignTimeLeft.days === 0 && campaignTimeLeft.hours === 0,
-    [campaignTimeLeft],
-  )
 
   const toggleVisibility = useCallback(() => {
     setVisibility((v) => !v)
@@ -175,15 +171,11 @@ function AccordionItem({
               <Flex>
                 <Image src={pocketWatch} alt="pocket-watch" height={30} width={30} />
                 <Text marginLeft="14px" fontSize="15px" color="#D67E0B">
-                  {t('No provider fees.')}{' '}
-                  {isCampaignLastHour
-                    ? t('Ends in %minutes% minutes.', {
-                        minutes: campaignTimeLeft?.minutes,
-                      })
-                    : t('Ends in %days% days and %hours% hours.', {
-                        days: campaignTimeLeft?.days,
-                        hours: campaignTimeLeft?.hours,
-                      })}
+                  {t('No provider fees. Ends in %days% days, %hours% hours and %minutes% minutes.', {
+                    days: campaignTimeLeft?.days,
+                    hours: campaignTimeLeft?.hours,
+                    minutes: campaignTimeLeft?.minutes,
+                  })}
                 </Text>
               </Flex>
             </Box>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2670,7 +2670,5 @@
   "Swap and Provide Liquidity on Linea now": "Swap and Provide Liquidity on Linea now",
   "day": "day",
   "Quote not available": "Quote not available",
-  "No provider fees.": "No provider fees.",
-  "Ends in %minutes% minutes.": "Ends in %minutes% minutes.",
-  "Ends in %days% days and %hours% hours.": "Ends in %days% days and %hours% hours."
+  "No provider fees. Ends in %days% days, %hours% hours and %minutes% minutes.": "No provider fees. Ends in %days% days, %hours% hours and %minutes% minutes."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b702afa</samp>

### Summary
🌐🗃️🗒️

<!--
1.  🌐 - This emoji represents the translation file and the different languages that the text message can be displayed in. It also conveys the idea of global or international communication and accessibility.
2.  🗃️ - This emoji represents the folder and file structure that the translation file and the component code are located in. It also conveys the idea of organization and storage of data and resources.
3.  🗒️ - This emoji represents the text message itself and the simplification of its format and content. It also conveys the idea of writing, editing, and updating information and messages.
-->
Simplify and update the text message for no provider fees campaign in `AccordionItem` component and its translation file. This change improves the clarity and consistency of the user interface.

> _Sing, O Muse, of the skillful coder who updated the translation file_
> _That holds the words of wisdom for the `AccordionItem` component_
> _He changed the key and value of the text that tells of no provider fees_
> _And made it clear and simple for the users of different languages_

### Walkthrough
*  Simplify the text message for no provider fees campaign and show the remaining time in one line ([link](https://github.com/pancakeswap/pancake-frontend/pull/7705/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L75-L78), [link](https://github.com/pancakeswap/pancake-frontend/pull/7705/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L178-R178), [link](https://github.com/pancakeswap/pancake-frontend/pull/7705/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2673-R2673))


