### PR TITLE
fix: Remove liquidity title

### DIFF
--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -342,8 +342,8 @@ function Remove({ tokenId }: { tokenId: bigint }) {
         <AppHeader
           backTo={`/liquidity/${tokenId}`}
           title={t('Remove %assetA%-%assetB% Liquidity', {
-            assetA: position?.token0 ?? '',
-            assetB: position?.token1 ?? '',
+            assetA: liquidityValue0?.currency?.symbol ?? '',
+            assetB: liquidityValue1?.currency?.symbol ?? '',
           })}
           noConfig
         />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 55d2bea</samp>

### Summary
🔄💱🎨

<!--
1.  🔄 This emoji could represent the change of using currency symbols instead of token names, as it implies switching or swapping something.
2. 💱 This emoji could also represent the change of using currency symbols, as it is often used to indicate currency exchange or conversion.
3. 🎨 This emoji could represent the change of updating the title to be more consistent and clear, as it implies improving the appearance or design of something.
-->
Updated the title of the Remove Liquidity page to use currency symbols. Refactored the code to store the token amounts and currencies in separate variables.

> _`Liquidity` page_
> _Symbols replace token names_
> _Clearer in winter_

### Walkthrough
* Updated the title of the Remove Liquidity page to use currency symbols instead of token names ([link](https://github.com/pancakeswap/pancake-frontend/pull/7774/files?diff=unified&w=0#diff-3639b5beb9d763170cb423e83fcbcd8129c820faa28a757bf95b2d841ca14261L345-R346))
* Added variables to store the amount and currency of each token in the liquidity position ([link](https://github.com/pancakeswap/pancake-frontend/pull/7774/files?diff=unified&w=0#diff-3639b5beb9d763170cb423e83fcbcd8129c820faa28a757bf95b2d841ca14261L345-R346))


