### PR TITLE
chore: remove moonpay quotes from bsc

### DIFF
--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -2,9 +2,11 @@ import { useCallback, useState } from 'react'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { Field } from 'state/buyCrypto/actions'
 import { useBuyCryptoState } from 'state/buyCrypto/hooks'
+import { ChainId } from '@pancakeswap/chains'
 import { fetchProviderQuotes } from './useProviderQuotes'
 import { fetchProviderAvailabilities } from './useProviderAvailability'
 import { ProviderQuote } from '../types'
+import { ONRAMP_PROVIDERS } from '../constants'
 
 const usePriceQuotes = () => {
   const [quotes, setQuotes] = useState<ProviderQuote[]>([])
@@ -33,13 +35,15 @@ const usePriceQuotes = () => {
           sortedFilteredQuotes.sort((a, b) => b.quote - a.quote)
         }
 
-        return sortedFilteredQuotes
+        return sortedFilteredQuotes.filter((quote: ProviderQuote) =>
+          chainId === ChainId.BSC ? quote.provider !== ONRAMP_PROVIDERS.MoonPay : quote.provider,
+        )
       } catch (error) {
         console.error('Error fetching price quotes:', error)
         return []
       }
     },
-    [userIp],
+    [userIp, chainId],
   )
 
   const fetchQuotes = useCallback(async () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 022efde</samp>

### Summary
🌖🔗🙌

<!--
1.  🌖 - This emoji represents the MoonPay provider and the fact that it is filtered out for BSC chain.
2.  🔗 - This emoji represents the chain selection and the relevance of the providers for each chain.
3.  🙌 - This emoji represents the improved user experience and the satisfaction of the users.
-->
Improve buy crypto feature for BSC chain by filtering out MoonPay provider. This affects the `usePriceQuoter` hook in `apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts`.

> _To quote prices for swaps, we use hooks_
> _But some providers don't match the looks_
> _So we filter out MoonPay_
> _For the BSC chain way_
> _And show only the ones in our books_

### Walkthrough
*  Filter out MoonPay provider for BSC chain in `usePriceQuoter` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/7965/files?diff=unified&w=0#diff-05cf008d35fa21dfccb294f5fe1bb9a2bc335765a3dab53a36b8b54ff7944e72L5-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/7965/files?diff=unified&w=0#diff-05cf008d35fa21dfccb294f5fe1bb9a2bc335765a3dab53a36b8b54ff7944e72L36-R40))


