### PR TITLE
fix: Lottery history card round not shown completely

### DIFF
--- a/apps/web/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
+++ b/apps/web/src/views/Lottery/components/AllHistoryCard/RoundSwitcher.tsx
@@ -1,9 +1,10 @@
 import { styled } from 'styled-components'
 import { IconButton, ArrowForwardIcon, ArrowBackIcon, ArrowLastIcon, Flex, Heading, Input } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { useCallback } from 'react'
 
 const StyledInput = styled(Input)`
-  width: 60px;
+  width: 70px;
   height: 100%;
   padding: 4px 16px;
 `
@@ -42,11 +43,14 @@ const RoundSwitcher: React.FC<React.PropsWithChildren<RoundSwitcherProps>> = ({
   const { t } = useTranslation()
   const selectedRoundIdAsInt = parseInt(selectedRoundId, 10)
 
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.currentTarget.validity.valid) {
-      handleInputChange(e)
-    }
-  }
+  const handleOnChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.currentTarget.validity.valid) {
+        handleInputChange(e)
+      }
+    },
+    [handleInputChange],
+  )
 
   return (
     <Flex alignItems="center" justifyContent="space-between">

--- a/apps/web/src/views/Lottery/components/AllHistoryCard/index.tsx
+++ b/apps/web/src/views/Lottery/components/AllHistoryCard/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { styled } from 'styled-components'
 import { Card, Text, Skeleton, CardHeader, Box } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
@@ -72,31 +72,34 @@ const AllHistoryCard = () => {
     return () => clearInterval(timer.current)
   }, [selectedRoundId, currentLotteryId, numRoundsFetched, dispatch])
 
-  const handleInputChange = (event) => {
-    const {
-      target: { value },
-    } = event
-    if (value) {
-      setSelectedRoundId(value)
-      if (parseInt(value, 10) <= 0) {
+  const handleInputChange = useCallback(
+    (event) => {
+      const {
+        target: { value },
+      } = event
+      if (value) {
+        setSelectedRoundId(value)
+        if (parseInt(value, 10) <= 0) {
+          setSelectedRoundId('')
+        }
+        if (parseInt(value, 10) >= latestRoundId) {
+          setSelectedRoundId(latestRoundId.toString())
+        }
+      } else {
         setSelectedRoundId('')
       }
-      if (parseInt(value, 10) >= latestRoundId) {
-        setSelectedRoundId(latestRoundId.toString())
-      }
-    } else {
-      setSelectedRoundId('')
-    }
-  }
+    },
+    [latestRoundId],
+  )
 
-  const handleArrowButtonPress = (targetRound) => {
+  const handleArrowButtonPress = useCallback((targetRound) => {
     if (targetRound) {
       setSelectedRoundId(targetRound.toString())
     } else {
       // targetRound is NaN when the input is empty, the only button press that will trigger this func is 'forward one'
       setSelectedRoundId('1')
     }
-  }
+  }, [])
 
   return (
     <StyledCard>


### PR DESCRIPTION
Before: 

<img width="326" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/faa763f8-247d-46a2-b87f-9c792f406ebb">

After:
<img width="254" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/941d8fd1-bf64-4278-9c9f-1e70d31d5d1c">

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e005b16</samp>

### Summary
🚀🎛️🎨

<!--
1.  🚀 This emoji conveys the idea of speed, performance, and optimization, which are the main goals of the pull request.
2.  🎛️ This emoji represents the round switcher component, which is a UI element that allows the user to switch between different rounds of the game. It also suggests the idea of fine-tuning or adjusting something.
3.  🎨 This emoji indicates the improvement of the appearance or design of the component, as well as the creative aspect of the pull request.
-->
Improved the performance and UI of the lottery history view by memoizing handlers and tweaking styles in `AllHistoryCard` and `RoundSwitcher` components.

> _Oh, we're the savvy coders of the `AllHistoryCard`_
> _We use `useCallback` to make it run fast and hard_
> _We don't waste our renders on the buttons or the switcher_
> _We memoize our handlers and we make our inputs fitter_

### Walkthrough
*  Wrap input change handlers with `useCallback` to memoize functions and improve performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-f881b6f9d79ccaa0f5f1bc67bd69ebeccbfbd680b421f32d4a2423efae9adf50L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-f881b6f9d79ccaa0f5f1bc67bd69ebeccbfbd680b421f32d4a2423efae9adf50L75-R95), [link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-f881b6f9d79ccaa0f5f1bc67bd69ebeccbfbd680b421f32d4a2423efae9adf50L99-R102), [link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-5eeefd8afc46a52f09877ceb0e09298895b73ee030c16390da1b15dfd96cd35eL4-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-5eeefd8afc46a52f09877ceb0e09298895b73ee030c16390da1b15dfd96cd35eL45-R53))
*  Increase `StyledInput` width to fit larger round numbers in `RoundSwitcher.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7863/files?diff=unified&w=0#diff-5eeefd8afc46a52f09877ceb0e09298895b73ee030c16390da1b15dfd96cd35eL4-R7))


