### PR TITLE
chore: Add content write permission to ts check

### DIFF
--- a/.github/workflows/tsCheck.yml
+++ b/.github/workflows/tsCheck.yml
@@ -7,6 +7,8 @@ jobs:
   ts-check:
     name: Typescript Error Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at de49dfc</samp>

### Summary
🔒📝🚀

<!--
1.  🔒 - This emoji represents the `permissions` key, which is related to security and access control. It also conveys that the change is intended to protect the repository from unauthorized modifications.
2.  📝 - This emoji represents the annotations feature, which is related to writing and commenting on the code. It also conveys that the change is intended to provide feedback and guidance for the TypeScript errors.
3.  🚀 - This emoji represents the `upload-sarif` action, which is related to code analysis and quality. It also conveys that the change is intended to improve the performance and reliability of the code.
-->
Add write permissions to `ts-check` job in `.github/workflows/tsCheck.yml`. This enables TypeScript error annotations using the `codeql-action/upload-sarif` action.

> _`ts-check` job needs_
> _write permissions to mark_
> _errors in autumn_

### Walkthrough
*  Grant write permissions to `ts-check` job to create annotations for TypeScript errors ([link](https://github.com/pancakeswap/pancake-frontend/pull/7897/files?diff=unified&w=0#diff-a347e684ced3a07c48e7e03c55692f1bd69af4c094a7fb599b9a1f8d41a37bb7R10-R11))


