### PR TITLE
feat: support base info page

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -31,6 +31,7 @@ export const BLOCKS_CLIENT_POLYGON_ZKEVM =
   'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest'
 export const BLOCKS_CLIENT_ZKSYNC = 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest'
 export const BLOCKS_CLIENT_LINEA = 'https://graph-query.linea.build/subgraphs/name/kybernetwork/linea-blocks'
+export const BLOCKS_CLIENT_BASE = 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest'
 export const STABLESWAP_SUBGRAPH_CLIENT = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap'
 export const GRAPH_API_NFTMARKET = 'https://api.thegraph.com/subgraphs/name/pancakeswap/nft-market'
 export const GRAPH_HEALTH = 'https://api.thegraph.com/index-node/graphql'
@@ -53,6 +54,7 @@ export const INFO_CLIENT_WITH_CHAIN = {
   [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
   [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
   [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exhange-v2',
+  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
 }
 
 export const BLOCKS_CLIENT_WITH_CHAIN = {
@@ -62,6 +64,7 @@ export const BLOCKS_CLIENT_WITH_CHAIN = {
   [ChainId.ZKSYNC]: BLOCKS_CLIENT_ZKSYNC,
   [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
   [ChainId.LINEA]: BLOCKS_CLIENT_LINEA,
+  [ChainId.BASE]: BLOCKS_CLIENT_BASE,
 }
 
 export const ASSET_CDN = 'https://assets.pancakeswap.finance'

--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -1,4 +1,10 @@
-import { BLOCKS_CLIENT, BLOCKS_CLIENT_ETH, BLOCKS_CLIENT_ZKSYNC, BLOCKS_CLIENT_LINEA } from 'config/constants/endpoints'
+import {
+  BLOCKS_CLIENT,
+  BLOCKS_CLIENT_ETH,
+  BLOCKS_CLIENT_ZKSYNC,
+  BLOCKS_CLIENT_LINEA,
+  BLOCKS_CLIENT_BASE,
+} from 'config/constants/endpoints'
 import { infoClientETH, infoClient, infoStableSwapClient, v2Clients } from 'utils/graphql'
 import { GraphQLClient } from 'graphql-request'
 
@@ -11,9 +17,9 @@ import {
   BSC_TOKEN_WHITELIST,
   ETH_TOKEN_WHITELIST,
 } from 'config/constants/info'
-import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea } from 'wagmi/chains'
+import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea, base } from 'wagmi/chains'
 
-export type MultiChainName = 'BSC' | 'ETH' | 'POLYGON_ZKEVM' | 'ZKSYNC' | 'ARB' | 'LINEA'
+export type MultiChainName = 'BSC' | 'ETH' | 'POLYGON_ZKEVM' | 'ZKSYNC' | 'ARB' | 'LINEA' | 'BASE'
 
 export type MultiChainNameExtend = MultiChainName | 'BSC_TESTNET' | 'ZKSYNC_TESTNET'
 
@@ -24,6 +30,7 @@ export const multiChainName: Record<number | string, MultiChainNameExtend> = {
   [ChainId.POLYGON_ZKEVM]: 'POLYGON_ZKEVM',
   [ChainId.ZKSYNC]: 'ZKSYNC',
   [ChainId.LINEA]: 'LINEA',
+  [ChainId.BASE]: 'BASE',
 }
 
 export const multiChainShortName: Record<number, string> = {
@@ -37,6 +44,7 @@ export const multiChainQueryMainToken: Record<MultiChainName, string> = {
   ZKSYNC: 'ETH',
   ARB: 'ARB',
   LINEA: 'ETH',
+  BASE: 'ETH',
 }
 
 export const multiChainBlocksClient: Record<MultiChainNameExtend, string> = {
@@ -48,6 +56,7 @@ export const multiChainBlocksClient: Record<MultiChainNameExtend, string> = {
   ZKSYNC: BLOCKS_CLIENT_ZKSYNC,
   ARB: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
   LINEA: BLOCKS_CLIENT_LINEA,
+  BASE: BLOCKS_CLIENT_BASE,
 }
 
 export const multiChainStartTime = {
@@ -57,6 +66,7 @@ export const multiChainStartTime = {
   ZKSYNC: 1690462800, // Thu Jul 27 2023 13:00:00 UTC+0000
   ARB: 1686732526,
   LINEA: 1692878400,
+  BASE: 1693483200,
 }
 
 export const multiChainId: Record<MultiChainName, ChainId> = {
@@ -66,6 +76,7 @@ export const multiChainId: Record<MultiChainName, ChainId> = {
   ZKSYNC: ChainId.ZKSYNC,
   ARB: ChainId.ARBITRUM_ONE,
   LINEA: ChainId.LINEA,
+  BASE: ChainId.BASE,
 }
 
 export const multiChainPaths = {
@@ -75,6 +86,7 @@ export const multiChainPaths = {
   [ChainId.ZKSYNC]: '/zksync',
   [ChainId.ARBITRUM_ONE]: '/arb',
   [ChainId.LINEA]: '/linea',
+  [ChainId.BASE]: '/base',
 }
 
 export const multiChainQueryClient = {
@@ -84,6 +96,7 @@ export const multiChainQueryClient = {
   ZKSYNC: v2Clients[ChainId.ZKSYNC],
   ARB: v2Clients[ChainId.ARBITRUM_ONE],
   LINEA: v2Clients[ChainId.LINEA],
+  BASE: v2Clients[ChainId.BASE],
 }
 
 export const multiChainScan: Record<MultiChainName, string> = {
@@ -93,6 +106,7 @@ export const multiChainScan: Record<MultiChainName, string> = {
   ZKSYNC: zkSync.blockExplorers.default.name,
   ARB: arbitrum.blockExplorers.default.name,
   LINEA: linea.blockExplorers.default.name,
+  BASE: base.blockExplorers.default.name,
 }
 
 export const multiChainTokenBlackList: Record<MultiChainName, string[]> = {
@@ -102,6 +116,7 @@ export const multiChainTokenBlackList: Record<MultiChainName, string[]> = {
   ZKSYNC: ['0x'],
   ARB: ['0x'],
   LINEA: ['0x'],
+  BASE: ['0x'],
 }
 
 export const multiChainTokenWhiteList: Record<MultiChainName, string[]> = {
@@ -111,6 +126,7 @@ export const multiChainTokenWhiteList: Record<MultiChainName, string[]> = {
   ZKSYNC: [],
   ARB: [],
   LINEA: [],
+  BASE: [],
 }
 
 export const getMultiChainQueryEndPointWithStableSwap = (chainName: MultiChainNameExtend): GraphQLClient => {

--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -304,6 +304,8 @@ export const useChainNameByQuery = (): MultiChainName => {
         return 'ARB'
       case 'linea':
         return 'LINEA'
+      case 'base':
+        return 'BASE'
       default:
         return 'BSC'
     }

--- a/apps/web/src/utils/graphql.ts
+++ b/apps/web/src/utils/graphql.ts
@@ -60,6 +60,7 @@ export const v2Clients = {
   [ChainId.POLYGON_ZKEVM]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.POLYGON_ZKEVM]),
   [ChainId.ZKSYNC]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.ZKSYNC]),
   [ChainId.LINEA]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.LINEA]),
+  [ChainId.BASE]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.BASE]),
 }
 
 export const infoStableSwapClient = new GraphQLClient(STABLESWAP_SUBGRAPH_CLIENT)

--- a/apps/web/src/views/Info/components/InfoNav/index.tsx
+++ b/apps/web/src/views/Info/components/InfoNav/index.tsx
@@ -22,7 +22,7 @@ import { useMultiChainPath, useChainNameByQuery, useChainIdByQuery } from 'state
 import { multiChainId, multiChainPaths, multiChainShortName } from 'state/info/constant'
 import { chains } from 'utils/wagmi'
 import { ChainLogo } from 'components/Logo/ChainLogo'
-import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea } from 'wagmi/chains'
+import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea, base } from 'wagmi/chains'
 import { ASSET_CDN } from 'config/constants/endpoints'
 
 const NavWrapper = styled(Flex)`
@@ -95,7 +95,7 @@ const InfoNav: React.FC<{ isStableSwap: boolean }> = ({ isStableSwap }) => {
   )
 }
 
-const targetChains = [mainnet, bsc, polygonZkEvm, zkSync, arbitrum, linea]
+const targetChains = [mainnet, bsc, polygonZkEvm, zkSync, arbitrum, linea, base]
 
 export const NetworkSwitcher: React.FC<{ activeIndex: number }> = ({ activeIndex }) => {
   const { t } = useTranslation()

--- a/apps/web/src/views/V3Info/components/Layout/InfoNav.tsx
+++ b/apps/web/src/views/V3Info/components/Layout/InfoNav.tsx
@@ -19,7 +19,7 @@ import { multiChainId, multiChainPaths, multiChainShortName } from 'state/info/c
 import { useChainNameByQuery, useMultiChainPath } from 'state/info/hooks'
 import styled from 'styled-components'
 import { chains } from 'utils/wagmi'
-import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea } from 'wagmi/chains'
+import { arbitrum, bsc, mainnet, polygonZkEvm, zkSync, linea, base } from 'wagmi/chains'
 import { v3InfoPath } from '../../constants'
 import Search from '../Search'
 
@@ -74,7 +74,7 @@ const InfoNav: React.FC<{ isStableSwap: boolean }> = ({ isStableSwap }) => {
   )
 }
 
-const targetChains = [mainnet, bsc, polygonZkEvm, zkSync, arbitrum, linea]
+const targetChains = [mainnet, bsc, polygonZkEvm, zkSync, arbitrum, linea, base]
 
 export const NetworkSwitcher: React.FC<{ activeIndex: number }> = ({ activeIndex }) => {
   const { t } = useTranslation()

--- a/apps/web/src/views/V3Info/constants.ts
+++ b/apps/web/src/views/V3Info/constants.ts
@@ -61,6 +61,7 @@ export const SUBGRAPH_START_BLOCK = {
   [ChainId.ZKSYNC]: 8639214,
   [ChainId.ARBITRUM_ONE]: 101028949,
   [ChainId.LINEA]: 1444,
+  [ChainId.BASE]: 2912007,
 }
 
 export const NODE_REAL_ADDRESS_LIMIT = 50


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d58a86e</samp>

### Summary
🌐📊🔗

<!--
1.  🌐 - This emoji represents the addition of a new chain and network to the app, which is a global and cross-chain feature.
2.  📊 - This emoji represents the addition of new GraphQL endpoints and queries for the base chain, which are related to data and analytics.
3.  🔗 - This emoji represents the addition of new links and references to the base chain, which are related to connectivity and navigation.
-->
This pull request adds support for the base chain to the PancakeSwap info app, by defining its configuration, constants, endpoints, and subgraph data. It also updates the UI components and hooks to include the base chain as a network option and query its exchange data. It affects the files `endpoints.ts`, `constant.ts`, `index.tsx`, `InfoNav.tsx`, `hooks.ts`, `graphql.ts`, and `constants.ts`.

> _`base` joins the app_
> _a new chain to explore_
> _autumn of DeFi_

### Walkthrough
*  Add support for the base chain, a new chain compatible with the PancakeSwap info app, by importing and using the `base` object from the `wagmi/chains` module ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80L1-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL25-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-bb26c7b8dd2db305bc739e7e4f031774af7349a6d30a7bf6431d335abf2a5c0eL22-R22))
* Define the URL of the GraphQL endpoint for querying the base blocks subgraph as a new constant `BLOCKS_CLIENT_BASE` and add it to the `BLOCKS_CLIENT_WITH_CHAIN` object ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62R67))
* Add a new entry to the `INFO_CLIENT_WITH_CHAIN` object that maps the `ChainId.BASE` enum value to the URL of the GraphQL endpoint for querying the exchange v2 base subgraph ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62R57))
* Add the `'BASE'` string literal to the `MultiChainName` type union and the `targetChains` array, which represent the possible names and the information of the chains supported by the info app ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80L14-R22))
* Add new entries to the `multiChainName`, `multiChainQueryMainToken`, `multiChainBlocksClient`, `multiChainStartTime`, `multiChainId`, `multiChainPaths`, `multiChainQueryClient`, `multiChainScan`, `multiChainExcludedTokens`, and `multiChainExcludedPairs` objects, which store various constants and configurations for each chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R59), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R69), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R79), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R89), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R99), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R109), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R119), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-85dec4f2520ab4d031442a39680ae804a521ef025a33f9b42fb151b108015d80R129))
* Add a new case to the `useChainNameByQuery` hook that returns the `'BASE'` string literal when the `query` parameter matches the `'/base'` string literal, which is the URL path of the base chain info page ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292R307-R308))
* Add a new entry to the `v2Clients` object that maps the `ChainId.BASE` enum value to the GraphQL client for querying the exchange v2 base subgraph ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-9a18c7fa948e0139245c60f3160a24972b35b6960387ac74cbf7b4d9da9e26a5R63))
* Add the `base` object to the `targetChains` array, which is used to render the network switcher component in the info app and the v3 info app ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-ae2fef01f2e4cbfcfafd8be2bd435854da0b178fbbbd7846f8a68194141de72aL98-R98), [link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-bb26c7b8dd2db305bc739e7e4f031774af7349a6d30a7bf6431d335abf2a5c0eL77-R77))
* Add a new entry to the `SUBGRAPH_START_BLOCK` object that maps the `ChainId.BASE` enum value to the block number of the start of the base chain subgraph ([link](https://github.com/pancakeswap/pancake-frontend/pull/7743/files?diff=unified&w=0#diff-77f9b222e9f5de52041b06ae540e3a8cb32c1fd777c20be054eb88990cabc845R64))


