### PR TITLE
chore: Move finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -86,15 +86,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 353,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.hay,
-    contractAddress: '0x8c41046b3C0D7b7C80316a57C39C74c9F5133852',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.02314',
-    version: 3,
-  },
-  {
     sousId: 352,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.sable,
@@ -148,14 +139,6 @@ export const livePools: SerializedPool[] = [
     tokenPerBlock: '0.02314',
     version: 3,
   },
-  {
-    sousId: 346,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.csix,
-    contractAddress: '0x5250320d765F366E2B96Cd5c7d08F1902422195e',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '2.017',
-  },
 ].map((p) => ({
   ...p,
   contractAddress: getAddress(p.contractAddress),
@@ -165,6 +148,23 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 353,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.hay,
+    contractAddress: '0x8c41046b3C0D7b7C80316a57C39C74c9F5133852',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.02314',
+    version: 3,
+  },
+  {
+    sousId: 346,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.csix,
+    contractAddress: '0x5250320d765F366E2B96Cd5c7d08F1902422195e',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '2.017',
+  },
   {
     sousId: 355,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 881bf67</samp>

### Summary
🏁🎁📜

<!--
1.  🏁 This emoji signifies the end of a race or a competition, and can be used to indicate that the events have finished and the pools are no longer active.
2.  🎁 This emoji represents a gift or a reward, and can be used to highlight that the users can access their rewards and see their history from the finished pools.
3.  📜 This emoji depicts a scroll or a document, and can be used to suggest that the pools have been moved to a different section or category in the pools list.
-->
This pull request removes the expired `HAY` and `CSIX` pools from the active pools list and adds them to the finished pools list in `packages/pools/src/constants/pools/56.ts`. This improves the user experience and clarity of the pools page.

> _`HAY` and `CSIX` end_
> _Pools move to finished section_
> _Autumn harvest time_

### Walkthrough
* Remove HAY and CSIX pools from active pools list ([link](https://github.com/pancakeswap/pancake-frontend/pull/7894/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL89-L97), [link](https://github.com/pancakeswap/pancake-frontend/pull/7894/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL151-L158)) in `packages/pools/src/constants/pools/56.ts`


