### PR TITLE
fix: universal router value type

### DIFF
--- a/packages/universal-router-sdk/src/SwapRouterPancake.ts
+++ b/packages/universal-router-sdk/src/SwapRouterPancake.ts
@@ -34,8 +34,14 @@ export abstract class PancakeUniSwapRouter {
     }
 
     const nativeCurrencyValue = inputCurrency.isNative
-      ? SmartRouter.maximumAmountIn(sampleTrade, options.slippageTolerance, sampleTrade.inputAmount).quotient.toString()
-      : '0'
+      ? toHex(
+          SmartRouter.maximumAmountIn(
+            sampleTrade,
+            options.slippageTolerance,
+            sampleTrade.inputAmount
+          ).quotient.toString()
+        )
+      : toHex('0')
 
     trade.encode(planner, { allowRevert: false })
     return PancakeUniSwapRouter.encodePlan(planner, nativeCurrencyValue as `0x${string}`, {


### PR DESCRIPTION

### <samp>🤖 Generated by Copilot at eb763fc</samp>

### Summary
🔢🔄📝

<!--
1.  🔢 - This emoji can represent the conversion from decimal to hexadecimal, as hexadecimal is a base-16 number system that uses 16 symbols (0-9 and A-F).
2.  🔄 - This emoji can represent the swap or exchange of tokens, as the `trade` object encapsulates the information about the trade route, price, and slippage for the swap.
3.  📝 - This emoji can represent the encoding or writing of the data for the transaction, as the `encode` function returns a hex string that can be used as the input data for the swap call.
-->
Convert `nativeCurrencyValue` to hex format for swap transaction data. This fixes a bug in the `SwapRouterPancake` class that uses the `@pancakeswap-libs/sdk-v2` package.

> _`nativeCurrencyValue`_
> _To hex, for `trade.encode`_
> _Autumn leaves falling_

### Walkthrough
*  Convert `nativeCurrencyValue` to hexadecimal format for swap transaction data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7974/files?diff=unified&w=0#diff-3bd8eeac545c378152790612294e83d0506314a367dab279e7a2b71015c5c065L37-R44))


