### PR TITLE
fix: swap message on user reject fix

### DIFF
--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -1,5 +1,5 @@
 import { captureException } from '@sentry/nextjs'
-import { UserRejectedRequestError, UnknownRpcError } from 'viem'
+import { UnknownRpcError, UserRejectedRequestError } from 'viem'
 
 const assignError = (maybeError: any) => {
   if (typeof maybeError === 'string') {
@@ -51,7 +51,7 @@ export const isUserRejected = (err) => {
 
 const ENABLED_LOG = false
 
-export const logError = (error: Error | unknown) => {
+export const logError = (error: Error | any) => {
   if (ENABLED_LOG) {
     if (error instanceof Error) {
       captureException(error)

--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -1,5 +1,5 @@
 import { captureException } from '@sentry/nextjs'
-import { UnknownRpcError, UserRejectedRequestError } from 'viem'
+import { UserRejectedRequestError, UnknownRpcError } from 'viem'
 
 const assignError = (maybeError: any) => {
   if (typeof maybeError === 'string') {
@@ -45,13 +45,12 @@ export const isUserRejected = (err) => {
       return isUserRejected(err.cause)
     }
   }
-  if (err.message.includes('Cannot read properties of undefined')) return true
   return false
 }
 
 const ENABLED_LOG = false
 
-export const logError = (error: Error | any) => {
+export const logError = (error: Error | unknown) => {
   if (ENABLED_LOG) {
     if (error instanceof Error) {
       captureException(error)

--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -45,6 +45,7 @@ export const isUserRejected = (err) => {
       return isUserRejected(err.cause)
     }
   }
+  if (err.message.includes('Cannot read properties of undefined')) return true
   return false
 }
 

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -211,7 +211,6 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
             data: calldata,
             value: hexToBigInt(value),
             gas: calculateGasMargin(gasLimit),
-            chainId,
           })
         })
         .then((response) => {

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -74,7 +74,7 @@ export default function RemoveLiquidityV3() {
     }
   }, [tokenId])
 
-  return <Remove tokenId={parsedTokenId} />
+  return parsedTokenId ? <Remove tokenId={parsedTokenId} /> : null
 }
 
 function Remove({ tokenId }: { tokenId: bigint }) {

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -186,7 +186,6 @@ function Remove({ tokenId }: { tokenId: bigint }) {
       sendTransactionAsync({
         ...txn,
         gas: calculateGasMargin(gas),
-        chainId,
       })
         .then((response) => {
           const amount0 = formatRawAmount(liquidityValue0.quotient.toString(), liquidityValue0.currency.decimals, 4)

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -141,7 +141,6 @@ export default function useSendSwapTransaction(
 
         return sendTransactionAsync({
           account,
-          chainId,
           to: call.address,
           data: call.calldata,
           value: call.value && !isZero(call.value) ? hexToBigInt(call.value) : 0n,

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -153,11 +153,11 @@ export default function useSendSwapTransaction(
             const inputAmount =
               trade.tradeType === TradeType.EXACT_INPUT
                 ? formatAmount(trade.inputAmount, 3)
-                : (formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3) as string)
+                : formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3) ?? '0'
             const outputAmount =
               trade.tradeType === TradeType.EXACT_OUTPUT
                 ? formatAmount(trade.outputAmount, 3)
-                : (formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3) as string)
+                : formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3) ?? '0'
 
             const base = `Swap ${
               trade.tradeType === TradeType.EXACT_OUTPUT ? 'max.' : ''

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -150,11 +150,11 @@ export default function useSendSwapTransaction(
             const inputSymbol = trade.inputAmount.currency.symbol
             const outputSymbol = trade.outputAmount.currency.symbol
             const pct = basisPointsToPercent(allowedSlippage)
-            const inputAmount =
+            const inputAmount: string =
               trade.tradeType === TradeType.EXACT_INPUT
                 ? formatAmount(trade.inputAmount, 3)
                 : formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3)
-            const outputAmount =
+            const outputAmount: string =
               trade.tradeType === TradeType.EXACT_OUTPUT
                 ? formatAmount(trade.outputAmount, 3)
                 : formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3)

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -151,13 +151,13 @@ export default function useSendSwapTransaction(
             const outputSymbol = trade.outputAmount.currency.symbol
             const pct = basisPointsToPercent(allowedSlippage)
             const inputAmount =
-              trade.tradeType === TradeType.EXACT_INPUT
+              (trade.tradeType === TradeType.EXACT_INPUT
                 ? formatAmount(trade.inputAmount, 3)
-                : formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3) ?? '0'
+                : formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3)) ?? '0'
             const outputAmount =
-              trade.tradeType === TradeType.EXACT_OUTPUT
+              (trade.tradeType === TradeType.EXACT_OUTPUT
                 ? formatAmount(trade.outputAmount, 3)
-                : formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3) ?? '0'
+                : formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3)) ?? '0'
 
             const base = `Swap ${
               trade.tradeType === TradeType.EXACT_OUTPUT ? 'max.' : ''

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -150,14 +150,14 @@ export default function useSendSwapTransaction(
             const inputSymbol = trade.inputAmount.currency.symbol
             const outputSymbol = trade.outputAmount.currency.symbol
             const pct = basisPointsToPercent(allowedSlippage)
-            const inputAmount: string =
+            const inputAmount =
               trade.tradeType === TradeType.EXACT_INPUT
                 ? formatAmount(trade.inputAmount, 3)
-                : formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3)
-            const outputAmount: string =
+                : (formatAmount(SmartRouter.maximumAmountIn(trade, pct), 3) as string)
+            const outputAmount =
               trade.tradeType === TradeType.EXACT_OUTPUT
                 ? formatAmount(trade.outputAmount, 3)
-                : formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3)
+                : (formatAmount(SmartRouter.minimumAmountOut(trade, pct), 3) as string)
 
             const base = `Swap ${
               trade.tradeType === TradeType.EXACT_OUTPUT ? 'max.' : ''


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at be5349d</samp>

### Summary
🛑🐛🛡️

<!--
1.  🛑 - This emoji represents the idea of stopping or rejecting something, which is relevant to the user rejecting the wallet connection and the function checking for that condition.
2.  🐛 - This emoji represents the idea of fixing a bug or an error, which is relevant to the unhandled error that was causing the blank screen and the change that prevents Sentry from reporting it.
3.  🛡️ - This emoji represents the idea of protecting or defending something, which is relevant to the change that improves the error handling and avoids exposing unnecessary information to Sentry.
-->
Improved error handling for wallet connection rejection. Added a check for undefined properties in `isUserRejected` function in `apps/web/src/utils/sentry.ts`.

> _`isUserRejected`_
> _now checks for undefined_
> _a winter bug fix_

### Walkthrough
*  Add a condition to the `isUserRejected` function to handle errors caused by user rejecting wallet connection ([link](https://github.com/pancakeswap/pancake-frontend/pull/8115/files?diff=unified&w=0#diff-a3898994b9c897df1f61a5132f19305441a63c27468cf5903db687dea5cf7d70R48))


