### PR TITLE
perf: Reduce split routing percentage on zksync era

### DIFF
--- a/packages/smart-router/evm/v3-router/constants/routeConfig.ts
+++ b/packages/smart-router/evm/v3-router/constants/routeConfig.ts
@@ -5,4 +5,7 @@ export const ROUTE_CONFIG_BY_CHAIN: { [key in ChainId]?: Partial<RouteConfig> } 
   [ChainId.POLYGON_ZKEVM]: {
     distributionPercent: 50,
   },
+  [ChainId.ZKSYNC]: {
+    distributionPercent: 20,
+  },
 }

--- a/packages/smart-router/evm/v3-router/functions/computeAllRoutes.ts
+++ b/packages/smart-router/evm/v3-router/functions/computeAllRoutes.ts
@@ -40,6 +40,10 @@ export function computeAllRoutes(input: Currency, output: Currency, candidatePoo
       }
 
       const currentTokenOut = getOutputCurrency(curPool, previousCurrencyOut)
+      if (currencyIn.wrapped.equals(currentTokenOut.wrapped)) {
+        // eslint-disable-next-line
+        continue
+      }
 
       currentRoute.push(curPool)
       poolsUsed[i] = true


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

copilot:all
