### PR TITLE
chore: shelve moonpay banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -12,6 +12,7 @@ import { ZksyncBanner } from '../ZksyncBanner'
 import useIsRenderCompetitionBanner from './useIsRenderCompetitionBanner'
 import useIsRenderIfoBanner from './useIsRenderIFOBanner'
 import LineaBanner from '../LineaBanner'
+import MoonPayBanner from '../MoonPayBanner'
 import BaseBanner from '../BaseBanner'
 
 interface IBannerConfig {
@@ -38,6 +39,7 @@ export const useMultipleBannerConfig = () => {
 
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
+      { shouldRender: true, banner: <MoonPayBanner /> },
       { shouldRender: true, banner: <BaseBanner /> },
       { shouldRender: true, banner: <LineaBanner /> },
       { shouldRender: true, banner: <ArbitrumOneBanner /> },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af4d366</samp>

### Summary
🌙🏠🎏

<!--
1.  🌙 - This emoji could be used to represent the MoonPay service, which is a platform for buying and selling cryptocurrencies with fiat currencies. The moon symbolizes the crypto space and the name of the service.
2.  🏠 - This emoji could be used to represent the home page, where the new banner component is displayed. The house symbolizes the main or default page of a website or app.
3.  🎏 - This emoji could be used to represent the banner component, which is a graphical element that displays a message or an advertisement. The carp streamer symbolizes a traditional Japanese banner that is flown on Children's Day.
-->
Added a new banner component to promote MoonPay service on the home page. Modified `useMultipleBannerConfig` hook to include `MoonPayBanner` in `apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx`.

> _The moon is calling, we must obey_
> _`useMultipleBannerConfig` to show the way_
> _A new component of doom and gloom_
> _`MoonPayBanner` will seal our fate soon_

### Walkthrough
*  Add `MoonPayBanner` component to display a banner for the MoonPay service on the home page ([link](https://github.com/pancakeswap/pancake-frontend/pull/7760/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/7760/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89R42))
*  Import `MoonPayBanner` from the same directory as `useMultipleBannerConfig` in `apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7760/files?diff=unified&w=0#diff-214af478b927b76b48361f0a7ba597c535ab140dcf4e7281bf15abde2a1a0e89R15))


