### PR TITLE
fix: Override approve return error

### DIFF
--- a/apps/web/src/hooks/useApproveCallback.ts
+++ b/apps/web/src/hooks/useApproveCallback.ts
@@ -75,7 +75,7 @@ export function useApproveCallback(
 
   const approve = useCallback(
     async (overrideAmountApprove?: bigint): Promise<SendTransactionResult> => {
-      if (approvalState !== ApprovalState.NOT_APPROVED) {
+      if (approvalState !== ApprovalState.NOT_APPROVED && isUndefinedOrNull(overrideAmountApprove)) {
         toastError(t('Error'), t('Approve was called unnecessarily'))
         console.error('approve was called unnecessarily')
         return undefined


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 246efb7</samp>

### Summary
🐛🛠️📝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🛠️ - This emoji represents a tool or a fix, which is what the `approve` function does by allowing the user to approve tokens.
3.  📝 - This emoji represents documentation or comments, which is what the error message and the log statement provide.
-->
Fixed a bug in `useApproveCallback` hook that prevented approving custom amounts of tokens. Added a null check for the `overrideAmountApprove` parameter in the `approve` function.

> _`approve` function_
> _fixes a token bug in fall_
> _checks `overrideAmountApprove`_

### Walkthrough
*  Fix a bug where the user could not approve a custom amount of tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7800/files?diff=unified&w=0#diff-30f4e9bda6809aacb9da9383d87f8a61a75ccbdae15da50c832e913381e30fb0L78-R78))


