### PR TITLE
feat: Add reset approval eth usdt for liquidity

### DIFF
--- a/apps/web/src/views/AddLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/index.tsx
@@ -60,9 +60,13 @@ export interface LP2ChildrenProps {
   shouldShowApprovalGroup: boolean
   showFieldAApproval: boolean
   approveACallback: () => Promise<SendTransactionResult>
+  revokeACallback: () => Promise<SendTransactionResult>
+  currentAllowanceA: CurrencyAmount<Currency> | undefined
   approvalA: ApprovalState
   showFieldBApproval: boolean
   approveBCallback: () => Promise<SendTransactionResult>
+  revokeBCallback: () => Promise<SendTransactionResult>
+  currentAllowanceB: CurrencyAmount<Currency> | undefined
   approvalB: ApprovalState
   onAdd: () => Promise<void>
   onPresentAddLiquidityModal: () => void
@@ -154,14 +158,18 @@ export default function AddLiquidity({
   )
 
   // check whether the user has approved the router on the tokens
-  const { approvalState: approvalA, approveCallback: approveACallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_A],
-    V2_ROUTER_ADDRESS[chainId],
-  )
-  const { approvalState: approvalB, approveCallback: approveBCallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_B],
-    V2_ROUTER_ADDRESS[chainId],
-  )
+  const {
+    approvalState: approvalA,
+    approveCallback: approveACallback,
+    revokeCallback: revokeACallback,
+    currentAllowance: currentAllowanceA,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_A], V2_ROUTER_ADDRESS[chainId])
+  const {
+    approvalState: approvalB,
+    approveCallback: approveBCallback,
+    revokeCallback: revokeBCallback,
+    currentAllowance: currentAllowanceB,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_B], V2_ROUTER_ADDRESS[chainId])
 
   const addTransaction = useTransactionAdder()
 
@@ -351,9 +359,13 @@ export default function AddLiquidity({
     showFieldAApproval,
     approveACallback,
     approvalA,
+    revokeACallback,
+    currentAllowanceA,
     showFieldBApproval,
     approveBCallback,
     approvalB,
+    revokeBCallback,
+    currentAllowanceB,
     onAdd,
     onPresentAddLiquidityModal,
     buttonDisabled,

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -138,14 +138,18 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   const manager = isStakedInMCv3 ? masterchefV3 : positionManager
   const interfaceManager = isStakedInMCv3 ? MasterChefV3 : NonfungiblePositionManager
 
-  const { approvalState: approvalA, approveCallback: approveACallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_A],
-    manager?.address,
-  )
-  const { approvalState: approvalB, approveCallback: approveBCallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_B],
-    manager?.address,
-  )
+  const {
+    approvalState: approvalA,
+    approveCallback: approveACallback,
+    revokeCallback: revokeACallback,
+    currentAllowance: currentAllowanceA,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_A], manager?.address)
+  const {
+    approvalState: approvalB,
+    approveCallback: approveBCallback,
+    revokeCallback: revokeBCallback,
+    currentAllowance: currentAllowanceB,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_B], manager?.address)
 
   // we need an existence check on parsed amounts for single-asset deposits
   const showApprovalA = approvalA !== ApprovalState.APPROVED && !!parsedAmounts[Field.CURRENCY_A]
@@ -302,8 +306,12 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
       isValid={isValid}
       showApprovalA={showApprovalA}
       approveACallback={approveACallback}
+      currentAllowanceA={currentAllowanceA}
+      revokeACallback={revokeACallback}
       currencies={currencies}
       approveBCallback={approveBCallback}
+      currentAllowanceB={currentAllowanceB}
+      revokeBCallback={revokeBCallback}
       showApprovalB={showApprovalB}
       parsedAmounts={parsedAmounts}
       onClick={handleButtonSubmit}

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -6,7 +6,7 @@ import { useDerivedPositionInfo } from 'hooks/v3/useDerivedPositionInfo'
 import { useV3PositionFromTokenId, useV3TokenIdsByAccount } from 'hooks/v3/useV3Positions'
 import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
 import { FeeAmount, MasterChefV3, NonfungiblePositionManager } from '@pancakeswap/v3-sdk'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import { useUserSlippage, useIsExpertMode } from '@pancakeswap/utils/user'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
