### PR TITLE
fix: style-component props forward

### DIFF
--- a/.changeset/nice-baboons-perform.md
+++ b/.changeset/nice-baboons-perform.md
@@ -1,0 +1,6 @@
+---
+'@pancakeswap/widgets-internal': patch
+'@pancakeswap/uikit': patch
+---
+
+Resolved props from styled-component and DOM

--- a/apps/web/src/components/AddressInputSelect/index.tsx
+++ b/apps/web/src/components/AddressInputSelect/index.tsx
@@ -16,7 +16,7 @@ interface AddressInputSelectProps extends BoxProps {
   onAddressClick: (value: string) => void
 }
 
-const SubMenu = styled.div<{ isOpen: boolean }>`
+const SubMenu = styled.div<{ $isOpen: boolean }>`
   align-items: center;
   background: ${({ theme }) => theme.colors.input};
   border: 1px solid ${({ theme }) => theme.colors.inputSecondary};
@@ -32,8 +32,8 @@ const SubMenu = styled.div<{ isOpen: boolean }>`
   width: 100%;
   z-index: 15;
 
-  ${({ isOpen }) =>
-    isOpen &&
+  ${({ $isOpen }) =>
+    $isOpen &&
     `
     height: auto;
     opacity: 1;
@@ -118,7 +118,7 @@ const AddressInputSelect: React.FC<React.PropsWithChildren<AddressInputSelectPro
           <CircleLoader />
         </Box>
       )}
-      <SubMenu isOpen={resultFound !== ResultStatus.NOT_VALID}>
+      <SubMenu $isOpen={resultFound !== ResultStatus.NOT_VALID}>
         {resultFound === ResultStatus.FOUND ? (
           <AddressLink onClick={handleClick}>{state.value}</AddressLink>
         ) : (

--- a/apps/web/src/components/Modal/ModalInput.tsx
+++ b/apps/web/src/components/Modal/ModalInput.tsx
@@ -16,7 +16,9 @@ interface ModalInputProps {
   decimals?: number
 }
 
-const StyledTokenInput = styled.div<InputProps>`
+const StyledTokenInput = styled('div').withConfig({
+  shouldForwardProp: (props) => !['isWaring', 'isSuccess', 'scale'].includes(props),
+})<InputProps>`
   display: flex;
   flex-direction: column;
   background-color: ${({ theme }) => theme.colors.input};

--- a/apps/web/src/utils/prices.ts
+++ b/apps/web/src/utils/prices.ts
@@ -2,7 +2,11 @@ import { Currency, Price } from '@pancakeswap/sdk'
 /**
  * Helper to multiply a Price object by an arbitrary amount
  */
-export const multiplyPriceByAmount = (price: Price<Currency, Currency>, amount: number, significantDigits = 18) => {
+export const multiplyPriceByAmount = (
+  price: Price<Currency, Currency> | undefined,
+  amount: number,
+  significantDigits = 18,
+) => {
   if (!price) {
     return 0
   }

--- a/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/TokenInfo.tsx
+++ b/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/TokenInfo.tsx
@@ -11,8 +11,8 @@ import { multiplyPriceByAmount } from 'utils/prices'
 import { useDelayedUnmount } from '@pancakeswap/hooks'
 import Expand from './Expand'
 
-const ArrowIcon = styled(ChevronDownIcon)<{ toggled: boolean }>`
-  transform: ${({ toggled }) => (toggled ? 'rotate(180deg)' : 'rotate(0)')};
+const ArrowIcon = styled(ChevronDownIcon)<{ $toggled: boolean }>`
+  transform: ${({ $toggled }) => ($toggled ? 'rotate(180deg)' : 'rotate(0)')};
   height: 24px;
 `
 
@@ -62,7 +62,7 @@ const TokenInfo: React.FC<React.PropsWithChildren<TokenInfoProps>> = ({ index, d
             </Text>
           </Flex>
         </Flex>
-        <ArrowIcon toggled={expanded} color="primary" ml="auto" />
+        <ArrowIcon $toggled={expanded} color="primary" ml="auto" />
       </Flex>
       {shouldRenderExpand && <Expand expanded={expanded} data={data} fetchUserVestingData={fetchUserVestingData} />}
     </Box>

--- a/apps/web/src/views/Migration/components/Cells/ExpandActionCell.tsx
+++ b/apps/web/src/views/Migration/components/Cells/ExpandActionCell.tsx
@@ -20,8 +20,8 @@ const StyledCell = styled(Pool.BaseCell)`
   }
 `
 
-const ArrowIcon = styled(ChevronDownIcon)<{ toggled: boolean }>`
-  transform: ${({ toggled }) => (toggled ? 'rotate(180deg)' : 'rotate(0)')};
+const ArrowIcon = styled(ChevronDownIcon)<{ $toggled: boolean }>`
+  transform: ${({ $toggled }) => ($toggled ? 'rotate(180deg)' : 'rotate(0)')};
   height: 24px;
 `
 
@@ -34,7 +34,7 @@ const ExpandActionCell: React.FC<React.PropsWithChildren<ExpandActionCellProps>>
           {expanded ? t('Hide') : t('Details')}
         </Text>
       )}
-      <ArrowIcon color="primary" toggled={expanded} />
+      <ArrowIcon color="primary" $toggled={expanded} />
     </StyledCell>
   )
 }

