### PR TITLE
chore: Move finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -59,15 +59,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 355,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.planet,
-    contractAddress: '0x69Aeec4EBA2333deC563E378a6AFD5eF23437677',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '150.4',
-    version: 3,
-  },
-  {
     sousId: 354,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.snbnb,
@@ -147,15 +138,6 @@ export const livePools: SerializedPool[] = [
     poolCategory: PoolCategory.CORE,
     tokenPerBlock: '2.017',
   },
-  {
-    sousId: 325,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.lvl,
-    contractAddress: '0x1394a09F868bE27B1c8D39D79F0b0D6f112bddAf',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.009765',
-    version: 3,
-  },
 ].map((p) => ({
   ...p,
   contractAddress: getAddress(p.contractAddress),
@@ -165,6 +147,24 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 355,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.planet,
+    contractAddress: '0x69Aeec4EBA2333deC563E378a6AFD5eF23437677',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '150.4',
+    version: 3,
+  },
+  {
+    sousId: 325,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.lvl,
+    contractAddress: '0x1394a09F868bE27B1c8D39D79F0b0D6f112bddAf',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.009765',
+    version: 3,
+  },
   {
     sousId: 345,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 42d8e48</samp>

### Summary
🐼?

<!--
1.  🚚
2.  🏁
3.  🎁
-->
This pull request moves two closed pools from `activePools` to `finishedPools` in `./packages/pools/src/constants/pools/56.ts`. This allows users to access their tokens and rewards from the Planet Finance and Level Up pools.

> _Two pools are closed now_
> _`activePools` and `finishedPools`_
> _Change with autumn leaves_

### Walkthrough
*  Remove closed pools from activePools array ([link](https://github.com/pancakeswap/pancake-frontend/pull/7730/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL62-L70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7730/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL150-L158))
*  Add closed pools to finishedPools array ([link](https://github.com/pancakeswap/pancake-frontend/pull/7730/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR151-R168))


