### PR TITLE
style(prediction): Fix style problem

### DIFF
--- a/apps/web/src/views/Predictions/components/JupiterPredictors.tsx
+++ b/apps/web/src/views/Predictions/components/JupiterPredictors.tsx
@@ -13,7 +13,11 @@ const JupiterPredictorsContainer = styled(Box)`
 
   ${({ theme }) => theme.mediaQueries.sm} {
     width: 406px;
-    margin: 0 0 0 16px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    position: absolute;
+    margin: -120px 0 0 16px;
   }
 `
 

--- a/apps/web/src/views/Predictions/components/Menu.tsx
+++ b/apps/web/src/views/Predictions/components/Menu.tsx
@@ -95,8 +95,8 @@ const Menu = () => {
 
   return (
     <FlexRow alignItems="center" p="16px" width="100%">
+      {isDesktop && <JupiterPredictors />}
       <SetCol>
-        {isDesktop && <JupiterPredictors />}
         <PricePairLabel />
       </SetCol>
       {status === PredictionStatus.LIVE && (

--- a/apps/web/src/views/Predictions/components/MobileMenu.tsx
+++ b/apps/web/src/views/Predictions/components/MobileMenu.tsx
@@ -99,14 +99,16 @@ const MobileMenu = () => {
         </IconButton>
       </ButtonNav>
       <TabNav>
-        <BunnyContainer>
-          <Image
-            width={isMobile ? 134 : 164}
-            height={isMobile ? 125 : 155}
-            src="/images/predictions/birthday/mobile-bunny.png"
-            alt="mobile-bunny"
-          />
-        </BunnyContainer>
+        {activeIndex === 0 && (
+          <BunnyContainer>
+            <Image
+              width={isMobile ? 134 : 164}
+              height={isMobile ? 125 : 155}
+              src="/images/predictions/birthday/mobile-bunny.png"
+              alt="mobile-bunny"
+            />
+          </BunnyContainer>
+        )}
         <ButtonMenu activeIndex={activeIndex} scale="sm" variant="subtle" onItemClick={handleItemClick}>
           <ButtonMenuItem>
             <Cards color="currentColor" />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cccbb4c</samp>

### Summary
🖥️🍰🐰

<!--
1.  🖥️ - This emoji represents the change to the `JupiterPredictorsContainer` styled component, which affects the layout on large screens.
2.  🍰 - This emoji represents the change to the `BunnyContainer` component, which displays a cake image.
3.  🐰 - This emoji represents the conditional rendering of the `BunnyContainer` component, which shows a bunny image.
-->
This pull request improves the layout and design of the Jupiter predictors and the mobile menu components in the predictions view. It aligns the `JupiterPredictorsContainer` with the background image on large screens and hides the `BunnyContainer` on non-birthday tabs.

> _`JupiterPredictorsContainer`_
> _Aligns with stars_
> _On large screens, no margin_

### Walkthrough
*  Align `JupiterPredictorsContainer` with background image on large screens by changing its position and margin ([link](https://github.com/pancakeswap/pancake-frontend/pull/8025/files?diff=unified&w=0#diff-c6e29f9ab87227791ccd58e68bf95d8775c63f83184ce4c2ccdaeb75e5d1ba74L16-R21))
*  Show `BunnyContainer` component only on birthday predictor tab in `MobileMenu` component by adding conditional rendering based on active tab index ([link](https://github.com/pancakeswap/pancake-frontend/pull/8025/files?diff=unified&w=0#diff-6019f6ac8793c6fd06a0fd7af0a33da59b012708177afce173a004d63101ae41L102-R111))


