### PR TITLE
fix: (buy-crypto): Buy crypto return to input page instead of query when closing fiat on ramp modal

### DIFF
--- a/apps/web/src/components/Card/index.tsx
+++ b/apps/web/src/components/Card/index.tsx
@@ -31,7 +31,7 @@ export const LightGreyCard = styled(Card)`
 export const CryptoCard = styled(Card)<{ isClicked: boolean; isDisabled: boolean }>`
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
   background-color: ${({ theme, isClicked }) => (isClicked ? theme.colors.input : theme.colors.background)};
-  transition: height 0.4s ease-in-out, background-color 0.1s ease-in-out;
+  transition: max-height 0.4s ease-in-out, background-color 0.1s ease-in-out;
   overflow: hidden;
   &:hover {
     cursor: ${({ isDisabled }) => (isDisabled ? 'not-allowed' : 'pointer')};

--- a/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
+++ b/apps/web/src/components/FiatOnRampModal/FiatOnRampModal.tsx
@@ -17,7 +17,7 @@ import { CommitButton } from 'components/CommitButton'
 import { MERCURYO_WIDGET_ID, MERCURYO_WIDGET_URL } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import Script from 'next/script'
-import { Dispatch, ReactNode, SetStateAction, memo, useCallback, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, memo, useCallback, useEffect, useState, useMemo } from 'react'
 import { styled, useTheme } from 'styled-components'
 import OnRampProviderLogo from 'views/BuyCrypto/components/OnRampProviderLogo/OnRampProviderLogo'
 import { ONRAMP_PROVIDERS, chainIdToMercuryoNetworkId } from 'views/BuyCrypto/constants'
@@ -146,19 +146,22 @@ export const FiatOnRampModalButton = ({
     />,
   )
 
-  let buttonText: ReactNode | string = t(`Buy with %provider%`, { provider })
-  if (disabled) {
-    buttonText = (
-      <>
-        <Flex alignItems="center">
-          <Text px="4px" fontWeight="bold" color="white">
-            {t('Fetching Quotes')}
-          </Text>
-          <CircleLoader stroke="white" />
-        </Flex>
-      </>
-    )
-  }
+  const buttonText = useMemo(() => {
+    if (disabled) {
+      return (
+        <>
+          <Flex alignItems="center">
+            <Text px="4px" fontWeight="bold" color="white">
+              {t('Fetching Quotes')}
+            </Text>
+            <CircleLoader stroke="white" />
+          </Flex>
+        </>
+      )
+    }
+    return t(`Buy with %provider%`, { provider })
+  }, [disabled, provider, t])
+
   return (
     <AutoColumn gap="md">
       <CommitButton onClick={onPresentConfirmModal} disabled={disabled} isLoading={disabled} mb="10px" mt="16px">
@@ -190,7 +193,7 @@ export const FiatOnRampModal = memo<InjectedModalProps & FiatOnRampProps>(functi
 
   const handleDismiss = useCallback(async () => {
     onDismiss?.()
-    setModalView(CryptoFormView.Input)
+    setModalView(CryptoFormView.Quote)
   }, [onDismiss, setModalView])
 
   const fetchSignedIframeUrl = useCallback(async () => {

--- a/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
+++ b/apps/web/src/views/BuyCrypto/components/AccordionDropdown/AccordionItem.tsx
@@ -60,22 +60,22 @@ function AccordionItem({
     currentLanguage: { locale },
   } = useTranslation()
   const contentRef = useRef<HTMLDivElement>(null)
-  const [height, setHeight] = useState(active ? 240 : 96)
+  const [maxHeight, setMaxHeight] = useState(active ? 500 : 150)
   const multiple = false
-  const [visiblity, setVisiblity] = useState(false)
+  const [visibility, setVisibility] = useState(false)
   const [mobileTooltipShow, setMobileTooltipShow] = useState(false)
   const currentTimestamp = Math.floor(Date.now() / 1000)
   const { days, hours, minutes, seconds } = getTimePeriods(currentTimestamp - CURRENT_CAMPAIGN_TIMESTAMP)
-  const isActive = () => (multiple ? visiblity : active)
+  const isActive = () => (multiple ? visibility : active)
 
-  const toogleVisiblity = useCallback(() => {
-    setVisiblity((v) => !v)
+  const toggleVisibility = useCallback(() => {
+    setVisibility((v) => !v)
     btnOnClick()
-  }, [setVisiblity, btnOnClick])
+  }, [setVisibility, btnOnClick])
 
   useEffect(() => {
     const contentEl = getRefValue(contentRef)
-    setHeight(contentEl?.scrollHeight + 96)
+    setMaxHeight(contentEl?.scrollHeight + 150)
   }, [active])
 
   const {
@@ -100,8 +100,8 @@ function AccordionItem({
   if (quote.amount === 0) {
     return (
       <Flex flexDirection="column">
-        <CryptoCard padding="16px 16px" style={{ height: '70px' }} position="relative" isClicked={false} isDisabled>
-          <RowBetween paddingBottom="24px" paddingTop="8px">
+        <CryptoCard position="relative" isClicked={false} isDisabled>
+          <RowBetween>
             <OnRampProviderLogo provider={quote.provider} />
             <TooltipText
               ref={buyCryptoTargetRef}
@@ -126,15 +126,14 @@ function AccordionItem({
     <Flex flexDirection="column">
       <CryptoCard
         padding="18px 18px"
-        style={{ height }}
-        onClick={!isActive() ? toogleVisiblity : () => null}
+        style={{ maxHeight }}
+        onClick={!isActive() ? toggleVisibility : () => null}
         position="relative"
         isClicked={active}
         isDisabled={false}
       >
         <RowBetween>
           <OnRampProviderLogo provider={quote.provider} />
-
           <Text ml="4px" fontSize="18px" color="#7A6EAA" fontWeight="bold">
             {formatLocaleNumber({
               number: quote.quote,


### PR DESCRIPTION

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3e53b6c</samp>

### Summary
📏🚀🛠️

<!--
1.  📏 - This emoji can represent the use of `max-height` for the transition property and the card style, as it suggests measuring and adjusting the dimensions of the elements.
2.  🚀 - This emoji can represent the performance and usability improvements of the `FiatOnRampModal` component, as it suggests speed, efficiency, and launching a feature.
3.  🛠️ - This emoji can represent the refactoring and fixing of the `AccordionItem` component, as it suggests repairing, building, and modifying the code.
-->
This pull request enhances the `FiatOnRampModal` and `CryptoCard` components with performance and design improvements, and refactors the `AccordionItem` component to follow best practices and fix errors. These changes aim to improve the user experience and code quality of the web app.

> _We're coding on the high seas, me hearties, yo ho ho_
> _We're fixing up the `CryptoCard` and the `FiatOnRampModal`_
> _We're refactoring the `AccordionItem`, making it neat and tidy_
> _We're heaving on the ropes, me lads and lasses, on the count of three_

### Walkthrough
*  Modify `CryptoCard` and `AccordionItem` components to use `maxHeight` instead of `height` for the transition property, to allow smooth expansion and collapse of the cards based on the content height ([link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-44ba08619785c9500e8a2cb2dd4f1711ac4cc76654e97e0f890392043c8ddcf9L34-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L63-R78), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L103-R104), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L129-R130))
*  Refactor `FiatOnRampModal` and `FiatOnRampModalButton` components to use `useMemo` for the button text, to avoid unnecessary re-rendering when the props do not change ([link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L20-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L149-R164))
*  Change `FiatOnRampModal` component to set the initial modal view to `CryptoFormView.Quote` instead of `CryptoFormView.Input`, to show the quote view by default, which is more user-friendly and consistent with the design ([link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-ec1dc15e7eaff4dffe6bf7d046f9b9f4c26a27a63089eee9af39f63659bb0905L193-R196))
*  Fix spelling errors and code style issues in `AccordionItem` component, such as `visiblity`, `toogleVisiblity`, `padding`, and empty lines ([link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L63-R78), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L129-R130), [link](https://github.com/pancakeswap/pancake-frontend/pull/8052/files?diff=unified&w=0#diff-42bfa28e2d5b0dcfa4819004d1638a06e694fdf9a2bf8a2dd0741431eefb1dc2L137))


