### PR TITLE
chore: mercuryo campaign end

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
@@ -17,12 +17,6 @@ function Accordion({
   const { t } = useTranslation()
   const [currentIdx, setCurrentIdx] = useState<number | string>(0)
 
-  combinedQuotes.sort((a: ProviderQuote, b: ProviderQuote) => {
-    if (a.provider === ONRAMP_PROVIDERS.Mercuryo && b.provider !== ONRAMP_PROVIDERS.Mercuryo) return -1
-    if (a.provider !== ONRAMP_PROVIDERS.Mercuryo && b.provider === ONRAMP_PROVIDERS.Mercuryo) return 1
-    return 0
-  })
-
   if (combinedQuotes.length === 0) {
     return (
       <FlexGap flexDirection="column" gap="16px">

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
@@ -1,8 +1,7 @@
-import { Dispatch, SetStateAction, useState } from 'react'
-import { Flex, FlexGap, Row, Text } from '@pancakeswap/uikit'
-import { CryptoFormView, ProviderQuote } from 'views/BuyCrypto/types'
 import { useTranslation } from '@pancakeswap/localization'
-import { ONRAMP_PROVIDERS } from 'views/BuyCrypto/constants'
+import { Flex, FlexGap, Row, Text } from '@pancakeswap/uikit'
+import { Dispatch, SetStateAction, useState } from 'react'
+import { CryptoFormView, ProviderQuote } from 'views/BuyCrypto/types'
 import AccordionItem from './AccordionItem'
 
 function Accordion({

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -22,7 +22,7 @@ const DropdownWrapper = styled.div<{ isClicked: boolean }>`
 
 const activeProviders: { [provider in keyof typeof ONRAMP_PROVIDERS]: boolean } = {
   [ONRAMP_PROVIDERS.Mercuryo]: false,
-  [ONRAMP_PROVIDERS.MoonPay]: true,
+  [ONRAMP_PROVIDERS.MoonPay]: false,
 }
 
 const FeeItem = ({ feeTitle, feeAmount, currency }: { feeTitle: string; feeAmount: number; currency: string }) => {

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 import { isMobile } from 'react-device-detect'
 import formatLocaleNumber from 'utils/formatLocaleNumber'
-import { providerFeeTypes } from 'views/BuyCrypto/constants'
+import { ONRAMP_PROVIDERS, providerFeeTypes } from 'views/BuyCrypto/constants'
 import Image from 'next/image'
 import getTimePeriods from '@pancakeswap/utils/getTimePeriods'
 import OnRampProviderLogo from '../OnRampProviderLogo/OnRampProviderLogo'
@@ -19,6 +19,11 @@ const DropdownWrapper = styled.div<{ isClicked: boolean }>`
   width: 100%;
   transition: display 0.6s ease-in-out;
 `
+
+const activeProviders: { [provider in keyof typeof ONRAMP_PROVIDERS]: boolean } = {
+  [ONRAMP_PROVIDERS.Mercuryo]: false,
+  [ONRAMP_PROVIDERS.MoonPay]: true,
+}
 
 const FeeItem = ({ feeTitle, feeAmount, currency }: { feeTitle: string; feeAmount: number; currency: string }) => {
   const {
@@ -59,7 +64,7 @@ function AccordionItem({
   const [visiblity, setVisiblity] = useState(false)
   const [mobileTooltipShow, setMobileTooltipShow] = useState(false)
   const currentTimestamp = Math.floor(Date.now() / 1000)
-  const { days, hours, minutes } = getTimePeriods(currentTimestamp - 1694512859)
+  const { days, hours, minutes, seconds } = getTimePeriods(currentTimestamp - 1694512859)
   const isActive = () => (multiple ? visiblity : active)
 
   const toogleVisiblity = useCallback(() => {
@@ -154,7 +159,7 @@ function AccordionItem({
             else fee = quote.providerFee
             return <FeeItem key={feeType} feeTitle={feeType} feeAmount={fee} currency={quote.fiatCurrency} />
           })}
-          {quote.provider === 'Mercuryo' ? (
+          {activeProviders[quote.provider] && seconds >= 1 ? (
             <Box mt="16px" background="#F0E4E2" padding="16px" border="1px solid #D67E0A" borderRadius="16px">
               <Flex>
                 <Image src={pocketWatch} alt="pocket-watch" height={30} width={30} />

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -11,6 +11,8 @@ import formatLocaleNumber from 'utils/formatLocaleNumber'
 import { CURRENT_CAMPAIGN_TIMESTAMP, ONRAMP_PROVIDERS, providerFeeTypes } from 'views/BuyCrypto/constants'
 import Image from 'next/image'
 import getTimePeriods from '@pancakeswap/utils/getTimePeriods'
+import { useBuyCryptoState } from 'state/buyCrypto/hooks'
+import { Field } from 'state/buyCrypto/actions'
 import OnRampProviderLogo from '../OnRampProviderLogo/OnRampProviderLogo'
 import pocketWatch from '../../../../../public/images/pocket-watch.svg'
 
@@ -65,6 +67,9 @@ function AccordionItem({
   const [mobileTooltipShow, setMobileTooltipShow] = useState(false)
   const currentTimestamp = Math.floor(Date.now() / 1000)
   const { days, hours, minutes, seconds } = getTimePeriods(currentTimestamp - CURRENT_CAMPAIGN_TIMESTAMP)
+  const {
+    [Field.INPUT]: { currencyId: inputCurrencyId },
+  } = useBuyCryptoState()
   const isActive = () => (multiple ? visiblity : active)
 
   const toogleVisiblity = useCallback(() => {
@@ -96,7 +101,7 @@ function AccordionItem({
 
   const providerFee = quote.providerFee < 3.5 && quote.provider === 'MoonPay' ? 3.5 : quote.providerFee
 
-  if (quote.amount === 0) {
+  if (quote.amount === 0 || (inputCurrencyId === 'BUSD' && quote.provider === ONRAMP_PROVIDERS.Mercuryo)) {
     return (
       <Flex flexDirection="column">
         <CryptoCard padding="16px 16px" style={{ height: '48px' }} position="relative" isClicked={false} isDisabled>

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 import { isMobile } from 'react-device-detect'
 import formatLocaleNumber from 'utils/formatLocaleNumber'
-import { ONRAMP_PROVIDERS, providerFeeTypes } from 'views/BuyCrypto/constants'
+import { CURRENT_CAMPAIGN_TIMESTAMP, ONRAMP_PROVIDERS, providerFeeTypes } from 'views/BuyCrypto/constants'
 import Image from 'next/image'
 import getTimePeriods from '@pancakeswap/utils/getTimePeriods'
 import OnRampProviderLogo from '../OnRampProviderLogo/OnRampProviderLogo'
@@ -64,7 +64,7 @@ function AccordionItem({
   const [visiblity, setVisiblity] = useState(false)
   const [mobileTooltipShow, setMobileTooltipShow] = useState(false)
   const currentTimestamp = Math.floor(Date.now() / 1000)
-  const { days, hours, minutes, seconds } = getTimePeriods(currentTimestamp - 1694512859)
+  const { days, hours, minutes, seconds } = getTimePeriods(currentTimestamp - CURRENT_CAMPAIGN_TIMESTAMP)
   const isActive = () => (multiple ? visiblity : active)
 
   const toogleVisiblity = useCallback(() => {

--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -11,10 +11,11 @@ export const SUPPORTED_MERCURYO_ARBITRUM_TOKENS = ['ETH', 'USDC']
 export const SUPPORTED_MONPAY_ETH_TOKENS = ['eth', 'usdc', 'dai', 'usdt']
 export const SUPPORTED_MOONPAY_BSC_TOKENS = ['bnb_bsc', 'busd_bsc']
 export const SUPPORTED_MOONPAY_ARBITRUM_TOKENS = ['eth_arbitrum', 'usdc_arbitrum']
-
 export const SUPPORTED_MERCURYO_FIAT_CURRENCIES = ['USD', 'EUR', 'GBP', 'HKD', 'CAD', 'AUD', 'BRL', 'JPY', 'KRW', 'VND']
 const MOONPAY_FEE_TYPES = ['Est. Total Fees', 'Networking Fees', 'Provider Fees']
 const MERCURYO_FEE_TYPES = ['Est Total Fees', 'Provider Fees', 'Processing Fees']
+
+export const CURRENT_CAMPAIGN_TIMESTAMP = 1694512859
 
 export const supportedTokenMap: {
   [chainId: number]: {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9579359</samp>

### Summary
🗑️🔄🕒

<!--
1.  🗑️ - This emoji represents the removal of the sorting logic that favored Mercuryo over other providers. It conveys the idea of deleting or discarding something that is no longer needed or wanted.
2.  🔄 - This emoji represents the update of the `AccordionItem` component to use the constants and the object that store the information about the onramp providers. It conveys the idea of refreshing or changing something to make it more consistent or accurate.
3.  🕒 - This emoji represents the modification of the condition for displaying the countdown timer and the buy button for each provider. It conveys the idea of time or deadline, as well as the urgency or availability of the providers.
-->
This pull request refactors the `AccordionItem` component to use constants and props for provider status and expiration, and removes the sorting logic that favored Mercuryo in the `Accordion` component. The goal is to improve the UI and the API integration, and to provide a fair and transparent comparison of providers for the Buy Crypto feature.

> _Sing, O Muse, of the code that removed the sorting logic_
> _That favored Mercuryo, the swift provider of crypto,_
> _And caused much strife and trouble for the UI and the API_
> _And went against the vision of the fair and transparent display._

### Walkthrough
*  Remove hardcoded preference for Mercuryo and allow user to choose provider based on quotes ([link](https://github.com/pancakeswap/pancake-frontend/pull/7824/files?diff=unified&w=0#diff-ab2dfeee40c6fdf86014787d7a6649b7732e47e6f04048a8176f9642a80fb608L20-L25))
*  Import and use `ONRAMP_PROVIDERS` constant to access provider names and logos ([link](https://github.com/pancakeswap/pancake-frontend/pull/7824/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L11-R11))
*  Add `activeProviders` object to store active status of each provider based on API response ([link](https://github.com/pancakeswap/pancake-frontend/pull/7824/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2R23-R27))
*  Use `seconds` variable to check if countdown timer is still running for each provider ([link](https://github.com/pancakeswap/pancake-frontend/pull/7824/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L62-R67))
*  Display countdown timer and buy button only for active providers with valid quotes and expiration times ([link](https://github.com/pancakeswap/pancake-frontend/pull/7824/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L157-R162))


