### PR TITLE
chore: Bump up swiper

### DIFF
--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^18.2.0",
     "styled-components": "^6.0.7",
     "typescript": "^5.1.3",
-    "swiper": "^10.2.0",
+    "swiper": "^10.3.1",
     "swr": "^2.1.5",
     "lodash": "^4.17.21"
   },

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.2.0",
     "react-wrap-balancer": "^0.4.0",
     "styled-components": "^6.0.7",
-    "swiper": "^10.2.0",
+    "swiper": "^10.3.1",
     "swr": "^2.1.5",
     "typescript": "^5.1.3",
     "qs": "^6.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -102,7 +102,7 @@
     "split-grid": "^1.0.11",
     "styled-components": "^6.0.7",
     "styled-system": "^5.1.5",
-    "swiper": "^10.2.0",
+    "swiper": "^10.3.1",
     "swr": "^2.1.5",
     "tiny-invariant": "^1.1.0",
     "typescript": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
         specifier: ^6.0.7
         version: 6.0.7(babel-plugin-styled-components@1.13.3)(react-dom@18.2.0)(react@18.2.0)
       swiper:
-        specifier: ^10.2.0
-        version: 10.2.0
+        specifier: ^10.3.1
+        version: 10.3.1
       swr:
         specifier: ^2.1.5
         version: 2.1.5(react@18.2.0)
@@ -428,8 +428,8 @@ importers:
         specifier: ^6.0.7
         version: 6.0.7(babel-plugin-styled-components@1.13.3)(react-dom@18.2.0)(react@18.2.0)
       swiper:
-        specifier: ^10.2.0
-        version: 10.2.0
+        specifier: ^10.3.1
+        version: 10.3.1
       swr:
         specifier: ^2.1.5
         version: 2.1.5(react@18.2.0)
@@ -770,8 +770,8 @@ importers:
         specifier: ^5.1.5
         version: 5.1.5
       swiper:
-        specifier: ^10.2.0
-        version: 10.2.0
+        specifier: ^10.3.1
+        version: 10.3.1
       swr:
         specifier: ^2.1.5
         version: 2.1.5(react@18.2.0)
@@ -1500,7 +1500,7 @@ importers:
         version: 2.1.2(react-dom@17.0.2)(react@18.2.0)
       swiper:
         specifier: '*'
-        version: 10.2.0
+        version: 10.3.1
 
   packages/uikit:
     dependencies:
@@ -24732,8 +24732,8 @@ packages:
       picocolors: 1.0.0
     dev: false
 
-  /swiper@10.2.0:
-    resolution: {integrity: sha512-nktQsOtBInJjr3f5DicxC8eHYGcLXDVIGPSon0QoXRaO6NjKnATCbQ8SZsD3dN1Ph1RH4EhVPwSYCcuDRFWHGQ==}
+  /swiper@10.3.1:
+    resolution: {integrity: sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==}
     engines: {node: '>= 4.7.0'}
     dev: false
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 65f30c6</samp>

### Summary
🆙🛠️🎡

<!--
1.  🆙 - This emoji can be used to indicate that a dependency was updated to a newer version, as in the case of swiper. It can also be used to show that something was improved or upgraded in general.
2.  🛠️ - This emoji can be used to indicate that a bug was fixed or a problem was solved, as in the case of swiper's latest patch release, which addressed some issues with navigation and pagination. It can also be used to show that something was repaired or maintained.
3.  🎡 - This emoji can be used to indicate that a feature or component related to sliders or carousels was added or modified, as in the case of swiper, which is used for creating such elements in the apps. It can also be used to show that something was fun or exciting.
-->
Updated the swiper dependency to version `10.3.1` in all the apps and the `pnpm-lock.yaml` file. This was done to improve the functionality and performance of the sliders and carousels used in the frontend.

> _To make sliders and carousels slick_
> _The swiper dependency we pick_
> _But it needed an update_
> _To version `10.3.1` great_
> _So we changed it in every `package.json` quick_

### Walkthrough
*  Updated swiper dependency from version 10.2.0 to 10.3.1 in all apps and packages that use it ([link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-2e0a28c02ce581e54b6b6f5803ee5d4b292c79f235eeeaed29cfc4666fa7cad0L47-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171L25-R25), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L105-R105), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL340-R341), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL431-R432), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL773-R774), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1503-R1503), [link](https://github.com/pancakeswap/pancake-frontend/pull/8011/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24735-R24736)). This was done to use the latest features and bug fixes of the swiper library, which is used for creating responsive and touch-friendly sliders and carousels in the `aptos`, `blog`, and `web` apps, as well as the `@pancakeswap-libs/uikit` and `@pancakeswap-libs/farm-auctions` packages. The changes affected the `package.json` files of the apps and the `pnpm-lock.yaml` file of the repository.


