### PR TITLE
fix: (homepage): Harvest card send failed trx if no v3 farms but only v2 farms, stop swiper when harvesting

### DIFF
--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -197,7 +197,8 @@ export function useFarmsV3BatchHarvest() {
 
   const masterChefV3Address = useMasterchefV3()?.address
   const onHarvestAll = useCallback(
-    async (tokenIds: string[]) => {
+    async (tokenIds: string[], onHarvestStart?: () => void | undefined, onHarvestEnd?: () => void | undefined) => {
+      onHarvestStart?.()
       const { calldata, value } = MasterChefV3.batchHarvestCallParameters(
         tokenIds.map((tokenId) => ({ tokenId, to: account })),
       )
@@ -230,6 +231,7 @@ export function useFarmsV3BatchHarvest() {
         )
         mutate((key) => Array.isArray(key) && key[0] === 'mcv3-harvest', undefined)
       }
+      onHarvestEnd?.()
     },
     [account, fetchWithCatchTxError, masterChefV3Address, sendTransactionAsync, signer, t, toastSuccess],
   )

--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -197,8 +197,7 @@ export function useFarmsV3BatchHarvest() {
 
   const masterChefV3Address = useMasterchefV3()?.address
   const onHarvestAll = useCallback(
-    async (tokenIds: string[], onHarvestStart?: () => void | undefined, onHarvestEnd?: () => void | undefined) => {
-      onHarvestStart?.()
+    async (tokenIds: string[]) => {
       const { calldata, value } = MasterChefV3.batchHarvestCallParameters(
         tokenIds.map((tokenId) => ({ tokenId, to: account })),
       )
@@ -231,7 +230,6 @@ export function useFarmsV3BatchHarvest() {
         )
         mutate((key) => Array.isArray(key) && key[0] === 'mcv3-harvest', undefined)
       }
-      onHarvestEnd?.()
     },
     [account, fetchWithCatchTxError, masterChefV3Address, sendTransactionAsync, signer, t, toastSuccess],
   )

--- a/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -100,7 +100,9 @@ const HarvestCard: React.FC<React.PropsWithChildren<HarvestCardProps>> = ({ onHa
       }[]
     ).map((farm) => farm.sendTx.tokenId)
     if (v3Farms.length > 0) {
-      onHarvestAll(v3Farms, onHarvestStart, onHarvestEnd)
+      onHarvestStart?.()
+      await onHarvestAll(v3Farms)
+      onHarvestEnd?.()
     }
   }, [
     farmsWithStakedBalance,

--- a/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -100,10 +100,9 @@ const HarvestCard: React.FC<React.PropsWithChildren<HarvestCardProps>> = ({ onHa
       }[]
     ).map((farm) => farm.sendTx.tokenId)
     if (v3Farms.length > 0) {
-      onHarvestStart?.()
       await onHarvestAll(v3Farms)
-      onHarvestEnd?.()
     }
+    onHarvestEnd?.()
   }, [
     farmsWithStakedBalance,
     onHarvestAll,

--- a/apps/web/src/views/Home/components/UserBanner/index.tsx
+++ b/apps/web/src/views/Home/components/UserBanner/index.tsx
@@ -1,5 +1,7 @@
+import { useCallback } from 'react'
 import { Box, Flex } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
+import { useSwiper } from 'swiper/react'
 import HarvestCard from './HarvestCard'
 import UserDetail from './UserDetail'
 
@@ -16,6 +18,16 @@ const StyledCard = styled(Box)`
 `
 
 const UserBanner = () => {
+  const swiper = useSwiper()
+
+  const handleHarvestStart = useCallback(() => {
+    swiper?.autoplay?.stop()
+  }, [swiper])
+
+  const handleHarvestEnd = useCallback(() => {
+    swiper?.autoplay?.start()
+  }, [swiper])
+
   return (
     <StyledCard p={['16px', null, null, '40px']}>
       <Flex alignItems="center" justifyContent="center" flexDirection={['column', null, null, 'row']}>
@@ -23,7 +35,7 @@ const UserBanner = () => {
           <UserDetail />
         </Flex>
         <Flex flex="1" width={['100%', null, 'auto']}>
-          <HarvestCard />
+          <HarvestCard onHarvestStart={handleHarvestStart} onHarvestEnd={handleHarvestEnd} />
         </Flex>
       </Flex>
     </StyledCard>


### PR DESCRIPTION
Adds a feature to stop swiping when user harvesting

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5308e7e</samp>

### Summary
🌾🔧⏸️

<!--
1.  🌾 - This emoji represents the farming and harvesting theme of the changes, as well as the addition of callbacks to the batch harvest function.
2.  🔧 - This emoji represents the refactoring and improvement of the `HarvestCard` component, as well as the use of TypeScript types and functional components.
3.  ⏸️ - This emoji represents the pause and resume functionality of the user banner carousel when harvesting rewards, as well as the use of hooks and callbacks to control the swiper autoplay.
-->
Added user feedback and improved performance for harvesting rewards from farms v2 and v3. Used optional callbacks in `useFarmV3Actions` hook and `HarvestCard` component to pause the user banner carousel and execute custom logic. Refactored `HarvestCard` to use functional component syntax and `TextProps` type.

> _Sing, O Muse, of the cunning code that the developers wrought,_
> _To harvest bounteous rewards from the farms of v2 and v3,_
> _With optional callbacks, swift and subtle, that they deftly taught_
> _The `HarvestCard` component, shining with new functionality._

### Walkthrough
*  Add optional callbacks to `onHarvestAll` function in `useFarmsV3BatchHarvest` hook to execute before and after the batch harvest transaction ([link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L200-R201), [link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R234))
*  Pass `onHarvestStart` and `onHarvestEnd` props to `HarvestCard` component and invoke them in `harvestAllFarms` function before and after harvesting v2 and v3 farms ([link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-f5f8c590921de2037c9b99cf48397f5da6b9674c2c5908cdff7686e73acacae7R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-f5f8c590921de2037c9b99cf48397f5da6b9674c2c5908cdff7686e73acacae7L43-R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-f5f8c590921de2037c9b99cf48397f5da6b9674c2c5908cdff7686e73acacae7L64-R71), [link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-f5f8c590921de2037c9b99cf48397f5da6b9674c2c5908cdff7686e73acacae7L93-R114))
*  Import and use `useSwiper` hook in `UserBanner` component to access the swiper instance that controls the user banner carousel ([link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-9735370a8024a1622b34c2cf2ae682c9879e6b3bb6c316c2ff5c47df143d4b94L1-R4))
*  Define and pass `handleHarvestStart` and `handleHarvestEnd` functions to `HarvestCard` component to stop and start the swiper autoplay when the harvest transaction is initiated and completed ([link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-9735370a8024a1622b34c2cf2ae682c9879e6b3bb6c316c2ff5c47df143d4b94R21-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/8044/files?diff=unified&w=0#diff-9735370a8024a1622b34c2cf2ae682c9879e6b3bb6c316c2ff5c47df143d4b94L26-R38))


