### PR TITLE
chore: Upgrade next axiom

### DIFF
--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -36,7 +36,7 @@
     "aptos": "^1.3.16",
     "bignumber.js": "^9.0.0",
     "next": "13.4.2",
-    "next-axiom": "^0.16.0",
+    "next-axiom": "^0.18.0",
     "next-themes": "^0.2.1",
     "next-seo": "^5.15.0",
     "react": "^18.2.0",

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -17,7 +17,7 @@
     "next-seo": "^5.15.0",
     "next-themes": "^0.2.1",
     "next": "13.4.2",
-    "next-axiom": "^0.16.0",
+    "next-axiom": "^0.18.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-wrap-balancer": "^0.4.0",

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -18,7 +18,7 @@
     "@wagmi/core": "^0.10.11",
     "ethers": "^5.0.0",
     "next": "13.4.2",
-    "next-axiom": "^0.16.0",
+    "next-axiom": "^0.18.0",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -79,7 +79,7 @@
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
     "next": "13.4.2",
-    "next-axiom": "^0.13.0",
+    "next-axiom": "^0.18.0",
     "next-seo": "^5.15.0",
     "next-themes": "^0.2.1",
     "polished": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: 13.4.2
         version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
       next-axiom:
-        specifier: ^0.16.0
-        version: 0.16.0(next@13.4.2)
+        specifier: ^0.18.0
+        version: 0.18.0(next@13.4.2)
       next-seo:
         specifier: ^5.15.0
         version: 5.15.0(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
@@ -404,8 +404,8 @@ importers:
         specifier: 13.4.2
         version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
       next-axiom:
-        specifier: ^0.16.0
-        version: 0.16.0(next@13.4.2)
+        specifier: ^0.18.0
+        version: 0.18.0(next@13.4.2)
       next-seo:
         specifier: ^5.15.0
         version: 5.15.0(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
@@ -498,8 +498,8 @@ importers:
         specifier: 13.4.2
         version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
       next-axiom:
-        specifier: ^0.16.0
-        version: 0.16.0(next@13.4.2)
+        specifier: ^0.18.0
+        version: 0.18.0(next@13.4.2)
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
@@ -701,8 +701,8 @@ importers:
         specifier: 13.4.2
         version: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
       next-axiom:
-        specifier: ^0.13.0
-        version: 0.13.0(next@13.4.2)
+        specifier: ^0.18.0
+        version: 0.18.0(next@13.4.2)
       next-seo:
         specifier: ^5.15.0
         version: 5.15.0(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
@@ -21276,18 +21276,8 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  /next-axiom@0.13.0(next@13.4.2):
-    resolution: {integrity: sha512-yWNsTd2abreXa9KBYeAhhVCsTFClZI37jUG0c+CfkENxl51EpSVlY+dWSA8hGJQtXWOXKs6yeW1PaiVr2NU1rw==}
-    engines: {node: '>=15'}
-    peerDependencies:
-      next: ^12.1.4
-    dependencies:
-      next: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
-      whatwg-fetch: 3.6.2
-    dev: false
-
-  /next-axiom@0.16.0(next@13.4.2):
-    resolution: {integrity: sha512-WlmObMtra/OJPiJ6Gim4g8OTuLlJx9DVTeEaNmBIO3wEkR+Nt4932/xng2a9XofOVR7RgaNk1QIyPrqZW9P25w==}
+  /next-axiom@0.18.0(next@13.4.2):
+    resolution: {integrity: sha512-OexBGAQ3l/EPCIxbaGVee+JmJZfW6DMT/NCqaRw6tsZ7dO72rsZCAMhDh6qT41+dCyb+X10Dzx3yHVy+3p1qyw==}
     engines: {node: '>=15'}
     peerDependencies:
       next: ^12.1.4 || ^13


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 05a2405</samp>

### Summary
🆙🛠️🗑️

<!--
1.  🆙 - This emoji can be used to indicate that a dependency was upgraded to a newer version, as in the case of `next-axiom`.
2.  🛠️ - This emoji can be used to indicate that a bug fix or improvement was made, as in the case of using the latest features and fixes of `next-axiom`.
3.  🗑️ - This emoji can be used to indicate that something was removed or cleaned up, as in the case of removing the unused versions of `next-axiom` from the lock file.
-->
Updated the `next-axiom` dependency to version `0.18.0` for all the Next.js applications in the repository. This was done to improve the performance and consistency of the applications and to use the latest features and bug fixes of the `next-axiom` package.

> _To update `next-axiom` they sought_
> _For the features and fixes it brought_
> _They changed every app_
> _And the lock file to wrap_
> _The dependencies as they ought_

### Walkthrough
*  Update `next-axiom` dependency to version `0.18.0` for four Next.js applications: `apps/aptos`, `apps/blog`, `apps/bridge`, and `apps/web` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-2e0a28c02ce581e54b6b6f5803ee5d4b292c79f235eeeaed29cfc4666fa7cad0L39-R39), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171L20-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-93041787b5656240bfc7426a90c1b833c952785415f626d87bd20770a9f59da0L21-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L82-R82))
*  Update `pnpm-lock.yaml` file to reflect the updated dependency and remove unused versions of `next-axiom` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL319-R320), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL407-R408), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL501-R502), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL704-R705), [link](https://github.com/pancakeswap/pancake-frontend/pull/8111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL21279-R21282))


