### PR TITLE
chore: Remove fixed staking from homepage

### DIFF
--- a/apps/web/src/views/Home/components/EcoSystemSection/index.tsx
+++ b/apps/web/src/views/Home/components/EcoSystemSection/index.tsx
@@ -20,7 +20,7 @@ import tradeBuy from '../../images/trade-buy-crypto.png'
 import earnFarm from '../../images/earn-farm.png'
 import earnPools from '../../images/earn-pools.png'
 import earnLiquidStaking from '../../images/earn-liquidity-staking.png'
-import earnFixedStaking from '../../images/earn-fixed-staking.png'
+// import earnFixedStaking from '../../images/earn-fixed-staking.png'
 import gamePrediction from '../../images/game-prediction.png'
 import gamePancakeProtectors from '../../images/game-pancake-protectors.png'
 import gameLottery from '../../images/game-lottery.png'
@@ -36,7 +36,7 @@ import tradeBuyPurple from '../../images/trade-buy-crypto-purple.png'
 import earnFarmPurple from '../../images/earn-farm-purple.png'
 import earnPoolsPurple from '../../images/earn-pools-purple.png'
 import earnLiquidStakingPurple from '../../images/earn-liquidity-staking-purple.png'
-import earnFixedStakingPurple from '../../images/earn-fixed-staking-purple.png'
+// import earnFixedStakingPurple from '../../images/earn-fixed-staking-purple.png'
 import gamePredictionPurple from '../../images/game-prediction-purple.png'
 import gamePancakeProtectorsPurple from '../../images/game-pancake-protectors-purple.png'
 import gameLotteryPurple from '../../images/game-lottery-purple.png'
@@ -261,13 +261,13 @@ const useEarnBlockData = () => {
         defaultImage: earnLiquidStakingPurple,
         path: '/liquid-staking',
       },
-      {
-        title: t('Coming Soon'),
-        description: t('Fixed staking'),
-        ctaTitle: t('Learn More'),
-        image: earnFixedStaking,
-        defaultImage: earnFixedStakingPurple,
-      },
+      // {
+      //   title: t('Coming Soon'),
+      //   description: t('Fixed staking'),
+      //   ctaTitle: t('Learn More'),
+      //   image: earnFixedStaking,
+      //   defaultImage: earnFixedStakingPurple,
+      // },
     ]
   }, [t])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5007ba8</samp>

### Summary
🚀🔇🧹

<!--
1.  🚀 - This emoji represents the improvement in performance that comes from removing unused imports and code.
2.  🔇 - This emoji represents the prevention of showing incomplete features that might confuse or mislead users.
3.  🧹 - This emoji represents the cleanup of the codebase and the removal of clutter.
-->
Removed unused code related to fixed staking feature in `EcoSystemSection` component. This cleans up the codebase and avoids confusion for users.

> _To make the app faster and sleeker_
> _We removed some imports and a feature_
> _`EcoSystemSection`_
> _Had some code correction_
> _No more fixed staking for the seeker_

### Walkthrough
* Comment out unused imports of `earnFixedStaking` and `earnFixedStakingPurple` images to reduce bundle size and avoid loading unused assets ([link](https://github.com/pancakeswap/pancake-frontend/pull/7995/files?diff=unified&w=0#diff-eb773e70dc574977f184dfbdfca993e7fe13a5995b9f433ab192864c6ee2c6e5L23-R23), [link](https://github.com/pancakeswap/pancake-frontend/pull/7995/files?diff=unified&w=0#diff-eb773e70dc574977f184dfbdfca993e7fe13a5995b9f433ab192864c6ee2c6e5L39-R39))
* Comment out fixed staking feature from `useEarnBlockData` hook to hide it from `EcoSystemSection` component until it is ready ([link](https://github.com/pancakeswap/pancake-frontend/pull/7995/files?diff=unified&w=0#diff-eb773e70dc574977f184dfbdfca993e7fe13a5995b9f433ab192864c6ee2c6e5L264-R270))


