### PR TITLE
fix: permit2 structure type

### DIFF
--- a/packages/permit2-sdk/src/allowanceTransfer.ts
+++ b/packages/permit2-sdk/src/allowanceTransfer.ts
@@ -1,8 +1,9 @@
 import invariant from 'tiny-invariant'
 import { BigintIsh } from '@pancakeswap/sdk'
+import { Address, TypedData } from 'viem'
 import { MaxSigDeadline, MaxOrderedNonce, MaxAllowanceTransferAmount, MaxAllowanceExpiration } from './constants'
 import { permit2Domain } from './domain'
-import { TypedDataDomain, TypedDataField } from './utils/types'
+import { TypedDataDomain } from './utils/types'
 
 export interface PermitDetails {
   token: string
@@ -15,25 +16,24 @@ export interface PermitSingle {
   details: PermitDetails
   spender: string
   sigDeadline: BigintIsh
+  [key: string]: unknown
 }
 
 export interface PermitBatch {
   details: PermitDetails[]
   spender: string
   sigDeadline: BigintIsh
+  [key: string]: unknown
 }
 
-export type PermitSingleData = {
+type TypedStructData<TValue> = {
   domain: TypedDataDomain
-  types: Record<string, TypedDataField[]>
-  values: PermitSingle
+  types: TypedData
+  values: TValue
 }
 
-export type PermitBatchData = {
-  domain: TypedDataDomain
-  types: Record<string, TypedDataField[]>
-  values: PermitBatch
-}
+export type PermitSingleData = TypedStructData<PermitSingle>
+export type PermitBatchData = TypedStructData<PermitBatch>
 
 const PERMIT_DETAILS = [
   { name: 'token', type: 'address' },
@@ -75,7 +75,7 @@ export abstract class AllowanceTransfer {
   // for signing the given permit data
   public static getPermitData(
     permit: PermitSingle | PermitBatch,
-    permit2Address: string,
+    permit2Address: Address,
     chainId: number
   ): PermitSingleData | PermitBatchData {
     invariant(MaxSigDeadline >= BigInt(permit.sigDeadline), 'SIG_DEADLINE_OUT_OF_RANGE')

--- a/packages/permit2-sdk/src/domain.ts
+++ b/packages/permit2-sdk/src/domain.ts
@@ -1,8 +1,9 @@
-import { TypedDataDomain, TypedDataField } from './utils/types'
+import type { Address } from 'viem'
+import { TypedDataDomain, TypedDataParameter } from './utils/types'
 
 const PERMIT2_DOMAIN_NAME = 'Permit2'
 
-export function permit2Domain(permit2Address: string, chainId: number): TypedDataDomain {
+export function permit2Domain(permit2Address: Address, chainId: number): TypedDataDomain {
   return {
     name: PERMIT2_DOMAIN_NAME,
     chainId,
@@ -12,6 +13,6 @@ export function permit2Domain(permit2Address: string, chainId: number): TypedDat
 
 export type PermitData = {
   domain: TypedDataDomain
-  types: Record<string, TypedDataField[]>
+  types: Record<string, TypedDataParameter[]>
   values: any
 }

--- a/packages/permit2-sdk/src/signatureTransfer.ts
+++ b/packages/permit2-sdk/src/signatureTransfer.ts
@@ -1,13 +1,14 @@
 import invariant from 'tiny-invariant'
 import { BigintIsh } from '@pancakeswap/sdk'
+import { Address } from 'viem'
 import { permit2Domain } from './domain'
 import { MaxSigDeadline, MaxUnorderedNonce, MaxSignatureTransferAmount } from './constants'
-import { TypedDataDomain, TypedDataField } from './utils/types'
+import { TypedDataDomain, TypedDataParameter } from './utils/types'
 
 export interface Witness {
   witness: any
   witnessTypeName: string
-  witnessType: Record<string, TypedDataField[]>
+  witnessType: Record<string, TypedDataParameter[]>
 }
 
 export interface TokenPermissions {
@@ -31,13 +32,13 @@ export interface PermitBatchTransferFrom {
 
 export type PermitTransferFromData = {
   domain: TypedDataDomain
-  types: Record<string, TypedDataField[]>
+  types: Record<string, TypedDataParameter[]>
   values: PermitTransferFrom
 }
 
 export type PermitBatchTransferFromData = {
   domain: TypedDataDomain
-  types: Record<string, TypedDataField[]>
+  types: Record<string, TypedDataParameter[]>
   values: PermitBatchTransferFrom
 }
 
@@ -66,7 +67,7 @@ const PERMIT_BATCH_TRANSFER_FROM_TYPES = {
   TokenPermissions: TOKEN_PERMISSIONS,
 }
 
-function permitTransferFromWithWitnessType(witness: Witness): Record<string, TypedDataField[]> {
+function permitTransferFromWithWitnessType(witness: Witness): Record<string, TypedDataParameter[]> {
   return {
     PermitWitnessTransferFrom: [
       { name: 'permitted', type: 'TokenPermissions' },
@@ -80,7 +81,7 @@ function permitTransferFromWithWitnessType(witness: Witness): Record<string, Typ
   }
 }
 
-function permitBatchTransferFromWithWitnessType(witness: Witness): Record<string, TypedDataField[]> {
+function permitBatchTransferFromWithWitnessType(witness: Witness): Record<string, TypedDataParameter[]> {
   return {
     PermitBatchWitnessTransferFrom: [
       { name: 'permitted', type: 'TokenPermissions[]' },
@@ -109,7 +110,7 @@ export abstract class SignatureTransfer {
   // for signing the given permit data
   public static getPermitData(
     permit: PermitTransferFrom | PermitBatchTransferFrom,
-    permit2Address: string,
+    permit2Address: Address,
     chainId: number,
     witness?: Witness
   ): PermitTransferFromData | PermitBatchTransferFromData {

--- a/packages/permit2-sdk/src/utils/types.ts
+++ b/packages/permit2-sdk/src/utils/types.ts
@@ -1,13 +1,6 @@
 export type Bytes = ArrayLike<number>
-type BytesLike = string | Bytes
 
-export interface TypedDataDomain {
-  name?: string
-  version?: string
-  chainId?: number
-  verifyingContract?: string
-  salt?: BytesLike
-}
+export type { TypedDataDomain, TypedDataParameter } from 'viem'
 
 export interface TypedDataField {
   name: string

--- a/packages/permit2-sdk/tsup.config.ts
+++ b/packages/permit2-sdk/tsup.config.ts
@@ -11,9 +11,9 @@ export default defineConfig((options) => ({
   treeshake: true,
   splitting: true,
   onSuccess: async () => {
-    exec('tsc --emitDeclarationOnly --declaration', (err) => {
+    exec('tsc --emitDeclarationOnly --declaration', (err, stdout) => {
       if (err) {
-        console.error(err)
+        console.error(stdout)
         if (!options.watch) {
           process.exit(1)
         }

--- a/packages/universal-router-sdk/test/utils/permit.ts
+++ b/packages/universal-router-sdk/test/utils/permit.ts
@@ -35,6 +35,7 @@ export const signPermit = async (permit: PermitSingle, wallet: WalletClient, per
   const { domain, types, values } = AllowanceTransfer.getPermitData(permit, permit2Address, chainId)
 
   return wallet.signTypedData({
+    account: wallet.account!,
     domain,
     types,
     primaryType: 'PermitSingle',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8631802</samp>

### Summary
📦🐛🧹

<!--
1.  📦 - This emoji represents the changes related to importing and exporting types and packages, such as the `viem` package and the `Bytes` type.
2.  🐛 - This emoji represents the changes related to fixing the error handling of the `exec` callback in the `tsup.config.ts` file, which was logging the wrong object and causing confusion.
3.  🧹 - This emoji represents the changes related to refactoring and improving the type safety and readability of the permit2-sdk package, such as adding an index signature, using the `Address` type, and updating the data types.
-->
The pull request updates the permit2-sdk and universal-router-sdk packages to use the viem package for type definitions and signing functionality. This improves the type safety, readability, and compatibility of the code. The pull request also fixes a minor error logging issue in the tsup.config.ts file.

> _We're heaving on the `viem` package, boys and girls, on the count of three_
> _We're importing all the types we need, and exporting `Bytes` with glee_
> _We're logging out the `stdout` and signing permits with `account`_
> _We're improving type safety and consistency, that's what we're all about_

### Walkthrough
*  Refactor the permit2-sdk package to use the viem package for EIP-712 typed data signatures and utilities ([link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-47058b67741fc8b0e7c5c8d35d65bfe24e9585163ee2363de7017599f191a0eeL3-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-47058b67741fc8b0e7c5c8d35d65bfe24e9585163ee2363de7017599f191a0eeR19), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-47058b67741fc8b0e7c5c8d35d65bfe24e9585163ee2363de7017599f191a0eeL24-R36), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-47058b67741fc8b0e7c5c8d35d65bfe24e9585163ee2363de7017599f191a0eeL78-R78), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-fbc8c91a8549cb58c0c3dc07023976022ebb00afe04d9de50affe72d0ae29da3L1-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-fbc8c91a8549cb58c0c3dc07023976022ebb00afe04d9de50affe72d0ae29da3L15-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL3-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL34-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL40-R41), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL69-R70), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL83-R84), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-3eeca72a6e77d6ad503c6834a68d6a37522753aae4589a610e7bdabd021c4a2aL112-R113), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-1b024f0640ce234ebbbc8ed1ccb64af8b6a24bf1483073c3f9e48904103f32b4L2-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-5230bd47f017734f4049f00f3d64dc4af9886ce0e42df304bf0530deea7a9194R38))
*  Change the error handling of the `exec` callback in the `tsup.config.ts` file to log the `stdout` instead of the `err` object ([link](https://github.com/pancakeswap/pancake-frontend/pull/8067/files?diff=unified&w=0#diff-e30f89115039806b329873dd382cf63980c0306cb0d558c5d95adabbda769fe1L14-R16))


