### PR TITLE
chore: list woo-eth/ethereum farm up

### DIFF
--- a/packages/farms/constants/1.ts
+++ b/packages/farms/constants/1.ts
@@ -49,6 +49,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 38,
+    lpAddress: '0xEa9b2D7ff9aE446ec067e50DF7C09f1Dd055bB71',
+    token0: ethereumTokens.woo,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 12,
     lpAddress: '0x4F64951A6583D56004fF6310834C70d182142A07',
     token0: ethereumTokens.wstETH,

--- a/packages/tokens/src/1.ts
+++ b/packages/tokens/src/1.ts
@@ -272,4 +272,12 @@ export const ethereumTokens = {
     'CyberConnect',
     'https://cyberconnect.me/',
   ),
+  woo: new ERC20Token(
+    ChainId.ETHEREUM,
+    '0x4691937a7508860F876c9c0a2a617E7d9E945D4B',
+    18,
+    'WOO',
+    'Wootrade Network',
+    'https://woo.network',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ba36e5</samp>

### Summary
🌾🦄🚀

<!--
1.  🌾 - This emoji represents farming or harvesting, and can be used to indicate the addition of a new farm for earning rewards.
2.  🦄 - This emoji represents Uniswap, the decentralized exchange protocol that hosts the WOO/WETH pair. It can be used to indicate the use of Uniswap V3 as the liquidity provider for the farm.
3.  🚀 - This emoji represents growth or innovation, and can be used to indicate the introduction of a new token that is part of a novel trading network.
-->
This pull request adds support for a new farm and a new token on the Ethereum network. It defines the WOO token in `packages/tokens/src/1.ts` and the WOO/WETH farm in `packages/farms/constants/1.ts`.

> _Adding `WOO/WETH`_
> _A new farm on Uniswap_
> _Harvest in autumn_

### Walkthrough
*  Add WOO token definition to `ethereumTokens` object ([link](https://github.com/pancakeswap/pancake-frontend/pull/7901/files?diff=unified&w=0#diff-5f81da2a1b12c306423ba81c127abdc5f541a950a6079e7b4c1d65de467a214eR275-R282))
*  Add WOO/WETH farm to `farmsV3` array with pid, lpAddress, feeAmount, and token references ([link](https://github.com/pancakeswap/pancake-frontend/pull/7901/files?diff=unified&w=0#diff-58ebc40aef86d0f8345b23128ffa10d36fa8cd1785c0c6cdc40ea642dae73eb8R52-R58))


