### PR TITLE
chore: list wstETH pool

### DIFF
--- a/packages/pools/src/constants/pools/1.ts
+++ b/packages/pools/src/constants/pools/1.ts
@@ -5,6 +5,14 @@ import { PoolCategory, SerializedPool } from '../../types'
 
 export const livePools: SerializedPool[] = [
   {
+    sousId: 8,
+    stakingToken: ethereumTokens.cake,
+    earningToken: ethereumTokens.wstETH,
+    contractAddress: '0x3C6452d5a217Cc65b98F0803c6D1BD7Fe588389A',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.00000271',
+  },
+  {
     sousId: 7,
     stakingToken: ethereumTokens.cake,
     earningToken: ethereumTokens.rpl,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c2153d2</samp>

### Summary
🍰🌐🌊

<!--
1.  🍰 - This emoji represents the CAKE token, which is the native token of the PancakeSwap platform and the staking token for the new pool. It also conveys the idea of earning rewards by staking CAKE.
2.  🌐 - This emoji represents the wstETH token, which is a wrapped version of staked ETH that accrues rewards from the Ethereum 2.0 network. It also conveys the idea of cross-chain interoperability and innovation.
3.  🌊 - This emoji represents the pool itself, which is a liquidity source for wstETH and CAKE holders. It also conveys the idea of fluidity and dynamism in the DeFi space.
-->
Add a new pool for staking CAKE and earning wstETH. Update `packages/pools/src/constants/pools/1.ts` with the pool details.

> _New pool for `CAKE`_
> _Stake and earn some `wstETH`_
> _Autumn harvest time_

### Walkthrough
* Add support for wstETH pools to the frontend
  * Add a new pool for staking CAKE and earning wstETH ([link](https://github.com/pancakeswap/pancake-frontend/pull/7845/files?diff=unified&w=0#diff-cd952ff17505198e44ad083b28429fef4a2875f01f94a9e41ced215ec21040a0R8-R15))


