### PR TITLE
chore: remove moon pay banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -11,7 +11,6 @@ import ArbitrumOneBanner from '../ArbitrumOneBanner'
 import { ZksyncBanner } from '../ZksyncBanner'
 import useIsRenderCompetitionBanner from './useIsRenderCompetitionBanner'
 import useIsRenderIfoBanner from './useIsRenderIFOBanner'
-import MoonPayBanner from '../MoonPayBanner'
 import LineaBanner from '../LineaBanner'
 
 interface IBannerConfig {
@@ -39,7 +38,6 @@ export const useMultipleBannerConfig = () => {
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
       { shouldRender: true, banner: <LineaBanner /> },
-      { shouldRender: true, banner: <MoonPayBanner /> },
       { shouldRender: true, banner: <ArbitrumOneBanner /> },
       { shouldRender: true, banner: <ZksyncBanner /> },
       { shouldRender: true, banner: <PolygonZkEvmBanner /> },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 01a3caa</samp>

### Summary
🗑️🔥🚫

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that something was deleted or removed from the codebase. In this case, the `MoonPayBanner` component and its import were deleted, so this emoji is appropriate to convey that.
2.  🔥 - This emoji means "fire" and can be used to indicate that something was burned, destroyed, or eliminated from the codebase. In this case, the MoonPay integration was removed from the app, so this emoji is appropriate to convey that.
3.  🚫 - This emoji means "prohibited" and can be used to indicate that something was blocked, disabled, or prevented from the codebase. In this case, the MoonPay integration was no longer supported by the app, so this emoji is appropriate to convey that.
-->
Refactored banner configuration hook to remove MoonPay integration. Deleted `MoonPayBanner` component and import from `useMultipleBannerConfig.tsx`.

> _No more MoonPay in our sight_
> _We tear it down with all our might_
> _Refactor the code, clean the hook_
> _We don't need their banner, look_

### Walkthrough
*  Remove MoonPay integration from the app
  - Delete unused import of `MoonPayBanner` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7708/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L14))
  - Remove `MoonPayBanner` from the array of banners ([link](https://github.com/pancakeswap/pancake-frontend/pull/7708/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89L42))


