### PR TITLE
fix(universal router): TypedDataDomain

### DIFF
--- a/packages/permit2-sdk/src/utils/types.ts
+++ b/packages/permit2-sdk/src/utils/types.ts
@@ -1,12 +1,10 @@
-import { BigintIsh } from '@pancakeswap/sdk'
-
 export type Bytes = ArrayLike<number>
 type BytesLike = string | Bytes
 
 export interface TypedDataDomain {
   name?: string
   version?: string
-  chainId?: BigintIsh
+  chainId?: number
   verifyingContract?: string
   salt?: BytesLike
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c3725c9</samp>

### Summary
🗑️🐛🔧

<!--
1.  🗑️ for removing unused import
2. 🐛 for fixing type mismatch bug
3. 🔧 for adjusting interface type
-->
Fixed type and import issues in `permit2-sdk` package. This improves compatibility and reliability when signing permits for different tokens.

> _To sign permits without any glitch_
> _We had to remove `BigintIsh`_
> _The type was mismatched_
> _And errors were dispatched_
> _So we changed `chainId` to `number` in `TypedDataDomain`'s niche_

### Walkthrough
* Change the type of `chainId` in the `TypedDataDomain` interface from `BigintIsh` to `number` to fix a bug in signing typed data ([link](https://github.com/pancakeswap/pancake-frontend/pull/7976/files?diff=unified&w=0#diff-1b024f0640ce234ebbbc8ed1ccb64af8b6a24bf1483073c3f9e48904103f32b4L9-R7))
* Remove the unused import of `BigintIsh` from `@pancakeswap/sdk` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7976/files?diff=unified&w=0#diff-1b024f0640ce234ebbbc8ed1ccb64af8b6a24bf1483073c3f9e48904103f32b4L1-L2))


