### PR TITLE
chore: remove play-usdt farm

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -43,13 +43,6 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
-    pid: 85,
-    token0: bscTokens.usdt,
-    token1: bscTokens.play,
-    lpAddress: '0x73D69D55893d6c97DCA44AF2Aa85B688C0242d7f',
-    feeAmount: FeeAmount.HIGH,
-  },
-  {
     pid: 84,
     token0: bscTokens.usdt,
     token1: bscTokens.xcad,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2eccab8</samp>

### Summary
🗑️🚫🔄

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, in this case the farm configuration for the USDT-PLAY pair.
2.  🚫 - This emoji represents the prohibition or discontinuation of something, in this case the trading of the USDT-PLAY pair on PancakeSwap.
3.  🔄 - This emoji represents the update or refresh of something, in this case the farm list to reflect the current state of the PancakeSwap exchange.
-->
Remove USDT-PLAY farm from `packages/farms/constants/56.ts`. This farm is no longer supported by the exchange and needs to be cleaned up.

> _`USDT-PLAY` gone_
> _Obsolete farms are removed_
> _Winter pruning time_

### Walkthrough
* Remove farm configuration for USDT-PLAY pair ([link](https://github.com/pancakeswap/pancake-frontend/pull/7784/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066L46-L52)) in `packages/farms/constants/56.ts`


