### PR TITLE
fix: Tapping tooltip button or text causes roi calculator open

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -294,8 +294,8 @@ export function AprCalculator({
             {hasFarmApr ? t('APR (with farming)') : t('APR')}
           </Text>
         )}
-        <AprButtonContainer onClick={() => setOpen(true)} alignItems="center">
-          <AprText>{aprDisplay}%</AprText>
+        <AprButtonContainer alignItems="center">
+          <AprText onClick={() => setOpen(true)}>{aprDisplay}%</AprText>
           <IconButton variant="text" scale="sm" onClick={() => setOpen(true)}>
             <CalculateIcon color="textSubtle" ml="0.25em" width="24px" />
           </IconButton>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 32f4f28</samp>

### Summary
🐛🖱️🎨

<!--
1.  🐛 - This emoji represents the bug that was fixed by moving the `onClick` prop from the `AprButtonContainer` to the `AprText` component. It conveys that the change was motivated by resolving an issue that affected the functionality of the component.
2.  🖱️ - This emoji represents the click event that was added to the `AprText` component. It conveys that the change was related to the user interaction and the event handler of the component.
3.  🎨 - This emoji represents the design improvement that was achieved by moving the `onClick` prop from the `AprButtonContainer` to the `AprText` component. It conveys that the change was related to the appearance and style of the component.
-->
Fixed a bug in the `AprCalculator` component that caused the `AprModal` to open and close immediately. Moved the `onClick` prop from the `AprButtonContainer` to the `AprText` component to allow the user to click on either the text or the icon to open the modal.

> _`onClick` moved down_
> _To avoid double trigger_
> _`AprText` welcomes spring_

### Walkthrough
*  Fix bug where clicking on APR button container would trigger modal open and close ([link](https://github.com/pancakeswap/pancake-frontend/pull/7891/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L297-R298))


