### PR TITLE
perf: Use cached big numbers

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -1,5 +1,4 @@
 import { Currency, CurrencyAmount, Token, ZERO, Price } from '@pancakeswap/sdk'
-import BigNumber from 'bignumber.js'
 import {
   useRoi,
   RoiCalculatorModalV2,
@@ -11,6 +10,7 @@ import {
   IconButton,
   QuestionHelper,
 } from '@pancakeswap/uikit'
+import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { encodeSqrtRatioX96, parseProtocolFees, Pool, FeeCalculator } from '@pancakeswap/v3-sdk'
 import { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
@@ -201,7 +201,7 @@ export function AprCalculator({
     if (!farm || !cakePrice || !positionLiquidity || !amount0 || !amount1 || !inRange) {
       return {
         positionFarmApr: '0',
-        positionFarmAprFactor: new BigNumber(0),
+        positionFarmAprFactor: BIG_ZERO,
       }
     }
     const { farm: farmDetail, cakePerSecond } = farm

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/MyReferralLink.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/MyReferralLink.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Flex, Text, Input, Box, Button, ArrowForwardIcon, useMatchBreakpoints, useToast } from '@pancakeswap/uikit'
 import styled from 'styled-components'
-import BigNumber from 'bignumber.js'
+import { BIG_ONE_HUNDRED } from '@pancakeswap/utils/bigNumber'
 import { keccak256, encodePacked } from 'viem'
 import { useAccount } from 'wagmi'
 import { useSignMessage } from '@pancakeswap/wagmi'
@@ -97,7 +97,7 @@ const MyReferralLink: React.FC<React.PropsWithChildren<MyReferralLinkProps>> = (
   const { isMobile } = useMatchBreakpoints()
   const [percentage, setPercentage] = useState('0')
 
-  const youWillReceive = useMemo(() => new BigNumber(100).minus(percentage).toString(), [percentage])
+  const youWillReceive = useMemo(() => BIG_ONE_HUNDRED.minus(percentage).toString(), [percentage])
 
   const dataList = useMemo(
     () => commissionList.filter((i) => i.percentage !== '?' || (i.id === 'perpetual' && affiliate.ablePerps)),

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -47,13 +47,11 @@ import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import { isV3MigrationSupported } from 'utils/isV3MigrationSupported'
 import FarmV3MigrationBanner from 'views/Home/components/Banners/FarmV3MigrationBanner'
 import { useAccount } from 'wagmi'
+import { BIG_ONE, BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import Table from './components/FarmTable/FarmTable'
 import { FarmTypesFilter } from './components/FarmTypesFilter'
 import { BCakeBoosterCard } from './components/YieldBooster/components/bCakeV3/BCakeBoosterCard'
 import { FarmsV3Context } from './context'
-
-const BIG_INT_ZERO = new BigNumber(0)
-const BIG_INT_ONE = new BigNumber(1)
 
 const ControlContainer = styled.div`
   display: flex;
@@ -315,7 +313,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
         }
         const totalLiquidityFromLp = new BigNumber(farm.lpTotalInQuoteToken).times(farm.quoteTokenPriceBusd)
         // Mock 1$ tvl if the farm doesn't have lp staked
-        const totalLiquidity = totalLiquidityFromLp.eq(BIG_INT_ZERO) && mockApr ? BIG_INT_ONE : totalLiquidityFromLp
+        const totalLiquidity = totalLiquidityFromLp.eq(BIG_ZERO) && mockApr ? BIG_ONE : totalLiquidityFromLp
         const { cakeRewardsApr, lpRewardsApr } = isActive
           ? getFarmApr(
               chainId,

--- a/apps/web/src/views/LiquidStaking/hooks/useExchangeRate.tsx
+++ b/apps/web/src/views/LiquidStaking/hooks/useExchangeRate.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { publicClient } from 'utils/wagmi'
 import { useLiquidStakingList } from 'views/LiquidStaking/hooks/useLiquidStakingList'
+import { getBalanceAmount } from '@pancakeswap/utils/formatBalance'
 
 interface UseExchangeRateProps {
   decimals: number
@@ -43,7 +44,7 @@ export const useExchangeRate = ({ decimals }: UseExchangeRateProps): UseExchange
               })
 
               const rateNumber: BigNumber | undefined = exchangeRate
-                ? new BigNumber(exchangeRate?.toString()).dividedBy(new BigNumber(10 ** decimals ?? 18))
+                ? getBalanceAmount(new BigNumber(exchangeRate?.toString()), decimals)
                 : BIG_ZERO
               rate = rateNumber?.toString() ?? '0'
             }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6386b92</samp>

### Summary
🧹📝🛠️

<!--
1.  🧹 - This emoji can be used to indicate that the code was cleaned up, simplified, or optimized. It suggests that unnecessary or redundant elements were removed or replaced with better alternatives.
2.  📝 - This emoji can be used to indicate that the code was refactored, improved, or made more consistent. It suggests that the code was rewritten or reorganized to enhance its quality, readability, or functionality.
3.  🛠️ - This emoji can be used to indicate that the code was updated, fixed, or modified. It suggests that the code was changed to adapt to new requirements, resolve issues, or add features.
-->
The pull request refactors and optimizes some components and hooks that use BigNumber objects, by replacing them with existing constants or utility functions. This improves the code quality, readability, and performance of the `pancake-frontend` app.

> _`BigNumber` objects_
> _Reduced and replaced by constants_
> _Code is more concise_

### Walkthrough
*  Replace new BigNumber instances with imported constants from '@pancakeswap/utils/bigNumber' to avoid unnecessary object creation and improve readability ([link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L204-R204), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-9a76eea96b9b771b05cbdaf5868946b6dee0d536c0b51199dd33bd1d0fe37d85L4-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-9a76eea96b9b771b05cbdaf5868946b6dee0d536c0b51199dd33bd1d0fe37d85L100-R100), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fR50), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fL55-L57), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-7c64c760be1e393dee45fb35e38cd0932308e931c85928c64cd5d66186d8440fL318-R316))
* Use `getBalanceAmount` function from '@pancakeswap/utils/formatBalance' to convert exchange rate value to human-readable format with correct decimals in `useExchangeRate` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-21f6693181e373137555a5bcf051c8a16423b591a14873d69012510a075725b3R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7732/files?diff=unified&w=0#diff-21f6693181e373137555a5bcf051c8a16423b591a14873d69012510a075725b3L46-R47))


