### PR TITLE
feat: remove moonpay during maintence hours

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/Accordion.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Flex, FlexGap, Row, Text } from '@pancakeswap/uikit'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { CryptoFormView, ProviderQuote } from 'views/BuyCrypto/types'
+import { ONRAMP_PROVIDERS } from 'views/BuyCrypto/constants'
 import AccordionItem from './AccordionItem'
 
 function Accordion({
@@ -31,18 +32,20 @@ function Accordion({
   }
   return (
     <FlexGap flexDirection="column" gap="16px">
-      {combinedQuotes.map((quote: ProviderQuote, idx) => {
-        return (
-          <AccordionItem
-            key={quote.provider}
-            active={currentIdx === idx}
-            btnOnClick={() => setCurrentIdx((a) => (a === idx ? '' : idx))}
-            quote={quote}
-            fetching={fetching}
-            setModalView={setModalView}
-          />
-        )
-      })}
+      {combinedQuotes
+        .filter((quote: ProviderQuote) => quote.provider !== ONRAMP_PROVIDERS.MoonPay)
+        .map((quote: ProviderQuote, idx) => {
+          return (
+            <AccordionItem
+              key={quote.provider}
+              active={currentIdx === idx}
+              btnOnClick={() => setCurrentIdx((a) => (a === idx ? '' : idx))}
+              quote={quote}
+              fetching={fetching}
+              setModalView={setModalView}
+            />
+          )
+        })}
     </FlexGap>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bbe5d59</samp>

### Summary
🚫🛒🚀

<!--
1.  🚫 - This emoji conveys the idea of filtering out or excluding something, which is what was done to MoonPay in the providers list.
2.  🛒 - This emoji represents the action of buying something, which is the goal of the users who want to buy crypto through the on-ramp providers.
3.  🚀 - This emoji suggests the idea of launching or boosting something, which is the potential outcome of buying crypto and using it for various purposes.
-->
Removed `MoonPay` from the on-ramp providers list in the `Accordion` component. This improves the user experience by hiding an unavailable option for buying crypto.

> _No more `MoonPay` in the list of on-ramps_
> _They tried to sell us crypto but they failed_
> _We filter out the weak and the corrupt_
> _We only trust the `Accordion` of the brave_

### Walkthrough
*  Exclude `MoonPay` provider from accordion items due to API issues ([link](https://github.com/pancakeswap/pancake-frontend/pull/8027/files?diff=unified&w=0#diff-ab2dfeee40c6fdf86014787d7a6649b7732e47e6f04048a8176f9642a80fb608L34-R48))
* Import `ONRAMP_PROVIDERS` constant from `views/BuyCrypto/constants` module ([link](https://github.com/pancakeswap/pancake-frontend/pull/8027/files?diff=unified&w=0#diff-ab2dfeee40c6fdf86014787d7a6649b7732e47e6f04048a8176f9642a80fb608R5))


