### PR TITLE
fix(Pools): Fix afterburn icon color

### DIFF
--- a/apps/web/src/views/Pools/components/Vault/VaultPositionTag.tsx
+++ b/apps/web/src/views/Pools/components/Vault/VaultPositionTag.tsx
@@ -46,7 +46,7 @@ const iconColorConfig: Record<VaultPosition, any> = {
   [VaultPosition.Flexible]: 'white',
   [VaultPosition.Locked]: 'white',
   [VaultPosition.LockedEnd]: null,
-  [VaultPosition.AfterBurning]: null,
+  [VaultPosition.AfterBurning]: 'failure',
 }
 
 const positionLabel: Record<VaultPosition, ReactNode> = {

--- a/apps/web/src/views/Pools/components/Vault/VaultPositionTag.tsx
+++ b/apps/web/src/views/Pools/components/Vault/VaultPositionTag.tsx
@@ -45,7 +45,7 @@ const iconColorConfig: Record<VaultPosition, any> = {
   [VaultPosition.None]: null,
   [VaultPosition.Flexible]: 'white',
   [VaultPosition.Locked]: 'white',
-  [VaultPosition.LockedEnd]: null,
+  [VaultPosition.LockedEnd]: 'secondary',
   [VaultPosition.AfterBurning]: 'failure',
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 14e0a37</samp>

### Summary
🔥🏷️🎨

<!--
1.  🔥 - This emoji represents the burning action that the user performs to exit the pool and the new tag that shows this status.
2.  🏷️ - This emoji represents the tag component that renders the different vault positions and the icon color config that determines the color of each tag.
3.  🎨 - This emoji represents the color change that was made to assign the 'failure' color to the `AfterBurning` case.
-->
Updated `iconColorConfig` in `VaultPositionTag.tsx` to use 'failure' color for `AfterBurning` vault position. This is part of a feature that adds a new tag for users who burned cake tokens to exit a pool.

> _`iconColorConfig`_
> _Updated for burned cake tokens_
> _Red tag of failure_

### Walkthrough
*  Assign 'failure' color to `AfterBurning` vault position tag ([link](https://github.com/pancakeswap/pancake-frontend/pull/7799/files?diff=unified&w=0#diff-9384888cb1a86f2503b692343c862f715520d66731dcb3a3050499cde125698aL49-R49))


