### PR TITLE
fix(HotToken): Fix weird gap

### DIFF
--- a/apps/web/src/components/TabToggle/index.tsx
+++ b/apps/web/src/components/TabToggle/index.tsx
@@ -2,7 +2,7 @@ import { Box, BoxProps, Flex } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
 
 const Wrapper = styled(Flex)`
-  overflow-x: scroll;
+  overflow-x: auto;
   padding: 0;
   border-radius: 24px 24px 0 0;
   ::-webkit-scrollbar {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af2dc1d</samp>

### Summary
📱🎨🚫

<!--
1.  📱 - This emoji represents the mobile version of the website, which was the main focus of the pull request and the reason for the change. It also implies that the change improves the responsiveness and adaptability of the component to different screen sizes.
2.  🎨 - This emoji represents the UI improvement and the appearance of the component, which was enhanced by hiding the unnecessary scrollbar. It also implies that the change was related to the design and style of the component, not the functionality or logic.
3.  🚫 - This emoji represents the removal of the scrollbar, which was the main effect of the change. It also implies that the change was a negative or subtractive one, not an additive or positive one. Alternatively, one could use the ❌ emoji, which has a similar meaning.
-->
Improved the UI of the `TabToggle` component by hiding the horizontal scrollbar unless needed. This change was part of a pull request that fixed some mobile UI issues.

> _`Wrapper` adapts_
> _No scrollbar unless needed_
> _Autumn of excess_

### Walkthrough
* Changed the horizontal scrollbar behavior of the `TabToggle` component to only show when needed ([link](https://github.com/pancakeswap/pancake-frontend/pull/7797/files?diff=unified&w=0#diff-6132dc6d90a9a90e3d8396ce5d36fc211cd9417544beb89b97310b451c8c0ce2L5-R5))



Before:
<img width="765" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/109973128/cb1885d7-e73b-4786-a5d1-b0372582dbfe">

After:
<img width="754" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/109973128/57feb221-3ee5-4aa9-ac74-2ceb2a65c845">