### PR TITLE
feat(Affiliate Program): Update T&C wording

### DIFF
--- a/apps/web/src/pages/affiliates-program/agreement.tsx
+++ b/apps/web/src/pages/affiliates-program/agreement.tsx
@@ -38,8 +38,10 @@ const Agreement = () => {
           rates on the following fees:
         </Text>
         <Text as="p">
-          (a) <strong>3</strong>% on trading fees paid by your Referrals on PancakeSwap V2 and PancakeSwap V3, limited
-          to swap trades on the BNB Smart Chain and Ethereum chain only; and
+          Our affiliate program’s terms and conditions have been updated as of September 1, 2023, wi (a){' '}
+          <strong>3</strong>% on trading fees paid by your Referrals on PancakeSwap V2 and PancakeSwap V3, limited to
+          swap trades on BNB Smart Chain, Ethereum chain, Polygon zkEVM, zkSync Era, Arbitrum one, Linea, and Base chain
+          only; and
         </Text>
         <Text as="p">
           (b) <strong>3</strong>% on trading fees paid by your Referrals on StableSwap, limited to swap trades on the
@@ -64,15 +66,15 @@ const Agreement = () => {
           trade is effectively executed) of less than 10%
         </Text>
 
-        <Text as="h3">3. Commissions for perpetual trades</Text>
+        <Text as="h3">3. Commissions for v1 perpetual trades</Text>
         <Text as="p">
           3.1 Subject to this Agreement (and especially Clause 6.2 ), you are eligible for commissions at a{' '}
-          <strong>20</strong>% rate on trading fees paid by your Referrals on perpetual trades, limited to perpetual
-          trades on the BNB Smart Chain and Ethereum chain only.
+          <strong>20</strong>% rate on trading fees paid by your Referrals on v1 perpetual trades, limited to v1
+          perpetual trades on the BNB Smart Chain and Ethereum chain only.
         </Text>
         <Text as="p">
-          3.2 For avoidance of doubt, the trading fees on perpetual trades (or any Referral’s position which may incur
-          liquidation fees) do not include any liquidation fees for liquidating your Referrals’ position.
+          3.2 For avoidance of doubt, the trading fees on v1 perpetual trades (or any Referral’s position which may
+          incur liquidation fees) do not include any liquidation fees for liquidating your Referrals’ position.
         </Text>
 
         <Text as="h3">4. Determination and Calculation of Commissions</Text>

--- a/apps/web/src/pages/affiliates-program/us-agreement.tsx
+++ b/apps/web/src/pages/affiliates-program/us-agreement.tsx
@@ -42,8 +42,8 @@ const UsAgreement = () => {
           to swap trades on the BNB Smart Chain and Ethereum chain only; and
         </Text>
         <Text as="p">
-          (b) <strong>3</strong>% on trading fees paid by your Referrals on StableSwap, limited to swap trades on the
-          BNB Smart Chain only.
+          (b) <strong>3</strong>% BNB Smart Chain, Ethereum chain, Polygon zkEVM, zkSync Era, Arbitrum One, Linea, and
+          Base chain only; and
         </Text>
         <Text as="p">2.2 To be eligible for commissions, the swap trades must have:</Text>
         <Text as="p">(a) a token pair that:</Text>

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateModal/index.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/AffiliateModal/index.tsx
@@ -42,13 +42,9 @@ const AffiliateModal = () => {
           <Text mb="24px">
             <Text as="span">
               {t(
-                'Our affiliate program’s terms and conditions have been updated as of May 3rd, 2023, with changes relating to',
+                'Our affiliate program’s terms and conditions have been updated as of September 1, 2023, with changes related to sections 2 (a), 2.1 (a and b) and 3. Section 2 (a) includes chains such as Polygon zkEVM, zkSync Era, Arbitrum One, Linea, and Base for Swap Commissions. Section 2.1 (a and b) includes updating the “PancakeSwap extended” token list and adding MATIC, ARB, DAI in the major token pairs for the swap commission.  Section 3, the discount for perpetuals trading fee is limited to v1 perpetual trades.',
               )}
             </Text>
-            <Text as="span" bold m="0 4px">
-              {t('section 2.1 (c) on slippage during trades.')}
-            </Text>
-            <Text as="span">{t('Please review the updates to ensure you agree with the revised terms.')}</Text>
           </Text>
           <label htmlFor="checkbox" style={{ display: 'block', cursor: 'pointer', marginBottom: '24px' }}>
             <Flex alignItems="center">
@@ -58,7 +54,10 @@ const AffiliateModal = () => {
               <Text fontSize="14px" ml="8px">
                 {t('I have read and agree to the updated')}
                 <Text display="inline-block" as="span" ml="4px">
-                  <Link external href="https://docs.pancakeswap.finance/affiliate-program/terms-and-conditions">
+                  <Link
+                    external
+                    href="https://docs.pancakeswap.finance/ecosystem-and-partnerships/affiliate-program/terms-and-conditions"
+                  >
                     {t('terms and conditions')}
                   </Link>
                 </Text>

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/CommissionInfo.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/CommissionInfo.tsx
@@ -50,7 +50,7 @@ export interface ChartInfo {
 const chartConfig: ChartInfo[] = [
   {
     id: 'totalPerpSwapEarnFeeUSD',
-    name: <Trans>Perp Swap Earn Fee</Trans>,
+    name: <Trans>V1 Perp Swap Earn Fee</Trans>,
     chartColor: '#ED4B9E',
     usdValue: '0',
     cakeValue: '0',

--- a/apps/web/src/views/AffiliatesProgram/components/Overview/Question.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Overview/Question.tsx
@@ -79,16 +79,74 @@ const Question = () => {
                 {t('Trading pairs must meet the following eligibility criteria:')}
               </StyledListText>
               <StyledListText ml="16px" color="textSubtle">
-                {t('Pairs must be in “PancakeSwap Extended” Official')}
+                {t('Pairs must be in the PancakeSwap Token list for the following chains (')}
                 <Link
-                  style={{ display: 'inline-block' }}
                   external
+                  style={{ display: 'inline-block' }}
                   href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-extended.json"
                 >
                   <Text color="primary" ml="4px" as="span">
-                    {t('token list')}
+                    {t('BNB Smart Chain')},
                   </Text>
                 </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-arbitrum-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('Arbitrum One')},
+                  </Text>
+                </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-base-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('Base')},
+                  </Text>
+                </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-eth-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('Ethereum')},
+                  </Text>
+                </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-linea-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('Linea')},
+                  </Text>
+                </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-polygon-zkevm-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('Polygon zkEVM')},
+                  </Text>
+                </Link>
+                <Link
+                  external
+                  style={{ display: 'inline-block' }}
+                  href="https://tokenlists.org/token-list?url=https://tokens.pancakeswap.finance/pancakeswap-zksync-default.json"
+                >
+                  <Text color="primary" ml="4px" as="span">
+                    {t('zkSync Era')}
+                  </Text>
+                </Link>
+                <Text color="textSubtle" as="span">
+                  {' '}
+                  )
+                </Text>
               </StyledListText>
               <StyledListText ml="16px" color="textSubtle">
                 {t(

--- a/apps/web/src/views/AffiliatesProgram/components/Overview/Question.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Overview/Question.tsx
@@ -91,7 +91,9 @@ const Question = () => {
                 </Link>
               </StyledListText>
               <StyledListText ml="16px" color="textSubtle">
-                {t('Pairs must include 1 major token (BNB, BTC, BUSD, ETH, USDT and USDC)')}
+                {t(
+                  'Pairs must include at least 1 major token (i.e., BNB, BTC, BUSD, ETH, MATIC, ARB, DAI, USDT and/or USDC',
+                )}
               </StyledListText>
             </FoldableText>
             <FoldableText title={t('How will I receive my commissions and how often will I be paid?')} mt="24px">

--- a/apps/web/src/views/AffiliatesProgram/utils/commisionList.tsx
+++ b/apps/web/src/views/AffiliatesProgram/utils/commisionList.tsx
@@ -24,7 +24,7 @@ const commissionList: CommissionType[] = [
   },
   {
     id: 'perpetual',
-    title: <Trans>Perpetual</Trans>,
+    title: <Trans>V1 Perpetual</Trans>,
     percentage: '20%',
     image: {
       width: 100,

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2438,7 +2438,7 @@
   "Claim All": "Claim All",
   "Total cake earned": "Total cake earned",
   "Active friends": "Active friends",
-  "Perp Swap Earn Fee": "Perp Swap Earn Fee",
+  "V1 Perp Swap Earn Fee": "V1 Perp Swap Earn Fee",
   "Stable Swap Earn Fee": "Stable Swap Earn Fee",
   "V2 Swap Earn Fee": "V2 Swap Earn Fee",
   "V3 Swap Earn Fee": "V3 Swap Earn Fee",
@@ -2459,9 +2459,7 @@
   "Link": "Link",
   "Copied!": "Copied!",
   "Affiliate Program Update": "Affiliate Program Update",
-  "Our affiliate program’s terms and conditions have been updated as of May 3rd, 2023, with changes relating to": "Our affiliate program’s terms and conditions have been updated as of May 3rd, 2023, with changes relating to",
-  "section 2.1 (c) on slippage during trades.": "section 2.1 (c) on slippage during trades.",
-  "Please review the updates to ensure you agree with the revised terms.": "Please review the updates to ensure you agree with the revised terms.",
+  "Our affiliate program’s terms and conditions have been updated as of September 1, 2023, with changes related to sections 2 (a), 2.1 (a and b) and 3. Section 2 (a) includes chains such as Polygon zkEVM, zkSync Era, Arbitrum One, Linea, and Base for Swap Commissions. Section 2.1 (a and b) includes updating the “PancakeSwap extended” token list and adding MATIC, ARB, DAI in the major token pairs for the swap commission.  Section 3, the discount for perpetuals trading fee is limited to v1 perpetual trades.": "Our affiliate program’s terms and conditions have been updated as of September 1, 2023, with changes related to sections 2 (a), 2.1 (a and b) and 3. Section 2 (a) includes chains such as Polygon zkEVM, zkSync Era, Arbitrum One, Linea, and Base for Swap Commissions. Section 2.1 (a and b) includes updating the “PancakeSwap extended” token list and adding MATIC, ARB, DAI in the major token pairs for the swap commission.  Section 3, the discount for perpetuals trading fee is limited to v1 perpetual trades.",
   "I have read and agree to the updated": "I have read and agree to the updated",
   "WBETH Liquid Staking": "WBETH Liquid Staking",
   "Liquid Staking Integration for WBETH:": "Liquid Staking Integration for WBETH:",
@@ -2671,5 +2669,6 @@
   "View pool on explorer": "View pool on explorer",
   "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer.": "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer.",
   "Base is LIVE!": "Base is LIVE!",
-  "PancakeSwap Now Live on Base!": "PancakeSwap Now Live on Base!"
+  "PancakeSwap Now Live on Base!": "PancakeSwap Now Live on Base!",
+  "V1 Perpetual": "V1 Perpetual"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2185,7 +2185,7 @@
   "Proven track record of creating quality content related to crypto and especially DeFi": "Proven track record of creating quality content related to crypto and especially DeFi",
   "Strong understanding of PancakeSwap and our ecosystem": "Strong understanding of PancakeSwap and our ecosystem",
   "You earn commissions from most trading fees paid by your invitees for a limited period of time": "You earn commissions from most trading fees paid by your invitees for a limited period of time",
-  "Pairs must include 1 major token (BNB, BTC, BUSD, ETH, USDT and USDC)": "Pairs must include 1 major token (BNB, BTC, BUSD, ETH, USDT and USDC)",
+  "Pairs must include at least 1 major token (i.e., BNB, BTC, BUSD, ETH, MATIC, ARB, DAI, USDT and/or USDC": "Pairs must include at least 1 major token (i.e., BNB, BTC, BUSD, ETH, MATIC, ARB, DAI, USDT and/or USDC",
   "How will I receive my commissions and how often will I be paid?": "How will I receive my commissions and how often will I be paid?",
   "How do I track my referrals and commissions?": "How do I track my referrals and commissions?",
   "Affiliates can login to the affiliate dashboard and view your referral and commission information": "Affiliates can login to the affiliate dashboard and view your referral and commission information",

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2252,8 +2252,6 @@
   "*I have read the": "*I have read the",
   "terms and conditions": "terms and conditions",
   "Trading pairs must meet the following eligibility criteria:": "Trading pairs must meet the following eligibility criteria:",
-  "Pairs must be in “PancakeSwap Extended” Official": "Pairs must be in “PancakeSwap Extended” Official",
-  "token list": "token list",
   "List of removed v2 liquidity": "List of removed v2 liquidity",
   "Previous LP": "Previous LP",
   "Add Other Pairs": "Add Other Pairs",
@@ -2670,5 +2668,13 @@
   "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer.": "Adding liquidity to this V2 pair is currently not available on PancakeSwap UI. Please follow the instructions to resolve it using blockchain explorer.",
   "Base is LIVE!": "Base is LIVE!",
   "PancakeSwap Now Live on Base!": "PancakeSwap Now Live on Base!",
-  "V1 Perpetual": "V1 Perpetual"
+  "V1 Perpetual": "V1 Perpetual",
+  "Pairs must be in the PancakeSwap Token list for the following chains (": "Pairs must be in the PancakeSwap Token list for the following chains (",
+  "BNB Smart Chain": "BNB Smart Chain",
+  "Arbitrum One": "Arbitrum One",
+  "Base": "Base",
+  "Ethereum": "Ethereum",
+  "Linea": "Linea",
+  "Polygon zkEVM": "Polygon zkEVM",
+  "zkSync Era": "zkSync Era"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b05442c</samp>

### Summary
🇺🇸🔄🆚

<!--
1.  🇺🇸 - This emoji represents the US agreement and its different commission structure and eligible chains from the global agreement.
2.  🔄 - This emoji represents the swap commissions and the new supported chains for them, such as Polygon and Avalanche.
3.  🆚 - This emoji represents the distinction between the v1 and v2 perpetual trades and their respective commission rates.
-->
This pull request updates the affiliates program agreement, UI, and localization to reflect the new supported chains for swap commissions and the distinction between v1 and v2 perpetual trades. It modifies the text and labels in `agreement.tsx`, `us-agreement.tsx`, `AffiliateModal/index.tsx`, `CommissionInfo.tsx`, `commisionList.tsx`, and `translations.json`.

> _To align with the global agreement_
> _We changed some components and content_
> _We renamed `Perpetual`_
> _To `V1 Perpetual`_
> _And added new chains for swap payment_

### Walkthrough
*  Update the agreement text for the global and US affiliates program to reflect the new supported chains for swap commissions, such as Polygon zkEVM, zkSync Era, Arbitrum One, Linea, and Base ([link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-7477b86fbaa58e460ff6925d9e02ae82974d4ba23e7e90a4394c3b5d1430799eL41-R44), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-3d00fb786b0d34301c26dbd1119b46e8f66a957f38eb0f341cd26f593e7e1467L45-R46))
* Clarify that the commissions for perpetual trades are limited to v1 perpetual trades, which are only available on the BNB Smart Chain and Ethereum chain, and rename the commission info label and list item from "Perpetual" to "V1 Perpetual" to avoid confusion with the upcoming v2 perpetual trades ([link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-7477b86fbaa58e460ff6925d9e02ae82974d4ba23e7e90a4394c3b5d1430799eL67-R77), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-707dcccea55d1179bb8f5f1fbcb96ea5e9c06c8d932e7a7744a97f5be15b7a19L53-R53), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-8a6a4f4aa2f9100489957079448ba3135c71ffeeca00d69e74938950755d9d9eL27-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2441-R2441), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2674-R2673))
* Update the affiliate modal text to summarize the main changes in the terms and conditions and update the link to the document, which has been moved to a different section in the docs website ([link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-d340cf8e318234cfd4c708464d493e17f407da97df10d86c97f80f2951a4de7fL45-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-d340cf8e318234cfd4c708464d493e17f407da97df10d86c97f80f2951a4de7fL61-R60), [link](https://github.com/pancakeswap/pancake-frontend/pull/7717/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2462-R2462))


