### PR TITLE
chore: Export chain id from v2 sdk

### DIFF
--- a/.changeset/curvy-drinks-remain.md
+++ b/.changeset/curvy-drinks-remain.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/sdk': minor
+---
+
+Add back ChainId export

--- a/packages/swap-sdk/src/index.ts
+++ b/packages/swap-sdk/src/index.ts
@@ -1,6 +1,9 @@
 export * from './constants'
 export * from './trade'
 
+// @deprecated
+export { ChainId } from '@pancakeswap/chains'
+
 export * from './entities'
 export * from './router'
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e772add</samp>

### Summary
🚀🔄🗑️

<!--
1.  🚀 This emoji means that the change adds a new feature or improvement to the package, which is the case for the changeset file that specifies a minor version bump. The rocket emoji is often used to indicate that something is launching or going to the next level.
2.  🔄 This emoji means that the change updates or modifies some existing code or functionality, which is the case for the re-export of the `ChainId` enum. The arrows emoji is often used to indicate that something is changing or moving in a circular or cyclical way.
3.  🗑️ This emoji means that the change removes or deprecates some code or functionality, which is the case for the deprecation warning on the re-export of the `ChainId` enum. The trash can emoji is often used to indicate that something is being discarded or thrown away.
-->
This pull request updates the `@pancakeswap/sdk` package to a minor version and adds a deprecated re-export of the `ChainId` enum from the `@pancakeswap/chains` package. This is done to document and automate the release process and to maintain backward compatibility for some existing code.

> _`@pancakeswap/sdk`_
> _Refactored, exports less now_
> _Deprecated `ChainId`_

### Walkthrough
*  Add a changeset file to document and automate a minor version bump for the `@pancakeswap/sdk` package ([link](https://github.com/pancakeswap/pancake-frontend/pull/8007/files?diff=unified&w=0#diff-3cc757fbf31983dfd5e25524e1ee47f0d8f4dd98d0f68a1f633a19077de20077R1-R5))
*  Re-export the `ChainId` enum from the `@pancakeswap/chains` package in the `packages/swap-sdk/src/index.ts` file for backward compatibility, and mark it as deprecated ([link](https://github.com/pancakeswap/pancake-frontend/pull/8007/files?diff=unified&w=0#diff-87e50c112da95136daaefc6bf29e2e7efb70f66f7845a32ecbd530baf9425a12R4-R6))


