### PR TITLE
fix(Blog): Fix blogCard width issue

### DIFF
--- a/apps/blog/components/BlogCard.tsx
+++ b/apps/blog/components/BlogCard.tsx
@@ -4,7 +4,6 @@ import { HeightProps } from 'styled-system'
 import { ArticleDataType } from 'utils/transformArticle'
 
 const StyledBackgroundImage = styled(Box)<{ imgUrl: string }>`
-  height: 100%;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -44,7 +43,7 @@ const BlogCard: React.FC<React.PropsWithChildren<BlogCardProps>> = ({ article, i
     <StyledBlogCard {...props}>
       <Card>
         <Box overflow="hidden" height={imgHeight ?? '200px'}>
-          <StyledBackgroundImage imgUrl={imgUrl} />
+          <StyledBackgroundImage imgUrl={imgUrl} height={imgHeight ?? '200px'} />
         </Box>
         <Box padding={['15px', '15px', '20px']}>
           <Flex justifyContent="space-between">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 11287d4</samp>

### Summary
🛠️🎨📱

<!--
1.  🛠️ - This emoji represents fixing or repairing something, which is suitable for the layout issue that was resolved.
2.  🎨 - This emoji represents improving or enhancing the appearance or design of something, which is suitable for the visual improvement of the blog post previews.
3.  📱 - This emoji represents mobile devices or responsiveness, which is suitable for the change that makes the blog post previews more adaptable to different screen sizes.
-->
This pull request improves the responsiveness and consistency of the blog post previews on the blog app. It adjusts the height of the `Card` and `StyledBackgroundImage` components in `apps/blog/components/BlogCard.tsx`.

> _Oh we're the coders of the sea, and we fix the layout with glee_
> _We remove the `height` from the `Card`, and we add it to the `StyledBackgroundImage`_
> _Heave away, me hearties, heave away_
> _For a responsive and consistent display_

### Walkthrough
* Remove height property from Card component to avoid excess whitespace ([link](https://github.com/pancakeswap/pancake-frontend/pull/8050/files?diff=unified&w=0#diff-f392ae424e2c767c7923543333ddedfda815753f242fb7fc2b7cb46655177046L7))
* Add height property to StyledBackgroundImage component to crop image to parent Box component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8050/files?diff=unified&w=0#diff-f392ae424e2c767c7923543333ddedfda815753f242fb7fc2b7cb46655177046L47-R46))


