### PR TITLE
chore: Enable Safepal switch network

### DIFF
--- a/apps/web/src/hooks/useSwitchNetwork.ts
+++ b/apps/web/src/hooks/useSwitchNetwork.ts
@@ -79,7 +79,7 @@ export function useSwitchNetwork() {
           !(
             typeof window !== 'undefined' &&
             // @ts-ignore // TODO: add type later
-            (window.ethereum?.isSafePal || window.ethereum?.isMathWallet)
+            window.ethereum?.isMathWallet
           )
         : true,
     [_switchNetworkAsync, isConnected],

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -17,7 +17,7 @@ export const registerToken = async (
 ) => {
   // better leave this undefined for default image instead of broken image url
   const image = tokenLogo ? (BAD_SRCS[tokenLogo] ? undefined : tokenLogo) : undefined
-  const tokenAdded = await window.ethereum.request({
+  const tokenAdded = await window?.ethereum?.request({
     method: 'wallet_watchAsset',
     params: {
       type: 'ERC20',
@@ -36,8 +36,8 @@ export const registerToken = async (
 export const canRegisterToken = () =>
   typeof window !== 'undefined' &&
   // @ts-ignore
-  !window?.ethereum?.isSafePal &&
-  (window?.ethereum?.isMetaMask ||
+  ((window?.ethereum?.isMetaMask ||
     window?.ethereum?.isTrust ||
     window?.ethereum?.isCoinbaseWallet ||
-    window?.ethereum?.isTokenPocket)
+    window?.ethereum?.isTokenPocket) ??
+    false)

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -36,8 +36,8 @@ export const registerToken = async (
 export const canRegisterToken = () =>
   typeof window !== 'undefined' &&
   // @ts-ignore
-  ((window?.ethereum?.isMetaMask ||
+  !window?.ethereum?.isSafePal &&
+  (window?.ethereum?.isMetaMask ||
     window?.ethereum?.isTrust ||
     window?.ethereum?.isCoinbaseWallet ||
-    window?.ethereum?.isTokenPocket) ??
-    false)
+    window?.ethereum?.isTokenPocket)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 777b39f</samp>

### Summary
🗑️🔧🌐

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, in this case the condition that checks for SafePal wallet.
2.  🔧 - This emoji represents the improvement or fixing of something, in this case the error handling and compatibility of the token registration functions.
3.  🌐 - This emoji represents the network or web-related aspect of the change, in this case the switching of networks programmatically.
-->
This pull request enhances the wallet integration and network switching features of the web app. It fixes some potential errors in `wallet.ts` and removes an unnecessary restriction in `useSwitchNetwork.ts`.

> _Switching networks with no remorse_
> _`window.ethereum` is our source_
> _We handle errors with skill and grace_
> _`registerToken` for any token base_

### Walkthrough
* Remove SafePal wallet condition from useSwitchNetwork hook to enable network switching for other wallets ([link](https://github.com/pancakeswap/pancake-frontend/pull/7798/files?diff=unified&w=0#diff-c6d71475f897fefce1f5c366ce258e7eb5eed73ee77011cfb050ab4578fadb0cL82-R82))
* Add optional chaining and fallback values to window and window.ethereum objects in wallet utils to prevent errors and crashes ([link](https://github.com/pancakeswap/pancake-frontend/pull/7798/files?diff=unified&w=0#diff-1e50c52a8270664a56c31c424f127ee269871f258c0d6ce57a81eb140fa1036eL20-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/7798/files?diff=unified&w=0#diff-1e50c52a8270664a56c31c424f127ee269871f258c0d6ce57a81eb140fa1036eL39-R43))


Safepal wallet can now switch networks.

https://github.com/pancakeswap/pancake-frontend/assets/109973128/9e310e7b-d509-451d-9c3d-f31664663be1


