### PR TITLE
fix: Link a tag descendant warning

### DIFF
--- a/apps/web/src/hooks/useLockedEndNotification.tsx
+++ b/apps/web/src/hooks/useLockedEndNotification.tsx
@@ -1,4 +1,4 @@
-import { useToast, Text, NextLinkFromReactRouter, Link } from '@pancakeswap/uikit'
+import { useToast, Text, NextLinkFromReactRouter, StyledLink } from '@pancakeswap/uikit'
 import { useEffect } from 'react'
 import { useSWRConfig } from 'swr'
 import { useTranslation } from '@pancakeswap/localization'
@@ -19,9 +19,7 @@ const LockedEndDescription: React.FC = () => {
     <>
       <Text>{t('The locked staking duration has ended.')}</Text>
       <NextLinkFromReactRouter to="/pools" prefetch={false}>
-        <Link href="/pools" color="primary">
-          {t('Go to Pools')}
-        </Link>
+        <StyledLink color="primary">{t('Go to Pools')}</StyledLink>
       </NextLinkFromReactRouter>
     </>
   )

--- a/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
+++ b/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
@@ -7,7 +7,7 @@ import {
   HelpIcon,
   useTooltip,
   RocketIcon,
-  Link,
+  StyledLink,
   ScanLink,
   NextLinkFromReactRouter,
 } from '@pancakeswap/uikit'
@@ -105,9 +105,7 @@ const DetailsView: React.FC<React.PropsWithChildren<DetailsViewProps>> = ({
             {`${t('CAKE locked:')} ${formatNumber(lockedCakeBalance, 0, 2)}`}
           </Text>
           <NextLinkFromReactRouter to="/pools" prefetch={false}>
-            <Link href="/pools" color="primary">
-              {t('Go to Pools')}
-            </Link>
+            <StyledLink color="primary">{t('Go to Pools')}</StyledLink>
           </NextLinkFromReactRouter>
         </Box>
       )}

--- a/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
+++ b/apps/web/src/views/Voting/components/CastVoteModal/DetailsView.tsx
@@ -1,16 +1,6 @@
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
-import {
-  Flex,
-  Text,
-  Box,
-  HelpIcon,
-  useTooltip,
-  RocketIcon,
-  StyledLink,
-  ScanLink,
-  NextLinkFromReactRouter,
-} from '@pancakeswap/uikit'
+import { Flex, Text, Box, HelpIcon, useTooltip, RocketIcon, ScanLink, Link } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { styled } from 'styled-components'
 import { getBlockExploreLink } from 'utils'
@@ -104,9 +94,9 @@ const DetailsView: React.FC<React.PropsWithChildren<DetailsViewProps>> = ({
           <Text bold m="10px 0">
             {`${t('CAKE locked:')} ${formatNumber(lockedCakeBalance, 0, 2)}`}
           </Text>
-          <NextLinkFromReactRouter to="/pools" prefetch={false}>
-            <StyledLink color="primary">{t('Go to Pools')}</StyledLink>
-          </NextLinkFromReactRouter>
+          <Link external href="/pools">
+            {t('Go to Pools')}
+          </Link>
         </Box>
       )}
     </>,

