### PR TITLE
fix: cannot swap on l2 chains

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/hooks/useWallchain.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useWallchain.ts
@@ -132,7 +132,10 @@ export function useWallchainApi(
   const swapCalls = useSwapCallArguments(trade, allowedSlippage, account, deadline, feeOptions)
 
   useEffect(() => {
-    if (!sdk || !walletClient || !trade) return
+    if (!sdk || !walletClient || !trade) {
+      setStatus('not-found')
+      return
+    }
     if (trade.routes.length === 0 || trade.inputAmount.currency.chainId !== ChainId.BSC) return
     if (lastUpdate > Date.now() - 2000) return
     const includesPair = trade.routes.some(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at abfeba3</samp>

### Summary
🔒🚫🔄

<!--
1.  🔒 - This emoji represents the security aspect of checking the wallet connection and trade validity before proceeding with the swap.
2.  🚫 - This emoji represents the negative or error status of 'not-found' that is set when the conditions are not met.
3.  🔄 - This emoji represents the swap or exchange functionality that is the main purpose of the component.
-->
Fix swap status when wallet or trade are missing. The change sets the status to 'not-found' in `useWallchain.ts` if the sdk, walletClient or trade are falsy.

> _`status` not found_
> _when wallet or trade missing_
> _autumn leaves fall fast_

### Walkthrough
*  Set status to 'not-found' if sdk, walletClient or trade are falsy ([link](https://github.com/pancakeswap/pancake-frontend/pull/7950/files?diff=unified&w=0#diff-bfe39efb83c5d5d051644d7ebcf06f35473f3a7d27706eae1706fd5e95acac8cL135-R138))


