### PR TITLE
chore: sync develop

### DIFF
--- a/apps/web/src/components/AddToWallet/AddToWalletButton.tsx
+++ b/apps/web/src/components/AddToWallet/AddToWalletButton.tsx
@@ -20,9 +20,9 @@ export enum AddToWalletTextOptions {
 }
 
 export interface AddToWalletButtonProps {
-  tokenAddress: string
-  tokenSymbol: string
-  tokenDecimals: number
+  tokenAddress?: string
+  tokenSymbol?: string
+  tokenDecimals?: number
   tokenLogo?: string
   textOptions?: AddToWalletTextOptions
   marginTextBetweenLogo?: string
@@ -38,7 +38,7 @@ const Icons = {
   MetaMask: MetamaskIcon,
 }
 
-const getWalletText = (textOptions: AddToWalletTextOptions, tokenSymbol: string, t: any) => {
+const getWalletText = (textOptions: AddToWalletTextOptions, tokenSymbol: string | undefined, t: any) => {
   return (
     textOptions !== AddToWalletTextOptions.NO_TEXT &&
     (textOptions === AddToWalletTextOptions.TEXT
@@ -93,6 +93,7 @@ const AddToWalletButton: React.FC<AddToWalletButtonProps & ButtonProps> = ({
       {...props}
       onClick={() => {
         const image = tokenLogo ? (BAD_SRCS[tokenLogo] ? undefined : tokenLogo) : undefined
+        if (!tokenAddress || !tokenSymbol || !image) return
         connector.watchAsset?.({
           address: tokenAddress,
           symbol: tokenSymbol,

--- a/apps/web/src/state/swap/reducer.ts
+++ b/apps/web/src/state/swap/reducer.ts
@@ -97,12 +97,14 @@ const reducer = createReducer<SwapState>(initialState, (builder) =>
       state.recipient = recipient
     })
     .addCase(updatePairData, (state, { payload: { pairData, pairId, timeWindow } }) => {
-      if (!state.pairDataById[pairId]) {
+      if (!state.pairDataById) state.pairDataById = {}
+      if (!state.pairDataById?.[pairId]) {
         state.pairDataById[pairId] = {}
       }
       state.pairDataById[pairId][timeWindow] = pairData
     })
     .addCase(updateDerivedPairData, (state, { payload: { pairData, pairId, timeWindow } }) => {
+      if (!state.derivedPairDataById) state.derivedPairDataById = {}
       if (!state.derivedPairDataById[pairId]) {
         state.derivedPairDataById[pairId] = {}
       }

--- a/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
@@ -85,7 +85,7 @@ export function MMSwapCommitButton({
     swapCalls,
   )
   const [{ tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
-    tradeToConfirm: SmartRouterTrade<TradeType>
+    tradeToConfirm?: SmartRouterTrade<TradeType>
     attemptingTxn: boolean
     swapErrorMessage: string | undefined
     txHash: string | undefined

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
@@ -40,14 +40,14 @@ export const SwapModalFooter = memo(function SwapModalFooter({
   isRFQReady,
   currencyBalances,
 }: {
-  trade: SmartRouterTrade<TradeType> | null | undefined
+  trade?: SmartRouterTrade<TradeType>
   tradeType: TradeType
-  lpFee: CurrencyAmount<Currency>
+  lpFee?: CurrencyAmount<Currency>
   inputAmount: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>
-  priceImpact: Percent
+  priceImpact?: Percent
   slippageAdjustedAmounts: { [field in Field]?: CurrencyAmount<Currency> }
-  isEnoughInputBalance: boolean
+  isEnoughInputBalance?: boolean
   swapErrorMessage?: string | undefined
   disabledConfirm: boolean
   isMM?: boolean
@@ -72,7 +72,7 @@ export const SwapModalFooter = memo(function SwapModalFooter({
       return mmFormatExecutionPrice(trade, showInverted)
     }
 
-    const price = SmartRouter.getExecutionPrice(trade)
+    const price = SmartRouter.getExecutionPrice(trade) ?? undefined
     return formatExecutionPrice(price, inputAmount, outputAmount, showInverted)
   }, [inputAmount, isMM, outputAmount, trade, showInverted])
 

--- a/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
@@ -39,7 +39,7 @@ interface TransactionConfirmSwapContentProps {
   onAcceptChanges: () => void
   allowedSlippage: number
   onConfirm: () => void
-  recipient: string
+  recipient?: string | null
   currencyBalances: {
     INPUT?: CurrencyAmount<Currency>
     OUTPUT?: CurrencyAmount<Currency>
@@ -80,7 +80,7 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
       if (trade?.tradeType !== TradeType.EXACT_OUTPUT) return null
 
       const isInputBalanceExist = !!(currencyBalances && currencyBalances[Field.INPUT])
-      const isInputBalanceBNB = isInputBalanceExist && currencyBalances[Field.INPUT].currency.isNative
+      const isInputBalanceBNB = isInputBalanceExist && currencyBalances[Field.INPUT]?.currency.isNative
       const inputCurrencyAmount = isInputBalanceExist
         ? isInputBalanceBNB
           ? maxAmountSpend(currencyBalances[Field.INPUT])
@@ -99,11 +99,11 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
           outputAmount={trade.outputAmount}
           currencyBalances={currencyBalances}
           tradeType={trade.tradeType}
-          priceImpactWithoutFee={priceImpactWithoutFee}
+          priceImpactWithoutFee={priceImpactWithoutFee ?? undefined}
           allowedSlippage={isMM ? <MMSlippageTolerance /> : allowedSlippage}
           slippageAdjustedAmounts={slippageAdjustedAmounts}
-          isEnoughInputBalance={isEnoughInputBalance}
-          recipient={recipient}
+          isEnoughInputBalance={isEnoughInputBalance ?? undefined}
+          recipient={recipient ?? undefined}
           showAcceptChanges={showAcceptChanges}
           onAcceptChanges={onAcceptChanges}
         />
@@ -131,11 +131,11 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
           inputAmount={trade.inputAmount}
           outputAmount={trade.outputAmount}
           currencyBalances={currencyBalances}
-          lpFee={lpFeeAmount}
-          priceImpact={priceImpactWithoutFee}
+          lpFee={lpFeeAmount ?? undefined}
+          priceImpact={priceImpactWithoutFee ?? undefined}
           disabledConfirm={showAcceptChanges}
           slippageAdjustedAmounts={slippageAdjustedAmounts}
-          isEnoughInputBalance={isEnoughInputBalance}
+          isEnoughInputBalance={isEnoughInputBalance ?? undefined}
           onConfirm={onConfirm}
         />
       ) : null

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
@@ -41,7 +41,7 @@ interface ConfirmSwapModalProps {
   txHash?: string
   approval: ApprovalState
   allowance?: Allowance
-  swapErrorMessage?: string
+  swapErrorMessage?: string | boolean
   showApproveFlow: boolean
   currentAllowance?: CurrencyAmount<Currency>
   confirmModalState: ConfirmModalState
@@ -106,10 +106,10 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
         <ApproveModalContent
           title={
             approval === ApprovalState.NOT_APPROVED || approval === ApprovalState.PENDING
-              ? t('Approve %symbol%', { symbol: trade?.inputAmount?.currency?.symbol })
-              : allowance.state === AllowanceState.REQUIRED
-              ? t('Permit %symbol%', { symbol: trade?.inputAmount?.currency?.symbol })
-              : t('Enable spending %symbol%', { symbol: trade?.inputAmount?.currency?.symbol })
+              ? t('Approve %symbol%', { symbol: `${trade?.inputAmount?.currency?.symbol}` })
+              : allowance?.state === AllowanceState.REQUIRED
+              ? t('Permit %symbol%', { symbol: `${trade?.inputAmount?.currency?.symbol}` })
+              : t('Enable spending %symbol%', { symbol: `${trade?.inputAmount?.currency?.symbol}` })
           }
           isMM={isMM}
           isBonus={isBonus}

--- a/apps/web/src/views/Swap/V3Swap/hooks/useConfirmModalState.tsx
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useConfirmModalState.tsx
@@ -9,8 +9,8 @@ import usePrevious from 'views/V3Info/hooks/usePrevious'
 import { usePublicClient } from 'wagmi'
 
 interface UseConfirmModalStateProps {
-  txHash: string
-  chainId: ChainId
+  txHash?: string
+  chainId?: ChainId
   approval: ApprovalState
   approvalToken: Currency
   currentAllowance: CurrencyAmount<Currency>

--- a/apps/web/src/views/Swap/components/SwapModalHeader.tsx
+++ b/apps/web/src/views/Swap/components/SwapModalHeader.tsx
@@ -32,8 +32,8 @@ export default function SwapModalHeader({
   tradeType: TradeType
   priceImpactWithoutFee?: Percent
   slippageAdjustedAmounts: { [field in Field]?: CurrencyAmount<Currency> }
-  isEnoughInputBalance: boolean
-  recipient: string | null
+  isEnoughInputBalance?: boolean
+  recipient?: string
   showAcceptChanges: boolean
   onAcceptChanges: () => void
   allowedSlippage: number | ReactElement
@@ -58,11 +58,11 @@ export default function SwapModalHeader({
   const tradeInfoText = useMemo(() => {
     return tradeType === TradeType.EXACT_INPUT
       ? t('Output is estimated. You will receive at least %amount% %symbol% or the transaction will revert.', {
-          amount,
+          amount: `${amount}`,
           symbol,
         })
       : t('Input is estimated. You will sell at most %amount% %symbol% or the transaction will revert.', {
-          amount,
+          amount: `${amount}`,
           symbol,
         })
   }, [t, tradeType, amount, symbol])

--- a/packages/widgets-internal/swap/ApproveModalContent.tsx
+++ b/packages/widgets-internal/swap/ApproveModalContent.tsx
@@ -3,7 +3,7 @@ import { Spinner, Text, Box, Flex, TooltipText, AutoColumn, ColumnCenter, useToo
 
 interface ApproveModalContentProps {
   title: string;
-  isMM: boolean;
+  isMM?: boolean;
   isBonus: boolean;
 }
 

--- a/packages/widgets-internal/swap/SwapPendingModalContent.tsx
+++ b/packages/widgets-internal/swap/SwapPendingModalContent.tsx
@@ -6,8 +6,8 @@ import TokenTransferInfo from "./TokenTransferInfo";
 interface SwapPendingModalContentProps {
   title: string;
   showIcon?: boolean;
-  currencyA: Currency;
-  currencyB: Currency;
+  currencyA?: Currency;
+  currencyB?: Currency;
   amountA: string;
   amountB: string;
   children?: ReactNode;

--- a/packages/widgets-internal/swap/TokenTransferInfo.tsx
+++ b/packages/widgets-internal/swap/TokenTransferInfo.tsx
@@ -3,12 +3,12 @@ import { Text, Box, Flex, ArrowForwardIcon } from "@pancakeswap/uikit";
 import { CurrencyLogo } from "../components/CurrencyLogo";
 
 interface TokenTransferInfoProps {
-  symbolA: string;
-  symbolB: string;
+  symbolA?: string;
+  symbolB?: string;
   amountA: string;
   amountB: string;
-  currencyA: Currency;
-  currencyB: Currency;
+  currencyA?: Currency;
+  currencyB?: Currency;
 }
 
 const TokenTransferInfo: React.FC<TokenTransferInfoProps> = ({


### PR DESCRIPTION

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a07dfd9</samp>

### Summary
🛠️🔄🤝

<!--
1.  🛠️ - This emoji represents fixing or improving something, and can be used for the changes that make the components more robust, flexible, and error-free.
2.  🔄 - This emoji represents swapping or exchanging something, and can be used for the changes that relate to the swap feature and the trade data.
3.  🤝 - This emoji represents confirming or agreeing on something, and can be used for the changes that relate to the confirmation and approval modals.
-->
This pull request improves the error handling and user experience of the swap feature on PancakeSwap, especially for the V3 version and the Market Maker feature. It makes some props and variables optional and adds fallback values or checks for undefined values in various components and state reducers. It affects files in the `apps/web/src` and `packages/widgets-internal` directories.

> _Swap tokens with ease_
> _`undefined` values handled_
> _Autumn leaves no bugs_

### Walkthrough
*  Make some props of `AddToWalletButton`, `SwapModalHeader`, `SwapModalFooter`, `TransactionConfirmSwapContent`, `ConfirmSwapModal`, `ApproveModalContent`, `SwapPendingModalContent` and `TokenTransferInfo` components optional to handle undefined values for some tokens or scenarios ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-863e9a19b5068c533e2b48e6ce5856b94d06376ad682d1e8159b700399ea1073L23-R25),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-863e9a19b5068c533e2b48e6ce5856b94d06376ad682d1e8159b700399ea1073L41-R41),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-863e9a19b5068c533e2b48e6ce5856b94d06376ad682d1e8159b700399ea1073R96),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aL35-R36),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aL61-R65),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-f865e19382202f261a05a2df67d7a41be905d0ee836426ff9bef86bf54c39578L43-R50),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-f865e19382202f261a05a2df67d7a41be905d0ee836426ff9bef86bf54c39578L75-R75),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7L42-R42),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7L83-R83),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7L102-R106),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7L134-R138),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-c83e4eec2c74b991702f46350b3eee8c029e14df4a79fae45f480542a806111dL44-R44),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-c83e4eec2c74b991702f46350b3eee8c029e14df4a79fae45f480542a806111dL109-R112),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-44741df1af3f8a528061cf8d254f354b0d418c3c2014891d6f2e3a5993c0d0eaL6-R6),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-338521a08a252903b2fde45bd5b0aaa0eac6aa93321e40813204fe970fe75fd4L9-R10),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-39c44ceef61efc05c15826c3f0795e5af9536305a0b99a3b43767f40c4ea4e21L6-R11))
* Add checks to the `reducer` function of the `swap` state to initialize `pairDataById` and `derivedPairDataById` objects if they are undefined for some pairs ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-fd0bbf93c819d7f0ade73211a30389bc8e2f17fb05cdf2a11ea610154783b308L100-R101),[link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-fd0bbf93c819d7f0ade73211a30389bc8e2f17fb05cdf2a11ea610154783b308R107))
* Change the `tradeToConfirm` state of the `MMSwapCommitButton` component to be optional, as it may be undefined if the user has not selected a trade yet ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-64cce548f87cb10257d780d98563d8c44d26c763287384a63492bc1dc27e56ceL88-R88))
* Change the `isInputBalanceBNB` variable in the `TransactionConfirmSwapContentComp` function to use optional chaining to access the `currency` property of the input balance, as it may be undefined for some tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-9a254471ee62257b0560ebbc531b04f23f5f8b194345a8963e7781fb73b842e7L83-R83))
* Change the `price` variable in the `SwapModalFooter` component to use a fallback value of `undefined` if the trade is undefined, as the `getExecutionPrice` function may return `null` in that case ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-f865e19382202f261a05a2df67d7a41be905d0ee836426ff9bef86bf54c39578L75-R75))
* Change the `swapErrorMessage` prop of the `ConfirmSwapModalProps` interface to accept a boolean value as well, as it may be set to `false` by the `useSwapCallback` hook to indicate that there is no error ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-c83e4eec2c74b991702f46350b3eee8c029e14df4a79fae45f480542a806111dL44-R44))
* Change the `title` prop of the `ApproveModalContent` component to use template literals to interpolate the token symbol, as it may be undefined for some tokens. Also, change the `allowance` variable to use optional chaining to access the state property, as it may be undefined for some tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-c83e4eec2c74b991702f46350b3eee8c029e14df4a79fae45f480542a806111dL109-R112))
* Make the `txHash` and `chainId` props of the `UseConfirmModalStateProps` interface optional, as they may be undefined if the user has not initiated a transaction yet ([link](https://github.com/pancakeswap/pancake-frontend/pull/8086/files?diff=unified&w=0#diff-38e6b244fe249e234c4eb1c94ae5e86c26718c41bbc9ab3498e4deeeed32c70dL12-R13))


