### PR TITLE
fix: Remove testnet tag

### DIFF
--- a/apps/web/src/config/chains.ts
+++ b/apps/web/src/config/chains.ts
@@ -128,7 +128,6 @@ export const opbnb = {
       blockCreated: 512881,
     },
   },
-  testnet: true,
 } as const satisfies Chain
 
 export const linea = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 53ce5c6</samp>

### Summary
:wastebasket::wrench::id:

<!--
1.  :wastebasket: - This emoji represents the removal or deletion of something, in this case the `testnet` property.
2.  :wrench: - This emoji represents a tool or a tweak, in this case a refactor or improvement of the chain configuration.
3.  :id: - This emoji represents an identifier or a label, in this case the chain ID that is used to distinguish between testnet and mainnet.
-->
Refactor chain configuration by removing `testnet` property from `opbnb` chain. Simplify the logic to detect testnet chains based on chain ID.

> _`testnet` is gone_
> _chain ID tells us enough_
> _simpler config now_

### Walkthrough
*  Remove `testnet` property from `opbnb` chain configuration ([link](https://github.com/pancakeswap/pancake-frontend/pull/7997/files?diff=unified&w=0#diff-870705bc610c873933b2d04d9a57db54345cab8d9ad2af707454ac577b21f6e4L131)) in `chains.ts` file


