### PR TITLE
chore: list farms on zksync

### DIFF
--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -41,15 +41,15 @@ export const farmsV3 = defineFarmV3Configs([
   {
     pid: 6,
     lpAddress: '0x9cB8b12cb0223e105155318B72AdddA15D588fB9',
-    token0: zksyncTokens.wbtc,
-    token1: zksyncTokens.weth,
+    token0: zksyncTokens.weth,
+    token1: zksyncTokens.wbtc,
     feeAmount: FeeAmount.LOW,
   },
   {
     pid: 7,
     lpAddress: '0x662cD659F91528FF27D7Cb6Ac25e6EBA11c4003C',
-    token0: zksyncTokens.usdc,
-    token1: zksyncTokens.busd,
+    token0: zksyncTokens.busd,
+    token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
 ])

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -31,4 +31,25 @@ export const farmsV3 = defineFarmV3Configs([
     token1: zksyncTokens.tes,
     feeAmount: FeeAmount.HIGH,
   },
+  {
+    pid: 5,
+    lpAddress: '0x3c11CAACc9FC70d9130792c39702C5F96cE68a93',
+    token0: zksyncTokens.cake,
+    token1: zksyncTokens.weth,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 6,
+    lpAddress: '0x9cB8b12cb0223e105155318B72AdddA15D588fB9',
+    token0: zksyncTokens.wbtc,
+    token1: zksyncTokens.weth,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
+    pid: 7,
+    lpAddress: '0x662cD659F91528FF27D7Cb6Ac25e6EBA11c4003C',
+    token0: zksyncTokens.usdc,
+    token1: zksyncTokens.busd,
+    feeAmount: FeeAmount.LOWEST,
+  },
 ])

--- a/packages/tokens/src/324.ts
+++ b/packages/tokens/src/324.ts
@@ -14,4 +14,13 @@ export const zksyncTokens = {
     'Tiny Era Shard',
     'https://tinyworlds.io/',
   ),
+  wbtc: new ERC20Token(ChainId.ZKSYNC, '0xBBeB516fb02a01611cBBE0453Fe3c580D7281011', 8, 'WBTC', 'Wrapped BTC'),
+  busd: new ERC20Token(
+    ChainId.ZKSYNC,
+    '0x2039bb4116B4EFc145Ec4f0e2eA75012D6C0f181',
+    18,
+    'BUSD',
+    'Binance USD',
+    'https://www.paxos.com/busd/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf8d23c</samp>

### Summary
🍰🌉💱

<!--
1.  🍰 - This emoji represents the CAKE token, which is the native token of the PancakeSwap platform and one of the new liquidity pool tokens added to the farmsV3 array. The emoji also suggests the idea of farming and earning rewards, which is the main purpose of the farmsV3 array.
2.  🌉 - This emoji represents the bridge functionality of the ZKSync network, which allows users to transfer tokens from the Ethereum mainnet to the ZKSync layer 2 network and vice versa. The emoji also implies the idea of connecting different networks and tokens, which is relevant for the new WBTC and BUSD tokens added to the zksyncTokens object, as they are wrapped versions of tokens from other blockchains (Bitcoin and Binance Smart Chain, respectively).
3.  💱 - This emoji represents the exchange or swap functionality of the ZKSync network, which allows users to trade tokens within the layer 2 network with low fees and high speed. The emoji also suggests the idea of liquidity and volatility, which are factors that affect the fee amounts of the new liquidity pools added to the farmsV3 array.
-->
This pull request adds support for three new liquidity pools and two new tokens on the ZKSync network. It updates the `farmsV3` and `zksyncTokens` arrays in `packages/farms/constants/324.ts` and `packages/tokens/src/324.ts`, respectively.

> _`farmsV3` expands_
> _with new liquidity pools_
> _autumn harvest grows_

### Walkthrough
*  Add three new liquidity pools for ZKSync network ([link](https://github.com/pancakeswap/pancake-frontend/pull/7706/files?diff=unified&w=0#diff-02f301415ffe755f42d9f7b6cf06c434ba122dc41c6e94a77e55ce9e389d62e6R34-R54))
*  Add two new tokens for ZKSync network ([link](https://github.com/pancakeswap/pancake-frontend/pull/7706/files?diff=unified&w=0#diff-a71af7ff44f6a2151f59a9720430da1d5c2a5d5c45623bbeba2d51e4acb77d56R17-R25))


