### PR TITLE
fix: Blog similar articles item width

### DIFF
--- a/apps/blog/components/Article/SingleArticle/SimilarArticles.tsx
+++ b/apps/blog/components/Article/SingleArticle/SimilarArticles.tsx
@@ -9,6 +9,7 @@ import MoreButton from 'components/MoreButton'
 import useSWR from 'swr'
 import { ArticleDataType } from 'utils/transformArticle'
 import 'swiper/css/bundle'
+import dynamic from 'next/dynamic'
 
 const SimilarArticles = () => {
   const { t } = useTranslation()
@@ -67,4 +68,6 @@ const SimilarArticles = () => {
   )
 }
 
-export default SimilarArticles
+export default dynamic(() => Promise.resolve(SimilarArticles), {
+  ssr: false,
+})

--- a/apps/blog/components/ChefsChoice/index.tsx
+++ b/apps/blog/components/ChefsChoice/index.tsx
@@ -9,6 +9,7 @@ import ArticleView from 'components/Article/ArticleView'
 import useSWR from 'swr'
 import { ArticleDataType } from 'utils/transformArticle'
 import 'swiper/css/bundle'
+import dynamic from 'next/dynamic'
 
 const StyledChefsChoiceContainer = styled(Flex)`
   margin: 61px auto 48px auto;
@@ -70,4 +71,6 @@ const ChefsChoice = () => {
   )
 }
 
-export default ChefsChoice
+export default dynamic(() => Promise.resolve(ChefsChoice), {
+  ssr: false,
+})

--- a/apps/blog/pages/api/articles.tsx
+++ b/apps/blog/pages/api/articles.tsx
@@ -35,7 +35,7 @@ export const articles = async (req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(requestUrl, mergedOptions)
 
   if (!response.ok) {
-    return res.status(400).json({ message: 'An error occured please try again' })
+    return res.status(400).json({ message: 'An error occurred please try again' })
   }
 
   const data = await response.json()

--- a/apps/blog/pages/articles/[slug].tsx
+++ b/apps/blog/pages/articles/[slug].tsx
@@ -90,7 +90,7 @@ const ArticlePage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
   const { title, description, imgUrl } = fallback['/article']
 
   return (
-    <div>
+    <>
       <PageMeta title={title} description={description} imgUrl={imgUrl} />
       <SWRConfig value={{ fallback }}>
         <Box>
@@ -103,7 +103,7 @@ const ArticlePage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
           )}
         </Box>
       </SWRConfig>
-    </div>
+    </>
   )
 }
 

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -19,16 +19,16 @@ import Script from 'next/script'
 import { Fragment } from 'react'
 import { DefaultSeo } from 'next-seo'
 import { PageMeta } from 'components/Layout/Page'
+import { SentryErrorBoundary } from 'components/ErrorBoundary'
 import { PersistGate } from 'redux-persist/integration/react'
 import { persistor, useStore } from 'state'
 import { usePollBlockNumber } from 'state/block/hooks'
+import { ThirdYearBirthdayCake } from 'views/Home/components/ThirdYearBirthdayCake'
 import { Blocklist, Updaters } from '..'
 import { SEO } from '../../next-seo.config'
-import { SentryErrorBoundary } from '../components/ErrorBoundary'
 import Menu from '../components/Menu'
 import Providers from '../Providers'
 import GlobalStyle from '../style/Global'
-import { ThirdYearBirthdayCake } from '../views/Home/components/ThirdYearBirthdayCake'
 
 const EasterEgg = dynamic(() => import('components/EasterEgg'), { ssr: false })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 30d5361</samp>

### Summary
📱🌟🗑️

<!--
1.  📱 - This emoji represents responsiveness, as the change makes the carousel adapt to different device widths and orientations.
2.  🌟 - This emoji represents improvement, as the change enhances the appearance and usability of the similar articles section.
3.  🗑️ - This emoji represents removal, as the change deletes a prop that is no longer needed.
-->
Removed `slidesPerView` prop from `Swiper` component in `SimilarArticles.tsx` to improve responsiveness of similar articles carousel.

> _`Swiper` adapts_
> _No more `slidesPerView` prop_
> _Autumn leaves vary_

### Walkthrough
* Remove `slidesPerView` prop from `Swiper` component to improve responsiveness of similar articles section ([link](https://github.com/pancakeswap/pancake-frontend/pull/8104/files?diff=unified&w=0#diff-083a28cd9147f41f63134a2d8a062f5fc2699d5bf413b5d0c58682fb2f81698dL25))


