### PR TITLE
feat: Add Testnet pools for zkEVM, Linea, base

### DIFF
--- a/apps/web/src/config/constants/priceHelperLps/index.ts
+++ b/apps/web/src/config/constants/priceHelperLps/index.ts
@@ -8,6 +8,12 @@ import PoolsArbPriceHelper from './pools/42161'
 import PoolsArbTestnetPriceHelper from './pools/421613'
 import PoolsZkSyncPriceHelper from './pools/324'
 import PoolsZkSyncTestnetPriceHelper from './pools/280'
+import PoolsBasePriceHelper from './pools/8453'
+import PoolsBaseTestnetPriceHelper from './pools/84531'
+import PoolsLineaPriceHelper from './pools/59144'
+import PoolsLineaTestnetPriceHelper from './pools/59140'
+import PoolsPolygonZkEvmPriceHelper from './pools/1101'
+import PoolsPolygonZkEvmTestnetPriceHelper from './pools/1442'
 
 export { getFarmsPriceHelperLpFiles }
 
@@ -29,6 +35,18 @@ export const getPoolsPriceHelperLpFiles = (chainId: ChainId) => {
       return PoolsZkSyncPriceHelper
     case ChainId.ZKSYNC_TESTNET:
       return PoolsZkSyncTestnetPriceHelper
+    case ChainId.BASE:
+      return PoolsBasePriceHelper
+    case ChainId.BASE_TESTNET:
+      return PoolsBaseTestnetPriceHelper
+    case ChainId.LINEA:
+      return PoolsLineaPriceHelper
+    case ChainId.LINEA_TESTNET:
+      return PoolsLineaTestnetPriceHelper
+    case ChainId.POLYGON_ZKEVM:
+      return PoolsPolygonZkEvmPriceHelper
+    case ChainId.POLYGON_ZKEVM_TESTNET:
+      return PoolsPolygonZkEvmTestnetPriceHelper
     default:
       return []
   }

--- a/apps/web/src/config/constants/priceHelperLps/pools/1101.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/1101.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/apps/web/src/config/constants/priceHelperLps/pools/1442.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/1442.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/apps/web/src/config/constants/priceHelperLps/pools/59140.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/59140.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/apps/web/src/config/constants/priceHelperLps/pools/59144.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/59144.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/apps/web/src/config/constants/priceHelperLps/pools/8453.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/8453.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/apps/web/src/config/constants/priceHelperLps/pools/84531.ts
+++ b/apps/web/src/config/constants/priceHelperLps/pools/84531.ts
@@ -1,0 +1,5 @@
+import { SerializedFarmConfig } from '../../types'
+
+const priceHelperLps: SerializedFarmConfig[] = []
+
+export default priceHelperLps

