### PR TITLE
chore: fix token search issue

### DIFF
--- a/apps/web/src/views/V3Info/components/Search/index.tsx
+++ b/apps/web/src/views/V3Info/components/Search/index.tsx
@@ -11,7 +11,6 @@ import { useWatchlistPools, useWatchlistTokens } from 'state/user/hooks'
 import { styled } from 'styled-components'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'views/Info/components/CurrencyLogo'
-import { getAddress } from 'viem'
 
 import { isAddress } from 'utils'
 import { v3InfoPath } from '../../constants'
@@ -328,8 +327,7 @@ const Search = () => {
                         <Text>{`${
                           (token.address && subgraphTokenName[isAddress(token.address) || undefined]) || token.name
                         } (${
-                          (token.address && getAddress(subgraphTokenSymbol[isAddress(token.address) || undefined])) ||
-                          token.symbol
+                          (token.address && subgraphTokenSymbol[isAddress(token.address) || undefined]) || token.symbol
                         })`}</Text>
                       </Text>
                       {/* <SaveIcon


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f54a70a</samp>

### Summary
🐛🚫🔁

<!--
1.  🐛 for fixing a bug
2.  🚫 for removing unused code
3.  🔁 for replacing or refactoring code
-->
Fixed token symbol display and code cleanup in `Search` component. Used subgraph data instead of `getAddress` to show correct token symbols in `V3Info` view.

> _The search component had a bug_
> _That showed the wrong token symbol, ugh_
> _So they used `subgraphTokenSymbol`_
> _And removed `getAddress` as well_
> _Now the symbols are correct, how smug_

### Walkthrough
*  Fix token symbol bug in search results by using `subgraphTokenSymbol` instead of `getAddress` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7979/files?diff=unified&w=0#diff-947d59362283e0d6dce157bebe4f8d107b8b6a3b1f7c17b0cec4a99ae5ac6836L331-R330))
* Remove unused import of `getAddress` from `viem` to avoid build error ([link](https://github.com/pancakeswap/pancake-frontend/pull/7979/files?diff=unified&w=0#diff-947d59362283e0d6dce157bebe4f8d107b8b6a3b1f7c17b0cec4a99ae5ac6836L14))


