### PR TITLE
fix: Invalid block number

### DIFF
--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -12,7 +12,7 @@ const REFRESH_BLOCK_INTERVAL = 6000
 export const usePollBlockNumber = () => {
   const { cache, mutate } = useSWRConfig()
   const { chainId } = useActiveChainId()
-  const { data: blockNumber, isError, isLoading } = useBlockNumber()
+  const { data: blockNumber, isError, isLoading } = useBlockNumber({ chainId })
 
   useSWR(
     chainId && ['blockNumberFetcher', chainId],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 70b652d</samp>

### Summary
🪄🔗🔄

<!--
1.  🪄 - This emoji represents the magic of using SWR to fetch and cache data from different chains, as well as the abstraction of the `useBlockNumber` hook that hides the implementation details from the consumers.
2.  🔗 - This emoji represents the concept of multiple chains and the ability to switch between them using the `useActiveChainId` hook and the chain selector component.
3.  🔄 - This emoji represents the polling mechanism that updates the block number every few seconds, as well as the revalidation logic that SWR provides to keep the data fresh and consistent.
-->
Refactor `useBlockNumber` and `usePollBlockNumber` hooks to support multiple chains. Use `chainId` parameter to fetch and cache block numbers from different chains.

> _`useBlockNumber` hook_
> _now takes `chainId` param_
> _multi-chain support_

### Walkthrough
*  Modify `useBlockNumber` hook to accept `chainId` parameter and fetch block number from corresponding chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7866/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L15-R15))
*  Update `usePollBlockNumber` hook to pass `chainId` from `useActiveChainId` hook to `useBlockNumber` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7866/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L15-R15))
*  Refactor hooks to enable multi-chain support in the app ([link](https://github.com/pancakeswap/pancake-frontend/pull/7866/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L15-R15))


