### PR TITLE
chore: Bump up jotai

### DIFF
--- a/.changeset/shy-sheep-smile.md
+++ b/.changeset/shy-sheep-smile.md
@@ -1,0 +1,6 @@
+---
+'@pancakeswap/token-lists': patch
+'@pancakeswap/utils': patch
+---
+
+chore: Bump up jotai

--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -32,7 +32,7 @@
     "@vanilla-extract/recipes": "^0.5.0",
     "@vanilla-extract/css": "^1.13.0",
     "react-window": "^1.8.7",
-    "jotai": "^2.2.2",
+    "jotai": "^2.4.3",
     "aptos": "^1.3.16",
     "bignumber.js": "^9.0.0",
     "next": "13.4.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,7 +72,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "graphql": "^16.8.1",
     "graphql-request": "^5.0.0",
-    "jotai": "^2.2.2",
+    "jotai": "^2.4.3",
     "js-cookie": "^3.0.1",
     "lightweight-charts": "^4.0.1",
     "local-storage": "^2.0.0",

--- a/packages/token-lists/package.json
+++ b/packages/token-lists/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.9.1",
-    "jotai": "^2.2.2",
+    "jotai": "^2.4.3",
     "localforage": "^1.10.0",
     "react": "^18.2.0"
   },
@@ -26,7 +26,7 @@
     "@pancakeswap/utils": "workspace:*",
     "@reduxjs/toolkit": "^1.9.1",
     "@types/react": "^18.2.21",
-    "jotai": "^2.2.2",
+    "jotai": "^2.4.3",
     "localforage": "^1.10.0",
     "react": "^18.2.0",
     "tsup": "^6.7.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -15,7 +15,7 @@
     "@pancakeswap/swap-sdk-core": "workspace:*",
     "@types/lodash": "^4.14.168",
     "bignumber.js": "^9.0.0",
-    "jotai": "^2.2.2",
+    "jotai": "^2.4.3",
     "styled-components": "^6.0.7",
     "swr": "^2.1.3",
     "vitest": "^0.30.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ importers:
         specifier: ^1.11.10
         version: 1.11.10
       jotai:
-        specifier: ^2.2.2
-        version: 2.2.2(react@18.2.0)
+        specifier: ^2.4.3
+        version: 2.4.3(@types/react@18.2.21)(react@18.2.0)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -680,8 +680,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(encoding@0.1.13)(graphql@16.8.1)
       jotai:
-        specifier: ^2.2.2
-        version: 2.2.2(react@18.2.0)
+        specifier: ^2.4.3
+        version: 2.4.3(@types/react@18.2.21)(react@18.2.0)
       js-cookie:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1430,8 +1430,8 @@ importers:
         specifier: ^18.2.21
         version: 18.2.21
       jotai:
-        specifier: ^2.2.2
-        version: 2.2.2(react@18.2.0)
+        specifier: ^2.4.3
+        version: 2.4.3(@types/react@18.2.21)(react@18.2.0)
       localforage:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1771,8 +1771,8 @@ importers:
         specifier: ^9.0.0
         version: 9.1.1
       jotai:
-        specifier: ^2.2.2
-        version: 2.2.2(react@18.2.0)
+        specifier: ^2.4.3
+        version: 2.4.3(@types/react@18.2.21)(react@18.2.0)
       styled-components:
         specifier: ^6.0.7
         version: 6.0.7(babel-plugin-styled-components@1.13.3)(react-dom@18.2.0)(react@18.2.0)
@@ -19326,6 +19326,22 @@ packages:
       react:
         optional: true
     dependencies:
+      react: 18.2.0
+    dev: false
+
+  /jotai@2.4.3(@types/react@18.2.21)(react@18.2.0):
+    resolution: {integrity: sha512-CSAHX9LqWG5WCrU8OgBoZbBJ+Bo9rQU0mPusEF4e0CZ/SNFgurG26vb3UpgvCSJZgYVcUQNiUBM5q86PA8rstQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.21
       react: 18.2.0
 
   /joycon@3.1.1:


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8db28cc</samp>

### Summary
📦🚀🚀

<!--
1.  📦 - This emoji represents a package update, which is suitable for the changeset file that specifies the patch versions for the `@pancakeswap/token-lists` and `@pancakeswap/utils` packages.
2.  🚀 - This emoji represents a feature or improvement, which is suitable for the changes that update the jotai dependency version in the `apps/aptos/package.json`, `apps/web/package.json`, and `packages/utils/package.json` files. These changes could potentially enhance the performance or functionality of the state management in the React applications that use jotai.
3.  🚀 - This emoji represents a feature or improvement, which is also suitable for the change that updates the jotai dependency version in the `packages/token-lists/package.json` file. This change could also potentially enhance the performance or functionality of the state management in the React applications that use jotai.
-->
This pull request updates the jotai dependency version from 2.2.2 to 2.4.1 across the project. This is a chore task to keep the state management library up to date and consistent. It also adds a changeset file to document the patch versions for the affected packages.

> _We are the jotai, we manage the state_
> _We are the jotai, we don't hesitate_
> _We are the jotai, we update and sync_
> _We are the jotai, we make your code link_

### Walkthrough
*  Bump up jotai dependency version from 2.2.2 to 2.4.1 across the project ([link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-2e0a28c02ce581e54b6b6f5803ee5d4b292c79f235eeeaed29cfc4666fa7cad0L34-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L71-R71), [link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-32d135d93ad68d85298f8be14539d906f2a3f8ffca7bfca0761362e20bcb1792L21-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-32d135d93ad68d85298f8be14539d906f2a3f8ffca7bfca0761362e20bcb1792L28-R28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L28-R28))
* Add a changeset file to specify the patch versions for the `@pancakeswap/token-lists` and `@pancakeswap/utils` packages ([link](https://github.com/pancakeswap/pancake-frontend/pull/7754/files?diff=unified&w=0#diff-a1908959e5c6ccb2113608ce61955394b84b5f8da56f0d74e67d5714e6b90439R1-R6))


