### PR TITLE
fix: (affiliate): Affiliate api's when development mode and improve wrong url check on prod

### DIFF
--- a/apps/web/src/pages/api/affiliates-program/affiliate-claim-fee.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-claim-fee.ts
@@ -5,8 +5,8 @@ import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 const affiliateClaimFee = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST' && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/fee/claim/request`

--- a/apps/web/src/pages/api/affiliates-program/affiliate-claim-list.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-claim-list.ts
@@ -12,8 +12,8 @@ const zQuery = zObject({
 const affiliateClaimList = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/affiliate-exist.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-exist.ts
@@ -7,8 +7,8 @@ const zQuery = zObject({
 })
 
 const affiliateExist = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/affiliate-fee-create.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-fee-create.ts
@@ -5,8 +5,8 @@ import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST' && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/fee/create`

--- a/apps/web/src/pages/api/affiliates-program/affiliate-fee-create.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-fee-create.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { getCookie } from 'cookies-next'
 import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 
-const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
+const affiliateFeeCreate = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
   if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
@@ -28,4 +28,4 @@ const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
   return res.status(200).json(result)
 }
 
-export default affiliateLogin
+export default affiliateFeeCreate

--- a/apps/web/src/pages/api/affiliates-program/affiliate-fee-exist.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-fee-exist.ts
@@ -7,8 +7,8 @@ const zQuery = zObject({
 })
 
 const affiliateFeeExist = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/affiliate-info.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-info.ts
@@ -5,8 +5,8 @@ import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 const affiliateInfo = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate`

--- a/apps/web/src/pages/api/affiliates-program/affiliate-login.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-login.ts
@@ -8,8 +8,8 @@ export const AFFILIATE_NONCE_SID = 'AFFILIATE_NONCE_SID'
 const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_NONCE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST' && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/login`

--- a/apps/web/src/pages/api/affiliates-program/affiliate-nonce.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-nonce.ts
@@ -5,7 +5,7 @@ import { MAX_AGE } from 'config/constants/affiliatesProgram'
 
 const affiliateNonce = async (req: NextApiRequest, res: NextApiResponse) => {
   if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const response = await fetch(`${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/nonce`)

--- a/apps/web/src/pages/api/affiliates-program/affiliate-regenerate-signature.ts
+++ b/apps/web/src/pages/api/affiliates-program/affiliate-regenerate-signature.ts
@@ -5,8 +5,8 @@ import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 const affiliateRegenerateSignature = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST' && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/fee/claim/regenerate-signature`

--- a/apps/web/src/pages/api/affiliates-program/leader-board.ts
+++ b/apps/web/src/pages/api/affiliates-program/leader-board.ts
@@ -5,8 +5,8 @@ import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 const leaderBoard = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/affiliate/leader-board`

--- a/apps/web/src/pages/api/affiliates-program/user-claim-fee.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-claim-fee.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const userClaimFee = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST') {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST') {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/user/fee/claim/request`

--- a/apps/web/src/pages/api/affiliates-program/user-claim-list.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-claim-list.ts
@@ -9,8 +9,8 @@ const zQuery = zObject({
 })
 
 const userClaimList = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/user-exist.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-exist.ts
@@ -7,8 +7,8 @@ const zQuery = zObject({
 })
 
 const userExist = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/user-info.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-info.ts
@@ -7,8 +7,8 @@ const zQuery = zObject({
 })
 
 const userInfo = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && !req.query) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || !req.query) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const queryString = qs.stringify(req.query)

