### PR TITLE
fix(universal-router): test setup

### DIFF
--- a/packages/permit2-sdk/tsup.config.ts
+++ b/packages/permit2-sdk/tsup.config.ts
@@ -9,14 +9,14 @@ export default defineConfig((options) => ({
   clean: !options.watch,
   treeshake: true,
   splitting: true,
-  //   onSuccess: async () => {
-  //     exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
-  //       if (err) {
-  //         console.error(err)
-  //         if (!options.watch) {
-  //           process.exit(1)
-  //         }
-  //       }
-  //     })
-  //   },
+  onSuccess: async () => {
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+      if (err) {
+        console.error(err)
+        if (!options.watch) {
+          process.exit(1)
+        }
+      }
+    })
+  },
 }))

--- a/packages/permit2-sdk/tsup.config.ts
+++ b/packages/permit2-sdk/tsup.config.ts
@@ -1,3 +1,4 @@
+import { exec } from 'child_process'
 import { defineConfig } from 'tsup'
 
 export default defineConfig((options) => ({
@@ -10,7 +11,7 @@ export default defineConfig((options) => ({
   treeshake: true,
   splitting: true,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
+    exec('tsc --emitDeclarationOnly --declaration', (err) => {
       if (err) {
         console.error(err)
         if (!options.watch) {

--- a/packages/universal-router-sdk/package.json
+++ b/packages/universal-router-sdk/package.json
@@ -75,6 +75,6 @@
     "bignumber.js": "^9.0.2",
     "jsbi": "^4.3.0",
     "tiny-invariant": "^1.1.0",
-    "viem": "^1.12.2"
+    "viem": "^1.10.9"
   }
 }

--- a/packages/universal-router-sdk/package.json
+++ b/packages/universal-router-sdk/package.json
@@ -45,6 +45,7 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
+    "@pancakeswap/tokens": "workspace:*",
     "@types/chai": "^4.2.18",
     "@types/jest": "^29.5.0",
     "@types/mocha": "^8.2.2",

--- a/packages/universal-router-sdk/src/utils/routerCommands.ts
+++ b/packages/universal-router-sdk/src/utils/routerCommands.ts
@@ -153,10 +153,10 @@ export const ABI_PARAMETER: Record<CommandType, any> = {
     'address recipient, uint256 amountOut, uint256 amountInMax, address[] path, bool payerIsUser'
   ),
   [CommandType.STABLE_SWAP_EXACT_IN]: parseAbiParameters(
-    'address recipient, uint256 amountIn, uint256 amountOutMin, bytes path, bytes flag, bool payerIsUser'
+    'address recipient, uint256 amountIn, uint256 amountOutMin, address[] path, uint256[] flag, bool payerIsUser'
   ),
   [CommandType.STABLE_SWAP_EXACT_OUT]: parseAbiParameters(
-    'address recipient, uint256 amountOut, uint256 amountInMax, bytes path, bytes flag, bool payerIsUser'
+    'address recipient, uint256 amountOut, uint256 amountInMax, address[] path, uint256[] flag, bool payerIsUser'
   ),
 
   // Token Actions and Checks

--- a/packages/universal-router-sdk/test/fixtures/address.ts
+++ b/packages/universal-router-sdk/test/fixtures/address.ts
@@ -1,0 +1,12 @@
+import { ChainId } from '@pancakeswap/chains'
+import { CAKE, ETHER, USDC, USDT, WETH9 } from './constants/tokens'
+
+export const fixtureAddresses = (chainId: ChainId) => {
+  return {
+    ETHER: ETHER.on(chainId),
+    USDC: USDC[chainId],
+    USDT: USDT[chainId],
+    CAKE: CAKE[chainId],
+    WETH: WETH9[chainId],
+  }
+}

--- a/packages/universal-router-sdk/test/fixtures/address.ts
+++ b/packages/universal-router-sdk/test/fixtures/address.ts
@@ -1,12 +1,51 @@
 import { ChainId } from '@pancakeswap/chains'
+import { CurrencyAmount, ERC20Token, Pair, computePairAddress, pancakePairV2ABI } from '@pancakeswap/sdk'
 import { CAKE, ETHER, USDC, USDT, WETH9 } from './constants/tokens'
+import { V2_FACTORY_ADDRESSES } from './constants/addresses'
+import { Provider, getPublicClient } from './clients'
 
-export const fixtureAddresses = (chainId: ChainId) => {
+const fixtureTokensAddresses = (chainId: ChainId) => {
   return {
     ETHER: ETHER.on(chainId),
     USDC: USDC[chainId],
     USDT: USDT[chainId],
     CAKE: CAKE[chainId],
     WETH: WETH9[chainId],
+  }
+}
+
+const getPair = (tokenA: ERC20Token, tokenB: ERC20Token) => {
+  return async (getClient: Provider) => {
+    // eslint-disable-next-line no-console
+    console.assert(tokenA.chainId === tokenB.chainId, 'Invalid token pair')
+    const chainId = tokenA.chainId as ChainId
+    const client = getClient({ chainId })
+    const pairAddress = computePairAddress({ factoryAddress: V2_FACTORY_ADDRESSES[chainId], tokenA, tokenB })
+
+    const [reserve0, reserve1] = await client.readContract({
+      abi: pancakePairV2ABI,
+      address: pairAddress,
+      functionName: 'getReserves',
+    })
+    const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
+
+    return new Pair(CurrencyAmount.fromRawAmount(token0, reserve0), CurrencyAmount.fromRawAmount(token1, reserve1))
+  }
+}
+
+export const fixtureAddresses = async (chainId: ChainId) => {
+  const tokens = fixtureTokensAddresses(chainId)
+  const { ETHER, USDC, USDT, WETH } = tokens
+
+  const v2Pairs = {
+    WETH_USDC_V2: await getPair(WETH, USDC)(getPublicClient),
+  }
+
+  const v3Pools = {}
+
+  return {
+    ...tokens,
+    ...v2Pairs,
+    ...v3Pools,
   }
 }

--- a/packages/universal-router-sdk/test/fixtures/clients.ts
+++ b/packages/universal-router-sdk/test/fixtures/clients.ts
@@ -1,0 +1,22 @@
+import { ChainId } from '@pancakeswap/chains'
+import { PublicClient, createPublicClient, http } from 'viem'
+import { CHAINS } from './constants/chains'
+
+export const viemClients: Record<ChainId, PublicClient> = CHAINS.reduce((prev, cur) => {
+  return {
+    ...prev,
+    [cur.id]: createPublicClient({
+      chain: cur,
+      transport: http(),
+      batch: {
+        multicall: {
+          batchSize: 1024 * 200,
+        },
+      },
+    }),
+  }
+}, {} as Record<ChainId, PublicClient>)
+
+export const getPublicClient = ({ chainId }: { chainId?: ChainId }) => {
+  return viemClients[chainId!]
+}

--- a/packages/universal-router-sdk/test/fixtures/clients.ts
+++ b/packages/universal-router-sdk/test/fixtures/clients.ts
@@ -20,3 +20,5 @@ export const viemClients: Record<ChainId, PublicClient> = CHAINS.reduce((prev, c
 export const getPublicClient = ({ chainId }: { chainId?: ChainId }) => {
   return viemClients[chainId!]
 }
+
+export type Provider = ({ chainId }: { chainId?: ChainId }) => PublicClient

--- a/packages/universal-router-sdk/test/fixtures/constants/addresses.ts
+++ b/packages/universal-router-sdk/test/fixtures/constants/addresses.ts
@@ -1,0 +1,2 @@
+export { FACTORY_ADDRESS_MAP as V2_FACTORY_ADDRESSES } from '@pancakeswap/sdk'
+export { FACTORY_ADDRESSES as V3_FACTORY_ADDRESSES } from '@pancakeswap/v3-sdk'

--- a/packages/universal-router-sdk/test/fixtures/constants/chains.ts
+++ b/packages/universal-router-sdk/test/fixtures/constants/chains.ts
@@ -1,0 +1,167 @@
+import { ChainId } from '@pancakeswap/chains'
+import {
+  bsc as bsc_,
+  bscTestnet,
+  goerli,
+  mainnet,
+  zkSync,
+  zkSyncTestnet,
+  polygonZkEvmTestnet,
+  polygonZkEvm,
+  lineaTestnet,
+  arbitrum,
+  arbitrumGoerli,
+  base,
+  baseGoerli,
+  scrollSepolia as scrollSepolia_,
+  Chain,
+} from 'viem/chains'
+
+export const CHAIN_QUERY_NAME = {
+  [ChainId.ETHEREUM]: 'eth',
+  [ChainId.GOERLI]: 'goerli',
+  [ChainId.BSC]: 'bsc',
+  [ChainId.BSC_TESTNET]: 'bscTestnet',
+  [ChainId.ARBITRUM_ONE]: 'arb',
+  [ChainId.ARBITRUM_GOERLI]: 'arbGoerli',
+  [ChainId.POLYGON_ZKEVM]: 'polygonZkEVM',
+  [ChainId.POLYGON_ZKEVM_TESTNET]: 'polygonZkEVMTestnet',
+  [ChainId.ZKSYNC]: 'zkSync',
+  [ChainId.ZKSYNC_TESTNET]: 'zkSyncTestnet',
+  [ChainId.LINEA]: 'linea',
+  [ChainId.LINEA_TESTNET]: 'lineaTestnet',
+  [ChainId.OPBNB_TESTNET]: 'opBnbTestnet',
+  [ChainId.BASE]: 'base',
+  [ChainId.BASE_TESTNET]: 'baseTestnet',
+  [ChainId.SCROLL_SEPOLIA]: 'scrollSepolia',
+} as const satisfies Record<ChainId, string>
+
+const bsc = {
+  ...bsc_,
+  rpcUrls: {
+    ...bsc_.rpcUrls,
+    public: {
+      ...bsc_.rpcUrls.public,
+      http: ['https://bsc-dataseed.binance.org/'],
+    },
+    default: {
+      ...bsc_.rpcUrls.default,
+      http: ['https://bsc-dataseed.binance.org/'],
+    },
+  },
+} satisfies Chain
+
+const scrollSepolia = {
+  ...scrollSepolia_,
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 9473,
+    },
+  },
+} as const satisfies Chain
+
+export const opbnbTestnet = {
+  id: 5_611,
+  name: 'opBNB Testnet',
+  network: 'opbnb-testnet',
+  nativeCurrency: bscTestnet.nativeCurrency,
+  rpcUrls: {
+    default: {
+      http: ['https://opbnb-testnet-rpc.bnbchain.org'],
+    },
+    public: {
+      http: ['https://opbnb-testnet-rpc.bnbchain.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'opBNBScan',
+      url: 'https://opbnbscan.com',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 3705108,
+    },
+  },
+  testnet: true,
+} as const satisfies Chain
+
+export const linea = {
+  id: 59_144,
+  name: 'Linea Mainnet',
+  network: 'linea-mainnet',
+  nativeCurrency: { name: 'Linea Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    infura: {
+      http: ['https://linea-mainnet.infura.io/v3'],
+      webSocket: ['wss://linea-mainnet.infura.io/ws/v3'],
+    },
+    default: {
+      http: ['https://rpc.linea.build'],
+      webSocket: ['wss://rpc.linea.build'],
+    },
+    public: {
+      http: ['https://rpc.linea.build'],
+      webSocket: ['wss://rpc.linea.build'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Etherscan',
+      url: 'https://lineascan.build',
+    },
+    etherscan: {
+      name: 'Etherscan',
+      url: 'https://lineascan.build',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 42,
+    },
+  },
+  testnet: false,
+} as const satisfies Chain
+
+/**
+ * Controls some L2 specific behavior, e.g. slippage tolerance, special UI behavior.
+ * The expectation is that all of these networks have immediate transaction confirmation.
+ */
+export const L2_CHAIN_IDS: ChainId[] = [
+  ChainId.ARBITRUM_ONE,
+  ChainId.ARBITRUM_GOERLI,
+  ChainId.POLYGON_ZKEVM,
+  ChainId.POLYGON_ZKEVM_TESTNET,
+  ChainId.ZKSYNC,
+  ChainId.ZKSYNC_TESTNET,
+  ChainId.LINEA_TESTNET,
+  ChainId.LINEA,
+  ChainId.BASE,
+  ChainId.BASE_TESTNET,
+  ChainId.OPBNB_TESTNET,
+]
+
+export const CHAINS = [
+  bsc,
+  mainnet,
+  bscTestnet,
+  goerli,
+  polygonZkEvm,
+  polygonZkEvmTestnet,
+  zkSync,
+  zkSyncTestnet,
+  arbitrum,
+  arbitrumGoerli,
+  linea,
+  lineaTestnet,
+  arbitrumGoerli,
+  arbitrum,
+  base,
+  baseGoerli,
+  opbnbTestnet,
+  scrollSepolia,
+]

--- a/packages/universal-router-sdk/test/fixtures/constants/tokens.ts
+++ b/packages/universal-router-sdk/test/fixtures/constants/tokens.ts
@@ -1,0 +1,40 @@
+import { ERC20Token, Ether } from '@pancakeswap/sdk'
+import { ChainId } from '@pancakeswap/chains'
+import { CAKE as _CAKE, USDT as _USDT, USDC as _USDC } from '@pancakeswap/tokens/src/common'
+import { zeroAddress } from 'viem'
+
+export { WETH9 } from '@pancakeswap/sdk'
+
+export const ETHER = {
+  on(chainId: ChainId): Ether {
+    return Ether.onChain(chainId)
+  },
+}
+
+export const CAKE = {
+  ..._CAKE,
+
+  // @notice: temporary ignore missed testnet address
+  [ChainId.OPBNB_TESTNET]: new ERC20Token(ChainId.OPBNB_TESTNET, zeroAddress, 0, 'CAKE'),
+  [ChainId.SCROLL_SEPOLIA]: new ERC20Token(ChainId.SCROLL_SEPOLIA, zeroAddress, 0, 'CAKE'),
+}
+
+export const USDT = {
+  ..._USDT,
+  [ChainId.BSC_TESTNET]: new ERC20Token(ChainId.BSC_TESTNET, '0x337610d27c682E347C9cD60BD4b3b107C9d34dDd', 6, 'USDT'),
+  // @notice: use USDC in goerli instead of
+  [ChainId.GOERLI]: new ERC20Token(ChainId.GOERLI, zeroAddress, 6, 'USDT'),
+
+  // @notice: temporary ignore missed testnet address
+  [ChainId.ZKSYNC_TESTNET]: new ERC20Token(ChainId.ZKSYNC_TESTNET, zeroAddress, 6, 'USDT'),
+  [ChainId.ARBITRUM_GOERLI]: new ERC20Token(ChainId.ARBITRUM_GOERLI, zeroAddress, 6, 'USDT'),
+  [ChainId.SCROLL_SEPOLIA]: new ERC20Token(ChainId.SCROLL_SEPOLIA, zeroAddress, 6, 'USDT'),
+  [ChainId.LINEA_TESTNET]: new ERC20Token(ChainId.LINEA_TESTNET, zeroAddress, 6, 'USDT'),
+  [ChainId.BASE]: new ERC20Token(ChainId.BASE, zeroAddress, 6, 'USDT'),
+  [ChainId.BASE_TESTNET]: new ERC20Token(ChainId.BASE_TESTNET, zeroAddress, 6, 'USDT'),
+}
+export const USDC = {
+  ..._USDC,
+  // @notice: temporary ignore missed testnet address
+  [ChainId.POLYGON_ZKEVM_TESTNET]: new ERC20Token(ChainId.POLYGON_ZKEVM_TESTNET, zeroAddress, 6, '_USDC'),
+}

--- a/packages/universal-router-sdk/test/trade.test.ts
+++ b/packages/universal-router-sdk/test/trade.test.ts
@@ -1,0 +1,34 @@
+import { ChainId } from '@pancakeswap/chains'
+import {
+  ERC20Token,
+  Ether,
+  Trade as V2Trade,
+  Route as V2Route,
+  Pair,
+  CurrencyAmount,
+  TradeType,
+  Percent,
+} from '@pancakeswap/sdk'
+import { hexToString, parseEther } from 'viem'
+import { fixtureAddresses } from './fixtures/address'
+import { PancakeUniSwapRouter, PancakeSwapOptions, PancakeSwapTrade } from '../src'
+
+describe('PancakeSwap Universal Router Trade', () => {
+  const chainId = ChainId.ETHEREUM
+  let ETHER: Ether
+  let USDC: ERC20Token
+  let USDT: ERC20Token
+  let WETH: ERC20Token
+  let WETH_USDC_V2: Pair
+
+  beforeAll(async () => {
+    ;({ ETHER, USDC, USDT, WETH, WETH_USDC_V2 } = await fixtureAddresses(chainId))
+  })
+
+  describe('v2', () => {
+    it('should encode a single exactIn ETH -> USDC Swap', async () => {})
+  })
+  describe('v3', () => {})
+  describe('mixed v2 & v3', () => {})
+  describe('multi-route', () => {})
+})

--- a/packages/universal-router-sdk/test/trade.test.ts
+++ b/packages/universal-router-sdk/test/trade.test.ts
@@ -11,7 +11,8 @@ import {
 } from '@pancakeswap/sdk'
 import { hexToString, parseEther } from 'viem'
 import { fixtureAddresses } from './fixtures/address'
-import { PancakeUniSwapRouter, PancakeSwapOptions, PancakeSwapTrade } from '../src'
+import { PancakeUniSwapRouter, PancakeSwapTrade } from '../src'
+import { PancakeSwapOptions } from '../src/utils/types'
 
 describe('PancakeSwap Universal Router Trade', () => {
   const chainId = ChainId.ETHEREUM

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1840,6 +1840,9 @@ importers:
         specifier: ^1.10.9
         version: 1.10.9(typescript@5.1.3)(zod@3.21.4)
     devDependencies:
+      '@pancakeswap/tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@types/chai':
         specifier: ^4.2.18
         version: 4.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1234,7 +1234,7 @@ importers:
         version: 2.6.2
       viem:
         specifier: 1.10.9
-        version: 1.10.9
+        version: 1.10.9(typescript@5.1.3)(zod@3.21.4)
     devDependencies:
       '@types/jest':
         specifier: ^24.0.25
@@ -1244,7 +1244,7 @@ importers:
         version: 2.8.3
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0
+        version: 6.7.0(@swc/core@1.2.218)(postcss@8.4.29)(typescript@5.1.3)
       vitest:
         specifier: ^0.30.1
         version: 0.30.1
@@ -1826,7 +1826,7 @@ importers:
         version: 1.4.3
       abitype:
         specifier: ^0.9.8
-        version: 0.9.8(typescript@4.3.3)
+        version: 0.9.8(typescript@5.1.3)(zod@3.21.4)
       bignumber.js:
         specifier: ^9.0.2
         version: 9.1.1
@@ -1837,8 +1837,8 @@ importers:
         specifier: ^1.1.0
         version: 1.3.1
       viem:
-        specifier: ^1.12.2
-        version: 1.12.2(typescript@4.3.3)
+        specifier: ^1.10.9
+        version: 1.10.9(typescript@5.1.3)(zod@3.21.4)
     devDependencies:
       '@types/chai':
         specifier: ^4.2.18
@@ -1866,7 +1866,7 @@ importers:
         version: 3.4.0(eslint-config-prettier@6.15.0)(eslint@6.8.0)(prettier@1.19.1)
       hardhat:
         specifier: ^2.6.8
-        version: 2.6.8
+        version: 2.6.8(encoding@0.1.13)
       prettier:
         specifier: ^2.3.1
         version: 2.8.3
@@ -1881,7 +1881,7 @@ importers:
         version: 2.4.0
       tsup:
         specifier: ^6.7.0
-        version: 6.7.0(ts-node@10.0.0)(typescript@4.3.3)
+        version: 6.7.0(postcss@8.4.29)(ts-node@10.0.0)(typescript@4.3.3)
       typedoc:
         specifier: ^0.21.2
         version: 0.21.2(typescript@4.3.3)
@@ -2295,7 +2295,7 @@ packages:
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       convert-source-map: 1.8.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -2317,7 +2317,7 @@ packages:
       '@babel/traverse': 7.22.17
       '@babel/types': 7.22.17
       convert-source-map: 1.9.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2509,7 +2509,7 @@ packages:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/traverse': 7.22.17
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -2556,7 +2556,7 @@ packages:
       '@babel/core': 7.22.17
       '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.22.17)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
       semver: 6.3.1
@@ -5588,7 +5588,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.21.5
       '@babel/types': 7.21.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5605,7 +5605,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.22.16
       '@babel/types': 7.22.17
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -6982,7 +6982,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.21.0
       ignore: 5.2.4
@@ -7014,7 +7014,7 @@ packages:
       '@ethereumjs/block': 3.6.3
       '@ethereumjs/common': 2.6.5
       '@ethereumjs/ethash': 1.1.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       ethereumjs-util: 7.1.5
       level-mem: 5.0.1
       lru-cache: 5.1.1
@@ -7075,7 +7075,7 @@ packages:
       '@ethereumjs/tx': 3.5.2
       async-eventemitter: 0.2.4
       core-js-pure: 3.26.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       ethereumjs-util: 7.1.5
       functional-red-black-tree: 1.0.1
       mcl-wasm: 0.7.9
@@ -7515,7 +7515,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9666,7 +9666,7 @@ packages:
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.7.0(encoding@0.1.13)
-      viem: 1.12.2(typescript@5.1.3)(zod@3.21.4)
+      viem: 1.10.9(typescript@5.1.3)(zod@3.21.4)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -12858,7 +12858,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -13324,7 +13324,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.21.0(@babel/core@7.21.4)
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.4)
       react-refresh: 0.14.0
-      vite: 4.4.9(@types/node@18.0.4)
+      vite: 4.4.9(@types/node@13.13.52)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -14533,32 +14533,6 @@ packages:
       typescript: 5.1.3
       zod: 3.21.4
 
-  /abitype@0.9.8:
-    resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dev: false
-
-  /abitype@0.9.8(typescript@4.3.3):
-    resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 4.3.3
-    dev: false
-
   /abitype@0.9.8(typescript@5.1.3)(zod@3.21.4):
     resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
     peerDependencies:
@@ -14715,7 +14689,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15212,7 +15186,7 @@ packages:
   /axios@0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.2)
+      follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
     transitivePeerDependencies:
       - debug
@@ -17512,16 +17486,6 @@ packages:
       supports-color: 6.0.0
     dev: true
 
-  /debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -17535,17 +17499,6 @@ packages:
 
   /debug@4.3.2:
     resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-
-  /debug@4.3.4:
-    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -18915,7 +18868,7 @@ packages:
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
@@ -18939,7 +18892,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 2.34.0(eslint@8.49.0)(typescript@4.3.3)
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
     transitivePeerDependencies:
@@ -19294,7 +19247,7 @@ packages:
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       eslint-scope: 5.1.1
       eslint-utils: 1.4.3
@@ -19393,7 +19346,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20288,8 +20241,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4
-    dev: true
+      debug: 4.3.4(supports-color@8.1.1)
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -20932,7 +20884,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /hardhat@2.6.8:
+  /hardhat@2.6.8(encoding@0.1.13):
     resolution: {integrity: sha512-iRVd5DgcIVV3rNXMlogOfwlXAhHp7Wy/OjjFiUhTey8Unvo6oq5+Is5ANiKVN+Iw07Pcb/HpkGt7jCB6a4ITgg==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     hasBin: true
@@ -20953,7 +20905,7 @@ packages:
       chalk: 2.4.2
       chokidar: 3.5.3
       ci-info: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       enquirer: 2.3.6
       env-paths: 2.2.1
       eth-sig-util: 2.5.4
@@ -20971,7 +20923,7 @@ packages:
       merkle-patricia-tree: 4.2.4
       mnemonist: 0.38.5
       mocha: 7.2.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       qs: 6.11.2
       raw-body: 2.5.1
       resolve: 1.17.0
@@ -21221,7 +21173,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21940,7 +21892,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -25460,18 +25412,6 @@ packages:
     resolution: {integrity: sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==}
     dev: true
 
-  /node-fetch@2.6.7:
-    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
-
   /node-fetch@2.6.7(encoding@0.1.13):
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -26225,22 +26165,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /postcss-load-config@3.1.4:
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.0.6
-      yaml: 1.10.2
-    dev: true
-
   /postcss-load-config@3.1.4(postcss@8.4.29)(ts-node@10.0.0):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -26255,23 +26179,6 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.29
-      ts-node: 10.0.0(@types/node@15.12.2)(typescript@4.3.3)
-      yaml: 1.10.2
-    dev: true
-
-  /postcss-load-config@3.1.4(ts-node@10.0.0):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.0.6
       ts-node: 10.0.0(@types/node@15.12.2)(typescript@4.3.3)
       yaml: 1.10.2
     dev: true
@@ -30060,41 +29967,6 @@ packages:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
     dev: true
 
-  /tsup@6.7.0:
-    resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.1.0'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.1(esbuild@0.17.19)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.17.19
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4
-      resolve-from: 5.0.0
-      rollup: 3.29.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.24.0
-      tree-kill: 1.2.2
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
-
   /tsup@6.7.0(@swc/core@1.2.218)(postcss@8.4.29)(typescript@5.1.3):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
@@ -30133,7 +30005,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@6.7.0(ts-node@10.0.0)(typescript@4.3.3):
+  /tsup@6.7.0(postcss@8.4.29)(ts-node@10.0.0)(typescript@4.3.3):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -30152,12 +30024,13 @@ packages:
       bundle-require: 4.0.1(esbuild@0.17.19)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.17.19
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.0.0)
+      postcss: 8.4.29
+      postcss-load-config: 3.1.4(postcss@8.4.29)(ts-node@10.0.0)
       resolve-from: 5.0.0
       rollup: 3.29.1
       source-map: 0.8.0-beta.0
@@ -30467,6 +30340,7 @@ packages:
     resolution: {integrity: sha512-rUvLW0WtF7PF2b9yenwWUi9Da9euvDRhmH7BLyBG4DCFfOJ850LGNknmRpp8Z8kXNUPObdZQEfKOiHtXuQHHKA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
@@ -30926,78 +30800,8 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /viem@1.10.9:
-    resolution: {integrity: sha512-fhQxnMBFwGbyE/VOfcvcavxAPyqIHSgOB793gQcMPH1B9ahQvjMe3C3icqypC01ACaqpDPgYWGfvF/ExTeIPuA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.4
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.5
-      abitype: 0.9.8
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
   /viem@1.10.9(typescript@5.1.3)(zod@3.21.4):
     resolution: {integrity: sha512-fhQxnMBFwGbyE/VOfcvcavxAPyqIHSgOB793gQcMPH1B9ahQvjMe3C3icqypC01ACaqpDPgYWGfvF/ExTeIPuA==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.4
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.5
-      abitype: 0.9.8(typescript@5.1.3)(zod@3.21.4)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      typescript: 5.1.3
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  /viem@1.12.2(typescript@4.3.3):
-    resolution: {integrity: sha512-aCaUCyg72ES+jK4s6tVYOMnOt4if71RwzgiUAUpAuaCgvHFfh9DCnwuEfwkxEZLE2vafOsirgJ3fcn7nsDVQoQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.4
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.5
-      abitype: 0.9.8(typescript@4.3.3)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      typescript: 4.3.3
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /viem@1.12.2(typescript@5.1.3)(zod@3.21.4):
-    resolution: {integrity: sha512-aCaUCyg72ES+jK4s6tVYOMnOt4if71RwzgiUAUpAuaCgvHFfh9DCnwuEfwkxEZLE2vafOsirgJ3fcn7nsDVQoQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -31110,7 +30914,7 @@ packages:
     engines: {node: '>=v14.18.0'}
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -31193,7 +30997,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.0.2(typescript@5.1.3)
-      vite: 4.4.9(@types/node@18.0.4)
+      vite: 4.4.9(@types/node@13.13.52)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -31497,7 +31301,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       local-pkg: 0.4.3
       magic-string: 0.30.3
       pathe: 1.1.1


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eb47b6d</samp>

### Summary
🛠️🧪🚀

<!--
1.  🛠️ - This emoji represents the fixing of bugs, errors, or issues in the code, as well as the improvement of code quality and functionality. This emoji is suitable for the changes that uncommented the `onSuccess` callback, fixed some imports, removed unnecessary whitespace, simplified a condition, and fixed a typo.
2.  🧪 - This emoji represents the testing of the code, as well as the creation of test cases, fixtures, and helpers. This emoji is suitable for the changes that added the `address.ts`, `clients.ts`, and `trade.test.ts` files, as well as the test cases and helpers they contain.
3.  🚀 - This emoji represents the addition of new features, functionality, or performance to the code, as well as the enhancement of existing features. This emoji is suitable for the changes that added the `addresses.ts`, `chains.ts`, and `tokens.ts` files, as well as the constants and functions they contain, and the changes that changed the types of the `path` and `flag` parameters in the `ABI_PARAMETER` object.
-->
This pull request updates and improves the `universal-router-sdk` package, which is used to route swaps across different protocols on different chains. It adds some dependencies, fixes some imports and types, removes some whitespace and typos, reorganizes some constants and helpers, and adds some test cases. It also uncommented a callback in the `tsup.config.ts` file of the `permit2-sdk` package, which is used to generate declaration files.

> _The `universal-router-sdk` package_
> _Has been updated with some changes to make_
> _It supports different chains and tokens_
> _And has more tests and types to be broken_
> _And it uses `tsup` to bundle and package_

### Walkthrough
*  Add and update dependencies for the `universal-router-sdk` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-f6540822464dc0df575ca5e40418c32c63bce949b2fdb8fced51c4be7d3995f7R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-f6540822464dc0df575ca5e40418c32c63bce949b2fdb8fced51c4be7d3995f7R70), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-f6540822464dc0df575ca5e40418c32c63bce949b2fdb8fced51c4be7d3995f7L80-R82))
*  Simplify and reorder imports in various files of the `universal-router-sdk` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-3bd8eeac545c378152790612294e83d0506314a367dab279e7a2b71015c5c065L17-R17), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L1-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L10), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-bd08cd2843cb17c99b8ca643141d230553873c11babb92a02f10dc198b2c30f6L13-R15))
*  Move some type imports to avoid circular dependencies and improve code organization in the `universal-router-sdk` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L22-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-bd08cd2843cb17c99b8ca643141d230553873c11babb92a02f10dc198b2c30f6L26-R29))
*  Uncomment the `onSuccess` callback in the `tsup.config.ts` file of the `permit2-sdk` package to enable declaration file generation ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-e30f89115039806b329873dd382cf63980c0306cb0d558c5d95adabbda769fe1L13-R22))
*  Simplify the condition for checking the `config.deadline` parameter in the `encodeSwap` method of the `PancakeUniSwapRouter` class ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-3bd8eeac545c378152790612294e83d0506314a367dab279e7a2b71015c5c065L113-R112))
*  Change the types of the `path` and `flag` parameters in the `ABI_PARAMETER` object to match the `UniversalRouter` contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L146-R155))
*  Fix a typo in the `feeAmount` parameter type in the `getPancakePool` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-bd08cd2843cb17c99b8ca643141d230553873c11babb92a02f10dc198b2c30f6L110-R100))
*  Add new files for defining and getting addresses, tokens, chains, and clients for testing the `universal-router-sdk` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-6cb37225df98ceba408ea84bfd04640ea21da81bf981acef444167b03b3b2a37R1-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-25c9dbce3519dd1bb2b27e5435c29df4e859236f5d474e85ae7cdecb36a27ef0R1-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-7b7a5d1ca0a1321ec0fb0f0b7fb43ba891235789034ad948df6d96f7aebe3485R1-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-5acb3e938e2e409648d2d515cc65e64f858155d535fa40d0db7e4677e1f932a3R1-R167), [link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-589441c6c966eeae82f2aefa682073c04322c90cadba59fafa1b517860716e45R1-R40))
*  Add new test cases for testing the `PancakeSwapTrade` and `PancakeUniSwapRouter` classes in the `trade.test.ts` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/7967/files?diff=unified&w=0#diff-97f69569125e6d51bbd9cb2374077f694d1f48672578ba870b20398c8cc1501eR1-R34))


