### PR TITLE
feat(Farm): Remove isCommunity tag

### DIFF
--- a/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionHistory.tsx
@@ -24,7 +24,7 @@ interface AuctionHistoryProps {
 const StyledIconButton = styled(IconButton)`
   width: 32px;
 
-  :disabled {
+  &:disabled {
     background: none;
 
     svg {

--- a/apps/web/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
+++ b/apps/web/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
@@ -11,7 +11,7 @@ const StyledInput = styled(Input)`
 const StyledIconButton = styled(IconButton)`
   width: 32px;
 
-  :disabled {
+  &:disabled {
     background: none;
 
     svg {

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -43,6 +43,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // keep those farms on top
   {
+    pid: 45,
+    token0: bscTokens.usdt,
+    token1: bscTokens.play,
+    lpAddress: '0x73D69D55893d6c97DCA44AF2Aa85B688C0242d7f',
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 84,
     token0: bscTokens.usdt,
     token1: bscTokens.xcad,
@@ -314,14 +321,6 @@ export const farmsV3 = defineFarmV3Configs([
     token1: bscTokens.axl,
     lpAddress: '0xD10612A288Bd5024Db6a47663750996d176130Fe',
     feeAmount: FeeAmount.MEDIUM,
-  },
-  {
-    pid: 45,
-    token0: bscTokens.usdt,
-    token1: bscTokens.play,
-    lpAddress: '0x73D69D55893d6c97DCA44AF2Aa85B688C0242d7f',
-    feeAmount: FeeAmount.HIGH,
-    isCommunity: true,
   },
   {
     pid: 46,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cdfe76b</samp>

### Summary
🐛🎨🌾

<!--
1.  🐛 for the bug fix in the CSS syntax error
2.  🎨 for the improvement in the appearance of the disabled buttons
3.  🌾 for the addition of the new farm and the removal of the `isCommunity` property
-->
Added a new USDT-PLAY V3 farm and fixed some CSS syntax errors in `StyledIconButton` components. These changes improve the functionality and appearance of the farms, auction, and lottery pages.

> _Oh we're the coders of the high seas_
> _We fix the bugs and style the `buttons`_
> _We add the farms and earn the `PLAY`_
> _And we work until the break of day_

### Walkthrough
*  Fix CSS syntax error in `StyledIconButton` component to correctly style disabled buttons ([link](https://github.com/pancakeswap/pancake-frontend/pull/7787/files?diff=unified&w=0#diff-a4caf83485e72681882202dbe7ec5da2f9b40eb5ad9280327ceaa201c1cbf85dL27-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7787/files?diff=unified&w=0#diff-5eeefd8afc46a52f09877ceb0e09298895b73ee030c16390da1b15dfd96cd35eL14-R14))
*  Add new USDT-PLAY farm to `farmsV3` constant in `56.ts` with pid 45, lpAddress, and feeAmount ([link](https://github.com/pancakeswap/pancake-frontend/pull/7787/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R46-R52))
*  Remove unnecessary `isCommunity` property from new farm object in `56.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7787/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066L319-L326))


