### PR TITLE
fix: ConvertToLock Message Text disappear

### DIFF
--- a/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Common/ConvertToLock.tsx
@@ -1,5 +1,5 @@
 import { Token } from '@pancakeswap/sdk'
-import { Flex, Message, MessageText, useMatchBreakpoints, SkeletonV2 } from '@pancakeswap/uikit'
+import { Flex, Message, MessageText, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { memo } from 'react'
 import { useVaultApy } from 'hooks/useVaultApy'
@@ -45,13 +45,13 @@ const ConvertToLock: React.FC<React.PropsWithChildren<ConvertToLockProps>> = ({
       }
       actionInline={isTableView}
     >
-      <SkeletonV2 isDataReady={!!(avgLockDurationsInSeconds && lockedApy)} wrapperProps={{ height: 'fit-content' }}>
+      {!!(avgLockDurationsInSeconds && lockedApy) && (
         <MessageText>
           {t('Lock staking users are earning an average of %amount%% APR. More benefits are coming soon.', {
             amount: lockedApy ? parseFloat(lockedApy).toFixed(2) : 0,
           })}
         </MessageText>
-      </SkeletonV2>
+      )}
     </Message>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7f1d76f</samp>

### Summary
🗑️💬🌟

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to represent the removal of the `SkeletonV2` component, which was no longer needed and added extra code.
2.  💬 - This emoji means "speech balloon" and can be used to represent the use of the `MessageText` component, which displays loading or error messages in a clear and consistent way.
3.  🌟 - This emoji means "glowing star" and can be used to represent the improvement of the user interface and the reduction of unnecessary code, which are positive outcomes of the changes.
-->
Improved locked pool UI and code quality by replacing `SkeletonV2` with `MessageText` in `ConvertToLock.tsx`.

> _Oh we're the coders of the sea, we make the web app run_
> _We pull and push and merge and branch, we always have some fun_
> _We don't need no `SkeletonV2`, we've got `MessageText` instead_
> _So heave away and clear the code, and let the users see what's said_

### Walkthrough
*  Remove unused `SkeletonV2` component from import statement ([link](https://github.com/pancakeswap/pancake-frontend/pull/7757/files?diff=unified&w=0#diff-9e5932337c4415dbe1a753d220201300af08e3b7e529522a6462a60982663276L2-R2))
*  Replace `SkeletonV2` component with conditional rendering of `MessageText` component to show locked APY and average lock duration ([link](https://github.com/pancakeswap/pancake-frontend/pull/7757/files?diff=unified&w=0#diff-9e5932337c4415dbe1a753d220201300af08e3b7e529522a6462a60982663276L48-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7757/files?diff=unified&w=0#diff-9e5932337c4415dbe1a753d220201300af08e3b7e529522a6462a60982663276L54-R54))
*  Simplify code and avoid empty skeleton in `ConvertToLock.tsx` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7757/files?diff=unified&w=0#diff-9e5932337c4415dbe1a753d220201300af08e3b7e529522a6462a60982663276L48-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7757/files?diff=unified&w=0#diff-9e5932337c4415dbe1a753d220201300af08e3b7e529522a6462a60982663276L54-R54))


