### PR TITLE
feat: add new bsc v3 farms

### DIFF
--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -45,6 +45,8 @@ const v3TopFixedLps: FarmConfigV3[] = [
 
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
+  // new lps should follow after the top fixed lps
+  // latest first
   {
     pid: 95,
     lpAddress: '0x832EeBF89F99aACcf6640fe6b5E838066c630Fbe',
@@ -66,7 +68,6 @@ export const farmsV3 = defineFarmV3Configs([
     token1: bscTokens.usdt,
     feeAmount: FeeAmount.MEDIUM,
   },
-  // latest first
   {
     pid: 92,
     lpAddress: '0x77d5b2560e4B84b3fC58875Cb0133F39560e8AE3',

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -48,6 +48,56 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 95,
+    lpAddress: '0x832EeBF89F99aACcf6640fe6b5E838066c630Fbe',
+    token0: bscTokens.chess,
+    token1: bscTokens.usdt,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 94,
+    lpAddress: '0xcfe783e16c9a8C74F2be9BCEb2339769439061Bf',
+    token0: bscTokens.usdt,
+    token1: bscTokens.alpaca,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 93,
+    lpAddress: '0xE4e695FA53598dA586F798A9844A3b03d86f421e',
+    token0: bscTokens.btt,
+    token1: bscTokens.usdt,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  // latest first
+  {
+    pid: 92,
+    lpAddress: '0x77d5b2560e4B84b3fC58875Cb0133F39560e8AE3',
+    token0: bscTokens.bnb,
+    token1: bscTokens.xvs,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 91,
+    lpAddress: '0xa98D8a5867D664B7A758652146fd93a7dE40eE82',
+    token0: bscTokens.usdt,
+    token1: bscTokens.trx,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 90,
+    lpAddress: '0x81Bef404f5C93d99ed04Ed55488c99722CDd7A50',
+    token0: bscTokens.axs,
+    token1: bscTokens.bnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 89,
+    lpAddress: '0xDcccC7d0B02C837d1B8D8a8D5E2683387bc2b910',
+    token0: bscTokens.usdt,
+    token1: bscTokens.wom,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 87,
     token0: bscTokens.wbnb,
     token1: bscTokens.rdnt,

--- a/packages/farms/constants/56.ts
+++ b/packages/farms/constants/56.ts
@@ -45,8 +45,6 @@ const v3TopFixedLps: FarmConfigV3[] = [
 
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
-  // new lps should follow after the top fixed lps
-  // latest first
   {
     pid: 95,
     lpAddress: '0x832EeBF89F99aACcf6640fe6b5E838066c630Fbe',
@@ -80,7 +78,7 @@ export const farmsV3 = defineFarmV3Configs([
     pid: 91,
     lpAddress: '0xa98D8a5867D664B7A758652146fd93a7dE40eE82',
     token0: bscTokens.usdt,
-    token1: bscTokens.trx,
+    token1: bscTokens.trxv2,
     feeAmount: FeeAmount.MEDIUM,
   },
   {

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -1316,7 +1316,7 @@ export const bscTokens = {
   trxv2: new ERC20Token(
     ChainId.BSC,
     '0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3',
-    18,
+    6,
     'TRX',
     'TRON Token v2',
     'https://tron.network/',

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -1313,6 +1313,14 @@ export const bscTokens = {
     'TRON Token',
     'https://tron.network/',
   ),
+  trxv2: new ERC20Token(
+    ChainId.BSC,
+    '0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3',
+    18,
+    'TRX',
+    'TRON Token v2',
+    'https://tron.network/',
+  ),
   win: new ERC20Token(
     ChainId.BSC,
     '0xaeF0d72a118ce24feE3cD1d43d383897D05B4e99',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b731300</samp>

### Summary
🌾🔄🆕

<!--
1.  🌾 (ear of rice), which is often used to symbolize farming or agriculture, and can also represent the PancakeSwap platform, which has a pancake logo.
2.  🔄 (arrows clockwise), which is used to indicate swapping or exchanging, and can also represent the liquidity pools or the V3 version of the exchange, which has a circular logo.
3.  🆕 (new), which is used to indicate something that is newly added or updated, and can also represent the new farms or the new tokens that are involved in the pairs.
-->
Add new farms for PancakeSwap V3 exchange in `packages/farms/constants/56.ts`. The new farms involve various tokens and swap fees, and are sorted by recency.

> _New farms in `farmsV3`_
> _Liquidity pools abound_
> _Autumn harvest time_

### Walkthrough
*  Add new farms to the `farmsV3` array for PancakeSwap V3 exchange ([link](https://github.com/pancakeswap/pancake-frontend/pull/8010/files?diff=unified&w=0#diff-b68c662a4cbcb945733d7c43d7c670219954b0f8395016547312ad2d6ad6a066R51-R100))


