### PR TITLE
fix: command abi type

### DIFF
--- a/packages/universal-router-sdk/src/entities/protocols/unwrapWETH.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/unwrapWETH.ts
@@ -36,6 +36,6 @@ export class UnwrapWETH implements Command {
         amount: this.amount.toString(),
       },
     })
-    planner.addCommand(CommandType.UNWRAP_WETH, [ROUTER_AS_RECIPIENT, this.amount.toString()])
+    planner.addCommand(CommandType.UNWRAP_WETH, [ROUTER_AS_RECIPIENT, BigInt(this.amount.toString())])
   }
 }

--- a/packages/universal-router-sdk/src/utils/routerCommands.ts
+++ b/packages/universal-router-sdk/src/utils/routerCommands.ts
@@ -117,7 +117,7 @@ struct AllowanceTransferDetails {
 }
 `.replaceAll('\n', '')
 
-export const ABI_PARAMETER: Record<CommandType, any> = {
+export const ABI_PARAMETER = {
   // Batch Reverts
   [CommandType.EXECUTE_SUB_PLAN]: parseAbiParameters('bytes _commands, bytes[] _inputs'),
 
@@ -194,6 +194,8 @@ export const ABI_PARAMETER: Record<CommandType, any> = {
   // [CommandType.ELEMENT_MARKET]: parseAbiParameters('uint256 value, bytes data'),
 }
 
+export type CommandUsed = keyof typeof ABI_PARAMETER
+
 export class RoutePlanner {
   commands: Hex
 
@@ -208,7 +210,7 @@ export class RoutePlanner {
     this.addCommand(CommandType.EXECUTE_SUB_PLAN, [subplan.commands, subplan.inputs], true)
   }
 
-  addCommand<TCommandType extends CommandType>(
+  addCommand<TCommandType extends CommandUsed>(
     type: TCommandType,
     parameters: ABIParametersType<TCommandType>,
     allowRevert = false
@@ -227,11 +229,11 @@ export class RoutePlanner {
 }
 
 export type RouterCommand = {
-  type: CommandType
+  type: CommandUsed
   encodedInput: Hex
 }
 
-export function createCommand<TCommandType extends CommandType>(
+export function createCommand<TCommandType extends CommandUsed>(
   type: TCommandType,
   parameters: ABIParametersType<TCommandType>
 ): RouterCommand {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 96bbe8f</samp>

### Summary
🎁🛠️🧹

<!--
1.  🎁 - This emoji represents the wrapping of the `amount` argument in `BigInt`, as it is a gift or a present to the command function that expects a `uint256` type.
2.  🛠️ - This emoji represents the fixing and updating of the router commands, as it is a tool or a wrench that is used to repair or improve something.
3.  🧹 - This emoji represents the simplification and cleaning of the `ABI_PARAMETER` object type, as it is a broom or a sweep that is used to tidy up or remove unnecessary things.
-->
This pull request updates the universal router SDK to work with the latest version of the smart router contract. It fixes the types and order of the parameters of the router commands, adds a new parameter to indicate the fee payer, and uses a new type to represent the supported commands. It also adjusts the `UNWRAP_WETH` command to match the expected input type.

> _We're fixing the router commands, me hearties_
> _To match the contract and the types_
> _We'll heave away on the count of three_
> _And swap with `payerIsUser` right_

### Walkthrough
*  Wrap amounts in `BigInt` to match the expected `uint256` type of the router commands ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L31-R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L99-R101), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L115-R125), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L143-R149), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L162-R167), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L184-R190), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L355-R382), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L393-R435), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-9ad0010dd501a5f5abb40b808dd70f8c2f44f77485f07284227b2d496af9a929L39-R39))
*  Change the order and types of the parameters of the `STABLE_SWAP_EXACT_IN` and `STABLE_SWAP_EXACT_OUT` commands to match the updated smart router contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L355-R382), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L393-R435))
*  Add the `payerIsUser` parameter to the `addV2Swap`, `addV3Swap`, and `addStableSwap` functions and pass it to the router commands to indicate whether the payer is the user or the router ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L283-R295), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L377-R399))
*  Fix the first argument of the `V2_SWAP_EXACT_OUT` command to be the recipient address instead of the path ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L162-R167))
*  Type the parameters of the router commands as `ABIParametersType` and pass the correct command type to the `createCommand` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L192-R197), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L201-R213), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L393-R435))
*  Remove unused imports of `Currency` and `CurrencyAmount` from `@pancakeswap/sdk` and add the import of `ABIParametersType` from `../../utils/types` in `pancakeswap.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L1-R6))
*  Change the `ABI_PARAMETER` object from a `Record` type to a plain object type in `routerCommands.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L120-R120))
*  Add the `CommandUsed` type and use it to restrict the possible command types that can be used in the router commands and the `addCommand` method of the `RoutePlanner` class in `routerCommands.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325R197-R198), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L211-R213), [link](https://github.com/pancakeswap/pancake-frontend/pull/7983/files?diff=unified&w=0#diff-c8076066028b7332dcb71499b1cbbd07d463bffa0436fe4d2e1ed9987edad325L230-R236))


