### PR TITLE
feat(Aptos): Network Select Add Base

### DIFF
--- a/apps/aptos/components/NetworkSwitcher.tsx
+++ b/apps/aptos/components/NetworkSwitcher.tsx
@@ -15,6 +15,7 @@ const evmChains = [
   { id: 1101, name: 'Polygon zkEVM', chainName: 'polygonZkEVM' },
   { id: 42161, name: 'Arbitrum One', chainName: 'arb' },
   { id: 59144, name: 'Linea', chainName: 'linea' },
+  { id: 8453, name: 'Base', chainName: 'base' },
 ]
 
 const NetworkSelect = () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8d756c</samp>

### Summary
🌐🥞🛠️

<!--
1.  🌐 - This emoji represents the network or chain aspect of the change, as the network switcher component is related to switching between different chains or networks.
2.  🥞 - This emoji represents the PancakeSwap aspect of the change, as the Base chain is a custom chain that supports PancakeSwap, which is a popular decentralized exchange on the Binance Smart Chain.
3.  🛠️ - This emoji represents the option or feature aspect of the change, as the change adds a new option to the existing component, which is a kind of tool or utility for the frontend.
-->
Add Base chain option to `NetworkSwitcher` component. This allows users to switch to a custom EVM chain that supports PancakeSwap.

> _`network switcher`_
> _adds Base chain option now_
> _autumn of choices_

### Walkthrough
* Add a new option for Base chain to the network switcher component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7750/files?diff=unified&w=0#diff-3ff81a954673aa998f9490c76adc346de7fb57b7b526e9bcddbc9cd7cc12af6cR18))


