### PR TITLE
feat(Blog): Add scroll to All articles section

### DIFF
--- a/apps/blog/components/Article/AllArticle/index.tsx
+++ b/apps/blog/components/Article/AllArticle/index.tsx
@@ -92,7 +92,10 @@ const AllArticle = () => {
       )
       if (searchedTopic) {
         setSelectCategoriesSelected(searchedTopic.id)
-        handleScrollToArticleSection()
+        window.scrollTo({
+          top: articlesWrapperEl?.current?.offsetTop,
+          behavior: 'smooth',
+        })
       }
     }
   }, [categoriesData, router.isReady, router.query.category])
@@ -125,13 +128,6 @@ const AllArticle = () => {
     if (blogCodeFromStorage !== language) {
       localStorage.setItem(LS_KEY, language)
     }
-  }
-
-  const handleScrollToArticleSection = () => {
-    window.scrollTo({
-      top: articlesWrapperEl?.current?.offsetTop,
-      behavior: 'smooth',
-    })
   }
 
   return (

--- a/apps/blog/components/Article/AllArticle/index.tsx
+++ b/apps/blog/components/Article/AllArticle/index.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 import useSWR from 'swr'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Box, Text, Flex, PaginationButton, SearchInput, InputGroup, SearchIcon } from '@pancakeswap/uikit'
 import CardArticle from 'components/Article/CardArticle'
 import { useTranslation } from '@pancakeswap/localization'
@@ -67,6 +67,7 @@ const AllArticle = () => {
   const { t } = useTranslation()
   const router = useRouter()
   const [query, setQuery] = useState('')
+  const articlesWrapperEl = useRef<HTMLDivElement>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [selectedCategories, setSelectCategoriesSelected] = useState(0)
   const [sortBy, setSortBy] = useState('createAt:desc')
@@ -86,11 +87,12 @@ const AllArticle = () => {
 
   useEffect(() => {
     if (router.isReady && router.query.category) {
-      const searchedTopic = categoriesData?.find(
+      const searchedTopic: Categories | undefined = categoriesData?.find(
         (category) => category.name.toLowerCase() === (router.query.category as string).toLowerCase(),
       )
       if (searchedTopic) {
         setSelectCategoriesSelected(searchedTopic.id)
+        handleScrollToArticleSection()
       }
     }
   }, [categoriesData, router.isReady, router.query.category])
@@ -125,8 +127,15 @@ const AllArticle = () => {
     }
   }
 
+  const handleScrollToArticleSection = () => {
+    window.scrollTo({
+      top: articlesWrapperEl?.current?.offsetTop,
+      behavior: 'smooth',
+    })
+  }
+
   return (
-    <StyledArticleContainer id="all">
+    <StyledArticleContainer id="all" ref={articlesWrapperEl}>
       <Text
         bold
         color="secondary"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e813f2b</samp>

### Summary
🖱️📰🪝

<!--
1.  🖱️ - This emoji represents the smooth scrolling feature, which is triggered by a mouse click on a category link. It also suggests the user interaction and navigation aspect of the change.
2.  📰 - This emoji represents the articles section, which is the main content of the page and the target of the smooth scrolling. It also suggests the news and information theme of the change.
3.  🪝 - This emoji represents the `useRef` hook, which is a React feature that allows accessing DOM elements in a functional component. It also suggests the technical and code-related aspect of the change.
-->
Improved the user experience of the blog app by enabling smooth scrolling to the articles section based on the URL query. Modified `apps/blog/components/Article/AllArticle/index.tsx` to implement this feature.

> _Oh, we're the coders of the sea, and we work with hooks and refs_
> _We make the pages smooth and neat, with `useRef` and `handleScrollToArticleSection`_
> _Heave away, me jolly lads, heave away with all your might_
> _We'll scroll to the articles section, when the category is in sight_

### Walkthrough
* Import `useRef` hook from `react` and create a reference to the articles wrapper element ([link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcL3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcR70))
* Type `searchedTopic` as `Categories | undefined` and call `handleScrollToArticleSection` after setting selected category ([link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcL89-R95))
* Define `handleScrollToArticleSection` function to scroll to the articles section using `articlesWrapperEl` and `window.scrollTo` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcL128-R138))
* Add `ref` prop to `StyledArticleContainer` component to pass `articlesWrapperEl` reference ([link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcR70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7829/files?diff=unified&w=0#diff-90fe91a04d505f100c27729fc4fb98d49e286574aabc0961a3db098868d534bcL128-R138))


