### PR TITLE
chore: add command abi type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deno.enablePaths": ["./cli/aptos-codegen"],
   "deno.config": "./cli/aptos-codegen/deno.jsonc",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": ["bips"]
 }

--- a/packages/universal-router-sdk/package.json
+++ b/packages/universal-router-sdk/package.json
@@ -72,9 +72,10 @@
     "@pancakeswap/v3-sdk": "workspace:*",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/universal-router": "1.4.3",
+    "abitype": "^0.9.8",
     "bignumber.js": "^9.0.2",
     "ethers": "^5.3.1",
     "tiny-invariant": "^1.1.0",
-    "viem": "^1.2.9"
+    "viem": "^1.12.2"
   }
 }

--- a/packages/universal-router-sdk/src/utils/routerCommands.ts
+++ b/packages/universal-router-sdk/src/utils/routerCommands.ts
@@ -1,4 +1,5 @@
-import { defaultAbiCoder } from 'ethers/lib/utils'
+import type { AbiParametersToPrimitiveTypes } from 'abitype'
+import { Hex, encodeAbiParameters, parseAbiParameters } from 'viem'
 
 /**
  * CommandTypes
@@ -62,61 +63,117 @@ const REVERTIBLE_COMMANDS = new Set<CommandType>([
   CommandType.ELEMENT_MARKET,
 ])
 
-const PERMIT_STRUCT =
-  '((address token,uint160 amount,uint48 expiration,uint48 nonce) details,address spender,uint256 sigDeadline)'
+const ABI_STRUCT_PERMIT_DETAILS = `
+struct PermitDetails {
+  address token;
+  uint160 amount;
+  uint48 expiration;
+  uint48 nonce;
+}`
 
-const PERMIT_BATCH_STRUCT =
-  '((address token,uint160 amount,uint48 expiration,uint48 nonce)[] details,address spender,uint256 sigDeadline)'
+const ABI_STRUCT_PERMIT_SINGLE = `
+struct PermitSingle {
+  PermitDetails details;
+  address spender;
+  uint256 sigDeadline;
+}
+`
 
-const PERMIT2_TRANSFER_FROM_STRUCT = '(address from,address to,uint160 amount,address token)'
-const PERMIT2_TRANSFER_FROM_BATCH_STRUCT = PERMIT2_TRANSFER_FROM_STRUCT + '[]'
+const ABI_STRUCT_PERMIT_BATCH = `
+struct PermitBatch {
+  PermitSingle[] details;
+  address spender;
+  uint256 sigDeadline;
+}
+`
 
-const ABI_DEFINITION: { [key in CommandType]: string[] } = {
+const ABI_STRUCT_ALLOWANCE_TRANSFER_DETAILS = `
+struct AllowanceTransferDetails {
+  address from;
+  address to;
+  uint160 amount;
+  address token;
+}
+`
+
+const ABI_PARAMETER = {
   // Batch Reverts
-  [CommandType.EXECUTE_SUB_PLAN]: ['bytes', 'bytes[]'],
+  [CommandType.EXECUTE_SUB_PLAN]: parseAbiParameters('bytes _commands, bytes[] _inputs'),
 
   // Permit2 Actions
-  [CommandType.PERMIT2_PERMIT]: [PERMIT_STRUCT, 'bytes'],
-  [CommandType.PERMIT2_PERMIT_BATCH]: [PERMIT_BATCH_STRUCT, 'bytes'],
-  [CommandType.PERMIT2_TRANSFER_FROM]: ['address', 'address', 'uint160'],
-  [CommandType.PERMIT2_TRANSFER_FROM_BATCH]: [PERMIT2_TRANSFER_FROM_BATCH_STRUCT],
+  [CommandType.PERMIT2_PERMIT]: parseAbiParameters([
+    'PermitSingle permitSingle, bytes data',
+    ABI_STRUCT_PERMIT_SINGLE,
+    ABI_STRUCT_PERMIT_DETAILS,
+  ]),
+  [CommandType.PERMIT2_PERMIT_BATCH]: parseAbiParameters([
+    'PermitBatch permitBatch, bytes data',
+    ABI_STRUCT_PERMIT_BATCH,
+    ABI_STRUCT_PERMIT_DETAILS,
+  ]),
+  [CommandType.PERMIT2_TRANSFER_FROM]: parseAbiParameters('address token, address recipient, uint160 amount'),
+  [CommandType.PERMIT2_TRANSFER_FROM_BATCH]: parseAbiParameters([
+    'AllowanceTransferDetails[] batchDetails',
+    ABI_STRUCT_ALLOWANCE_TRANSFER_DETAILS,
+  ]),
 
-  // Pancake Actions
-  [CommandType.V3_SWAP_EXACT_IN]: ['address', 'uint256', 'uint256', 'bytes', 'bool'],
-  [CommandType.V3_SWAP_EXACT_OUT]: ['address', 'uint256', 'uint256', 'bytes', 'bool'],
-  [CommandType.V2_SWAP_EXACT_IN]: ['address', 'uint256', 'uint256', 'address[]', 'bool'],
-  [CommandType.V2_SWAP_EXACT_OUT]: ['address', 'uint256', 'uint256', 'address[]', 'bool'],
+  // swap actions
+  [CommandType.V3_SWAP_EXACT_IN]: parseAbiParameters(
+    'address recipient, uint256 amountIn, uint256 amountOutMin, bytes path, bool payerIsUser'
+  ),
+  [CommandType.V3_SWAP_EXACT_OUT]: parseAbiParameters(
+    'address recipient, uint256 amountOut, uint256 amountInMax, bytes path, bool payerIsUser'
+  ),
+  [CommandType.V2_SWAP_EXACT_IN]: parseAbiParameters(
+    'address recipient, uint256 amountIn, uint256 amountOutMin, bytes path, bool payerIsUser'
+  ),
+  [CommandType.V2_SWAP_EXACT_OUT]: parseAbiParameters(
+    'address recipient, uint256 amountOut, uint256 amountInMax, bytes path, bool payerIsUser'
+  ),
 
   // Token Actions and Checks
-  [CommandType.WRAP_ETH]: ['address', 'uint256'],
-  [CommandType.UNWRAP_WETH]: ['address', 'uint256'],
-  [CommandType.SWEEP]: ['address', 'address', 'uint256'],
-  [CommandType.SWEEP_ERC721]: ['address', 'address', 'uint256'],
-  [CommandType.SWEEP_ERC1155]: ['address', 'address', 'uint256', 'uint256'],
-  [CommandType.TRANSFER]: ['address', 'address', 'uint256'],
-  [CommandType.PAY_PORTION]: ['address', 'address', 'uint256'],
-  [CommandType.BALANCE_CHECK_ERC20]: ['address', 'address', 'uint256'],
-  [CommandType.OWNER_CHECK_721]: ['address', 'address', 'uint256'],
-  [CommandType.OWNER_CHECK_1155]: ['address', 'address', 'uint256', 'uint256'],
-  [CommandType.APPROVE_ERC20]: ['address', 'uint256'],
+  [CommandType.WRAP_ETH]: parseAbiParameters('address recipient, uint256 amountMin'),
+  [CommandType.UNWRAP_WETH]: parseAbiParameters('address recipient, uint256 amountMin'),
+  [CommandType.SWEEP]: parseAbiParameters('address token, address recipient, uint256 amountMin'),
+  [CommandType.SWEEP_ERC721]: parseAbiParameters('address token, address recipient, uint256 id'),
+  [CommandType.SWEEP_ERC1155]: parseAbiParameters('address token, address recipient, uint256 id, uint256 amount'),
+  [CommandType.TRANSFER]: parseAbiParameters('address token, address recipient, uint256 value'),
+  [CommandType.PAY_PORTION]: parseAbiParameters('address token, address recipient, uint256 bips'),
+  [CommandType.BALANCE_CHECK_ERC20]: parseAbiParameters('address owner, address token, uint256 minBalance'),
+  [CommandType.OWNER_CHECK_721]: parseAbiParameters('address owner, address token, uint256 id'),
+  [CommandType.OWNER_CHECK_1155]: parseAbiParameters('address owner, address token, uint256 id, uint256 minBalance'),
+  [CommandType.APPROVE_ERC20]: parseAbiParameters('address token, uint256 spender'),
 
   // NFT Markets
-  [CommandType.SEAPORT_V1_5]: ['uint256', 'bytes'],
-  [CommandType.SEAPORT_V1_4]: ['uint256', 'bytes'],
-  [CommandType.NFTX]: ['uint256', 'bytes'],
-  [CommandType.LOOKS_RARE_V2]: ['uint256', 'bytes'],
-  [CommandType.X2Y2_721]: ['uint256', 'bytes', 'address', 'address', 'uint256'],
-  [CommandType.X2Y2_1155]: ['uint256', 'bytes', 'address', 'address', 'uint256', 'uint256'],
-  [CommandType.FOUNDATION]: ['uint256', 'bytes', 'address', 'address', 'uint256'],
-  [CommandType.SUDOSWAP]: ['uint256', 'bytes'],
-  [CommandType.NFT20]: ['uint256', 'bytes'],
-  [CommandType.CRYPTOPUNKS]: ['uint256', 'address', 'uint256'],
-  [CommandType.ELEMENT_MARKET]: ['uint256', 'bytes'],
+  [CommandType.SEAPORT_V1_5]: parseAbiParameters('uint256 value, bytes data'),
+  [CommandType.SEAPORT_V1_4]: parseAbiParameters('uint256 value, bytes data'),
+  // @fixme: contract not implemented
+  [CommandType.NFTX]: parseAbiParameters('uint256 value, bytes data'),
+  [CommandType.LOOKS_RARE_V2]: parseAbiParameters('uint256 value, bytes data'),
+  [CommandType.X2Y2_721]: parseAbiParameters('uint256 value, bytes data, address recipient, address token, uint256 id'),
+  [CommandType.X2Y2_1155]: parseAbiParameters(
+    'uint256 value, bytes data, address recipient, address token, uint256 id, uint256 amount'
+  ),
+  // @fixme: contract not implemented
+  [CommandType.FOUNDATION]: parseAbiParameters(
+    'uint256 value, bytes data, address recipient, address token, uint256 id'
+  ),
+  // @fixme: contract not implemented
+  [CommandType.SUDOSWAP]: parseAbiParameters('uint256 value, bytes data'),
+  // @fixme: contract not implemented
+  [CommandType.NFT20]: parseAbiParameters('uint256 value, bytes data'),
+  // @fixme: contract not implemented
+  [CommandType.CRYPTOPUNKS]: parseAbiParameters('uint256 punkId, address recipient, uint256 value'),
+  // @fixme: contract not implemented
+  [CommandType.ELEMENT_MARKET]: parseAbiParameters('uint256 value, bytes data'),
 }
 
+type ABIType = typeof ABI_PARAMETER
+type ABIParametersType<TCommandType extends CommandType> = AbiParametersToPrimitiveTypes<ABIType[TCommandType]>
 export class RoutePlanner {
-  commands: string
-  inputs: string[]
+  commands: Hex
+
+  inputs: Hex[]
 
   constructor() {
     this.commands = '0x'
@@ -127,27 +184,34 @@ export class RoutePlanner {
     this.addCommand(CommandType.EXECUTE_SUB_PLAN, [subplan.commands, subplan.inputs], true)
   }
 
-  addCommand(type: CommandType, parameters: any[], allowRevert = false): void {
-    let command = createCommand(type, parameters)
+  addCommand<TCommandType extends CommandType>(
+    type: TCommandType,
+    parameters: ABIParametersType<TCommandType>,
+    allowRevert = false
+  ): void {
+    const command = createCommand(type, parameters)
     this.inputs.push(command.encodedInput)
     if (allowRevert) {
       if (!REVERTIBLE_COMMANDS.has(command.type)) {
         throw new Error(`command type: ${command.type} cannot be allowed to revert`)
       }
-      command.type = command.type | ALLOW_REVERT_FLAG
+      command.type |= ALLOW_REVERT_FLAG
     }
 
-    this.commands = this.commands.concat(command.type.toString(16).padStart(2, '0'))
+    this.commands = this.commands.concat(command.type.toString(16).padStart(2, '0')) as Hex
   }
 }
 
 export type RouterCommand = {
   type: CommandType
-  encodedInput: string
+  encodedInput: Hex
 }
 
-export function createCommand(type: CommandType, parameters: any[]): RouterCommand {
+export function createCommand<TCommandType extends CommandType>(
+  type: TCommandType,
+  parameters: ABIParametersType<TCommandType>
+): RouterCommand {
   // const params = parameters.filter((param) => param !== null)
-  const encodedInput = defaultAbiCoder.encode(ABI_DEFINITION[type], parameters)
+  const encodedInput = encodeAbiParameters(ABI_PARAMETER[type], parameters as any)
   return { type, encodedInput }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,7 +928,7 @@ importers:
         version: 18.2.1
       next:
         specifier: 13.4.2
-        version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.2(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1189,7 +1189,7 @@ importers:
     devDependencies:
       next:
         specifier: 13.4.2
-        version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.2(@babel/core@7.21.4)(react-dom@18.2.0)(react@18.2.0)
 
   packages/pools:
     dependencies:
@@ -1763,6 +1763,9 @@ importers:
       '@uniswap/universal-router':
         specifier: 1.4.3
         version: 1.4.3
+      abitype:
+        specifier: ^0.9.8
+        version: 0.9.8(typescript@5.1.3)(zod@3.21.4)
       bignumber.js:
         specifier: ^9.0.2
         version: 9.1.1
@@ -1773,8 +1776,8 @@ importers:
         specifier: ^1.1.0
         version: 1.3.1
       viem:
-        specifier: ^1.2.9
-        version: 1.2.9(typescript@5.1.3)(zod@3.21.4)
+        specifier: ^1.12.2
+        version: 1.12.2(typescript@5.1.3)(zod@3.21.4)
     devDependencies:
       '@types/chai':
         specifier: ^4.2.18
@@ -9525,7 +9528,7 @@ packages:
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.7.0(encoding@0.1.13)
-      viem: 1.10.9(typescript@5.1.3)(zod@3.21.4)
+      viem: 1.12.2(typescript@5.1.3)(zod@3.21.4)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -9540,9 +9543,6 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@scure/base@1.1.1:
-    resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
-
   /@scure/base@1.1.3:
     resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
 
@@ -9551,7 +9551,7 @@ packages:
     dependencies:
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.1
+      '@scure/base': 1.1.3
 
   /@scure/bip32@1.3.2:
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
@@ -9564,13 +9564,13 @@ packages:
     resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
     dependencies:
       '@noble/hashes': 1.1.3
-      '@scure/base': 1.1.1
+      '@scure/base': 1.1.3
 
   /@scure/bip39@1.2.0:
     resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
     dependencies:
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.1
+      '@scure/base': 1.1.3
 
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
@@ -13255,7 +13255,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       react-refresh: 0.14.0
-      vite: 4.4.9(@types/node@13.13.52)
+      vite: 4.4.9(@types/node@18.0.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15116,7 +15116,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2(debug@4.3.2)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -20159,6 +20159,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -25245,7 +25246,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: true
 
   /next@13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aNFqLs3a3nTGvLWlO9SUhCuMUHVPSFQC0+tDNGAsDXqx+WJDFSbvc233gOJ5H19SBc7nw36A9LwQepOJ2u/8Kg==}
@@ -28827,7 +28827,6 @@ packages:
       '@babel/core': 7.21.4
       client-only: 0.0.1
       react: 18.2.0
-    dev: true
 
   /styled-jsx@5.1.1(@babel/core@7.22.17)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -30645,8 +30644,8 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /viem@1.10.9(typescript@5.1.3)(zod@3.21.4):
-    resolution: {integrity: sha512-fhQxnMBFwGbyE/VOfcvcavxAPyqIHSgOB793gQcMPH1B9ahQvjMe3C3icqypC01ACaqpDPgYWGfvF/ExTeIPuA==}
+  /viem@1.12.2(typescript@5.1.3)(zod@3.21.4):
+    resolution: {integrity: sha512-aCaUCyg72ES+jK4s6tVYOMnOt4if71RwzgiUAUpAuaCgvHFfh9DCnwuEfwkxEZLE2vafOsirgJ3fcn7nsDVQoQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -30867,7 +30866,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.0.2(typescript@5.1.3)
-      vite: 4.4.9(@types/node@13.13.52)
+      vite: 4.4.9(@types/node@18.0.4)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7f06c0</samp>

### Summary
:memo::package::zap:

<!--
1.  :memo: - This emoji represents the addition of a new word to the cSpell.words array, which is a documentation-related change.
2. :package: - This emoji represents the update of the dependencies of the `universal-router-sdk` package, which is a dependency-related change.
3. :zap: - This emoji represents the improvement of the type safety and performance of the router commands, which is a performance-related change.
-->
This pull request enhances the `universal-router-sdk` package by using new and updated libraries for ABI encoding and decoding, and by improving the type safety and readability of the router commands. It also fixes a spelling issue in the `.vscode/settings.json` file.

> _To avoid spelling errors in `bips`_
> _We added a new word to cSpell's list_
> _And to make router commands more robust_
> _We used `abitype` and `viem` as a must_
> _And improved the types with generics and structs_

### Walkthrough
*  Add `bips` to cSpell.words array to avoid spelling errors in code editor ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L4-R5))
*  Update dependencies of `universal-router-sdk` package, adding `abitype` for ABI encoding and decoding and updating `viem` for hex and bytes manipulation ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-f6540822464dc0df575ca5e40418c32c63bce949b2fdb8fced51c4be7d3995f7L75-R79))
*  Replace `defaultAbiCoder` from `ethers` with `abitype` and `viem` in `routerCommands.ts` for improved type safety and performance of router commands ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L1-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L65-R177), [link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L130-R192), [link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L137-R201), [link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L146-R215))
*  Add generic type parameter to `addCommand` method of `RoutePlanner` class in `routerCommands.ts` to infer correct type of parameters based on command type ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L130-R192))
*  Simplify bitwise operation and cast `this.commands` to `Hex` type in `addCommand` method of `RoutePlanner` class in `routerCommands.ts` for readability and consistency ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L137-R201))
*  Change `encodedInput` property of `RouterCommand` type to `Hex` type and add generic type parameter to `createCommand` function in `routerCommands.ts` for type safety and performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/7957/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L146-R215))


