### PR TITLE
fix: Unix timestamp issues

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -996,7 +996,7 @@ function PositionHistoryRow({
 
   const isPlus = type !== 'burn'
 
-  const date = useMemo(() => dayjs(+positionTx.timestamp * 1_000), [positionTx.timestamp])
+  const date = useMemo(() => dayjs.unix(+positionTx.timestamp), [positionTx.timestamp])
   const mobileDate = useMemo(() => isMobile && date.format('YYYY/MM/DD'), [isMobile, date])
   const mobileTime = useMemo(() => isMobile && date.format('HH:mm:ss'), [isMobile, date])
   const desktopDate = useMemo(() => !isMobile && date.toDate().toLocaleString(), [isMobile, date])

--- a/apps/web/src/pages/swap.tsx
+++ b/apps/web/src/pages/swap.tsx
@@ -2,8 +2,8 @@ import { CHAIN_IDS } from 'utils/wagmi'
 
 import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 
+import { SwapFeaturesProvider } from 'views/Swap/SwapFeaturesContext'
 import Swap from '../views/Swap'
-import { SwapFeaturesProvider } from '../views/Swap/SwapFeaturesContext'
 
 const SwapPage = () => {
   return (

--- a/apps/web/src/utils/getNow.ts
+++ b/apps/web/src/utils/getNow.ts
@@ -1,1 +1,0 @@
-export const getNow = () => Math.floor(Date.now() / 1000)

--- a/apps/web/src/utils/getNowInSeconds.ts
+++ b/apps/web/src/utils/getNowInSeconds.ts
@@ -1,0 +1,1 @@
+export const getNowInSeconds = () => Math.floor(Date.now() / 1000)

--- a/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionProgress.tsx
+++ b/apps/web/src/views/FarmAuction/components/AuctionLeaderboard/AuctionProgress.tsx
@@ -11,9 +11,8 @@ const AuctionProgress: React.FC<React.PropsWithChildren<{ auction: Auction }>> =
       if (auction.status === AuctionStatus.ToBeAnnounced || auction.status === AuctionStatus.Pending) {
         return 0
       }
-      const now = dayjs()
       const auctionDuration = dayjs(auction.endDate).diff(dayjs(auction.startDate), 'seconds')
-      const secondsPassed = now.diff(dayjs(auction.startDate), 'seconds')
+      const secondsPassed = dayjs().diff(dayjs(auction.startDate), 'seconds')
       const percentagePassed = (secondsPassed * 100) / auctionDuration
       return percentagePassed < 100 ? percentagePassed : 100
     },

--- a/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
+++ b/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
@@ -115,7 +115,7 @@ const Info: React.FC<React.PropsWithChildren<InfoProps>> = ({ poolId, data, fetc
           {cliff === 0 ? t('Vesting Start') : t('Cliff')}
         </Text>
         <Text fontSize="12px" color="textSubtle">
-          {dayjs.unix(timeCliff).format('MM/DD/YYYY HH:mm')}
+          {dayjs(timeCliff).format('MM/DD/YYYY HH:mm')}
         </Text>
       </Flex>
       <Flex justifyContent="space-between">
@@ -123,7 +123,7 @@ const Info: React.FC<React.PropsWithChildren<InfoProps>> = ({ poolId, data, fetc
           {t('Vesting end')}
         </Text>
         <Text fontSize="12px" color="textSubtle">
-          {dayjs.unix(timeVestingEnd).format('MM/DD/YYYY HH:mm')}
+          {dayjs(timeVestingEnd).format('MM/DD/YYYY HH:mm')}
         </Text>
       </Flex>
       <WhiteCard>

--- a/apps/web/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/LiveRoundCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 import { Card, CardBody, Flex, PlayCircleOutlineIcon, Text, useTooltip } from '@pancakeswap/uikit'
-import { getNow } from 'utils/getNow'
+import { getNowInSeconds } from 'utils/getNowInSeconds'
 import { useTranslation } from '@pancakeswap/localization'
 import { NodeRound, NodeLedger, BetPosition } from 'state/types'
 import { useGetBufferSeconds } from 'state/predictions/hooks'
@@ -47,7 +47,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
   const isHouse = useMemo(() => {
-    const secondsToClose = closeTimestamp ? closeTimestamp - getNow() : 0
+    const secondsToClose = closeTimestamp ? closeTimestamp - getNowInSeconds() : 0
     return lockPrice && price === lockPrice && secondsToClose <= SHOW_HOUSE_BEFORE_SECONDS_TO_CLOSE
   }, [closeTimestamp, lockPrice, price])
 
@@ -63,7 +63,7 @@ const LiveRoundCard: React.FC<React.PropsWithChildren<LiveRoundCardProps>> = ({
   })
 
   useEffect(() => {
-    const secondsToClose = closeTimestamp ? closeTimestamp - getNow() : 0
+    const secondsToClose = closeTimestamp ? closeTimestamp - getNowInSeconds() : 0
     if (secondsToClose > 0) {
       const refreshPriceTimeout = setTimeout(() => {
         refresh()

--- a/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -17,7 +17,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { fetchLedgerData } from 'state/predictions'
 import { ROUND_BUFFER } from 'state/predictions/config'
 import { BetPosition, NodeLedger, NodeRound } from 'state/types'
-import { getNow } from 'utils/getNow'
+import { getNowInSeconds } from 'utils/getNowInSeconds'
 import { useConfig } from 'views/Predictions/context/ConfigProvider'
 import { formatTokenv2 } from '../../helpers'
 import CardFlip from '../CardFlip'
@@ -86,7 +86,7 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
   )
 
   useEffect(() => {
-    const secondsToLock = lockTimestamp ? lockTimestamp - getNow() : 0
+    const secondsToLock = lockTimestamp ? lockTimestamp - getNowInSeconds() : 0
     if (secondsToLock > 0) {
       const setIsBufferPhaseTimeout = setTimeout(() => {
         setIsBufferPhase(true)

--- a/apps/web/src/views/Predictions/hooks/useCountdown.ts
+++ b/apps/web/src/views/Predictions/hooks/useCountdown.ts
@@ -1,10 +1,10 @@
-import { getNow } from 'utils/getNow'
+import { getNowInSeconds } from 'utils/getNowInSeconds'
 import { accurateTimer } from 'utils/accurateTimer'
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { useIsWindowVisible } from '@pancakeswap/hooks'
 
 const getSecondsRemainingToNow = (timestamp: number) => {
-  const now = getNow()
+  const now = getNowInSeconds()
   return Number.isFinite(timestamp) && timestamp > now ? timestamp - now : 0
 }
 

--- a/packages/uikit/src/widgets/Ifo/IfoProgressStepper.tsx
+++ b/packages/uikit/src/widgets/Ifo/IfoProgressStepper.tsx
@@ -64,7 +64,7 @@ const IfoProgressStepper: React.FC<React.PropsWithChildren<IfoProgressStepperPro
     <Flex>
       {steps.map((step, index: number) => {
         const isPastSpacer = index < activeStepIndex;
-        const dateText = step.timeStamp === 0 ? t("Now") : dayjs.unix(step.timeStamp).format("MM/DD/YYYY HH:mm");
+        const dateText = step.timeStamp === 0 ? t("Now") : dayjs(step.timeStamp).format("MM/DD/YYYY HH:mm");
 
         return (
           <Fragment key={step.key}>

--- a/packages/utils/user/phishingBanner.ts
+++ b/packages/utils/user/phishingBanner.ts
@@ -7,7 +7,7 @@ const phishingBannerAtom = atomWithStorage<number>('pcs:phishing-banner', 0)
 const hidePhishingBannerAtom = atom(
   (get) => {
     const now = dayjs()
-    const last = dayjs.unix(get(phishingBannerAtom))
+    const last = dayjs(get(phishingBannerAtom))
     const notPreview = process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview'
     return last ? now.diff(last, 'days', true) >= 1 && notPreview : notPreview
   },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b16a49</samp>

### Summary
🕒🛠️🐛

<!--
1.  🕒 - This emoji represents the main theme of the changes, which is fixing and improving the date and time display and calculation across various components.
2.  🛠️ - This emoji represents the secondary theme of the changes, which is refactoring and simplifying the code by using a new utility function and removing unnecessary variables.
3.  🐛 - This emoji represents the outcome of the changes, which is fixing some bugs and errors that affected the user interface and experience.
-->
Refactored and fixed date and time display issues in various components and utils by using `dayjs` and `dayjs.unix` correctly. Added a new utility function `getNowInSeconds` to simplify getting the current time in seconds. Removed an unused utility function `getNow`. Improved import order in `swap.tsx`.

> _The subgraph gives timestamps in seconds_
> _But `dayjs` expects milliseconds_
> _So we fixed the display_
> _With `dayjs.unix` or `dayjs`_
> _And added a function for convenience_

### Walkthrough
*  Fix incorrect date and time display for position history, vesting period, IFO progress, and phishing banner by using `dayjs` instead of `dayjs.unix` or vice versa to parse timestamps in milliseconds or seconds ([link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL999-R999), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-eba34d6766cd2b3114be012cd43036123731ce4583812b7d3fb019a071ccd292L118-R118), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-eba34d6766cd2b3114be012cd43036123731ce4583812b7d3fb019a071ccd292L126-R126), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-dfc955acb2dd1af9b0e7cf7c7355d6ad1fa8ff6af7a205de414f8b952f6593bdL67-R67), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-e2ccd4ac57051b2e294ecb268e17770ca768d49bb0928ffe8e505fa4164184f8L10-R10))
* Add `getNowInSeconds` utility function to return the current time in seconds and use it instead of `getNow` in components and hooks that depend on the time difference in seconds between the current time and a given timestamp ([link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-f996830bb05a6501896a4bd9535fb63c567ed46eec14eee18e5d45c00b65151bR1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-7a3c8eb618f6b7a5aae797d9ea6c33a4ea7fbd7423e84dc3f7b0e5433dab0553L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-7a3c8eb618f6b7a5aae797d9ea6c33a4ea7fbd7423e84dc3f7b0e5433dab0553L50-R50), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-7a3c8eb618f6b7a5aae797d9ea6c33a4ea7fbd7423e84dc3f7b0e5433dab0553L66-R66), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-81a36b5893d166d431aec8d8257f7049441dd870210dc74269ca3a68376edf33L20-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-81a36b5893d166d431aec8d8257f7049441dd870210dc74269ca3a68376edf33L89-R89), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-ea452a3a469a0af051142b937facba796b234f080cd56366a6d80ae1c9651357L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-ea452a3a469a0af051142b937facba796b234f080cd56366a6d80ae1c9651357L7-R7))
* Simplify `AuctionProgress` component by removing unnecessary `now` variable and using `dayjs()` directly to get the current time in seconds ([link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-8c7012d9db27e9bbe024dc89eb6adfdd2dafd5fb6bd3113b7d0b53ab1d3d1db0L14-R15))
* Swap import order of `SwapFeaturesProvider` and `Swap` in `swap.tsx` to match alphabetical order and convention ([link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-3fd7c8e09e38b86dbe850c10c87c1fcdf3e81b86864bafee265a52e3b7f51968L5-R6))
* Delete unused `getNow` utility function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8101/files?diff=unified&w=0#diff-0ea7f17607eec457792d3dc34eedb852382777694084f1877b0460bcd74888e1))