@@ -69,10 +69,14 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
 
   const addTransaction = useTransactionAdder()
   // fee selection from url
-  const feeAmount: FeeAmount | undefined =
-    feeAmountFromUrl && Object.values(FeeAmount).includes(parseFloat(feeAmountFromUrl))
-      ? parseFloat(feeAmountFromUrl)
-      : undefined
+  const feeAmount: FeeAmount | undefined = useMemo(
+    () =>
+      feeAmountFromUrl && Object.values(FeeAmount).includes(parseFloat(feeAmountFromUrl))
+        ? parseFloat(feeAmountFromUrl)
+        : undefined,
+    [feeAmountFromUrl],
+  )
+
   // check for existing position if tokenId in url
   const { position: existingPositionDetails, loading: positionLoading } = useV3PositionFromTokenId(
     tokenId ? BigInt(tokenId) : undefined,
@@ -81,8 +85,11 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   const hasExistingPosition = !!existingPositionDetails && !positionLoading
   const { position: existingPosition } = useDerivedPositionInfo(existingPositionDetails)
   // prevent an error if they input NATIVE/WNATIVE
-  const quoteCurrency =
-    baseCurrency && currencyB && baseCurrency.wrapped.equals(currencyB.wrapped) ? undefined : currencyB
+  const quoteCurrency = useMemo(
+    () => (baseCurrency && currencyB && baseCurrency.wrapped.equals(currencyB.wrapped) ? undefined : currencyB),
+    [baseCurrency, currencyB],
+  )
+
   // mint state
   const formState = useV3FormState()
   const { independentField, typedValue } = formState
@@ -114,26 +121,33 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   // txn values
   const deadline = useTransactionDeadline() // custom from users settings
   // get formatted amounts
-  const formattedAmounts = {
-    [independentField]: typedValue,
-    [dependentField]: parsedAmounts[dependentField]?.toSignificant(6) ?? '',
-  }
+  const formattedAmounts = useMemo(
+    () => ({
+      [independentField]: typedValue,
+      [dependentField]: parsedAmounts[dependentField]?.toSignificant(6) ?? '',
+    }),
+    [parsedAmounts, typedValue, independentField, dependentField],
+  )
 
   // get the max amounts user can add
-  const maxAmounts: { [field in Field]?: CurrencyAmount<Currency> } = [Field.CURRENCY_A, Field.CURRENCY_B].reduce(
-    (accumulator, field) => {
-      return {
-        ...accumulator,
-        [field]: maxAmountSpend(currencyBalances[field]),
-      }
-    },
-    {},
+  const maxAmounts: { [field in Field]?: CurrencyAmount<Currency> } = useMemo(
+    () =>
+      [Field.CURRENCY_A, Field.CURRENCY_B].reduce((accumulator, field) => {
+        return {
+          ...accumulator,
+          [field]: maxAmountSpend(currencyBalances[field]),
+        }
+      }, {}),
+    [currencyBalances],
   )
 
   const positionManager = useV3NFTPositionManagerContract()
   const [allowedSlippage] = useUserSlippage() // custom from users
 
-  const isStakedInMCv3 = Boolean(tokenId && stakedTokenIds.find((id) => id === BigInt(tokenId)))
+  const isStakedInMCv3 = useMemo(
+    () => Boolean(tokenId && stakedTokenIds.find((id) => id === BigInt(tokenId))),
+    [tokenId, stakedTokenIds],
+  )
 
   const manager = isStakedInMCv3 ? masterchefV3 : positionManager
   const interfaceManager = isStakedInMCv3 ? MasterChefV3 : NonfungiblePositionManager
@@ -258,11 +272,15 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     }
   }, [onFieldAInput, router, txHash, tokenId])
 