--- a/packages/uikit/src/__tests__/components/balanceinput.test.tsx
+++ b/packages/uikit/src/__tests__/components/balanceinput.test.tsx
@@ -105,7 +105,6 @@ it("renders correctly", () => {
                 min="0"
                 pattern="^[0-9]*[.,]?[0-9]{0,18}$"
                 placeholder="0.0"
-                scale="md"
                 value="14"
               />
             </div>
@@ -236,7 +235,6 @@ it("renders correctly with unit prop", () => {
                 min="0"
                 pattern="^[0-9]*[.,]?[0-9]{0,18}$"
                 placeholder="0.0"
-                scale="md"
                 value="14"
               />
               <div
@@ -454,7 +452,6 @@ it("renders correctly with unit prop and switchEditingUnits", () => {
                 min="0"
                 pattern="^[0-9]*[.,]?[0-9]{0,18}$"
                 placeholder="0.0"
-                scale="md"
                 value="14"
               />
               <div

--- a/packages/uikit/src/__tests__/components/buttonmenu.test.tsx
+++ b/packages/uikit/src/__tests__/components/buttonmenu.test.tsx
@@ -97,6 +97,7 @@ it("renders correctly", () => {
 
     <div
         class="c0"
+        variant="primary"
       >
         <button
           class="c1"

--- a/packages/uikit/src/__tests__/components/input.test.tsx
+++ b/packages/uikit/src/__tests__/components/input.test.tsx
@@ -39,7 +39,6 @@ it("renders correctly", () => {
 
     <input
         class="c0"
-        scale="md"
         type="text"
         value="input"
       />

--- a/packages/uikit/src/components/Button/StyledButton.tsx
+++ b/packages/uikit/src/components/Button/StyledButton.tsx
@@ -43,7 +43,9 @@ const getOpacity = ({ $isLoading = false }: TransientButtonProps) => {
   return $isLoading ? ".5" : "1";
 };
 
-const StyledButton = styled.button<BaseButtonProps>`
+const StyledButton = styled("button").withConfig({
+  shouldForwardProp: (props) => !["fullWidth"].includes(props),
+})<BaseButtonProps>`
   position: relative;
   align-items: center;
   border: 0;

--- a/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -1,4 +1,3 @@
-import shouldForwardProp from "@styled-system/should-forward-prop";
 import React, { cloneElement, Children, ReactElement } from "react";
 import { styled, DefaultTheme } from "styled-components";
 import { space } from "styled-system";
@@ -18,7 +17,7 @@ const getBorderColor = ({ theme, variant }: StyledButtonMenuProps) => {
 };
 
 const StyledButtonMenu = styled.div.withConfig({
-  shouldForwardProp,
+  shouldForwardProp: (props) => !["fullWidth"].includes(props),
 })<StyledButtonMenuProps>`
   background-color: ${getBackgroundColor};
   border-radius: 16px;

--- a/packages/uikit/src/components/DropdownMenu/styles.tsx
+++ b/packages/uikit/src/components/DropdownMenu/styles.tsx
@@ -14,7 +14,9 @@ const getTextColor = ({
   return theme.colors.textSubtle;
 };
 
-export const DropdownMenuItem = styled.button<StyledDropdownMenuItemProps & { $isActive: boolean }>`
+export const DropdownMenuItem = styled("button").withConfig({
+  shouldForwardProp: (props) => !["confirmModalId"].includes(props),
+})<StyledDropdownMenuItemProps & { $isActive: boolean }>`
   align-items: center;
   border: 0;
   background: transparent;

--- a/packages/uikit/src/components/Input/Input.tsx
+++ b/packages/uikit/src/components/Input/Input.tsx
@@ -32,7 +32,9 @@ const getHeight = ({ scale = scales.MD }: StyledInputProps) => {
   }
 };
 
-const Input = styled.input<InputProps>`
+const Input = styled("input").withConfig({
+  shouldForwardProp: (props) => !["scale", "isSuccess", "isWarning"].includes(props),
+})<InputProps>`
   background-color: ${({ theme }) => theme.colors.input};
   border-radius: 16px;
   box-shadow: ${getBoxShadow};

--- a/packages/uikit/src/components/NextLink/NextLink.tsx
+++ b/packages/uikit/src/components/NextLink/NextLink.tsx
@@ -11,7 +11,9 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   prefetch?: boolean;
 }
 
-const A = styled.a``;
+const A = styled("a").withConfig({
+  shouldForwardProp: (props) => !["hideSubNav", "supportChainIds"].includes(props),
+})``;
 
 /**
  * temporary solution for migrating React Router to Next.js Link

--- a/packages/uikit/src/components/NotificationDot/NotificationDot.tsx
+++ b/packages/uikit/src/components/NotificationDot/NotificationDot.tsx
@@ -8,7 +8,9 @@ const NotificationDotRoot = styled.span`
   position: relative;
 `;
 
-const Dot = styled.span<DotProps>`
+const Dot = styled("span").withConfig({
+  shouldForwardProp: (props) => !["show"].includes(props),
+})<DotProps>`
   display: ${({ show }) => (show ? "inline-flex" : "none")};
   position: absolute;
   top: 0;

--- a/packages/uikit/src/components/SubMenuItems/SubMenuItems.tsx
+++ b/packages/uikit/src/components/SubMenuItems/SubMenuItems.tsx
@@ -49,7 +49,6 @@ const SubMenuItems: React.FC<React.PropsWithChildren<SubMenuItemsProps>> = ({
   useIsomorphicLayoutEffect(() => {
     layerController();
   }, [layerController, items]);
-
   return (
     <AtomBox display={{ xs: "none", sm: "block" }} asChild>
       <SubMenuItemWrapper $isMobileOnly={isMobileOnly} {...props}>

--- a/packages/uikit/src/components/Svg/Svg.tsx
+++ b/packages/uikit/src/components/Svg/Svg.tsx
@@ -16,7 +16,9 @@ const spinStyle = css`
   animation: ${rotate} 2s linear infinite;
 `;
 
-const Svg = styled.svg<SvgProps>`
+const Svg = styled("svg").withConfig({
+  shouldForwardProp: (p) => !["spin"].includes(p),
+})<SvgProps>`
   align-self: center; // Safari fix
   fill: ${({ theme, color }) =>
     getThemeValue(theme, `colors.${color}`, color)}; // should use color and currentColor in svg path

--- a/packages/uikit/src/components/Svg/styles.tsx
+++ b/packages/uikit/src/components/Svg/styles.tsx
@@ -9,7 +9,9 @@ export const StyledIconContainer = styled.div.withConfig({ shouldForwardProp })<
     activeBackgroundColor ? theme.colors[activeBackgroundColor] : "transparent"};
 `;
 
-export const StyledAnimatedIconComponent = styled.div<{
+export const StyledAnimatedIconComponent = styled("div").withConfig({
+  shouldForwardProp: (props) => !["isActive", "hasFillIcon"].includes(props),
+})<{
   isActive: boolean;
   height?: string;
   width?: string;

--- a/packages/uikit/src/widgets/Menu/Menu.tsx
+++ b/packages/uikit/src/widgets/Menu/Menu.tsx
@@ -38,7 +38,9 @@ const StyledNav = styled.nav`
   padding-right: 16px;
 `;
 
-const FixedContainer = styled.div<{ showMenu: boolean; height: number }>`
+const FixedContainer = styled("div").withConfig({
+  shouldForwardProp: (props) => !["showMenu"].includes(props),
+})<{ showMenu: boolean; height: number }>`
   position: fixed;
   top: ${({ showMenu, height }) => (showMenu ? 0 : `-${height}px`)};
   left: 0;

--- a/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
+++ b/packages/uikit/src/widgets/Menu/components/UserMenu/index.tsx
@@ -36,7 +36,7 @@ export const LabelText = styled.div`
   }
 `;
 
-const Menu = styled.div<{ isOpen: boolean }>`
+const Menu = styled.div<{ $isOpen: boolean }>`
   background-color: ${({ theme }) => theme.card.background};
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
   border-radius: 16px;
@@ -47,8 +47,8 @@ const Menu = styled.div<{ isOpen: boolean }>`
   visibility: visible;
   z-index: 1001;
 
-  ${({ isOpen }) =>
-    !isOpen &&
+  ${({ $isOpen }) =>
+    !$isOpen &&
     `
     pointer-events: none;
     visibility: hidden;
@@ -129,7 +129,7 @@ const UserMenu: React.FC<UserMenuProps> = ({
         {!disabled && <ChevronDownIcon color="text" width="24px" />}
       </StyledUserMenu>
       {!disabled && (
-        <Menu style={styles.popper} ref={setTooltipRef} {...attributes.popper} isOpen={isOpen}>
+        <Menu style={styles.popper} ref={setTooltipRef} {...attributes.popper} $isOpen={isOpen}>
           <Box onClick={() => setIsOpen(false)}>{children?.({ isOpen })}</Box>
         </Menu>
       )}

--- a/packages/widgets-internal/farm/components/FarmTable/Details.tsx
+++ b/packages/widgets-internal/farm/components/FarmTable/Details.tsx
@@ -17,15 +17,15 @@ const Container = styled.div`
   }
 `
 
-const ArrowIcon = styled(ChevronDownIcon)<{ toggled?: boolean }>`
-  transform: ${({ toggled }) => (toggled ? 'rotate(180deg)' : 'rotate(0)')};
+const ArrowIcon = styled(ChevronDownIcon)<{ $toggled?: boolean }>`
+  transform: ${({ $toggled }) => ($toggled ? 'rotate(180deg)' : 'rotate(0)')};
   height: 20px;
 `
 
 const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({ actionPanelToggled }) => {
   return (
     <Container>
-      <ArrowIcon color="primary" toggled={actionPanelToggled} />
+      <ArrowIcon color="primary" $toggled={actionPanelToggled} />
     </Container>
   )
 }

--- a/packages/widgets-internal/pool/Cells/ExpandActionCell.tsx
+++ b/packages/widgets-internal/pool/Cells/ExpandActionCell.tsx
@@ -23,8 +23,8 @@ const StyledCell = styled(BaseCell)`
   }
 `
 
-const ArrowIcon = styled((props: any) => <ChevronDownIcon {...props} />)<{ toggled?: boolean }>`
-  transform: ${({ toggled }) => (toggled ? 'rotate(180deg)' : 'rotate(0)')};
+const ArrowIcon = styled((props: any) => <ChevronDownIcon {...props} />)<{ $toggled?: boolean }>`
+  transform: ${({ $toggled }) => ($toggled ? 'rotate(180deg)' : 'rotate(0)')};
   height: 24px;
 `
 
@@ -40,7 +40,7 @@ export const ExpandActionCell: React.FC<React.PropsWithChildren<ExpandActionCell
           {expanded ? t('Hide') : t('Details')}
         </Text>
       )}
-      <ArrowIcon color="primary" toggled={expanded} />
+      <ArrowIcon color="primary" $toggled={expanded} />
     </StyledCell>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f6550a3</samp>

### Summary
🧹🎨🛠️

<!--
1.  🧹 - This emoji represents cleaning up code, removing unused or deprecated props, and avoiding React warnings.
2.  🎨 - This emoji represents adding or changing styling, color, or design aspects of the components.
3.  🛠️ - This emoji represents refactoring or improving code structure, logic, or functionality of the components.
-->
This pull request updates various components and their usages to follow the `$` prefix convention for non-forwarded props, use the `withConfig` method to filter out unnecessary props, and remove deprecated or invalid props. These changes improve code readability, consistency, and performance, and avoid React warnings. The affected components include `SubMenu`, `ArrowIcon`, `BalanceInput`, `ButtonMenu`, `Menu`, `ModalInput`, `Input`, `NextLink`, `NotificationDot`, `SubMenuItems`, `Svg`, and `FixedContainer`. The affected files are in the `apps/web/src`, `packages/uikit/src`, and `packages/widgets-internal` directories.

> _Sing, O Muse, of the skillful coder who refined the codebase_
> _With `withConfig` method and `$` prefix he purged the warnings_
> _Like Hephaestus who forged the shield of Achilles with cunning art_
> _He shaped the `StyledButton`, `Input`, `Svg` and many more components_

### Walkthrough
*  Use the `withConfig` method to specify which props should not be forwarded to the underlying DOM elements in various components, avoiding unnecessary attributes and React warnings ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-f2a82efb517a1643584d7dd5992bd381b45b0d820cfb6af73cbf7f95fd1d06a7L19-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-a31b659bde9d1e097f36a7702220e74e7e7cf7763e86ce91589e05247f43297dL46-R48), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-0407a67c7c3c6fe68ae47aab8d12c931e430a4c72e1fcafb2edc98a283cb90cdL21-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-1187df2d5644fc3bcec9282335693f90d9875cfb92ce936637d99d1b7d13067aL17-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-aef04eb40c33900833007e0f4909ccc5f15a040cf511e8e4e7fd3d7f3614700dL35-R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-154a851c93abdd8399218cb80a8352261319648501f3d363ba2d32cc38709c4cL14-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-827ea02caeccc24515ec2c1f660b46733cafecced0af50051dad749c1365dfdcL11-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-afcc786f3d882f90ae8a6fc8748f65ba26f4224cfdabcb1efe88daaecd561268L19-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-8517af4a62addc9b093f812e23c726ab2d79d153efa5b6ffcb26b726ca960061L12-R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-f1d51a3e8a3d5ebab85da832561177073051362276bc2305a1b715566b06dc53L41-R43))
* Use the `$` prefix for the `isOpen` prop in the `SubMenu` and `Menu` components, following the convention to indicate that the prop is not forwarded to the underlying DOM elements ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-e1c2f01087fe88a02117c2cb75ad2a281de59f082735f9a08d17842512ab56f7L19-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-e1c2f01087fe88a02117c2cb75ad2a281de59f082735f9a08d17842512ab56f7L35-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-e1c2f01087fe88a02117c2cb75ad2a281de59f082735f9a08d17842512ab56f7L121-R121), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-032373cba4013a06ea91ee87881152fb78d8abbd2476e13328d03ea888519e75L39-R39), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-032373cba4013a06ea91ee87881152fb78d8abbd2476e13328d03ea888519e75L50-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-032373cba4013a06ea91ee87881152fb78d8abbd2476e13328d03ea888519e75L132-R132))
* Use the `$` prefix for the `toggled` prop in the `ArrowIcon` component, following the convention to indicate that the prop is not forwarded to the underlying DOM element ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-d034676fc302b50a478a40e06ef60dd5d65b8be9e5a4520ff3d1dc8a65ad28ceL14-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-d034676fc302b50a478a40e06ef60dd5d65b8be9e5a4520ff3d1dc8a65ad28ceL65-R65), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-18af0cb4d4a6822624848bb27fefa8faf98ddf74b67d82ba9e018bedf438ce1dL23-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-18af0cb4d4a6822624848bb27fefa8faf98ddf74b67d82ba9e018bedf438ce1dL37-R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-55135b1cc4a321d4fbce01bfdbfcb3d6b66a104f242131436172e826a557f020L20-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-55135b1cc4a321d4fbce01bfdbfcb3d6b66a104f242131436172e826a557f020L28-R28), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-f7039dce9009f6d3511ea7be814504f35b7e81b252718dfb0710d724aed2f82eL26-R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-f7039dce9009f6d3511ea7be814504f35b7e81b252718dfb0710d724aed2f82eL43-R43))
* Remove the `scale` prop from the `BalanceInput` and `Input` component usages, as it is no longer a valid prop for the components ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-a83141a670a9e827409a1ba2853d740b33debb1d25d8f576ea8eb20d5cfd0fe6L108), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-a83141a670a9e827409a1ba2853d740b33debb1d25d8f576ea8eb20d5cfd0fe6L239), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-a83141a670a9e827409a1ba2853d740b33debb1d25d8f576ea8eb20d5cfd0fe6L457), [link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-3f6d4c9012c2b615e13b34bc3f235fe70406bd0f73c9d373abd167393ed8bc53L42))
* Add the `variant` prop to the `ButtonMenu` component usage, as it is a required prop for the component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-f75f24fbc0cc8ba849dbe406164d78a5287c75348e95f0e0a66724ef9106889bR100))
* Remove the unused `shouldForwardProp` import from the `ButtonMenu` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-0407a67c7c3c6fe68ae47aab8d12c931e430a4c72e1fcafb2edc98a283cb90cdL1))
* Remove the empty line from the `SubMenuItems` component, as it was a formatting error ([link](https://github.com/pancakeswap/pancake-frontend/pull/7911/files?diff=unified&w=0#diff-7b1a6a3f05ab0aa56579faf8e5c5fdd339241a62cc292bc5649a0442935fcca5L52))


