### PR TITLE
feat: Liquidity url filter pair

### DIFF
--- a/apps/web/src/hooks/useV2Pairs.ts
+++ b/apps/web/src/hooks/useV2Pairs.ts
@@ -4,7 +4,7 @@ import { toV2LiquidityToken, useTrackedTokenPairs } from 'state/user/hooks'
 import { useTokenBalancesWithLoadingIndicator } from 'state/wallet/hooks'
 import { PairState, useV2Pairs } from './usePairs'
 
-export default function useV2PairsByAccount(account: string) {
+export default function useV2PairsByAccount(account: string | undefined) {
   // fetch the user's balances of all tracked V2 LP tokens
   const trackedTokenPairs = useTrackedTokenPairs()
 
@@ -37,7 +37,7 @@ export default function useV2PairsByAccount(account: string) {
       fetchingV2PairBalances ||
       v2Pairs?.length < liquidityTokensWithBalances.length ||
       (v2Pairs?.length && v2Pairs.every(([pairState]) => pairState === PairState.LOADING))
-    const allV2PairsWithLiquidity: Pair[] = v2Pairs
+    const allV2PairsWithLiquidity: (Pair | null)[] = v2Pairs
       ?.filter(([pairState, pair]) => pairState === PairState.EXISTS && Boolean(pair))
       .map(([, pair]) => pair)
 

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -93,7 +93,7 @@ export default function PoolListPage() {
   const stablePairs = useLPTokensWithBalanceByAccount(account)
 
   const { token0, token1, fee } = router.query as { token0: string; token1: string; fee: string }
-  const isNeedFilterByQuery = useMemo(() => token0 && token1 && fee, [token0, token1, fee])
+  const isNeedFilterByQuery = useMemo(() => token0 || token1 || fee, [token0, token1, fee])
   const [showAllPositionWithQuery, setShowAllPositionWithQuery] = useState(false)
 
   let v2PairsSection: null | JSX.Element[] = null
@@ -186,13 +186,30 @@ export default function PoolListPage() {
           const pairToken1 = pair?.props?.positionDetails?.token1?.toLowerCase()
           const token0ToLowerCase = token0?.toLowerCase()
           const token1ToLowerCase = token1?.toLowerCase()
-          if (
-            ((pairToken0 === token0ToLowerCase && pairToken1 === token1ToLowerCase) ||
-              (pairToken0 === token1ToLowerCase && pairToken1 === token0ToLowerCase)) &&
-            pair?.props?.positionDetails?.fee === Number(fee ?? 0)
-          ) {
+
+          if (token0 && token1 && fee) {
+            if (
+              ((pairToken0 === token0ToLowerCase && pairToken1 === token1ToLowerCase) ||
+                (pairToken0 === token1ToLowerCase && pairToken1 === token0ToLowerCase)) &&
+              pair?.props?.positionDetails?.fee === Number(fee ?? 0)
+            ) {
+              return pair
+            }
+            return null
+          }
+
+          if (token0 && (pairToken0 === token0ToLowerCase || pairToken1 === token0ToLowerCase)) {
             return pair
           }
+
+          if (token1 && (pairToken0 === token1ToLowerCase || pairToken1 === token1ToLowerCase)) {
+            return pair
+          }
+
+          if (fee && pair?.props?.positionDetails?.fee === Number(fee ?? 0)) {
+            return pair
+          }
+
           return null
         })
         .filter(Boolean)

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -182,9 +182,13 @@ export default function PoolListPage() {
     if (isNeedFilterByQuery && !showAllPositionWithQuery && v3PairsSection) {
       return v3PairsSection
         .filter((pair) => {
+          const pairToken0 = pair?.props?.positionDetails?.token0?.toLowerCase()
+          const pairToken1 = pair?.props?.positionDetails?.token1?.toLowerCase()
+          const token0ToLowerCase = token0?.toLowerCase()
+          const token1ToLowerCase = token1?.toLowerCase()
           if (
-            pair?.props?.positionDetails?.token0?.toLowerCase() === token0?.toLowerCase() &&
-            pair?.props?.positionDetails?.token1?.toLowerCase() === token1?.toLowerCase() &&
+            ((pairToken0 === token0ToLowerCase && pairToken1 === token1ToLowerCase) ||
+              (pairToken0 === token1ToLowerCase && pairToken1 === token0ToLowerCase)) &&
             pair?.props?.positionDetails?.fee === Number(fee ?? 0)
           ) {
             return pair

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -200,11 +200,15 @@ export default function PoolListPage() {
   const showAllPositionButton = useMemo(() => {
     if (v3PairsSection && filteredWithQueryFilter) {
       return (
-        v3PairsSection?.length > filteredWithQueryFilter?.length && isNeedFilterByQuery && !showAllPositionWithQuery
+        v3PairsSection?.length > filteredWithQueryFilter?.length &&
+        isNeedFilterByQuery &&
+        !showAllPositionWithQuery &&
+        !v3Loading &&
+        !v2Loading
       )
     }
     return false
-  }, [filteredWithQueryFilter, isNeedFilterByQuery, showAllPositionWithQuery, v3PairsSection])
+  }, [filteredWithQueryFilter, isNeedFilterByQuery, showAllPositionWithQuery, v3PairsSection, v3Loading, v2Loading])
 
   const mainSection = useMemo(() => {
     let resultSection: null | JSX.Element | (JSX.Element[] | null | undefined)[] = null
@@ -232,6 +236,15 @@ export default function PoolListPage() {
 
   const [onPresentTransactionsModal] = useModal(<TransactionsModal />)
   const isMigrationSupported = useMemo(() => isV3MigrationSupported(chainId), [chainId])
+
+  const handleClickShowAllPositions = () => {
+    setShowAllPositionWithQuery(true)
+
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
 
   return (
     <Page>
@@ -293,12 +306,7 @@ export default function PoolListPage() {
               <Text color="textSubtle" mb="10px">
                 {t("Don't see a pair you joined?")}
               </Text>
-              <Button
-                scale="sm"
-                width="fit-content"
-                variant="secondary"
-                onClick={() => setShowAllPositionWithQuery(true)}
-              >
+              <Button scale="sm" width="fit-content" variant="secondary" onClick={handleClickShowAllPositions}>
                 {t('Show all positions')}
               </Button>
             </Flex>

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -183,8 +183,8 @@ export default function PoolListPage() {
       return v3PairsSection
         .filter((pair) => {
           if (
-            pair?.props?.positionDetails?.token0?.toLowerCase() === token0?.toLowerCase() ||
-            pair?.props?.positionDetails?.token1?.toLowerCase() === token1?.toLowerCase() ||
+            pair?.props?.positionDetails?.token0?.toLowerCase() === token0?.toLowerCase() &&
+            pair?.props?.positionDetails?.token1?.toLowerCase() === token1?.toLowerCase() &&
             pair?.props?.positionDetails?.fee === Number(fee ?? 0)
           ) {
             return pair
@@ -194,7 +194,7 @@ export default function PoolListPage() {
         .filter(Boolean)
     }
 
-    return v3PairsSection
+    return []
   }, [fee, isNeedFilterByQuery, showAllPositionWithQuery, token0, token1, v3PairsSection])
 
   const showAllPositionButton = useMemo(() => {
@@ -204,11 +204,20 @@ export default function PoolListPage() {
         isNeedFilterByQuery &&
         !showAllPositionWithQuery &&
         !v3Loading &&
-        !v2Loading
+        !v2Loading &&
+        (selectedTypeIndex === FILTER.ALL || selectedTypeIndex === FILTER.V3)
       )
     }
     return false
-  }, [filteredWithQueryFilter, isNeedFilterByQuery, showAllPositionWithQuery, v3PairsSection, v3Loading, v2Loading])
+  }, [
+    filteredWithQueryFilter,
+    isNeedFilterByQuery,
+    showAllPositionWithQuery,
+    v3PairsSection,
+    v3Loading,
+    v2Loading,
+    selectedTypeIndex,
+  ])
 
   const mainSection = useMemo(() => {
     let resultSection: null | JSX.Element | (JSX.Element[] | null | undefined)[] = null
@@ -226,13 +235,25 @@ export default function PoolListPage() {
       )
     } else {
       // Order should be v3, stable, v2
-      const sections = [filteredWithQueryFilter, stablePairsSection, v2PairsSection]
+      const sections = showAllPositionButton
+        ? [filteredWithQueryFilter]
+        : [v3PairsSection, stablePairsSection, v2PairsSection]
 
       resultSection = selectedTypeIndex ? sections.filter((_, index) => selectedTypeIndex === index + 1) : sections
     }
 
     return resultSection
-  }, [selectedTypeIndex, stablePairsSection, t, v2Loading, v2PairsSection, v3Loading, filteredWithQueryFilter])
+  }, [
+    selectedTypeIndex,
+    stablePairsSection,
+    t,
+    v2Loading,
+    v2PairsSection,
+    v3Loading,
+    v3PairsSection,
+    filteredWithQueryFilter,
+    showAllPositionButton,
+  ])
 
   const [onPresentTransactionsModal] = useModal(<TransactionsModal />)
   const isMigrationSupported = useMemo(() => isV3MigrationSupported(chainId), [chainId])

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -58,7 +58,6 @@ export const StableContextProvider = (props: { pair: LPStablePair; account: stri
   if (!stableConfig.stableSwapConfig) return null
 
   return (
-    // @ts-ignore
     <StableConfigContext.Provider value={stableConfig}>
       <StablePairCard {...props} />
     </StableConfigContext.Provider>

--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -182,8 +182,8 @@ export default function PoolListPage() {
       return v3PairsSection
         .filter((pair) => {
           if (
-            pair?.props?.positionDetails?.token0?.toLowerCase() === token0?.toLowerCase() &&
-            pair?.props?.positionDetails?.token1?.toLowerCase() === token1?.toLowerCase() &&
+            pair?.props?.positionDetails?.token0?.toLowerCase() === token0?.toLowerCase() ||
+            pair?.props?.positionDetails?.token1?.toLowerCase() === token1?.toLowerCase() ||
             pair?.props?.positionDetails?.fee === Number(fee ?? 0)
           ) {
             return pair

--- a/apps/web/src/utils/isV3MigrationSupported.ts
+++ b/apps/web/src/utils/isV3MigrationSupported.ts
@@ -2,6 +2,10 @@ import { ChainId } from '@pancakeswap/chains'
 
 export const V3_MIGRATION_SUPPORTED_CHAINS = [ChainId.BSC, ChainId.ETHEREUM]
 
-export function isV3MigrationSupported(chainId: ChainId) {
+export function isV3MigrationSupported(chainId: ChainId | undefined) {
+  if (!chainId) {
+    return []
+  }
+
   return V3_MIGRATION_SUPPORTED_CHAINS.includes(chainId)
 }

--- a/apps/web/src/views/AddLiquidityV3/components/StablePairCard.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/StablePairCard.tsx
@@ -4,11 +4,11 @@ import { useGetRemovedTokenAmounts } from 'views/RemoveLiquidity/RemoveStableLiq
 import { LPStablePair } from 'views/Swap/hooks/useStableConfig'
 import { LiquidityCardRow } from 'components/LiquidityCardRow'
 
-export function StablePairCard({ pair, account }: { pair: LPStablePair; account: string }) {
+export function StablePairCard({ pair, account }: { pair: LPStablePair; account: string | undefined }) {
   const userPoolBalance = useTokenBalance(account ?? undefined, pair.liquidityToken)
 
   const [token0Deposited, token1Deposited] = useGetRemovedTokenAmounts({
-    lpAmount: userPoolBalance?.quotient?.toString(),
+    lpAmount: userPoolBalance?.quotient?.toString() ?? '0',
   })
 
   return (

--- a/apps/web/src/views/AddLiquidityV3/components/V2PairCard.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/V2PairCard.tsx
@@ -7,12 +7,16 @@ import { LiquidityCardRow } from 'components/LiquidityCardRow'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 import currencyId from 'utils/currencyId'
 
-export function V2PairCard({ pair, account }: { pair: Pair; account: string }) {
-  const userPoolBalance = useTokenBalance(account ?? undefined, pair.liquidityToken)
+export function V2PairCard({ pair, account }: { pair: null | Pair; account: string | undefined }) {
+  const userPoolBalance = useTokenBalance(account ?? undefined, pair?.liquidityToken)
 
-  const totalPoolTokens = useTotalSupply(pair.liquidityToken)
+  const totalPoolTokens = useTotalSupply(pair?.liquidityToken)
 
   const [token0Deposited, token1Deposited] = useTokensDeposited({ pair, userPoolBalance, totalPoolTokens })
+
+  if (!pair) {
+    return null
+  }
 
   const unwrappedToken0 = unwrappedToken(pair.token0)
   const unwrappedToken1 = unwrappedToken(pair.token1)

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2700,5 +2700,6 @@
   "Mercury Mysteries": "Mercury Mysteries",
   "Venus Protectors": "Venus Protectors",
   "Uranus Unity Rain": "Uranus Unity Rain",
-  "0%  Provider  Fee until Sep 12th!": "0%  Provider  Fee until Sep 12th!"
+  "0%  Provider  Fee until Sep 12th!": "0%  Provider  Fee until Sep 12th!",
+  "Show all positions": "Show all positions"
 }

--- a/packages/smart-router/evm/constants/stableSwap/pools.ts
+++ b/packages/smart-router/evm/constants/stableSwap/pools.ts
@@ -8,8 +8,12 @@ export type StableSwapPoolMap<TChainId extends number> = {
   [chainId in TChainId]: StableSwapPool[]
 }
 
-export const isStableSwapSupported = (chainId: number): chainId is StableSupportedChainId =>
-  STABLE_SUPPORTED_CHAIN_IDS.includes(chainId)
+export const isStableSwapSupported = (chainId: number | undefined): chainId is StableSupportedChainId => {
+  if (!chainId) {
+    return false
+  }
+  return STABLE_SUPPORTED_CHAIN_IDS.includes(chainId)
+}
 
 export const STABLE_SUPPORTED_CHAIN_IDS = [ChainId.BSC, ChainId.BSC_TESTNET] as const
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 65d87e1</samp>

### Summary
🌐🔎🔄

<!--
1.  🌐 - This emoji represents the addition of a new translation key and value, which is related to localization and internationalization.
2. 🔎 - This emoji represents the addition of a filter feature, which allows the user to search and narrow down the results based on certain criteria.
3. 🔄 - This emoji represents the addition of a button to show all positions, which allows the user to reset the filter and see the full list of results.
-->
This pull request adds a filter feature to the liquidity page that lets users view their positions by token pair and fee tier. It also adds a localization key for the new button that shows all positions. The changes affect the `apps/web/src/pages/liquidity/index.tsx` and `packages/localization/src/config/translations.json` files.

> _Oh we are the coders of the `translations.json`_
> _We add the keys and values for everyone_
> _And when we want to filter the `positions` by the `query`_
> _We press the button that says "Show all" and we are free_

### Walkthrough
*  Import `useRouter` hook to access query parameters from URL ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeR21))
*  Reorder variable declarations in `PoolListPage` component to group hooks and move `router` closer to usage ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL81-R84))
*  Destructure `token0`, `token1`, and `fee` values from `router.query` and cast them as strings ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeR95-R98))
*  Create boolean variables `isNeedFilterByQuery` and `showAllPositionWithQuery` to control query filter and display toggle ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeR95-R98))
*  Create memoized variable `filteredWithQueryFilter` that filters `v3PairsSection` based on query parameters ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeR180-R202))
*  Replace `v3PairsSection` with `filteredWithQueryFilter` in result section condition and rendering ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL182-R211))
*  Replace `v3PairsSection` with `filteredWithQueryFilter` in type filter ordering and filtering ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL190-R219))
*  Add `filteredWithQueryFilter` as dependency to `useMemo` hook that returns result section ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeL196-R225))
*  Add conditional rendering of button to show all positions regardless of query parameters ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-f3879201f1ad7d67b9ec65c51c2f5ee7f2d48611263deb03043775a107a887eeR285-R299))
*  Add translation key and value for "Show all positions" button in `translations.json` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7914/files?diff=unified&w=0#diff-eb2ab983e2cefc22516cb7814c86346f4b2bd2b971980952868173095d48f459L2699-R2700))