-  const pendingText = `Supplying ${
-    !depositADisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale) : ''
-  } ${!depositADisabled ? currencies[Field.CURRENCY_A]?.symbol : ''} ${!outOfRange ? 'and' : ''} ${
-    !depositBDisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale) : ''
-  } ${!depositBDisabled ? currencies[Field.CURRENCY_B]?.symbol : ''}`
+  const pendingText = useMemo(
+    () =>
+      `Supplying ${!depositADisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale) : ''} ${
+        !depositADisabled ? currencies[Field.CURRENCY_A]?.symbol : ''
+      } ${!outOfRange ? 'and' : ''} ${
+        !depositBDisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale) : ''
+      } ${!depositBDisabled ? currencies[Field.CURRENCY_B]?.symbol : ''}`,
+    [depositADisabled, depositBDisabled, currencies, parsedAmounts, outOfRange, locale],
+  )
 
   const [onPresentIncreaseLiquidityModal] = useModal(
     <TransactionConfirmationModal

--- a/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
@@ -90,9 +90,9 @@ export default function ApproveLiquidityTokens({
         (revokeANeeded ? (
           <Button onClick={revokeACallback} disabled={approvalA === ApprovalState.PENDING} width="100%">
             {approvalA === ApprovalState.PENDING ? (
-              <Dots>{t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
+              <Dots>{t('Reset Approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
             ) : (
-              t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })
+              t('Reset Approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })
             )}
           </Button>
         ) : (
@@ -108,9 +108,9 @@ export default function ApproveLiquidityTokens({
         (revokeBNeeded ? (
           <Button onClick={revokeBCallback} disabled={approvalB === ApprovalState.PENDING} width="100%">
             {approvalB === ApprovalState.PENDING ? (
-              <Dots>{t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
+              <Dots>{t('Reset Approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
             ) : (
-              t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })
+              t('Reset Approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })
             )}
           </Button>
         ) : (

--- a/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
@@ -1,0 +1,129 @@
+import { useTranslation } from '@pancakeswap/localization'
+import { ApprovalState } from 'hooks/useApproveCallback'
+import { Field } from 'state/mint/actions'
+import { styled } from 'styled-components'
+import { ethereumTokens } from '@pancakeswap/tokens'
+import { Link, RowBetween, Message, MessageText, Button, Dots } from '@pancakeswap/uikit'
+import { Currency, CurrencyAmount } from '@pancakeswap/swap-sdk-core'
+import { SendTransactionResult } from 'wagmi/actions'
+import { useMemo } from 'react'
+
+const InlineLink = styled(Link)`
+  display: inline-flex;
+  text-decoration: underline;
+  color: #d67e0a;
+`
+
+interface ApproveLiquidityTokensProps {
+  currencies: {
+    [Field.CURRENCY_A]?: Currency
+    [Field.CURRENCY_B]?: Currency
+  }
+  shouldShowApprovalGroup: boolean
+  showFieldAApproval: boolean
+  approveACallback: () => Promise<SendTransactionResult>
+  revokeACallback: () => Promise<SendTransactionResult>
+  currentAllowanceA: CurrencyAmount<Currency> | undefined
+  approvalA: ApprovalState
+  showFieldBApproval: boolean
+  approveBCallback: () => Promise<SendTransactionResult>
+  revokeBCallback: () => Promise<SendTransactionResult>
+  currentAllowanceB: CurrencyAmount<Currency> | undefined
+  approvalB: ApprovalState
+}
+
+export default function ApproveLiquidityTokens({
+  shouldShowApprovalGroup,
+  showFieldAApproval,
+  approvalA,
+  approveACallback,
+  revokeACallback,
+  currentAllowanceA,
+  currencies,
+  showFieldBApproval,
+  approvalB,
+  approveBCallback,
+  revokeBCallback,
+  currentAllowanceB,
+}: ApproveLiquidityTokensProps) {
+  const { t } = useTranslation()
+
+  const revokeANeeded = useMemo(() => {
+    return (
+      showFieldAApproval &&
+      currentAllowanceA?.greaterThan(0) &&
+      currencies[Field.CURRENCY_A]?.chainId === ethereumTokens.usdt.chainId &&
+      currencies[Field.CURRENCY_A]?.wrapped.address.toLowerCase() === ethereumTokens.usdt.address.toLowerCase()
+    )
+  }, [showFieldAApproval, currentAllowanceA, currencies])
+  const revokeBNeeded = useMemo(() => {
+    return (
+      showFieldBApproval &&
+      currentAllowanceB?.greaterThan(0) &&
+      currencies[Field.CURRENCY_B]?.chainId === ethereumTokens.usdt.chainId &&
+      currencies[Field.CURRENCY_B]?.wrapped.address.toLowerCase() === ethereumTokens.usdt.address.toLowerCase()
+    )
+  }, [showFieldBApproval, currentAllowanceB, currencies])
+  const anyRevokeNeeded = useMemo(() => {
+    return revokeANeeded || revokeBNeeded
+  }, [revokeANeeded, revokeBNeeded])
+
+  return shouldShowApprovalGroup ? (
+    <RowBetween style={{ gap: '8px' }}>
+      {anyRevokeNeeded && (
+        <Message variant="warning">
+          <MessageText>
+            <span>
+              {t('USDT on Ethereum requires resetting approval when spending allowances are too low.')}
+              <InlineLink
+                external
+                fontSize={14}
+                href="https://docs.pancakeswap.finance/products/pancakeswap-exchange/faq#why-do-i-need-to-reset-approval-on-usdt-before-enabling-approving"
+              >
+                {' '}
+                {t('Learn More')}
+                {' >>'}
+              </InlineLink>
+            </span>
+          </MessageText>
+        </Message>
+      )}
+      {showFieldAApproval &&
+        (revokeANeeded ? (
+          <Button onClick={revokeACallback} disabled={approvalA === ApprovalState.PENDING} width="100%">
+            {approvalA === ApprovalState.PENDING ? (
+              <Dots>{t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
+            ) : (
+              t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_A]?.symbol })
+            )}
+          </Button>
+        ) : (
+          <Button onClick={approveACallback} disabled={approvalA === ApprovalState.PENDING} width="100%">
+            {approvalA === ApprovalState.PENDING ? (
+              <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
+            ) : (
+              t('Enable %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })
+            )}
+          </Button>
+        ))}
+      {showFieldBApproval &&
+        (revokeBNeeded ? (
+          <Button onClick={revokeBCallback} disabled={approvalB === ApprovalState.PENDING} width="100%">
+            {approvalB === ApprovalState.PENDING ? (
+              <Dots>{t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
+            ) : (
+              t('Reset approval on USDT', { asset: currencies[Field.CURRENCY_B]?.symbol })
+            )}
+          </Button>
+        ) : (
+          <Button onClick={approveBCallback} disabled={approvalB === ApprovalState.PENDING} width="100%">
+            {approvalB === ApprovalState.PENDING ? (
+              <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
+            ) : (
+              t('Enable %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })
+            )}
+          </Button>
+        ))}
+    </RowBetween>
+  ) : null
+}

--- a/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/ApproveLiquidityTokens.tsx
@@ -64,9 +64,7 @@ export default function ApproveLiquidityTokens({
       currencies[Field.CURRENCY_B]?.wrapped.address.toLowerCase() === ethereumTokens.usdt.address.toLowerCase()
     )
   }, [showFieldBApproval, currentAllowanceB, currencies])
-  const anyRevokeNeeded = useMemo(() => {
-    return revokeANeeded || revokeBNeeded
-  }, [revokeANeeded, revokeBNeeded])
+  const anyRevokeNeeded = revokeANeeded || revokeBNeeded
 
   return shouldShowApprovalGroup ? (
     <RowBetween style={{ gap: '8px' }}>

--- a/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
@@ -68,15 +68,15 @@ export function V3SubmitButton({
 }: V3SubmitButtonProps) {
   const { t } = useTranslation()
 
-  const approvalANeeded = useMemo(() => {
-    return showApprovalA && (approvalA === ApprovalState.NOT_APPROVED || approvalA === ApprovalState.PENDING) && isValid
-  }, [showApprovalA, approvalA, isValid])
-  const approvalBNeeded = useMemo(() => {
-    return showApprovalB && (approvalB === ApprovalState.NOT_APPROVED || approvalB === ApprovalState.PENDING) && isValid
-  }, [showApprovalB, approvalB, isValid])
-  const anyApprovalNeeded = useMemo(() => {
-    return approvalANeeded || approvalBNeeded
-  }, [approvalANeeded, approvalBNeeded])
+  const shouldShowApprovalGroup = useMemo(
+    () =>
+      (approvalA === ApprovalState.NOT_APPROVED ||
+        approvalA === ApprovalState.PENDING ||
+        approvalB === ApprovalState.NOT_APPROVED ||
+        approvalB === ApprovalState.PENDING) &&
+      isValid,
+    [approvalA, approvalB, isValid],
+  )
 
   let buttons = null
   if (addIsUnsupported || addIsWarning) {
@@ -95,8 +95,8 @@ export function V3SubmitButton({
         <ApproveLiquidityTokens
           approvalA={approvalA}
           approvalB={approvalB}
-          showFieldAApproval={approvalANeeded}
-          showFieldBApproval={approvalBNeeded}
+          showFieldAApproval={showApprovalA}
+          showFieldBApproval={showApprovalB}
           approveACallback={approveACallback}
           approveBCallback={approveBCallback}
           revokeACallback={revokeACallback}
@@ -104,7 +104,7 @@ export function V3SubmitButton({
           currencies={currencies}
           currentAllowanceA={currentAllowanceA}
           currentAllowanceB={currentAllowanceB}
-          shouldShowApprovalGroup={anyApprovalNeeded}
+          shouldShowApprovalGroup={shouldShowApprovalGroup}
         />
         <CommitButton
           variant={

--- a/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
@@ -1,11 +1,12 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { SendTransactionResult } from 'wagmi/actions'
 import { Currency, CurrencyAmount } from '@pancakeswap/sdk'
-import { AutoColumn, Button, Dots, RowBetween } from '@pancakeswap/uikit'
+import { AutoColumn, Button } from '@pancakeswap/uikit'
 import { CommitButton } from 'components/CommitButton'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { ApprovalState } from 'hooks/useApproveCallback'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
+import ApproveLiquidityTokens from 'views/AddLiquidityV3/components/ApproveLiquidityTokens'
 import { Field } from '../formViews/V3FormView/form/actions'
 
 interface V3SubmitButtonProps {
@@ -18,11 +19,15 @@ interface V3SubmitButtonProps {
   isValid: boolean
   showApprovalA: boolean
   approveACallback: () => Promise<SendTransactionResult>
+  currentAllowanceA: CurrencyAmount<Currency> | undefined
+  revokeACallback: () => Promise<SendTransactionResult>
   currencies: {
     CURRENCY_A?: Currency
     CURRENCY_B?: Currency
   }
   approveBCallback: () => Promise<SendTransactionResult>
+  currentAllowanceB: CurrencyAmount<Currency> | undefined
+  revokeBCallback: () => Promise<SendTransactionResult>
   showApprovalB: boolean
   parsedAmounts: {
     CURRENCY_A?: CurrencyAmount<Currency>
@@ -46,8 +51,12 @@ export function V3SubmitButton({
   isValid,
   showApprovalA,
   approveACallback,
+  currentAllowanceA,
+  revokeACallback,
   currencies,
   approveBCallback,
+  currentAllowanceB,
+  revokeBCallback,
   showApprovalB,
   parsedAmounts,
   onClick,
@@ -58,6 +67,16 @@ export function V3SubmitButton({
   depositBDisabled,
 }: V3SubmitButtonProps) {
   const { t } = useTranslation()
+
+  const approvalANeeded = useMemo(() => {
+    return showApprovalA && (approvalA === ApprovalState.NOT_APPROVED || approvalA === ApprovalState.PENDING) && isValid
+  }, [showApprovalA, approvalA, isValid])
+  const approvalBNeeded = useMemo(() => {
+    return showApprovalB && (approvalB === ApprovalState.NOT_APPROVED || approvalB === ApprovalState.PENDING) && isValid
+  }, [showApprovalB, approvalB, isValid])
+  const anyApprovalNeeded = useMemo(() => {
+    return approvalANeeded || approvalBNeeded
+  }, [approvalANeeded, approvalBNeeded])
 
   let buttons = null
   if (addIsUnsupported || addIsWarning) {
@@ -73,32 +92,20 @@ export function V3SubmitButton({
   } else {
     buttons = (
       <AutoColumn gap="md">
-        {(approvalA === ApprovalState.NOT_APPROVED ||
-          approvalA === ApprovalState.PENDING ||
-          approvalB === ApprovalState.NOT_APPROVED ||
-          approvalB === ApprovalState.PENDING) &&
-          isValid && (
-            <RowBetween style={{ gap: '8px' }}>
-              {showApprovalA && (
-                <Button onClick={approveACallback} disabled={approvalA === ApprovalState.PENDING} width="100%">
-                  {approvalA === ApprovalState.PENDING ? (
-                    <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
-                  ) : (
-                    t('Enable %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })
-                  )}
-                </Button>
-              )}
-              {showApprovalB && (
-                <Button onClick={approveBCallback} disabled={approvalB === ApprovalState.PENDING} width="100%">
-                  {approvalB === ApprovalState.PENDING ? (
-                    <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
-                  ) : (
-                    t('Enable %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })
-                  )}
-                </Button>
-              )}
-            </RowBetween>
-          )}
+        <ApproveLiquidityTokens
+          approvalA={approvalA}
+          approvalB={approvalB}
+          showFieldAApproval={approvalANeeded}
+          showFieldBApproval={approvalBNeeded}
+          approveACallback={approveACallback}
+          approveBCallback={approveBCallback}
+          revokeACallback={revokeACallback}
+          revokeBCallback={revokeBCallback}
+          currencies={currencies}
+          currentAllowanceA={currentAllowanceA}
+          currentAllowanceB={currentAllowanceB}
+          shouldShowApprovalGroup={anyApprovalNeeded}
+        />
         <CommitButton
           variant={
             !isValid && !!parsedAmounts[Field.CURRENCY_A] && !!parsedAmounts[Field.CURRENCY_B] ? 'danger' : 'primary'

--- a/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
@@ -1,8 +1,6 @@
 import {
   AutoColumn,
   Button,
-  Dots,
-  RowBetween,
   Text,
   Box,
   BunnyKnownPlaceholder,
@@ -21,7 +19,6 @@ import { Percent, Pair } from '@pancakeswap/sdk'
 import { CommitButton } from 'components/CommitButton'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import { Field } from 'state/mint/actions'
-import { ApprovalState } from 'hooks/useApproveCallback'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { Bound } from 'config/constants/types'
@@ -32,6 +29,7 @@ import { CommonBasesType } from 'components/SearchModal/types'
 import { getBlockExploreLink } from 'utils'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 
+import ApproveLiquidityTokens from 'views/AddLiquidityV3/components/ApproveLiquidityTokens'
 import { HideMedium, MediumOnly, RightContainer } from './V3FormView'
 import RangeSelector from './V3FormView/components/RangeSelector'
 
@@ -41,9 +39,13 @@ export default function V2FormView({
   addIsWarning,
   shouldShowApprovalGroup,
   approveACallback,
+  revokeACallback,
+  currentAllowanceA,
   approvalA,
   approvalB,
   approveBCallback,
+  revokeBCallback,
+  currentAllowanceB,
   showFieldBApproval,
   showFieldAApproval,
   currencies,
@@ -82,28 +84,20 @@ export default function V2FormView({
   } else {
     buttons = (
       <AutoColumn gap="md">
-        {shouldShowApprovalGroup && (
-          <RowBetween style={{ gap: '8px' }}>
-            {showFieldAApproval && (
-              <Button onClick={approveACallback} disabled={approvalA === ApprovalState.PENDING} width="100%">
-                {approvalA === ApprovalState.PENDING ? (
-                  <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })}</Dots>
-                ) : (
-                  t('Enable %asset%', { asset: currencies[Field.CURRENCY_A]?.symbol })
-                )}
-              </Button>
-            )}
-            {showFieldBApproval && (
-              <Button onClick={approveBCallback} disabled={approvalB === ApprovalState.PENDING} width="100%">
-                {approvalB === ApprovalState.PENDING ? (
-                  <Dots>{t('Enabling %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })}</Dots>
-                ) : (
-                  t('Enable %asset%', { asset: currencies[Field.CURRENCY_B]?.symbol })
-                )}
-              </Button>
-            )}
-          </RowBetween>
-        )}
+        <ApproveLiquidityTokens
+          approvalA={approvalA}
+          approvalB={approvalB}
+          showFieldAApproval={showFieldAApproval}
+          showFieldBApproval={showFieldBApproval}
+          approveACallback={approveACallback}
+          approveBCallback={approveBCallback}
+          revokeACallback={revokeACallback}
+          revokeBCallback={revokeBCallback}
+          currencies={currencies}
+          currentAllowanceA={currentAllowanceA}
+          currentAllowanceB={currentAllowanceB}
+          shouldShowApprovalGroup={shouldShowApprovalGroup}
+        />
         {isOneWeiAttack ? (
           <Message variant="warning">
             <Flex flexDirection="column">

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -232,14 +232,18 @@ export default function V3FormView({
 
   const nftPositionManagerAddress = useV3NFTPositionManagerContract()?.address
   // check whether the user has approved the router on the tokens
-  const { approvalState: approvalA, approveCallback: approveACallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_A],
-    nftPositionManagerAddress,
-  )
-  const { approvalState: approvalB, approveCallback: approveBCallback } = useApproveCallback(
-    parsedAmounts[Field.CURRENCY_B],
-    nftPositionManagerAddress,
-  )
+  const {
+    approvalState: approvalA,
+    approveCallback: approveACallback,
+    revokeCallback: revokeACallback,
+    currentAllowance: currentAllowanceA,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_A], nftPositionManagerAddress)
+  const {
+    approvalState: approvalB,
+    approveCallback: approveBCallback,
+    revokeCallback: revokeBCallback,
+    currentAllowance: currentAllowanceB,
+  } = useApproveCallback(parsedAmounts[Field.CURRENCY_B], nftPositionManagerAddress)
 
   const [allowedSlippage] = useUserSlippage() // custom from users
 
@@ -414,9 +418,13 @@ export default function V3FormView({
       isValid={isValid}
       showApprovalA={showApprovalA}
       approveACallback={approveACallback}
+      currentAllowanceA={currentAllowanceA}
+      revokeACallback={revokeACallback}
       currencies={currencies}
-      approveBCallback={approveBCallback}
       showApprovalB={showApprovalB}
+      approveBCallback={approveBCallback}
+      currentAllowanceB={currentAllowanceB}
+      revokeBCallback={revokeBCallback}
       parsedAmounts={parsedAmounts}
       onClick={handleButtonSubmit}
       attemptingTxn={attemptingTxn}

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
@@ -263,7 +263,7 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
     const amountB = formatAmount(trade?.outputAmount, 6) ?? ''
 
     if (confirmModalState === ConfirmModalState.RESETTING_APPROVAL) {
-      return <ApproveModalContent title={t('Reset approval on USDT')} isMM={isMM} />
+      return <ApproveModalContent title={t('Reset Approval on USDT')} isMM={isMM} />
     }
 
     if (

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
@@ -263,7 +263,7 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
     const amountB = formatAmount(trade?.outputAmount, 6) ?? ''
 
     if (confirmModalState === ConfirmModalState.RESETTING_APPROVAL) {
-      return <ApproveModalContent title={t('Reset approval on USDT.')} isMM={isMM} />
+      return <ApproveModalContent title={t('Reset approval on USDT')} isMM={isMM} />
     }
 
     if (

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2690,6 +2690,6 @@
   "Pancakeswap MM": "Pancakeswap MM",
   "Pancakeswap AMM": "Pancakeswap AMM",
   "Why resetting approval": "Why resetting approval",
-  "Reset approval on USDT": "Reset approval on USDT",
+  "Reset Approval on USDT": "Reset Approval on USDT",
   "USDT on Ethereum requires resetting approval when spending allowances are too low.": "USDT on Ethereum requires resetting approval when spending allowances are too low."
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2690,5 +2690,6 @@
   "Pancakeswap MM": "Pancakeswap MM",
   "Pancakeswap AMM": "Pancakeswap AMM",
   "Why resetting approval": "Why resetting approval",
-  "Reset approval on USDT.": "Reset approval on USDT."
+  "Reset approval on USDT": "Reset approval on USDT",
+  "USDT on Ethereum requires resetting approval when spending allowances are too low.": "USDT on Ethereum requires resetting approval when spending allowances are too low."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b37c345</samp>

### Summary
🆕🛠️📝

<!--
1.  🆕 - This emoji represents the addition of a new component (`ApproveLiquidityTokens`) and a new feature (revoking token approvals) to the codebase.
2.  🛠️ - This emoji represents the refactoring and improvement of existing components (`V3SubmitButton`, `V2FormView`, `ConfirmSwapModal`) and logic (approval and revocation callbacks) to make them more reusable and consistent.
3.  📝 - This emoji represents the update of the translations file and the removal of an extra dot from a string.
-->
The pull request adds the ability to revoke token approvals before adding liquidity to V2 and V3 pools, especially for USDT tokens. It refactors some components to use a common `ApproveLiquidityTokens` component for handling the approval logic and UI. It also fixes a minor UI issue with the `ConfirmSwapModal` component and updates the translations file accordingly.

> _To add liquidity with ease_
> _You can approve or revoke as you please_
> _With `ApproveLiquidityTokens`_
> _And `useApproveCallback` tokens_
> _You can handle USDT allowances with breeze_

### Walkthrough
*  Add `ApproveLiquidityTokens` component to render approval buttons and warning message for liquidity tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2b57442ef43c59d5335272858bd62e5a1811e6a49be15a37ea90469420022295R1-R129), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfL76-R108), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-444d142f4223c31b935d74fc0a7d76ce1260006d46e6b5de6364619e2fcc59fcR32), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-444d142f4223c31b935d74fc0a7d76ce1260006d46e6b5de6364619e2fcc59fcL85-R100))
*  Update `useApproveCallback` hook to return revoke callbacks and current allowances of tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-8a80bd0e80e574a8cb11df92acd3768bdea6a86ba2dc86247db3037f0eb40a69L157-R172), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL141-R152), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L235-R246))
*  Update `LP2ChildrenProps` interface and `LP2` component to include revoke callbacks and current allowances of tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-8a80bd0e80e574a8cb11df92acd3768bdea6a86ba2dc86247db3037f0eb40a69L63-R69), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-8a80bd0e80e574a8cb11df92acd3768bdea6a86ba2dc86247db3037f0eb40a69L354-R368))
*  Update `V3SubmitButton` component to use `useMemo` and `ApproveLiquidityTokens` component for approval logic and rendering ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfL4-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfR22-R23), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfR29-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfL49-R59), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-2f7a1458b657fd7576356c1ef0daab7ff137121c46842e0511a623a9b22f73cfR71-R80))
*  Update `V2FormView` and `V3FormView` components to pass revoke callbacks and current allowances of tokens to `V3SubmitButton` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-444d142f4223c31b935d74fc0a7d76ce1260006d46e6b5de6364619e2fcc59fcL4-L5), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-444d142f4223c31b935d74fc0a7d76ce1260006d46e6b5de6364619e2fcc59fcL24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-444d142f4223c31b935d74fc0a7d76ce1260006d46e6b5de6364619e2fcc59fcL44-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L417-R427))
*  Update `ConfirmSwapModal` component to remove extra dot from `ApproveModalContent` title ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-c83e4eec2c74b991702f46350b3eee8c029e14df4a79fae45f480542a806111dL266-R266))
*  Update translations file to remove extra dot from `Reset approval on USDT` string and add `USDT on Ethereum requires resetting approval when spending allowances are too low` string ([link](https://github.com/pancakeswap/pancake-frontend/pull/7832/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2693-R2694))


