### PR TITLE
fix: Incorrect date time on simple staking

### DIFF
--- a/apps/web/src/utils/formatTime.ts
+++ b/apps/web/src/utils/formatTime.ts
@@ -3,3 +3,7 @@ import dayjs from 'dayjs'
 export function formatTime(time: number | Date) {
   return dayjs(time).format('MMM D, YYYY HH:mm')
 }
+
+export function formatUnixTime(time: number) {
+  return formatTime(dayjs.unix(time).toDate())
+}

--- a/apps/web/src/views/FixedStaking/components/ClaimModal.tsx
+++ b/apps/web/src/views/FixedStaking/components/ClaimModal.tsx
@@ -3,7 +3,7 @@ import { LightCard } from 'components/Card'
 import { useTranslation } from '@pancakeswap/localization'
 import { CurrencyAmount, Percent, Token } from '@pancakeswap/swap-sdk-core'
 import { ReactNode, useMemo, useState } from 'react'
-import { formatTime } from 'utils/formatTime'
+import { formatUnixTime } from 'utils/formatTime'
 
 import { UnstakeEndedModal } from './UnstakeModal'
 import { HarvestModal } from './HarvestModal'
@@ -87,7 +87,7 @@ export function ClaimModal({
 
   const poolEnded = unlockTime >= poolEndDay * 86400 + 43200
 
-  const unlockTimeFormat = formatTime(unlockTime)
+  const unlockTimeFormat = formatUnixTime(unlockTime)
 
   return (
     <>
@@ -114,7 +114,7 @@ export function ClaimModal({
             <Modal
               title={<ModalTitle tokenTitle={token.symbol} token={token} lockPeriod={lockPeriod} />}
               width={['100%', '100%', '420px']}
-              maxWidth={['100%', , '420px']}
+              maxWidth={['100%', '', '420px']}
             >
               <PreTitle color="textSubtle">{t('Overview')}</PreTitle>
               <LightCard mb="16px">

--- a/apps/web/src/views/FixedStaking/components/FixedStakingOverview.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingOverview.tsx
@@ -71,7 +71,7 @@ export default function FixedStakingOverview({
 
   const { projectedReturnAmount } = useCalculateProjectedReturnAmount({
     amountDeposit: stakeAmount.add(safeAlreadyStakedAmount),
-    lastDayAction: safeAlreadyStakedAmount.greaterThan(0) && stakeAmount.equalTo(0) ? lastDayAction : currentDay,
+    lastDayAction: (safeAlreadyStakedAmount.greaterThan(0) && stakeAmount.equalTo(0) ? lastDayAction : currentDay) || 0,
     lockPeriod: lockPeriod || 0,
     apr,
     poolEndDay,

--- a/apps/web/src/views/FixedStaking/components/FixedStakingOverview.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingOverview.tsx
@@ -5,7 +5,7 @@ import { LightGreyCard } from 'components/Card'
 
 import { ReactNode, useMemo } from 'react'
 import TextRow from 'views/Pools/components/LockedPool/Common/Overview/TextRow'
-import { formatTime } from 'utils/formatTime'
+import { formatUnixTime } from 'utils/formatTime'
 
 import { CurrencyAmount, Percent, Token } from '@pancakeswap/swap-sdk-core'
 import { AmountWithUSDSub } from './AmountWithUSDSub'
@@ -128,7 +128,11 @@ export default function FixedStakingOverview({
           {t('Stake Period Ends')}
         </Text>
         <Text color={safeAlreadyStakedAmount.greaterThan(0) ? 'failure' : undefined} bold>
-          {unlockTime ? formatTime(unlockTime) : <StakedLimitEndOn lockPeriod={lockPeriod} poolEndDay={poolEndDay} />}
+          {unlockTime ? (
+            formatUnixTime(unlockTime)
+          ) : (
+            <StakedLimitEndOn lockPeriod={lockPeriod} poolEndDay={poolEndDay} />
+          )}
         </Text>
       </Flex>
       <Flex alignItems="baseline" justifyContent="space-between">

--- a/apps/web/src/views/FixedStaking/components/StakedLimitEndOn.tsx
+++ b/apps/web/src/views/FixedStaking/components/StakedLimitEndOn.tsx
@@ -1,8 +1,8 @@
-import { formatTime } from 'utils/formatTime'
+import { formatUnixTime } from 'utils/formatTime'
 
 import { useCurrentDay } from '../hooks/useStakedPools'
 
-export function StakedLimitEndOn({ lockPeriod, poolEndDay }: { lockPeriod: number; poolEndDay: number }) {
+export function StakedLimitEndOn({ lockPeriod, poolEndDay }: { lockPeriod?: number; poolEndDay?: number }) {
   const lastDayAction = useCurrentDay()
 
   /**
@@ -13,11 +13,15 @@ export function StakedLimitEndOn({ lockPeriod, poolEndDay }: { lockPeriod: numbe
         : info.userInfo.lastDayAction * 86400 + 43200;
    */
 
+  if (!lockPeriod || !poolEndDay) {
+    return null
+  }
+
   const lockEndDay = lastDayAction + lockPeriod
 
   const exceedPoolEndDay = lockEndDay > poolEndDay
 
   const endTime = exceedPoolEndDay ? poolEndDay : lockEndDay
 
-  return <>{formatTime(endTime * 86400 + 43200)}</>
+  return <>{formatUnixTime(endTime * 86400 + 43200)}</>
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b2f09b</samp>

### Summary
🕒🐛🧹

<!--
1.  🕒 - This emoji represents the addition of the `formatUnixTime` function and the use of it in various components to format the unlock time of the staked tokens. It also conveys the idea of time and date, which are relevant to the function's purpose.
2. 🐛 - This emoji represents the fix of a minor typo in the modal style and the improved error handling of the `StakedLimitEndOn` component. It also conveys the idea of bug fixing and code quality.
3. 🧹 - This emoji represents the improved code readability with parentheses and the removal of unnecessary imports and comments. It also conveys the idea of cleaning and tidying up the code.
-->
Added a new utility function `formatUnixTime` to format unix timestamps for fixed staking. Updated several components to use this function and improved the UI and code quality of the fixed staking feature.

> _Oh, we're the coders of the sea, and we work with skill and glee_
> _We format the time with `dayjs` and `formatUnixTime`_
> _We fix the typos and the bugs, and we handle undefined props_
> _We heave away and pull the code, on the count of three_

### Walkthrough
*  Add a new function `formatUnixTime` to convert a unix timestamp to a human-readable date and time string using `dayjs` and `formatTime` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-925c4df24d5549b1a92fbb1f832460245065743bb551226bfa1131f062d91902R6-R9))
* Replace the import and usage of `formatTime` with `formatUnixTime` in `ClaimModal.tsx`, `FixedStakingOverview.tsx`, and `StakedLimitEndOn.tsx` to format the unlock time and end time of the staked tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-c547e3f232ba92d9b48daeab14a844ca60afe0b53eed2439fc9a8996dd34d0e8L6-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-c547e3f232ba92d9b48daeab14a844ca60afe0b53eed2439fc9a8996dd34d0e8L90-R90), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-6007006c13e6fc6f63c297a1455d4cdf7fdd3fed65c102954d04da1fd96741aaL8-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-6007006c13e6fc6f63c297a1455d4cdf7fdd3fed65c102954d04da1fd96741aaL131-R135), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-5e6d49c12862071bb477283bd26adfc99b4814d7a521d393b44fda97a89471c0L1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-5e6d49c12862071bb477283bd26adfc99b4814d7a521d393b44fda97a89471c0L22-R26))
* Fix a typo in the `maxWidth` prop of the `Modal` component in `ClaimModal.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-c547e3f232ba92d9b48daeab14a844ca60afe0b53eed2439fc9a8996dd34d0e8L117-R117))
* Make the `lockPeriod` and `poolEndDay` props optional and add a conditional return statement to handle the case when they are undefined in `StakedLimitEndOn.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-5e6d49c12862071bb477283bd26adfc99b4814d7a521d393b44fda97a89471c0L1-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8099/files?diff=unified&w=0#diff-5e6d49c12862071bb477283bd26adfc99b4814d7a521d393b44fda97a89471c0R16-R19))