--- a/packages/pools/src/constants/contracts.ts
+++ b/packages/pools/src/constants/contracts.ts
@@ -15,6 +15,9 @@ export const ICAKE = {
   [ChainId.ARBITRUM_GOERLI]: '0x',
   [ChainId.ZKSYNC]: '0x',
   [ChainId.ZKSYNC_TESTNET]: '0x',
+  [ChainId.BASE_TESTNET]: '0x',
+  [ChainId.LINEA_TESTNET]: '0x',
+  [ChainId.POLYGON_ZKEVM_TESTNET]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const CAKE_VAULT = {
@@ -25,6 +28,9 @@ export const CAKE_VAULT = {
   [ChainId.ARBITRUM_GOERLI]: '0x',
   [ChainId.ZKSYNC]: '0x',
   [ChainId.ZKSYNC_TESTNET]: '0x',
+  [ChainId.BASE_TESTNET]: '0x',
+  [ChainId.LINEA_TESTNET]: '0x',
+  [ChainId.POLYGON_ZKEVM_TESTNET]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const CAKE_FLEXIBLE_SIDE_VAULT = {
@@ -35,4 +41,7 @@ export const CAKE_FLEXIBLE_SIDE_VAULT = {
   [ChainId.ARBITRUM_GOERLI]: '0x',
   [ChainId.ZKSYNC]: '0x',
   [ChainId.ZKSYNC_TESTNET]: '0x',
+  [ChainId.BASE_TESTNET]: '0x',
+  [ChainId.LINEA_TESTNET]: '0x',
+  [ChainId.POLYGON_ZKEVM_TESTNET]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>

--- a/packages/pools/src/constants/pools/1101.ts
+++ b/packages/pools/src/constants/pools/1101.ts
@@ -1,0 +1,8 @@
+import { SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = []
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/1442.ts
+++ b/packages/pools/src/constants/pools/1442.ts
@@ -1,0 +1,52 @@
+import { getAddress } from 'viem'
+import { polygonZkEvmTestnetTokens } from '@pancakeswap/tokens'
+import { PoolCategory, SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = [
+  {
+    sousId: 4,
+    stakingToken: polygonZkEvmTestnetTokens.cake,
+    earningToken: polygonZkEvmTestnetTokens.mockA,
+    contractAddress: '0x6e9Cf632243070984A44743d9009CD48cb232F83',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 3,
+    stakingToken: polygonZkEvmTestnetTokens.cake,
+    earningToken: polygonZkEvmTestnetTokens.mockA,
+    contractAddress: '0x6C9ffC1FE0f6aD00eeedbF99384E60517CA3E706',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 2,
+    stakingToken: polygonZkEvmTestnetTokens.cake,
+    earningToken: polygonZkEvmTestnetTokens.mockA,
+    contractAddress: '0x452ED06e65aF886Ff778E9aF319fdC0ffaFA9d85',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 1,
+    stakingToken: polygonZkEvmTestnetTokens.cake,
+    earningToken: polygonZkEvmTestnetTokens.mockA,
+    contractAddress: '0xd6bF7f0C9B1A19A7124625ECF7d6Db8b5610444A',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+].map((p) => ({
+  ...p,
+  contractAddress: getAddress(p.contractAddress),
+  stakingToken: p.stakingToken.serialize,
+  earningToken: p.earningToken.serialize,
+}))
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/59140.ts
+++ b/packages/pools/src/constants/pools/59140.ts
@@ -1,0 +1,52 @@
+import { getAddress } from 'viem'
+import { lineaTestnetTokens } from '@pancakeswap/tokens'
+import { PoolCategory, SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = [
+  {
+    sousId: 4,
+    stakingToken: lineaTestnetTokens.cake,
+    earningToken: lineaTestnetTokens.mockA,
+    contractAddress: '0x5d4A2dCefA1B6D5031f57a05651F0b49f4E0eC74',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 3,
+    stakingToken: lineaTestnetTokens.cake,
+    earningToken: lineaTestnetTokens.mockA,
+    contractAddress: '0xa014641f932E8b7985Ffd6F722DfE6995bbA15aF',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 2,
+    stakingToken: lineaTestnetTokens.cake,
+    earningToken: lineaTestnetTokens.mockA,
+    contractAddress: '0x4dc9C14A5542f3D0544a6c11d717AD04A70afF8C',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 1,
+    stakingToken: lineaTestnetTokens.cake,
+    earningToken: lineaTestnetTokens.mockA,
+    contractAddress: '0x30669C960b90Eb71DB4173D8b5069ca83CD2d400',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+].map((p) => ({
+  ...p,
+  contractAddress: getAddress(p.contractAddress),
+  stakingToken: p.stakingToken.serialize,
+  earningToken: p.earningToken.serialize,
+}))
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/59144.ts
+++ b/packages/pools/src/constants/pools/59144.ts
@@ -1,0 +1,8 @@
+import { SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = []
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/8453.ts
+++ b/packages/pools/src/constants/pools/8453.ts
@@ -1,0 +1,8 @@
+import { SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = []
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/84531.ts
+++ b/packages/pools/src/constants/pools/84531.ts
@@ -1,0 +1,52 @@
+import { getAddress } from 'viem'
+import { baseTestnetTokens } from '@pancakeswap/tokens'
+import { PoolCategory, SerializedPool } from '../../types'
+
+export const livePools: SerializedPool[] = [
+  {
+    sousId: 4,
+    stakingToken: baseTestnetTokens.cake,
+    earningToken: baseTestnetTokens.mockA,
+    contractAddress: '0x55F8912596F06453466e208e79AB808328146d06',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 3,
+    stakingToken: baseTestnetTokens.cake,
+    earningToken: baseTestnetTokens.mockA,
+    contractAddress: '0xE61a1065B740a61950E08C073833B85D3362f48B',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 2,
+    stakingToken: baseTestnetTokens.cake,
+    earningToken: baseTestnetTokens.mockA,
+    contractAddress: '0xF9991a0e33115c1B7e0690109115747ab5C48D9E',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+  {
+    sousId: 1,
+    stakingToken: baseTestnetTokens.cake,
+    earningToken: baseTestnetTokens.mockA,
+    contractAddress: '0x35DB927618560B8878543ea0019A8E664581ADb5',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.01',
+    version: 3,
+  },
+].map((p) => ({
+  ...p,
+  contractAddress: getAddress(p.contractAddress),
+  stakingToken: p.stakingToken.serialize,
+  earningToken: p.earningToken.serialize,
+}))
+
+// known finished pools
+export const finishedPools: SerializedPool[] = []
+
+export const pools: SerializedPool[] = [...livePools, ...finishedPools]

--- a/packages/pools/src/constants/pools/index.ts
+++ b/packages/pools/src/constants/pools/index.ts
@@ -7,6 +7,13 @@ import { pools as arbPools, livePools as arbLivePools } from './42161'
 import { pools as arbTestnetPools, livePools as arbTestnetLivePools } from './421613'
 import { pools as zkSyncPools, livePools as zkSyncLivePools } from './324'
 import { pools as zkSyncTestnetPools, livePools as zkSyncTestnetLivePools } from './280'
+import { pools as basePools, livePools as baseLivePools } from './8453'
+import { pools as baseTestnetPools, livePools as baseTestnetLivePools } from './84531'
+import { pools as lineaPools, livePools as lineaLivePools } from './59144'
+import { pools as lineaTestnetPools, livePools as lineaTestnetLivePools } from './59140'
+import { pools as polygonZkEvmPools, livePools as polygonZkEvmLivePools } from './1101'
+import { pools as polygonZkEvmTestnetPools, livePools as polygonZkEvmTestnetLivePools } from './1442'
+
 import { SerializedPool } from '../../types'
 import { SupportedChainId } from '../supportedChains'
 import { isPoolsSupported } from '../../utils/isPoolsSupported'
@@ -23,6 +30,12 @@ export const POOLS_CONFIG_BY_CHAIN = {
   [ChainId.ARBITRUM_GOERLI]: arbTestnetPools,
   [ChainId.ZKSYNC]: zkSyncPools,
   [ChainId.ZKSYNC_TESTNET]: zkSyncTestnetPools,
+  [ChainId.BASE]: basePools,
+  [ChainId.BASE_TESTNET]: baseTestnetPools,
+  [ChainId.LINEA]: lineaPools,
+  [ChainId.LINEA_TESTNET]: lineaTestnetPools,
+  [ChainId.POLYGON_ZKEVM]: polygonZkEvmPools,
+  [ChainId.POLYGON_ZKEVM_TESTNET]: polygonZkEvmTestnetPools,
 } as PoolsConfigByChain<SupportedChainId>
 
 export const LIVE_POOLS_CONFIG_BY_CHAIN = {
@@ -33,6 +46,12 @@ export const LIVE_POOLS_CONFIG_BY_CHAIN = {
   [ChainId.ARBITRUM_GOERLI]: arbTestnetLivePools,
   [ChainId.ZKSYNC]: zkSyncLivePools,
   [ChainId.ZKSYNC_TESTNET]: zkSyncTestnetLivePools,
+  [ChainId.BASE]: baseLivePools,
+  [ChainId.BASE_TESTNET]: baseTestnetLivePools,
+  [ChainId.LINEA]: lineaLivePools,
+  [ChainId.LINEA_TESTNET]: lineaTestnetLivePools,
+  [ChainId.POLYGON_ZKEVM]: polygonZkEvmLivePools,
+  [ChainId.POLYGON_ZKEVM_TESTNET]: polygonZkEvmTestnetLivePools,
 } as PoolsConfigByChain<SupportedChainId>
 
 export const getPoolsConfig = (chainId: ChainId) => {

--- a/packages/pools/src/constants/supportedChains.ts
+++ b/packages/pools/src/constants/supportedChains.ts
@@ -8,6 +8,9 @@ export const SUPPORTED_CHAIN_IDS = [
   ChainId.ARBITRUM_GOERLI,
   ChainId.ZKSYNC,
   ChainId.ZKSYNC_TESTNET,
+  ChainId.LINEA_TESTNET,
+  ChainId.BASE_TESTNET,
+  ChainId.POLYGON_ZKEVM_TESTNET,
 ] as const
 
 export type SupportedChainId = (typeof SUPPORTED_CHAIN_IDS)[number]

--- a/packages/tokens/src/1442.ts
+++ b/packages/tokens/src/1442.ts
@@ -1,9 +1,10 @@
 import { ChainId, ERC20Token, WETH9 } from '@pancakeswap/sdk'
-import { USDT } from './common'
+import { USDT, CAKE } from './common'
 
 export const polygonZkEvmTestnetTokens = {
   weth: WETH9[ChainId.POLYGON_ZKEVM_TESTNET],
   usdt: USDT[ChainId.POLYGON_ZKEVM_TESTNET],
+  cake: CAKE[ChainId.POLYGON_ZKEVM_TESTNET],
   mockA: new ERC20Token(ChainId.POLYGON_ZKEVM_TESTNET, '0xa8209d33Bfc9cA15138dDaB6A637f6c4617379c9', 18, 'MOCKA'),
   mockB: new ERC20Token(ChainId.POLYGON_ZKEVM_TESTNET, '0x62d907974C0b72334373f34b8272467857402Ec3', 18, 'MOCKB'),
   mockC: new ERC20Token(ChainId.POLYGON_ZKEVM_TESTNET, '0xf317eD77Baed624d0EA2384AA88D91B774a9b009', 18, 'MOCKC'),

--- a/packages/tokens/src/59140.ts
+++ b/packages/tokens/src/59140.ts
@@ -1,7 +1,9 @@
-import { ChainId, WETH9 } from '@pancakeswap/sdk'
-import { USDC } from './common'
+import { ChainId, WETH9, ERC20Token } from '@pancakeswap/sdk'
+import { USDC, CAKE } from './common'
 
 export const lineaTestnetTokens = {
   weth: WETH9[ChainId.LINEA_TESTNET],
   usdc: USDC[ChainId.LINEA_TESTNET],
+  cake: CAKE[ChainId.LINEA_TESTNET],
+  mockA: new ERC20Token(ChainId.BASE_TESTNET, '0x6cc56b20bf8C4FfD58050D15AbA2978A745CC691', 18, 'A', 'Mock A'),
 }

--- a/packages/tokens/src/84531.ts
+++ b/packages/tokens/src/84531.ts
@@ -1,7 +1,9 @@
-import { ChainId, WETH9 } from '@pancakeswap/sdk'
-import { USDC } from './common'
+import { ChainId, WETH9, ERC20Token } from '@pancakeswap/sdk'
+import { USDC, CAKE } from './common'
 
 export const baseTestnetTokens = {
   weth: WETH9[ChainId.BASE_TESTNET],
   usdc: USDC[ChainId.BASE_TESTNET],
+  cake: CAKE[ChainId.BASE_TESTNET],
+  mockA: new ERC20Token(ChainId.BASE_TESTNET, '0x15571d4a7D08e16108b97cf7c80Ffd5C3fcb9657', 18, 'A', 'Mock A'),
 }

--- a/packages/tokens/src/common.ts
+++ b/packages/tokens/src/common.ts
@@ -203,6 +203,22 @@ export const CAKE = {
     'PancakeSwap Token',
     'https://pancakeswap.finance/',
   ),
+  [ChainId.BASE_TESTNET]: new ERC20Token(
+    ChainId.BASE_TESTNET,
+    '0x052a99849Ef2e13a5CB28275862991671D4b6fF5',
+    18,
+    'CAKE',
+    'PancakeSwap Token',
+    'https://pancakeswap.finance/',
+  ),
+  [ChainId.LINEA_TESTNET]: new ERC20Token(
+    ChainId.LINEA_TESTNET,
+    '0x2B3C5df29F73dbF028BA82C33e0A5A6e5800F75e',
+    18,
+    'CAKE',
+    'PancakeSwap Token',
+    'https://pancakeswap.finance/',
+  ),
 }
 
 export const USDC = {

--- a/packages/utils/llamaPrice.ts
+++ b/packages/utils/llamaPrice.ts
@@ -5,6 +5,9 @@ const CHAIN_MAPPING = {
   [ChainId.BSC]: 'bsc',
   [ChainId.ARBITRUM_ONE]: 'arbitrum',
   [ChainId.ZKSYNC]: 'era',
+  [ChainId.LINEA]: 'linea',
+  [ChainId.BASE]: 'base',
+  [ChainId.POLYGON_ZKEVM]: 'polygon_zkevm',
 } as const satisfies Record<number, string>
 
 // use for fetch usd outside of the liquidity pools on PancakeSwap


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1465843</samp>

### Summary
🏊📈🧪

<!--
1.  🏊 - This emoji represents the pools feature and the creation of new pool files for different chains.
2.  📈 - This emoji represents the price helper LP feature and the creation of new price helper LP files for different chains.
3.  🧪 - This emoji represents the testnet chains and the addition of mock pools and tokens for testing purposes.
-->
This pull request enables the pools and price helper LP features for multiple chains and testnet chains by creating and modifying various files in the `apps/web/src/config/constants/priceHelperLps`, `packages/pools/src/constants`, and `packages/tokens/src` folders. It also adds the contract addresses for the `ICAKE`, `CAKE_VAULT`, and `CAKE_FLEXIBLE_SIDE_VAULT` contracts for three testnet chains to the `packages/pools/src/constants/contracts.ts` file. It also imports and returns the appropriate price helper LP and pool files based on the chain ID in the `apps/web/src/config/constants/priceHelperLps/index.ts` and `packages/pools/src/constants/pools/index.ts` files. It also creates mock pools and tokens for testing the pools feature on some testnet chains.

> _We're setting sail for new chains, me hearties_
> _We've got the pools and the price helper LPs_
> _So grab the `CAKE` and the `MOCKA` tokens_
> _And heave away on the count of three_

### Walkthrough
*  Enable the pools feature for different chains by importing and exporting the pools files based on the chain ID ([link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-0351669c1f46d6d6f1483a652effe0c3881f52b38b14755e43eaf606997059c5R1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-4a03939f9df7578a5a9cf9dde755138e0d460ff570c99b79c6e69dde6d5dc2c8R1-R52), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e20a023cd66b8c0a1deaa99c4c586526f2eb44342afdc3c987506e8097aee453R1-R52), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-1e7b1647aa72d5dbef69eecdd14c8f94bdcb497a3e60b4f39f0bf99d4b414e3dR1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-fc08fcd5c6f977d1656aa9f8dcd9b8bc2233b8c7740585ff621c90b0efd6edabR1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e7af8afa5bb6d746e48e933329e961284f0b45351118cd1e4fd25dc034255937R1-R52), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-f5ab55bf4078135a7bd2ebb8bf5c23c7f0de1e8c6d36c27861bc43805419dc25R10-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-f5ab55bf4078135a7bd2ebb8bf5c23c7f0de1e8c6d36c27861bc43805419dc25R33-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-f5ab55bf4078135a7bd2ebb8bf5c23c7f0de1e8c6d36c27861bc43805419dc25R49-R54), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-9d58fdf9947758c1915460c83ccb4265e39446a1e47804ca27c2500580945d09R11-R13))
*  Enable the price helper LP feature for different chains by importing and exporting the price helper LP files based on the chain ID ([link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-d78bf8d1c667faba4e13657e1bbc2abe377978eb57c350b22dfe54e3354c8ab2R11-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-d78bf8d1c667faba4e13657e1bbc2abe377978eb57c350b22dfe54e3354c8ab2R38-R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-35c14c4f1664001c2f8b792d439fddde373d7edc00f77e17bf3382e1d1bf8156R1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-89f6676507dca9d16de8fbe47e83a1af2bbe787c0dd10ae221d84338e783c287R1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-0f6d7366e8972a5cdd6f45a4003af4b8c28019338a421238c7c48ff210b55338R1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e071ddf3ecfccee26f3b30f56af8aff44a232f0945c9cf53ff797ca86d0bc25cR1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-06dc4d45d27e4c0e19e68b387dc889cc16a76e20b532bf9f7dc122cbad62c497R1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e3c84b8536cbedb190fdb70b9786e0354ca2f5e6239fe3dd9ff45960b89b02ceR1-R5))
*  Add the contract addresses for the `ICAKE`, `CAKE_VAULT`, and `CAKE_FLEXIBLE_SIDE_VAULT` contracts for the Base Testnet, Linea Testnet, and Polygon ZK-EVM Testnet chains to the `contracts.ts` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-6617e1b6b671418fcbaeee30a67fa7198f5b270e377dccf8393cd40db8b92534R18-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-6617e1b6b671418fcbaeee30a67fa7198f5b270e377dccf8393cd40db8b92534R31-R33), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-6617e1b6b671418fcbaeee30a67fa7198f5b270e377dccf8393cd40db8b92534R44-R46))
*  Add the `CAKE` token and the mock tokens for the Base Testnet, Linea Testnet, and Polygon ZK-EVM Testnet chains to the `common.ts`, `84531.ts`, `59140.ts`, and `1442.ts` files ([link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-3b2667a546404aa108d7b7fc031b95806acb21af196bd10b1de5b7f72d4affafL2-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-cc9c2265fc94765ee731aedb28d3b9ff92c9bd01d89b4a834f69110e2e32e5a9L1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-a489cc69c86a87ca44ae4bb4790004a70f8da6190e2d9ed7ea257922ce1ba5ecL1-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-8dce334490b3aef54ec2484deec6ef79b4438828dc1ee3324cfa3b2a5244251bR198-R213))
*  Create mock pools that use the `CAKE` token as the staking token and the mock tokens as the earning tokens for the Base Testnet, Linea Testnet, and Polygon ZK-EVM Testnet chains and map the contract addresses, staking tokens, and earning tokens to their serialized versions ([link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-4a03939f9df7578a5a9cf9dde755138e0d460ff570c99b79c6e69dde6d5dc2c8R1-R52), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e20a023cd66b8c0a1deaa99c4c586526f2eb44342afdc3c987506e8097aee453R1-R52), [link](https://github.com/pancakeswap/pancake-frontend/pull/7756/files?diff=unified&w=0#diff-e7af8afa5bb6d746e48e933329e961284f0b45351118cd1e4fd25dc034255937R1-R52))


