### PR TITLE
chore: add arbitrum v2 subgraph to config

### DIFF
--- a/apps/web/src/utils/graphql.ts
+++ b/apps/web/src/utils/graphql.ts
@@ -61,6 +61,7 @@ export const v2Clients = {
   [ChainId.ZKSYNC]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.ZKSYNC]),
   [ChainId.LINEA]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.LINEA]),
   [ChainId.BASE]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.BASE]),
+  [ChainId.ARBITRUM_ONE]: new GraphQLClient(INFO_CLIENT_WITH_CHAIN[ChainId.ARBITRUM_ONE]),
 }
 
 export const infoStableSwapClient = new GraphQLClient(STABLESWAP_SUBGRAPH_CLIENT)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a8d974c</samp>

### Summary
🌐🚀🍰

<!--
1.  🌐 - This emoji represents the addition of a new network or chain, as Arbitrum One is a layer 2 scaling solution for Ethereum that has its own chain and RPC endpoints.
2.  🚀 - This emoji represents the improvement of performance or scalability, as Arbitrum One claims to offer faster and cheaper transactions than the main Ethereum network.
3.  🍰 - This emoji represents the PancakeSwap project itself, as the change is part of the frontend codebase that powers the popular decentralized exchange and yield farming platform.
-->
Add Arbitrum One GraphQL client to `graphql.ts`. This enables querying data from the Arbitrum One chain in the frontend.

> _`v2Clients` grows_
> _Adding Arbitrum One chain_
> _Autumn of pancakes_

### Walkthrough
* Add a new GraphQL client for the Arbitrum One chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/7980/files?diff=unified&w=0#diff-9a18c7fa948e0139245c60f3160a24972b35b6960387ac74cbf7b4d9da9e26a5R64))


