### PR TITLE
feat: list 3 farm

### DIFF
--- a/packages/farms/constants/42161.ts
+++ b/packages/farms/constants/42161.ts
@@ -45,4 +45,11 @@ export const farmsV3 = defineFarmV3Configs([
     token1: arbitrumTokens.lvl,
     feeAmount: FeeAmount.MEDIUM,
   },
+  {
+    pid: 7,
+    lpAddress: '0x5e3C3a063cc9A4AEB5310C7faDc2A98aEbDD245d',
+    token0: arbitrumTokens.weth,
+    token1: arbitrumTokens.mgp,
+    feeAmount: FeeAmount.MEDIUM,
+  },
 ])

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -1827,7 +1827,7 @@ const farms: SerializedFarmConfig[] = [
     lpAddress: '0xB6040A9F294477dDAdf5543a24E5463B8F2423Ae',
     token: bscTokens.hay,
     quoteToken: bscTokens.busd,
-    stableSwapAddress: '0x49079d07ef47449af808a4f36c2a8dec975594ec',
+    stableSwapAddress: '0x49079D07ef47449aF808A4f36c2a8dEC975594eC',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -3,9 +3,9 @@ import { FeeAmount, Pool } from '@pancakeswap/v3-sdk'
 import { getAddress } from 'viem'
 import { CAKE_BNB_LP_MAINNET } from './common'
 import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
-import { SerializedFarmConfig } from '..'
+import { FarmConfigV3, SerializedFarmConfig } from '..'
 
-export const farmsV3 = defineFarmV3Configs([
+const v3TopFixedLps: FarmConfigV3[] = [
   {
     pid: 1,
     token0: bscTokens.cake,
@@ -41,7 +41,26 @@ export const farmsV3 = defineFarmV3Configs([
     lpAddress: '0x36696169C63e42cd08ce11f5deeBbCeBae652050',
     feeAmount: FeeAmount.LOW,
   },
-  // keep those farms on top
+]
+
+export const farmsV3 = defineFarmV3Configs([
+  ...v3TopFixedLps,
+  // new lps should follow after the top fixed lps
+  // latest first
+  {
+    pid: 87,
+    token0: bscTokens.wbnb,
+    token1: bscTokens.rdnt,
+    lpAddress: '0xB55A0B97B7D9Ebe4208b08AB00feC0C419cc32A3',
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 88,
+    token0: bscTokens.mbox,
+    token1: bscTokens.wbnb,
+    lpAddress: '0x0004222c2075E9A1291E41f1cA4C8d32141dB501',
+    feeAmount: FeeAmount.MEDIUM,
+  },
   {
     pid: 86,
     token0: bscTokens.ltc,

--- a/packages/tokens/src/42161.ts
+++ b/packages/tokens/src/42161.ts
@@ -1,4 +1,5 @@
-import { ChainId, ERC20Token, WETH9 } from '@pancakeswap/sdk'
+import { ERC20Token, WETH9 } from '@pancakeswap/sdk'
+import { ChainId } from '@pancakeswap/chains'
 import { USDT, USDC, CAKE } from './common'
 
 export const arbitrumTokens = {
@@ -18,4 +19,5 @@ export const arbitrumTokens = {
     'Level Token',
     'https://level.finance/',
   ),
+  mgp: new ERC20Token(ChainId.ARBITRUM_ONE, '0xa61F74247455A40b01b0559ff6274441FAfa22A3', 18, 'MGP', 'Magpie Token'),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c1afc4b</samp>

### Summary
🌾🌉🪙

<!--
1.  🌾 for adding new farms
2.  🌉 for adding support for a new network (Arbitrum One)
3.  🪙 for adding a new token (MGP)
-->
This pull request adds support for a new token (MGP) and three new farms on Arbitrum One and Binance Smart Chain networks. The changes allow users to swap, stake and earn rewards with MGP and other tokens on the PancakeSwap frontend.

> _Sing, O Muse, of the valiant PancakeSwap team_
> _Who added new farms and tokens to their scheme_
> _On Arbitrum One they deployed `WETH-MGP`_
> _A pair of great worth, with a fee not too steep_

### Walkthrough
*  Add new farms for WETH-MGP, WBNB-RDNT and MBOX-WBNB pairs ([link](https://github.com/pancakeswap/pancake-frontend/pull/7934/files?diff=unified&w=0#diff-0d559ee9d53aaf984239d69ebee96a5f389e8c0a2b724a27814387faba4a3546R48-R54), [link](https://github.com/pancakeswap/pancake-frontend/pull/7934/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R614-R627))
*  Add new token definition for MGP on Arbitrum One network ([link](https://github.com/pancakeswap/pancake-frontend/pull/7934/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8R22))
*  Update import statements for ChainId, ERC20Token and WETH9 in `packages/tokens/src/42161.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7934/files?diff=unified&w=0#diff-ab21739cfdac48707d4b9c121d061b2856a86c256319d79879d8a7e5be8c08a8L1-R2))


