### PR TITLE
feat: Hide AnniversaryAchievementModal

### DIFF
--- a/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/index.tsx
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/sdk'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import AnniversaryAchievementModal from './AnniversaryAchievementModal'
+// import AnniversaryAchievementModal from './AnniversaryAchievementModal'
 import V3AirdropModal from './V3AirdropModal'
 
 interface GlobalCheckClaimStatusProps {
@@ -25,10 +25,10 @@ const GlobalCheckClaimStatus: React.FC<React.PropsWithChildren<GlobalCheckClaimS
  * TODO: Put global checks in redux or make a generic area to house global checks
  */
 
-const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusProps>> = ({ excludeLocations }) => {
+const GlobalCheckClaim: React.FC<React.PropsWithChildren<GlobalCheckClaimStatusProps>> = () => {
   return (
     <>
-      <AnniversaryAchievementModal excludeLocations={excludeLocations} />
+      {/* <AnniversaryAchievementModal excludeLocations={excludeLocations} /> */}
       <V3AirdropModal />
     </>
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0be17f9</samp>

### Summary
🗑️🎁🎨

<!--
1.  🗑️ - This emoji means "wastebasket" and can be used to indicate that something was deleted or removed.
2.  🎁 - This emoji means "wrapped gift" and can be used to indicate that something was related to a reward, a celebration, or a special occasion.
3.  🎨 - This emoji means "artist palette" and can be used to indicate that something was related to design, creativity, or aesthetics.
-->
Remove unused modal component for NFT claim. This simplifies the code and avoids unnecessary rendering of `AnniversaryAchievementModal` in `GlobalCheckClaimStatus`.

> _No more `AnniversaryAchievementModal`_
> _You missed your chance to claim the NFT_
> _The `GlobalCheckClaim` is now free_
> _From the burden of the obsolete_

### Walkthrough
*  Remove the `AnniversaryAchievementModal` component and its import from the UI, as the NFT claim period has ended ([link](https://github.com/pancakeswap/pancake-frontend/pull/7872/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7872/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L28-R31))
*  Comment out the `excludeLocations` prop from the `GlobalCheckClaim` component, as it was only used for the modal ([link](https://github.com/pancakeswap/pancake-frontend/pull/7872/files?diff=unified&w=0#diff-db39cfb6726323b2ef55ab35980fd64b186a0e3948ed2e3040bd46528529afe4L28-R31))


