### PR TITLE
fix: Changing apr in price direction

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -160,8 +160,8 @@ export function AprCalculator({
     currencyBUsdPrice: inverted ? currencyAUsdPrice : currencyBUsdPrice,
   })
 
-  const validAmountA = amountA || (inverted ? tokenAmount1 : tokenAmount0) || aprAmountA
-  const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || aprAmountB
+  const validAmountA = amountA || (inverted ? tokenAmount1 : tokenAmount0) || (inverted ? aprAmountB : aprAmountA)
+  const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || (inverted ? aprAmountA : aprAmountB)
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
   const inRange = isPoolTickInRange(pool, tickLower, tickUpper)
   const { apr } = useRoi({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c281d74</samp>

### Summary
🐛🔄📈

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It conveys that the change addresses an existing issue or error in the code.
2.  🔄 - This emoji represents a switch or a swap, which is relevant to the change because it involves checking the `inverted` flag and using the appropriate `aprAmount` values. It conveys that the change handles different scenarios or cases depending on the token order.
3.  📈 - This emoji represents an improvement or an enhancement, which is also an outcome of the change. It conveys that the change makes the APR calculator more accurate and user-friendly for V3 liquidity pools.
-->
Fixed a bug in `AprCalculator.tsx` that caused incorrect APR values when switching token order. Improved the UX and accuracy of the APR calculator for V3 pools.

> _`inverted` flag_
> _fixes APR calculator_
> _autumn bug harvest_

### Walkthrough
* Fix APR calculation bug when switching token order ([link](https://github.com/pancakeswap/pancake-frontend/pull/7714/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L163-R164))


