### PR TITLE
feat: remove moonpay block

### DIFF
--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -1,12 +1,10 @@
-import { useCallback, useState } from 'react'
 import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useCallback, useState } from 'react'
 import { Field } from 'state/buyCrypto/actions'
 import { useBuyCryptoState } from 'state/buyCrypto/hooks'
-import { ChainId } from '@pancakeswap/chains'
-import { fetchProviderQuotes } from './useProviderQuotes'
-import { fetchProviderAvailabilities } from './useProviderAvailability'
 import { ProviderQuote } from '../types'
-import { ONRAMP_PROVIDERS } from '../constants'
+import { fetchProviderAvailabilities } from './useProviderAvailability'
+import { fetchProviderQuotes } from './useProviderQuotes'
 
 const usePriceQuotes = () => {
   const [quotes, setQuotes] = useState<ProviderQuote[]>([])

--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -35,9 +35,7 @@ const usePriceQuotes = () => {
           sortedFilteredQuotes.sort((a, b) => b.quote - a.quote)
         }
 
-        return sortedFilteredQuotes.filter((quote: ProviderQuote) =>
-          chainId === ChainId.BSC ? quote.provider !== ONRAMP_PROVIDERS.MoonPay : quote.provider,
-        )
+        return sortedFilteredQuotes
       } catch (error) {
         console.error('Error fetching price quotes:', error)
         return []

--- a/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
+++ b/apps/web/src/views/BuyCrypto/hooks/usePriceQuoter.ts
@@ -39,7 +39,7 @@ const usePriceQuotes = () => {
         return []
       }
     },
-    [userIp, chainId],
+    [userIp],
   )
 
   const fetchQuotes = useCallback(async () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bd104dd</samp>

### Summary
🪙🌐🚫

<!--
1.  🪙 - This emoji represents the crypto or coin aspect of the change, as it is a coin with a dollar sign on it. It could also symbolize the price or value of the crypto providers.
2.  🌐 - This emoji represents the network or web aspect of the change, as it is a globe with meridians. It could also symbolize the BSC network or the cross-chain compatibility of the crypto providers.
3.  🚫 - This emoji represents the removal or deletion aspect of the change, as it is a red circle with a slash. It could also symbolize the filter or the exclusion of the crypto providers.
-->
Removed a filter that prevented some providers from being displayed on the buy crypto page. This improves the user experience and resolves issue #2419.

> _`filter` is gone_
> _all providers can be seen_
> _autumn of BSC_

### Walkthrough
* Remove the network filter for the price quotes to show all providers on the buy crypto page ([link](https://github.com/pancakeswap/pancake-frontend/pull/8048/files?diff=unified&w=0#diff-05cf008d35fa21dfccb294f5fe1bb9a2bc335765a3dab53a36b8b54ff7944e72L38-R38))


