### PR TITLE
fix: Trading reward leaderboard previous rounds switch not working

### DIFF
--- a/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/index.tsx
@@ -25,11 +25,11 @@ const Leaderboard: React.FC<React.PropsWithChildren<LeaderboardProps>> = ({ camp
   const [index, setIndex] = useState(0)
   const [campaignPage, setCampaignPage] = useState(1)
   const [campaignMaxPage, setCampaignMaxPages] = useState(1)
-  const [campaignLeaderBoardList, setCampaignLeaderBoardList] = useState({
+  const [campaignLeaderBoardList, setCampaignLeaderBoardList] = useState(() => ({
     campaignId: '0',
     campaignStart: 0,
     campaignClaimTime: 0,
-  })
+  }))
 
   const [currentPage, setCurrentPage] = useState(1)
   const [maxPage, setMaxPages] = useState(1)
@@ -83,7 +83,7 @@ const Leaderboard: React.FC<React.PropsWithChildren<LeaderboardProps>> = ({ camp
           setCampaignPage(1)
           setCampaignLeaderBoardList(currentLeaderBoard)
         } else {
-          setCampaignPage(2)
+          setCampaignPage((prevState) => (prevState === 1 ? 2 : prevState))
           sliceAllLeaderBoard()
         }
       } else {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c57f3c0</samp>

### Summary
🚀🛠️🧑‍💻

<!--
1.  🚀 - This emoji represents the improvement in performance and speed of the leaderboard component, as it suggests that the component is now faster and more responsive to user interactions.
2.  🛠️ - This emoji represents the enhancement in functionality and features of the leaderboard component, as it suggests that the component is now more robust and flexible to handle different scenarios and data.
3.  🧑‍💻 - This emoji represents the use of functions to manage the state of the leaderboard component, as it suggests that the component is now more modular and maintainable, and follows the best practices of React development.
-->
Optimized the leaderboard component for trading rewards by using state functions in `Leaderboard/index.tsx`.

> _To make the leaderboard component better_
> _They used functions to set and resetter_
> _The `campaignLeaderBoardList`_
> _And the `campaignPage` gist_
> _And thus they improved the performance and fetter_

### Walkthrough
* Optimize `campaignLeaderBoardList` state initialization with a function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7916/files?diff=unified&w=0#diff-94382753793192a4edd427aba2521b380c88958dbcc9821b7f456a923c67847aL28-R32))
* Fix `campaignPage` state update with a function that preserves the current page when switching campaigns ([link](https://github.com/pancakeswap/pancake-frontend/pull/7916/files?diff=unified&w=0#diff-94382753793192a4edd427aba2521b380c88958dbcc9821b7f456a923c67847aL86-R86))


