### PR TITLE
chore: Disable staking and unstaking buttons

### DIFF
--- a/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
@@ -82,7 +82,11 @@ export function FixedStakingCard({ pool, stakedPositions }: { pool: PoolGroup; s
                   stakedPositions={stakedPositions}
                 >
                   {(openModal, hideStakeButton) =>
-                    hideStakeButton ? null : <Button onClick={openModal}>{t('Stake')}</Button>
+                    hideStakeButton ? null : (
+                      <Button disabled onClick={openModal}>
+                        {t('Stake')}
+                      </Button>
+                    )
                   }
                 </FixedStakingModal>
               ) : null}

--- a/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
@@ -168,7 +168,11 @@ const FixedStakingRow = ({ pool, stakedPositions }: { pool: PoolGroup; stakedPos
                       stakingToken={pool.token}
                       stakedPositions={stakedPositions}
                     >
-                      {(openModal) => <Button onClick={openModal}>{t('Stake')}</Button>}
+                      {(openModal) => (
+                        <Button onClick={openModal} disabled>
+                          {t('Stake')}
+                        </Button>
+                      )}
                     </FixedStakingModal>
                   </LightGreyCard>
                 </ActionContainer>

--- a/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
+++ b/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
@@ -196,7 +196,7 @@ export function StakedPositionSection({
       >
         {(openClaimModal) =>
           shouldUnlock ? (
-            <Button height="auto" onClick={openClaimModal}>
+            <Button disabled height="auto" onClick={openClaimModal}>
               {t('Claim')}
             </Button>
           ) : null
@@ -218,8 +218,9 @@ export function StakedPositionSection({
             poolIndex={poolIndex}
             lastDayAction={stakePositionUserInfo.lastDayAction}
           >
-            {(openUnstakeModal, notAllowWithdrawal) => (
-              <IconButton disabled={notAllowWithdrawal} variant="secondary" onClick={openUnstakeModal} mr="6px">
+            {(openUnstakeModal) => (
+              /* disabled={notAllowWithdrawal} */
+              <IconButton disabled variant="secondary" onClick={openUnstakeModal} mr="6px">
                 <MinusIcon color="primary" width="14px" />
               </IconButton>
             )}
@@ -233,7 +234,8 @@ export function StakedPositionSection({
             initialLockPeriod={lockPeriod}
           >
             {(openModal) => (
-              <IconButton disabled={currentDay + lockPeriod > poolEndDay} variant="secondary" onClick={openModal}>
+              /* disabled=currentDay + lockPeriod > poolEndDay */
+              <IconButton disabled variant="secondary" onClick={openModal}>
                 <AddIcon color="primary" width="14px" />
               </IconButton>
             )}

--- a/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
+++ b/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
@@ -15,7 +15,7 @@ import { UnstakeBeforeEnededModal } from './UnstakeBeforeEndedModal'
 import { useFixedStakeAPR } from '../hooks/useFixedStakeAPR'
 import { AmountWithUSDSub } from './AmountWithUSDSub'
 import { useCalculateProjectedReturnAmount } from '../hooks/useCalculateProjectedReturnAmount'
-import { useCurrentDay } from '../hooks/useStakedPools'
+// import { useCurrentDay } from '../hooks/useStakedPools'
 
 const FlexLeft = styled(Flex)`
   width: 100%;
@@ -168,7 +168,7 @@ export function StakedPositionSection({
 
   const apr = stakePosition.userInfo.boost ? boostAPR : lockAPR
 
-  const currentDay = useCurrentDay()
+  // const currentDay = useCurrentDay()
 
   const actionSection = (
     <Flex justifyContent="space-between" width="100%">

--- a/apps/web/src/views/FixedStaking/index.tsx
+++ b/apps/web/src/views/FixedStaking/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, FlexLayout, Heading, PageHeader, ToggleView, ViewMode } from '@pancakeswap/uikit'
+import { Flex, FlexLayout, Heading, Message, MessageText, PageHeader, ToggleView, ViewMode } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
 import Page from 'components/Layout/Page'
 import { useMemo, useState } from 'react'
@@ -75,6 +75,12 @@ const FixedStaking = () => {
         </Flex>
       </PageHeader>
       <Page title={t('Pools')}>
+        <Message variant="warning" mb="16px">
+          <MessageText>
+            Simple staking deposits and withdrawals are currently paused due to technical difficulties. Current user
+            funds are not affected and staking positions are safe and locked.
+          </MessageText>
+        </Message>
         <Flex mb="24px">
           <ToggleView idPrefix="clickFarm" viewMode={viewMode} onToggle={setViewMode} />
         </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e29a870</samp>

### Summary
:construction::no_entry_sign::lock:

<!--
1.  :construction: This emoji represents that the feature is under construction or development, and that some parts of it are not fully functional or ready for use. It can be used to indicate that the stake button is disabled because the pool is not active or has reached its maximum capacity, and that it will be enabled later when the feature is complete and tested.
2. :no_entry_sign: This emoji represents that the action or option is not available or prohibited, and that the user should not attempt to perform it. It can be used to indicate that the stake button is disabled because the pool is not open for staking, and that the user should not try to stake in it.
3. :lock: This emoji represents that something is locked or restricted, and that the user needs a key or permission to access it. It can be used to indicate that the stake button is disabled because the pool is full or has reached its maximum capacity, and that the user cannot stake in it unless some space is freed up.
-->
Disable stake, claim, and unstake buttons in fixed staking components. This is to avoid user confusion and errors while the fixed staking feature is under development and testing. The buttons will be enabled when the pools are ready and open for staking. The affected components are `StakedPositionSection`, `FixedStakingCard`, and `FixedStakingRow`.

> _The pools of staking are closed and dark_
> _No stake, no claim, no more rewards_
> _The buttons of power are disabled and stark_
> _We wait for the dawn of the fixed staking hordes_

### Walkthrough
*  Disable stake button in fixed staking card and row components to prevent staking in inactive or full pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/8108/files?diff=unified&w=0#diff-587cdcd0802c7d65cfa2a5c7fa308533abbc2688dca6daaff5656529f6b6be22L85-R89), [link](https://github.com/pancakeswap/pancake-frontend/pull/8108/files?diff=unified&w=0#diff-8ca9d02451a4cbef48a7621a5975c3891edf7aa93fd656aa1623b0c7d4c340faL171-R175))
* Disable claim button in staked position section component to prevent claiming rewards before pool end or lock period ([link](https://github.com/pancakeswap/pancake-frontend/pull/8108/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L199-R199))
* Disable unstake button in staked position section component to prevent unstaking tokens before pool end or lock period ([link](https://github.com/pancakeswap/pancake-frontend/pull/8108/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L221-R223))
* Disable stake more button in staked position section component to prevent staking more tokens in inactive or full pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/8108/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L236-R238))


