### PR TITLE
feat: add new zksync farms

### DIFF
--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -70,7 +70,7 @@ export const farmsV3 = defineFarmV3Configs([
     pid: 10,
     lpAddress: '0x38848d93a410446848CA55Fdc777Fe0B2C30B071',
     token0: zksyncTokens.reth,
-    token1: zksyncTokens.eth,
+    token1: zksyncTokens.weth,
     feeAmount: FeeAmount.LOW,
   },
   {

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -59,7 +59,7 @@ export const farmsV3 = defineFarmV3Configs([
     token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
-   {
+  {
     pid: 9,
     lpAddress: '0x38848d93a410446848ca55fdc777fe0b2c30b071',
     token0: zksyncTokens.busd,

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -71,6 +71,13 @@ export const farmsV3 = defineFarmV3Configs([
     lpAddress: '0x38848d93a410446848CA55Fdc777Fe0B2C30B071',
     token0: zksyncTokens.reth,
     token1: zksyncTokens.eth,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
+    pid: 11,
+    lpAddress: '0x38848d93a410446848CA55Fdc777Fe0B2C30B071',
+    token0: zksyncTokens.usdp,
+    token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
 ])

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -52,4 +52,25 @@ export const farmsV3 = defineFarmV3Configs([
     token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
+  {
+    pid: 8,
+    lpAddress: '0x662cD659F91528FF27D7Cb6Ac25e6EBA11c4003C',
+    token0: zksyncTokens.weth,
+    token1: zksyncTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
+    pid: 9,
+    lpAddress: '0x38848d93a410446848ca55fdc777fe0b2c30b071',
+    token0: zksyncTokens.busd,
+    token1: zksyncTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
+    pid: 10,
+    lpAddress: '0x3693ec2590e6bf8f221f61776dc9274aed7056d6',
+    token0: zksyncTokens.reth,
+    token1: zksyncTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
 ])

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -54,23 +54,23 @@ export const farmsV3 = defineFarmV3Configs([
   },
   {
     pid: 8,
-    lpAddress: '0x662cD659F91528FF27D7Cb6Ac25e6EBA11c4003C',
+    lpAddress: '0x7C0e7D6066aF191977a4483B445B5C06FC41ECd6',
     token0: zksyncTokens.weth,
     token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
   {
     pid: 9,
-    lpAddress: '0x38848d93a410446848ca55fdc777fe0b2c30b071',
+    lpAddress: '0x38848d93a410446848CA55Fdc777Fe0B2C30B071',
     token0: zksyncTokens.busd,
     token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
   {
     pid: 10,
-    lpAddress: '0x3693ec2590e6bf8f221f61776dc9274aed7056d6',
+    lpAddress: '0x38848d93a410446848CA55Fdc777Fe0B2C30B071',
     token0: zksyncTokens.reth,
-    token1: zksyncTokens.usdc,
+    token1: zksyncTokens.eth,
     feeAmount: FeeAmount.LOWEST,
   },
 ])

--- a/packages/farms/constants/324.ts
+++ b/packages/farms/constants/324.ts
@@ -59,7 +59,7 @@ export const farmsV3 = defineFarmV3Configs([
     token1: zksyncTokens.usdc,
     feeAmount: FeeAmount.LOWEST,
   },
-  {
+   {
     pid: 9,
     lpAddress: '0x38848d93a410446848ca55fdc777fe0b2c30b071',
     token0: zksyncTokens.busd,

--- a/packages/tokens/src/324.ts
+++ b/packages/tokens/src/324.ts
@@ -24,4 +24,12 @@ export const zksyncTokens = {
     'Binance USD',
     'https://www.paxos.com/busd/',
   ),
+  reth: new ERC20Token(
+    ChainId.ZKSYNC,
+    '0x32Fd44bB869620C0EF993754c8a00Be67C464806',
+    18,
+    'rETH',
+    'RETH',
+    'https://www.paxos.com/busd/',
+  ),
 }

--- a/packages/tokens/src/324.ts
+++ b/packages/tokens/src/324.ts
@@ -29,7 +29,15 @@ export const zksyncTokens = {
     '0x32Fd44bB869620C0EF993754c8a00Be67C464806',
     18,
     'rETH',
-    'RETH',
+    'Rocket Pool ETH',
     'https://www.paxos.com/busd/',
+  ),
+  usdp: new ERC20Token(
+    ChainId.ZKSYNC,
+    '0x32Fd44bB869620C0EF993754c8a00Be67C464806',
+    18,
+    'USD+',
+    'USD Plus',
+    '',
   ),
 }

--- a/packages/tokens/src/324.ts
+++ b/packages/tokens/src/324.ts
@@ -32,7 +32,7 @@ export const zksyncTokens = {
     'Rocket Pool ETH',
     'https://www.paxos.com/busd/',
   ),
-  usdp: new ERC20Token(
+  usdPlus: new ERC20Token(
     ChainId.ZKSYNC,
     '0x8E86e46278518EFc1C5CEd245cBA2C7e3ef11557',
     18,

--- a/packages/tokens/src/324.ts
+++ b/packages/tokens/src/324.ts
@@ -34,7 +34,7 @@ export const zksyncTokens = {
   ),
   usdp: new ERC20Token(
     ChainId.ZKSYNC,
-    '0x32Fd44bB869620C0EF993754c8a00Be67C464806',
+    '0x8E86e46278518EFc1C5CEd245cBA2C7e3ef11557',
     18,
     'USD+',
     'USD Plus',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f6d609c</samp>

### Summary
🌾🚀🌈

<!--
1.  🌾 - This emoji represents farming, which is the activity of providing liquidity to pools and earning rewards. It is suitable for the change that adds new liquidity pools to the farmsV3 array.
2.  🚀 - This emoji represents fast and scalable transactions, which are enabled by the zkSync layer 2 solution. It is suitable for the change that adds support for the zkSync chain and its tokens.
3.  🌈 - This emoji represents the rainbow bridge, which is a term used to describe the cross-chain transfer of assets between Ethereum and zkSync. It is suitable for the change that adds the rETH token, which is a wrapped version of ETH on zkSync.
-->
This pull request adds support for three new low-fee liquidity pools and a new token on the zkSync layer 2 chain. It updates the `farmsV3` and `zksyncTokens` arrays in `packages/farms/constants/324.ts` and `packages/tokens/src/324.ts` respectively.

> _New pools for `farmsV3`_
> _zkSync scales with low fees_
> _Autumn harvest time_

### Walkthrough
*  Add three new liquidity pools for zkSync-supported pairs ([link](https://github.com/pancakeswap/pancake-frontend/pull/8046/files?diff=unified&w=0#diff-02f301415ffe755f42d9f7b6cf06c434ba122dc41c6e94a77e55ce9e389d62e6R55-R75))
*  Add new token for wrapped ETH on zkSync ([link](https://github.com/pancakeswap/pancake-frontend/pull/8046/files?diff=unified&w=0#diff-a71af7ff44f6a2151f59a9720430da1d5c2a5d5c45623bbeba2d51e4acb77d56R27-R34))


