### PR TITLE
style(Pool): Earning skeleton

### DIFF
--- a/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -29,7 +29,10 @@ const EarningsCell: React.FC<React.PropsWithChildren<EarningsCellProps>> = ({ po
 
   const earnings = userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO
   const earningTokenBalance = getBalanceNumber(earnings, earningToken.decimals)
-  const earningTokenDollarBalance = getBalanceNumber(earnings.multipliedBy(earningTokenPrice), earningToken.decimals)
+  const earningTokenDollarBalance = getBalanceNumber(
+    earnings.multipliedBy(earningTokenPrice ?? 0),
+    earningToken.decimals,
+  )
   const hasEarnings = account && earnings.gt(0)
   const fullBalance = getFullDisplayBalance(earnings, earningToken.decimals)
   const formattedBalance = formatNumber(earningTokenBalance, 3, 3)
@@ -73,7 +76,7 @@ const EarningsCell: React.FC<React.PropsWithChildren<EarningsCellProps>> = ({ po
                 />
                 {hasEarnings ? (
                   <>
-                    {earningTokenPrice > 0 && (
+                    {new BigNumber(earningTokenPrice ?? 0).gt(0) && (
                       <Balance
                         display="inline"
                         fontSize="12px"

--- a/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -95,8 +95,8 @@ const EarningsCell: React.FC<React.PropsWithChildren<EarningsCellProps>> = ({ po
           </>
         ) : (
           <>
-            <Skeleton width="40px" height="16px" />
-            <Skeleton width="80px" height="16px" />
+            <Skeleton width="30px" height="12px" mb="4px" />
+            <Skeleton width="80px" height="12px" />
           </>
         )}
       </Pool.CellContent>

--- a/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/Cells/EarningsCell.tsx
@@ -56,13 +56,11 @@ const EarningsCell: React.FC<React.PropsWithChildren<EarningsCellProps>> = ({ po
   return (
     <StyledCell role="cell">
       <Pool.CellContent>
-        <Text fontSize="12px" color="textSubtle" textAlign="left">
-          {labelText}
-        </Text>
-        {!pool.userDataLoaded && account ? (
-          <Skeleton width="80px" height="16px" />
-        ) : (
+        {pool?.totalStaked?.gte(0) ? (
           <>
+            <Text fontSize="12px" color="textSubtle" textAlign="left">
+              {labelText}
+            </Text>
             <Flex>
               <Box mr="8px" height="32px" onClick={hasEarnings ? handleEarningsClick : undefined}>
                 <Balance
@@ -94,6 +92,11 @@ const EarningsCell: React.FC<React.PropsWithChildren<EarningsCellProps>> = ({ po
                 )}
               </Box>
             </Flex>
+          </>
+        ) : (
+          <>
+            <Skeleton width="40px" height="16px" />
+            <Skeleton width="80px" height="16px" />
           </>
         )}
       </Pool.CellContent>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@pancakeswap/tsconfig/nextjs.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@pancakeswap/tsconfig/nextjs.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "strictNullChecks": true,
+    "strictNullChecks": false,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,


### PR DESCRIPTION
Before
![Screenshot 2023-09-19 at 11 11 00 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/fc91a40c-af95-4305-817c-f76e7fed14dc)


After
![Screenshot 2023-09-19 at 11 32 26 AM](https://github.com/pancakeswap/pancake-frontend/assets/98292246/ca5a6cf7-97f6-45e5-93ee-e5e24013839e)




<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d597c36</samp>

### Summary
🖌️🛠️🌟

<!--
1.  🖌️ - This emoji represents the improvement of the rendering of the earnings cell, which is a visual or design change.
2.  🛠️ - This emoji represents the addition of conditions to handle different cases, which is a bug fix or enhancement of the existing functionality.
3.  🌟 - This emoji represents the addition of a skeleton loading component, which is a new feature or addition to the existing functionality.
-->
Improve the UI of the earnings cell in the pools table. Add conditions and a skeleton component to handle different data states in `EarningsCell.tsx`.

> _Sing, O Muse, of the skillful coder who enhanced_
> _the `earnings` cell of the `pools` table, a marvel to behold,_
> _and made it show the proper values, whether staked or not,_
> _or if the data from the server was delayed or lost._

### Walkthrough
*  Prevent rendering incorrect earnings data when pool has no totalStaked amount ([link](https://github.com/pancakeswap/pancake-frontend/pull/7910/files?diff=unified&w=0#diff-46ebe2fea5339bc15ff213671c262b3acdaad42f48a2ba91f5bb7b63d157b0f8L59-R63))
*  Add skeleton loading component for earnings cell when pool has no totalStaked amount ([link](https://github.com/pancakeswap/pancake-frontend/pull/7910/files?diff=unified&w=0#diff-46ebe2fea5339bc15ff213671c262b3acdaad42f48a2ba91f5bb7b63d157b0f8R96-R100))