--- a/apps/web/src/pages/api/affiliates-program/user-regenerate-signature.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-regenerate-signature.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const userRegenerateSignature = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST') {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST') {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/user/fee/claim/regenerate-signature`

--- a/apps/web/src/pages/api/affiliates-program/user-register-fee.ts
+++ b/apps/web/src/pages/api/affiliates-program/user-register-fee.ts
@@ -2,11 +2,11 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { getCookie } from 'cookies-next'
 import { AFFILIATE_SID } from './affiliate-login'
 
-const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
+const userRegisterFee = async (req: NextApiRequest, res: NextApiResponse) => {
   const cookie = getCookie(AFFILIATE_SID, { req, res, sameSite: true })
 
-  if (!process.env.AFFILIATE_PROGRAM_API_URL && req.method === 'POST' && !cookie) {
-    return res.status(400).json({ message: 'API URL Empty' })
+  if (!process.env.AFFILIATE_PROGRAM_API_URL || req.method !== 'POST' || !cookie) {
+    return res.status(400).json({ message: 'API URL Empty / Method wrong / Cookie not exist' })
   }
 
   const requestUrl = `${process.env.AFFILIATE_PROGRAM_API_URL}/user/register`
@@ -28,4 +28,4 @@ const affiliateLogin = async (req: NextApiRequest, res: NextApiResponse) => {
   return res.status(200).json(result)
 }
 
-export default affiliateLogin
+export default userRegisterFee


### PR DESCRIPTION
Api url is empty on development but condition has and cause therefore it tries to request with undefined request instead of fail fast. Improves fail condition on prod too.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9680ecf</samp>

### Summary
🛑🍪🔄

<!--
1.  🛑 - This emoji represents the stricter and more consistent error handling logic that uses `||` instead of `&&` to return a 400 response for any invalid request.
2.  🍪 - This emoji represents the cookie validation that is required for some of the API endpoints, and the different cookie names that are used (`AFFILIATE_SID` and `AFFILIATE_NONCE_SID`).
3.  🔄 - This emoji represents the renaming of the API endpoint function `affiliateLogin` to `userRegisterFee`, which implies a change in functionality and purpose.
-->
Renamed one API endpoint function and updated its export statement. Changed the error response logic for all API endpoints in the affiliates-program folder to use `||` instead of `&&`. This makes the code more consistent, clear, and strict.

> _`affiliateLogin`_
> _now `userRegisterFee` / kireji_
> _a clear autumn name_

### Walkthrough
*  Simplify and standardize the error response logic for 13 API endpoints by changing the condition from `&&` to `||` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-5839dbfa0b17519e2efeaf1cb125c8562eb97d884b06a2dfd246314dcf684bb8L8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-392ade97d77eac7ef904a4d7145c367a84288a69d3ec8717fea2ccdb013cf504L15-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-7f895c57e266eb6bba26acfd9d4fb1c7f833969a6e4066600a3a49094efc4285L10-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-e7e39e5d580bc963ec2bfe662014fd0abaa76e39ecb6a7a6772df7d3105e43b2L8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-0a9659c298e1b4d569885fe915173e9018877e1a53273488b0c20cc379a733fdL10-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-aeb8b646e6738d6497b1fa9f505feb6c6d2a68f0eb7122f3595a2f41385b3d4dL8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-751489b854a969ce0946c610f153d398fdea39eeac5bff112e26212e5ae7d948L11-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-8e92db447bb9008784329d5252ca6ac39d42170e80e05cd417680a624c78a5e9L8-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-e6a21a95e6e6808964f98d9fd57235ae73e2f72897b743d5925f1a4f7c851487L8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-9ecfe836c7875a602a51788690fc8f6772d2d935ac2475d4eeddabefe0ce266aL8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-38dbce6053afbd4c607e2825a9a7f2697ce6c568d78e4b8ddc22384d63482866L4-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-91f38e2ce1308057c7d74c732db2a3343fcc5915068869443bc6c7337be91a77L12-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-3d9c6f209fc5228aedc0ef180ff2c234a8abf4297a4386484aaacf28ea29253cL10-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-ebcaddd2121edba2bbcb59eeb618e1da9e6e3f2c49ec66780286fd2e5ad72befL10-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-bc2905af8acc0d438c70b92c3264aa4d84c9d549221f538ba4218b0320735d3bL4-R5))
* Rename the function and export statement in `user-register-fee.ts` to match the endpoint purpose ([link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-ae788bf19a4cf5a71fea67f0f2411e803c1ce37465815e05e17553e77293b454L5-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8018/files?diff=unified&w=0#diff-ae788bf19a4cf5a71fea67f0f2411e803c1ce37465815e05e17553e77293b454L31-R31))


