### PR TITLE
chore: No ts check on forked repos

### DIFF
--- a/.github/workflows/tsCheck.yml
+++ b/.github/workflows/tsCheck.yml
@@ -8,6 +8,7 @@ jobs:
     name: Typescript Error Check
     runs-on: ubuntu-latest
     permissions: write-all
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +63,7 @@ jobs:
           echo 'Files removed: ${{steps.files.outputs.files_deleted}}'
 
       - name: Check typescript errors
-        uses: chefjackson/action-check-typescript@v1.1.0
+        uses: chefjackson/action-check-typescript@v1.1.2
         if: steps.files.outputs.changed == 'true'
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aca953d</samp>

### Summary
🔒🛡️🚀

<!--
1.  🔒 - This emoji represents security, and is appropriate for the change to run the workflow only on same-repo pull requests, which prevents unauthorized code from running on the repository.
2.  🛡️ - This emoji represents reliability, and is appropriate for the change to update the action-check-typescript action to the latest version, which ensures that the workflow uses the most up-to-date and stable features of the action.
3.  🚀 - This emoji represents speed, and is appropriate for the change to use the action-check-typescript action, which is faster and more efficient than running the TypeScript compiler manually.
-->
Improve tsCheck workflow security and reliability. Add condition to run `tsCheck.yml` only on same-repo PRs and update `action-check-typescript` action.

> _No more rogue forks can break our code_
> _We stand united with `tsCheck` as our sword_
> _We wield the latest power of `action-check-typescript`_
> _We are the masters of the type-safe script_

### Walkthrough
*  Prevent unauthorized code execution from forked PRs by adding a condition to the workflow ([link](https://github.com/pancakeswap/pancake-frontend/pull/7903/files?diff=unified&w=0#diff-a347e684ced3a07c48e7e03c55692f1bd69af4c094a7fb599b9a1f8d41a37bb7R11))
*  Fix a bug in the action-check-typescript action by updating its version to v1.1.2 ([link](https://github.com/pancakeswap/pancake-frontend/pull/7903/files?diff=unified&w=0#diff-a347e684ced3a07c48e7e03c55692f1bd69af4c094a7fb599b9a1f8d41a37bb7L65-R66))


