### PR TITLE
feat: Update Perp chain query name

### DIFF
--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -15,7 +15,7 @@ const mapPerpChain = (chainId: ChainId): string => {
     case ChainId.ARBITRUM_ONE:
       return 'arbitrum'
     default:
-      return 'bnbchain'
+      return 'bsc'
   }
 }
 


### PR DESCRIPTION
Perp team provide new query name for `chain`



<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c20b228</samp>

### Summary
🐛🔄🌐

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes a bug that prevented the Perpetuals UI from loading the correct chain data for Binance Smart Chain.
2.  🔄 - This emoji represents a change or update, since the change modifies the existing behavior of the `mapPerpChain` function and returns a different value than before.
3.  🌐 - This emoji represents a network or chain, since the change affects the chain identifier that is used to connect to the Perpetuals UI.
-->
Fixed a bug in `getPerpetualUrl` function that caused Perpetuals UI to fail on Binance Smart Chain. Changed the default chain identifier from 'bnbchain' to 'bsc' to match the UI.

> _`mapPerpChain` changed_
> _Binance Smart Chain now 'bsc'_
> _Winter bug is fixed_

### Walkthrough
*  Fix Perpetuals UI bug for Binance Smart Chain by returning 'bsc' as the default value in `mapPerpChain` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7803/files?diff=unified&w=0#diff-4c2d20aeaac9ab3c1c64428aaea6bb8f67d93af622de190e76242dc2b2717f5bL18-R18))


