### PR TITLE
feat: update top pair spam strategy

### DIFF
--- a/apps/web/src/views/Info/Overview/index.tsx
+++ b/apps/web/src/views/Info/Overview/index.tsx
@@ -62,10 +62,15 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   const poolsData = useMemo(
     () =>
       rawPoolsData.reduce((acc, data) => {
+        if (acc.length > 10) {
+          acc.push(data)
+          return acc
+        }
+
         const maySpam = dayjs().diff(dayjs.unix(data.timestamp), 'day') < 4
 
         // top 10 should not show may spam tokens,
-        if (maySpam && acc.length < 10) return acc
+        if (maySpam) return acc
 
         // after top 10 will not filtered
         acc.push(data)

--- a/apps/web/src/views/Info/Overview/index.tsx
+++ b/apps/web/src/views/Info/Overview/index.tsx
@@ -9,7 +9,6 @@ import {
   useProtocolTransactionsSWR,
 } from 'state/info/hooks'
 import { TokenData } from 'state/info/types'
-import dayjs from 'dayjs'
 import { styled } from 'styled-components'
 import BarChart from 'views/Info/components/InfoCharts/BarChart'
 import LineChart from 'views/Info/components/InfoCharts/LineChart'
@@ -17,7 +16,7 @@ import PoolTable from 'views/Info/components/InfoTables/PoolsTable'
 import TokenTable from 'views/Info/components/InfoTables/TokensTable'
 import TransactionTable from 'views/Info/components/InfoTables/TransactionsTable'
 import HoverableChart from '../components/InfoCharts/HoverableChart'
-import { usePoolsData } from '../hooks/usePoolsData'
+import { useNonSpamPoolsData } from '../hooks/usePoolsData'
 
 export const ChartCardsContainer = styled(Flex)`
   justify-content: space-between;
@@ -58,27 +57,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
       .filter<TokenData>((token): token is TokenData => token?.name !== 'unknown')
   }, [allTokens])
 
-  const { poolsData: rawPoolsData } = usePoolsData()
-  // top 10 pair need create at least 4 days
-  const poolsData = useMemo(
-    () =>
-      rawPoolsData.reduce((acc, data) => {
-        if (acc.length > 10) {
-          acc.push(data)
-          return acc
-        }
-
-        const maySpam = dayjs().diff(dayjs.unix(data.timestamp), 'day') < 4
-
-        // top 10 should not show may spam tokens,
-        if (maySpam) return acc
-
-        // after top 10 will not filtered
-        acc.push(data)
-        return acc
-      }, [] as typeof rawPoolsData),
-    [rawPoolsData],
-  )
+  const { poolsData } = useNonSpamPoolsData()
 
   const somePoolsAreLoading = useMemo(() => {
     return poolsData.some((pool) => !pool?.token0Price)

--- a/apps/web/src/views/Info/Overview/index.tsx
+++ b/apps/web/src/views/Info/Overview/index.tsx
@@ -8,6 +8,7 @@ import {
   useProtocolDataSWR,
   useProtocolTransactionsSWR,
 } from 'state/info/hooks'
+import { TokenData } from 'state/info/types'
 import dayjs from 'dayjs'
 import { styled } from 'styled-components'
 import BarChart from 'views/Info/components/InfoCharts/BarChart'
@@ -54,7 +55,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   const formattedTokens = useMemo(() => {
     return Object.values(allTokens)
       .map((token) => token.data)
-      .filter((token) => token.name !== 'unknown')
+      .filter<TokenData>((token): token is TokenData => token?.name !== 'unknown')
   }, [allTokens])
 
   const { poolsData: rawPoolsData } = usePoolsData()

--- a/apps/web/src/views/Info/Overview/index.tsx
+++ b/apps/web/src/views/Info/Overview/index.tsx
@@ -60,7 +60,17 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   const { poolsData: rawPoolsData } = usePoolsData()
   // top 10 pair need create at least 4 days
   const poolsData = useMemo(
-    () => rawPoolsData.filter((data) => dayjs().diff(dayjs.unix(data.timestamp), 'day') > 4),
+    () =>
+      rawPoolsData.reduce((acc, data) => {
+        const maySpam = dayjs().diff(dayjs.unix(data.timestamp), 'day') < 4
+
+        // top 10 should not show may spam tokens,
+        if (maySpam && acc.length < 10) return acc
+
+        // after top 10 will not filtered
+        acc.push(data)
+        return acc
+      }, [] as typeof rawPoolsData),
     [rawPoolsData],
   )
 

--- a/apps/web/src/views/Info/Pools/index.tsx
+++ b/apps/web/src/views/Info/Pools/index.tsx
@@ -5,11 +5,11 @@ import useInfoUserSavedTokensAndPools from 'hooks/useInfoUserSavedTokensAndPools
 import { useMemo } from 'react'
 import { useChainIdByQuery, usePoolDatasSWR } from 'state/info/hooks'
 import PoolTable from 'views/Info/components/InfoTables/PoolsTable'
-import { usePoolsData } from '../hooks/usePoolsData'
+import { useNonSpamPoolsData } from '../hooks/usePoolsData'
 
 const PoolsOverview: React.FC<React.PropsWithChildren> = () => {
   const { t } = useTranslation()
-  const { poolsData, stableSwapsAprs } = usePoolsData()
+  const { poolsData, stableSwapsAprs } = useNonSpamPoolsData()
   const chainId = useChainIdByQuery()
   const { savedPools } = useInfoUserSavedTokensAndPools(chainId)
   const watchlistPools = usePoolDatasSWR(savedPools)

--- a/apps/web/src/views/Info/components/InfoCharts/HoverableChart.tsx
+++ b/apps/web/src/views/Info/components/InfoCharts/HoverableChart.tsx
@@ -7,8 +7,8 @@ import BarChart from './BarChart'
 import LineChart from './LineChart'
 
 interface HoverableChartProps {
-  chartData: ChartEntry[]
-  protocolData: ProtocolData
+  chartData: ChartEntry[] | undefined
+  protocolData: ProtocolData | undefined
   currentDate: string
   valueProperty: string
   title: string
@@ -28,11 +28,11 @@ const HoverableChart = ({
 
   // Getting latest data to display on top of chart when not hovered
   useEffect(() => {
-    setHover(null)
+    setHover(undefined)
   }, [protocolData])
 
   useEffect(() => {
-    if (hover == null && protocolData) {
+    if (typeof hover === 'undefined' && protocolData) {
       setHover(protocolData[valueProperty])
     }
   }, [protocolData, hover, valueProperty])
@@ -54,7 +54,7 @@ const HoverableChart = ({
       <Text bold color="secondary">
         {title}
       </Text>
-      {hover > -1 ? ( // sometimes data is 0
+      {Number(hover) > -1 ? ( // sometimes data is 0
         <Text bold fontSize="24px">
           ${formatAmount(hover)}
         </Text>

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -102,8 +102,12 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
   const abs1 = Math.abs(transaction.amountToken1)
   const chainName = useChainNameByQuery()
   const { domainName } = useDomainNameForAddress(transaction.sender)
-  const token0Symbol = subgraphTokenSymbol[safeGetAddress(transaction.token0Address)] ?? transaction.token0Symbol
-  const token1Symbol = subgraphTokenSymbol[safeGetAddress(transaction.token1Address)] ?? transaction.token1Symbol
+  const [token0Address, token1Address] = [transaction.token0Address, transaction.token1Address].map(safeGetAddress)
+  const [token0Symbol = transaction.token0Symbol, token1Symbol = transaction.token1Symbol] = [
+    token0Address,
+    token1Address,
+  ].map((address) => (address ? subgraphTokenSymbol[address] : undefined))
+
   const outputTokenSymbol = transaction.amountToken0 < 0 ? token0Symbol : token1Symbol
   const inputTokenSymbol = transaction.amountToken1 < 0 ? token0Symbol : token1Symbol
 

--- a/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TransactionsTable.tsx
@@ -150,7 +150,7 @@ const DataRow: React.FC<React.PropsWithChildren<{ transaction: Transaction }>> =
 
 const TransactionTable: React.FC<
   React.PropsWithChildren<{
-    transactions: Transaction[]
+    transactions: Transaction[] | undefined
   }>
 > = ({ transactions }) => {
   const [sortField, setSortField] = useState(SORT_FIELD.timestamp)
@@ -200,7 +200,7 @@ const TransactionTable: React.FC<
   }, [transactions, txFilter])
 
   const handleFilter = useCallback(
-    (newFilter: TransactionType) => {
+    (newFilter: TransactionType | undefined) => {
       if (newFilter !== txFilter) {
         setTxFilter(newFilter)
         setPage(1)

--- a/apps/web/src/views/Info/hooks/usePoolsData.ts
+++ b/apps/web/src/views/Info/hooks/usePoolsData.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { useMemo } from 'react'
 import { checkIsStableSwap } from 'state/info/constant'
 import { useAllPoolDataSWR, useStableSwapTopPoolsAPR } from 'state/info/hooks'
@@ -25,4 +26,33 @@ export const usePoolsData = () => {
       .filter((pool) => pool.token1.name !== 'unknown' && pool.token0.name !== 'unknown')
   }, [allPoolData, isStableSwap, stableSwapsAprs])
   return { poolsData, stableSwapsAprs }
+}
+
+export const useNonSpamPoolsData = () => {
+  const { poolsData: rawPoolsData, ...others } = usePoolsData()
+  // top 10 pair need create at least 4 days
+  const poolsData = useMemo(
+    () =>
+      rawPoolsData.reduce((acc, data) => {
+        if (acc.length > 10) {
+          acc.push(data)
+          return acc
+        }
+
+        const maySpam = dayjs().diff(dayjs.unix(data.timestamp), 'day') < 4
+
+        // top 10 should not show may spam tokens,
+        if (maySpam) return acc
+
+        // after top 10 will not filtered
+        acc.push(data)
+        return acc
+      }, [] as typeof rawPoolsData),
+    [rawPoolsData],
+  )
+
+  return {
+    poolsData,
+    ...others,
+  }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 673e013</samp>

### Summary
📊🆕🚀

<!--
1.  📊 - This emoji represents the overview page and the data visualization of the pools.
2.  🆕 - This emoji represents the new pairs that are created on the platform and that are now shown on the overview page.
3.  🚀 - This emoji represents the improvement of the logic and the performance of the pools data fetching.
-->
Improved the logic of selecting the top 10 pairs to show on the overview page of the `Info` app. Changed the `poolsData` variable in `apps/web/src/views/Info/Overview/index.tsx` to use a `reduce` method instead of a `filter` method.

> _`poolsData` changed_
> _Using `reduce` method now_
> _Overview more fair_

### Walkthrough
* Improve the logic of selecting the top 10 pairs to show on the overview page by using a `reduce` method instead of a `filter` method ([link](https://github.com/pancakeswap/pancake-frontend/pull/8001/files?diff=unified&w=0#diff-e8968dd1774ec65b03552c785f82fa9eb9059e7f38af517de51a4bbae9d78924L63-R73))


