### PR TITLE
fix: Fail to execute update lp apr script

### DIFF
--- a/scripts/updateLPsAPR.ts
+++ b/scripts/updateLPsAPR.ts
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js'
 import chunk from 'lodash/chunk'
 import _toLower from 'lodash/toLower'
 import dayjs from 'dayjs'
-import { ChainId } from '@pancakeswap/chains'
+import { ChainId, getChainName } from '@pancakeswap/chains'
 import { SerializedFarmConfig } from '@pancakeswap/farms'
 import { BlockResponse } from '../apps/web/src/components/SubgraphHealthIndicator'
 import { BLOCKS_CLIENT_WITH_CHAIN } from '../apps/web/src/config/constants/endpoints'
@@ -218,13 +218,14 @@ const fetchAndUpdateLPsAPR = async () => {
 
 let logged = false
 export const getFarmConfig = async (chainId: ChainId) => {
+  const chainName = getChainName(chainId)
   try {
-    return (await import(`../packages/farms/constants/${chainId}`)).default.filter(
+    return (await import(`../packages/farms/constants/${chainName}`)).default.filter(
       (f: SerializedFarmConfig) => f.pid !== null,
     ) as SerializedFarmConfig[]
   } catch (error) {
     if (!logged) {
-      console.error('Cannot get farm config', error, chainId)
+      console.error('Cannot get farm config', error, chainId, chainName)
       logged = true
     }
     return []


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4ce4dd4</samp>

### Summary
🐛🔄🔗

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It also conveys a sense of relief or satisfaction for resolving the issue.
2.  🔄 - This emoji represents a change or update, which is the effect of the change on the script. It also conveys a sense of improvement or enhancement for the functionality of the script.
3.  🔗 - This emoji represents a chain or a link, which is the concept that the change relates to. It also conveys a sense of connection or compatibility for the script with different chains.
-->
Fixed a bug in `updateLPsAPR.ts` script that caused incorrect farm config import. Improved script compatibility and error handling for different chains.

> _There once was a script for LPs_
> _That updated their APR with ease_
> _But it had a bug_
> _With the chain id it dug_
> _So it switched to the chain name, oh please!_

### Walkthrough
*  Import `getChainName` function to get chain name from chain id ([link](https://github.com/pancakeswap/pancake-frontend/pull/8107/files?diff=unified&w=0#diff-e82ff81fb1b024db1bba1e31e89a03c0a9746c2d956d8d941cd0d801fe2cd7baL8-R8))
*  Declare and assign `chainName` variable using `getChainName` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8107/files?diff=unified&w=0#diff-e82ff81fb1b024db1bba1e31e89a03c0a9746c2d956d8d941cd0d801fe2cd7baL221-R228))
*  Use `chainName` variable to import farm config file dynamically ([link](https://github.com/pancakeswap/pancake-frontend/pull/8107/files?diff=unified&w=0#diff-e82ff81fb1b024db1bba1e31e89a03c0a9746c2d956d8d941cd0d801fe2cd7baL221-R228))
*  Add `chainName` variable to console error message for failed import ([link](https://github.com/pancakeswap/pancake-frontend/pull/8107/files?diff=unified&w=0#diff-e82ff81fb1b024db1bba1e31e89a03c0a9746c2d956d8d941cd0d801fe2cd7baL221-R228))