--- a/packages/uikit/src/__tests__/components/link.test.tsx
+++ b/packages/uikit/src/__tests__/components/link.test.tsx
@@ -7,13 +7,14 @@ it("renders link correctly", () => {
     <DocumentFragment>
       .c0 {
       color: var(--colors-primary);
-      font-weight: 600;
+      font-weight: 400;
       line-height: 1.5;
       font-size: 16px;
     }
 
     .c1 {
       display: flex;
+      font-weight: 600;
       align-items: center;
       width: fit-content;
     }
@@ -46,13 +47,14 @@ it("renders link external link correctly", () => {
 
     .c0 {
       color: var(--colors-primary);
-      font-weight: 600;
+      font-weight: 400;
       line-height: 1.5;
       font-size: 16px;
     }
 
     .c1 {
       display: flex;
+      font-weight: 600;
       align-items: center;
       width: fit-content;
     }

--- a/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
+++ b/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
@@ -1526,7 +1526,7 @@ exports[`renders correctly 1`] = `
   flex-shrink: 0;
 }
 
-.c55 {
+.c54 {
   align-self: center;
   fill: var(--colors-text);
   color: var(--colors-text);
@@ -1572,7 +1572,7 @@ exports[`renders correctly 1`] = `
   flex-shrink: 0;
 }
 
-.c26 {
+.c55 {
   color: var(--colors-textSubtle);
   font-weight: 600;
   line-height: 1.5;
@@ -1595,28 +1595,28 @@ exports[`renders correctly 1`] = `
 
 .c20 {
   color: var(--colors-primary);
-  font-weight: 600;
+  font-weight: 400;
   line-height: 1.5;
   margin-right: 24px;
   font-size: 16px;
 }
 
-.c27 {
-  color: var(--colors-primary);
-  font-weight: 600;
-  line-height: 1.5;
-  margin-right: 0;
-  font-size: 16px;
-}
-
-.c47 {
+.c26 {
   color: var(--colors-textSubtle);
   font-weight: 400;
   line-height: 1.5;
   font-size: 16px;
 }
 
-.c49 {
+.c27 {
+  color: var(--colors-primary);
+  font-weight: 400;
+  line-height: 1.5;
+  margin-right: 0;
+  font-size: 16px;
+}
+
+.c48 {
   position: relative;
   align-items: center;
   border: 0;
@@ -1642,19 +1642,19 @@ exports[`renders correctly 1`] = `
   height: sm;
 }
 
-.c49 :focus-visible {
+.c48 :focus-visible {
   outline: none;
   box-shadow: var(--shadows-focus);
 }
 
-.c49:active:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled) {
+.c48:active:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled) {
   opacity: 0.85;
   transform: translateY(1px);
   box-shadow: none;
 }
 
-.c49:disabled,
-.c49.pancake-button--disabled {
+.c48:disabled,
+.c48.pancake-button--disabled {
   background-color: var(--colors-backgroundDisabled);
   border-color: var(--colors-backgroundDisabled);
   box-shadow: none;
@@ -1753,7 +1753,7 @@ exports[`renders correctly 1`] = `
   height: 100%;
 }
 
-.c53 {
+.c52 {
   margin-right: 20px;
 }
 
@@ -1784,7 +1784,7 @@ exports[`renders correctly 1`] = `
   margin-bottom: 0;
 }
 
-.c51 {
+.c50 {
   margin-bottom: 24px;
 }
 
@@ -1829,7 +1829,7 @@ exports[`renders correctly 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c51 {
   display: flex;
   order: 1;
   justify-content: space-between;
@@ -1883,21 +1883,22 @@ exports[`renders correctly 1`] = `
   transform: translate3d(0, 0, 0);
 }
 
-.c54 {
+.c53 {
   display: flex;
   align-items: center;
 }
 
-.c54 svg {
+.c53 svg {
   transition: transform 0.3s;
 }
 
-.c54 :hover svg {
+.c53 :hover svg {
   transform: scale(1.2);
 }
 
 .c13 {
   display: flex;
+  font-weight: 600;
   align-items: center;
   width: fit-content;
 }
@@ -1927,7 +1928,7 @@ exports[`renders correctly 1`] = `
   pointer-events: none;
 }
 
-.c48 {
+.c47 {
   width: max-content;
   display: flex;
   flex-direction: column;
@@ -2003,7 +2004,7 @@ exports[`renders correctly 1`] = `
   color: var(--colors-text);
 }
 
-.c50 {
+.c49 {
   color: var(--colors-text);
   padding: 0 8px;
   border-radius: 8px;
@@ -2069,7 +2070,7 @@ exports[`renders correctly 1`] = `
 }
 
 @supports (-webkit-text-size-adjust: none) and (not (-ms-accelerator: true)) and (not (-moz-appearance: none)) {
-  .c55 {
+  .c54 {
     filter: none!important;
   }
 }
@@ -2113,7 +2114,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media (hover: hover) {
-  .c49:hover:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled):not(:active) {
+  .c48:hover:not(:disabled):not(.pancake-button--disabled):not(.pancake-button--disabled):not(:active) {
     opacity: 0.65;
   }
 }
@@ -2173,7 +2174,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media screen and (min-width: 576px) {
-  .c51 {
+  .c50 {
     margin-bottom: 0;
   }
 }
@@ -2207,7 +2208,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media screen and (min-width: 576px) {
-  .c52 {
+  .c51 {
     order: 2;
   }
 }
@@ -2985,16 +2986,16 @@ exports[`renders correctly 1`] = `
                 />
               </svg>
               <div
-                class="c47"
+                class="c26"
               >
                 EN-US
               </div>
             </button>
             <div
-              class="c24 c48"
+              class="c24 c47"
             >
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3002,7 +3003,7 @@ exports[`renders correctly 1`] = `
                 English0
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3010,7 +3011,7 @@ exports[`renders correctly 1`] = `
                 English1
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3018,7 +3019,7 @@ exports[`renders correctly 1`] = `
                 English2
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3026,7 +3027,7 @@ exports[`renders correctly 1`] = `
                 English3
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3034,7 +3035,7 @@ exports[`renders correctly 1`] = `
                 English4
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3042,7 +3043,7 @@ exports[`renders correctly 1`] = `
                 English5
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3050,7 +3051,7 @@ exports[`renders correctly 1`] = `
                 English6
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3058,7 +3059,7 @@ exports[`renders correctly 1`] = `
                 English7
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3066,7 +3067,7 @@ exports[`renders correctly 1`] = `
                 English8
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3074,7 +3075,7 @@ exports[`renders correctly 1`] = `
                 English9
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3082,7 +3083,7 @@ exports[`renders correctly 1`] = `
                 English10
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3090,7 +3091,7 @@ exports[`renders correctly 1`] = `
                 English11
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3098,7 +3099,7 @@ exports[`renders correctly 1`] = `
                 English12
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3106,7 +3107,7 @@ exports[`renders correctly 1`] = `
                 English13
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3114,7 +3115,7 @@ exports[`renders correctly 1`] = `
                 English14
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3122,7 +3123,7 @@ exports[`renders correctly 1`] = `
                 English15
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3130,7 +3131,7 @@ exports[`renders correctly 1`] = `
                 English16
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3138,7 +3139,7 @@ exports[`renders correctly 1`] = `
                 English17
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3146,7 +3147,7 @@ exports[`renders correctly 1`] = `
                 English18
               </button>
               <button
-                class="c49 c50"
+                class="c48 c49"
                 scale="md"
                 style="min-height: 32px; height: auto;"
                 variant="text"
@@ -3157,18 +3158,18 @@ exports[`renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="c51 c52"
+          class="c50 c51"
         >
           <div
-            class="c53"
+            class="c52"
           >
             <a
-              class="c54"
+              class="c53"
               href="https://pancakeswap.finance/swap?outputCurrency=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82&chainId=56"
               target="_blank"
             >
               <svg
-                class="c55"
+                class="c54"
                 color="text"
                 mr="8px"
                 viewBox="0 0 96 96"
@@ -3219,7 +3220,7 @@ exports[`renders correctly 1`] = `
                 </defs>
               </svg>
               <div
-                class="c26"
+                class="c55"
               >
                 $0.232
               </div>

--- a/packages/uikit/src/components/Link/Link.tsx
+++ b/packages/uikit/src/components/Link/Link.tsx
@@ -4,8 +4,9 @@ import EXTERNAL_LINK_PROPS from "../../util/externalLinkProps";
 import Text from "../Text/Text";
 import { LinkProps } from "./types";
 
-const StyledLink = styled(Text)<LinkProps>`
+export const StyledLink = styled(Text)<LinkProps>`
   display: flex;
+  font-weight: 600;
   align-items: center;
   width: fit-content;
   &:hover {
@@ -15,7 +16,7 @@ const StyledLink = styled(Text)<LinkProps>`
 
 const Link: React.FC<React.PropsWithChildren<LinkProps>> = ({ external, ...props }) => {
   const internalProps = external ? EXTERNAL_LINK_PROPS : {};
-  return <StyledLink as="a" bold {...internalProps} {...props} />;
+  return <StyledLink as="a" {...internalProps} {...props} />;
 };
 
 /* eslint-disable react/default-props-match-prop-types */

--- a/packages/uikit/src/components/Link/index.tsx
+++ b/packages/uikit/src/components/Link/index.tsx
@@ -1,4 +1,5 @@
 export { default as Link } from "./Link";
+export { StyledLink } from "./Link";
 export { default as LinkExternal } from "./LinkExternal";
 export { default as ScanLink } from "./ScanLink";
 export type { LinkProps } from "./types";


### PR DESCRIPTION
`Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
a
O@webpack-internal:///../../node_modules/.pnpm/styled-components@5.3.3_react-dom@18.2.0_react-is@17.0.2_react@18.2.0/node_modules/styled-components/dist/styled-components.browser.esm.js:31:19811
Link@webpack-internal:///../../packages/uikit/src/components/Link/Link.tsx:27:35`

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a69efc1</samp>

### Summary
📦🔗💅

<!--
1.  📦 - This emoji represents exporting or importing something, such as a component or a module. It can be used to indicate the first change, where the `StyledLink` component was exported from the `Link` file.
2.  🔗 - This emoji represents a link or a connection, such as a hyperlink or a reference. It can be used to indicate the second and third changes, where the `Link` components from `@pancakeswap/uikit` were replaced with `StyledLink` components in various files.
3.  💅 - This emoji represents styling or beautifying something, such as a component or a layout. It can be used to indicate the fourth change, where the `Link` component was refactored to use a styled component with a default bold font-weight.
-->
Refactored and replaced `Link` components from `@pancakeswap/uikit` to avoid naming conflicts and simplify props. Exported `StyledLink` component from `Link.tsx` for reuse.

> _`StyledLink` exports_
> _Customize and simplify_
> _Autumn of refactoring_

### Walkthrough
*  Replace `Link` component from `@pancakeswap/uikit` with `StyledLink` component in voting and locked end notification features to avoid conflicts with `react-router-dom` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-4fbcef3620fffae1ea181f74ec4e3b9db7cf4036d2cc77c3e9388a045bc2248aL1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-4fbcef3620fffae1ea181f74ec4e3b9db7cf4036d2cc77c3e9388a045bc2248aL22-R22), [link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-e3a0019712ee9175649f5ec9fa7fb4cf1d2a224629b70d40167d3ebaaff3e137L10-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-e3a0019712ee9175649f5ec9fa7fb4cf1d2a224629b70d40167d3ebaaff3e137L108-R108))
*  Define and export `StyledLink` component as a styled component that extends `Text` component and has bold font-weight by default in `packages/uikit/src/components/Link` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-af03d4cb9c8967db83611bd6b6831f96b9473f5f18e8261affeaafe431a95901L7-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-af03d4cb9c8967db83611bd6b6831f96b9473f5f18e8261affeaafe431a95901L18-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7724/files?diff=unified&w=0#diff-fb7d5f07f7bdfb1d198945886df8f8b792448c30a9cd9ec4aed6236cd1a0adbbR2))


