### PR TITLE
fix: Wrong token address being used for price query

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -306,7 +306,7 @@ export const useFetchPairPricesV3 = ({
   const { data: protocol1 } = useSWRImmutable(
     token1Address && chainId && ['protocol', token1Address, chainId],
     async () => {
-      return getTokenBestTvlProtocol(token0Address, chainId)
+      return getTokenBestTvlProtocol(token1Address, chainId)
     },
   )
 


### PR DESCRIPTION
seems like a tiny copy mistake. But can cause price charts not working when input and output tokens are only available on different subgraph instances (v2/v2/stable) for pricing.