### PR TITLE
feat: Move Eth finished Pools

### DIFF
--- a/packages/pools/src/constants/pools/1.ts
+++ b/packages/pools/src/constants/pools/1.ts
@@ -20,6 +20,15 @@ export const livePools: SerializedPool[] = [
     poolCategory: PoolCategory.CORE,
     tokenPerSecond: '0.00000271',
   },
+].map((p) => ({
+  ...p,
+  contractAddress: getAddress(p.contractAddress),
+  stakingToken: p.stakingToken.serialize,
+  earningToken: p.earningToken.serialize,
+}))
+
+// known finished pools
+export const finishedPools: SerializedPool[] = [
   {
     sousId: 7,
     stakingToken: ethereumTokens.cake,
@@ -36,15 +45,6 @@ export const livePools: SerializedPool[] = [
     poolCategory: PoolCategory.CORE,
     tokenPerSecond: '0.0005093',
   },
-].map((p) => ({
-  ...p,
-  contractAddress: getAddress(p.contractAddress),
-  stakingToken: p.stakingToken.serialize,
-  earningToken: p.earningToken.serialize,
-}))
-
-// known finished pools
-export const finishedPools: SerializedPool[] = [
   {
     sousId: 5,
     stakingToken: ethereumTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37fa95b</samp>

### Summary
🔄🏗️🗑️

<!--
1.  🔄 - This emoji represents the refactoring of the pool data fetching and caching logic, which involves changing the existing code to improve its structure, readability, or performance without altering its functionality or behavior.
2.  🏗️ - This emoji represents the use of the `getAddress` and `serialize` functions, which are utilities that help with building and manipulating pool addresses and data in a consistent and reliable way.
3.  🗑️ - This emoji represents the removal of unnecessary serialization of the `finishedPools` array, which is a cleanup action that reduces the amount of redundant or unused code.
-->
Refactor pool data fetching and caching logic for `activePools` and remove redundant serialization for `finishedPools` in `packages/pools/src/constants/pools/1.ts`.

> _Sing, O Muse, of the cunning refactorer_
> _Who tamed the pool data with his skill_
> _And made the activePools array slender_
> _By using `getAddress` and `serialize` at will_

### Walkthrough
*  Add contractAddress, stakingToken, and earningToken properties to each pool object in the activePools array by mapping the getAddress and serialize functions on the corresponding values ([link](https://github.com/pancakeswap/pancake-frontend/pull/8078/files?diff=unified&w=0#diff-cd952ff17505198e44ad083b28429fef4a2875f01f94a9e41ced215ec21040a0R23-R31))
* Remove the same mapping function from the finishedPools array to avoid unnecessary serialization ([link](https://github.com/pancakeswap/pancake-frontend/pull/8078/files?diff=unified&w=0#diff-cd952ff17505198e44ad083b28429fef4a2875f01f94a9e41ced215ec21040a0L39-L47))


