### PR TITLE
revert: Disable staking and unstaking buttons (#8108)

### DIFF
--- a/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
@@ -82,11 +82,7 @@ export function FixedStakingCard({ pool, stakedPositions }: { pool: PoolGroup; s
                   stakedPositions={stakedPositions}
                 >
                   {(openModal, hideStakeButton) =>
-                    hideStakeButton ? null : (
-                      <Button disabled onClick={openModal}>
-                        {t('Stake')}
-                      </Button>
-                    )
+                    hideStakeButton ? null : <Button onClick={openModal}>{t('Stake')}</Button>
                   }
                 </FixedStakingModal>
               ) : null}

--- a/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
@@ -168,11 +168,7 @@ const FixedStakingRow = ({ pool, stakedPositions }: { pool: PoolGroup; stakedPos
                       stakingToken={pool.token}
                       stakedPositions={stakedPositions}
                     >
-                      {(openModal) => (
-                        <Button onClick={openModal} disabled>
-                          {t('Stake')}
-                        </Button>
-                      )}
+                      {(openModal) => <Button onClick={openModal}>{t('Stake')}</Button>}
                     </FixedStakingModal>
                   </LightGreyCard>
                 </ActionContainer>

--- a/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
+++ b/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
@@ -15,7 +15,7 @@ import { UnstakeBeforeEnededModal } from './UnstakeBeforeEndedModal'
 import { useFixedStakeAPR } from '../hooks/useFixedStakeAPR'
 import { AmountWithUSDSub } from './AmountWithUSDSub'
 import { useCalculateProjectedReturnAmount } from '../hooks/useCalculateProjectedReturnAmount'
-// import { useCurrentDay } from '../hooks/useStakedPools'
+import { useCurrentDay } from '../hooks/useStakedPools'
 
 const FlexLeft = styled(Flex)`
   width: 100%;
@@ -168,7 +168,7 @@ export function StakedPositionSection({
 
   const apr = stakePosition.userInfo.boost ? boostAPR : lockAPR
 
-  // const currentDay = useCurrentDay()
+  const currentDay = useCurrentDay()
 
   const actionSection = (
     <Flex justifyContent="space-between" width="100%">
@@ -196,7 +196,7 @@ export function StakedPositionSection({
       >
         {(openClaimModal) =>
           shouldUnlock ? (
-            <Button disabled height="auto" onClick={openClaimModal}>
+            <Button height="auto" onClick={openClaimModal}>
               {t('Claim')}
             </Button>
           ) : null
@@ -218,9 +218,8 @@ export function StakedPositionSection({
             poolIndex={poolIndex}
             lastDayAction={stakePositionUserInfo.lastDayAction}
           >
-            {(openUnstakeModal) => (
-              /* disabled={notAllowWithdrawal} */
-              <IconButton disabled variant="secondary" onClick={openUnstakeModal} mr="6px">
+            {(openUnstakeModal, notAllowWithdrawal) => (
+              <IconButton disabled={notAllowWithdrawal} variant="secondary" onClick={openUnstakeModal} mr="6px">
                 <MinusIcon color="primary" width="14px" />
               </IconButton>
             )}
@@ -234,8 +233,7 @@ export function StakedPositionSection({
             initialLockPeriod={lockPeriod}
           >
             {(openModal) => (
-              /* disabled=currentDay + lockPeriod > poolEndDay */
-              <IconButton disabled variant="secondary" onClick={openModal}>
+              <IconButton disabled={currentDay + lockPeriod > poolEndDay} variant="secondary" onClick={openModal}>
                 <AddIcon color="primary" width="14px" />
               </IconButton>
             )}

--- a/apps/web/src/views/FixedStaking/index.tsx
+++ b/apps/web/src/views/FixedStaking/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, FlexLayout, Heading, Message, MessageText, PageHeader, ToggleView, ViewMode } from '@pancakeswap/uikit'
+import { Flex, FlexLayout, Heading, PageHeader, ToggleView, ViewMode } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
 import Page from 'components/Layout/Page'
 import { useMemo, useState } from 'react'
@@ -75,12 +75,6 @@ const FixedStaking = () => {
         </Flex>
       </PageHeader>
       <Page title={t('Pools')}>
-        <Message variant="warning" mb="16px">
-          <MessageText>
-            Simple staking deposits and withdrawals are currently paused due to technical difficulties. Current user
-            funds are not affected and staking positions are safe and locked.
-          </MessageText>
-        </Message>
         <Flex mb="24px">
           <ToggleView idPrefix="clickFarm" viewMode={viewMode} onToggle={setViewMode} />
         </Flex>


### PR DESCRIPTION
This reverts commit f1c03d8a3a58c26839b28c3ea55949b5e9923433.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1619752</samp>

### Summary
🎁🕒🧹

<!--
1.  🎁 - This emoji represents the feature of claiming rewards, which is a benefit for the users who staked their tokens in the pool.
2.  🕒 - This emoji represents the time-based logic and display of the staking actions, which depends on the current day and the lock period of the pool.
3.  🧹 - This emoji represents the removal of unused and outdated components, which is a cleanup and improvement of the code quality.
-->
This pull request allows users to stake tokens and claim rewards in fixed staking pools. It removes the `disabled` prop from the staking buttons and adds logic to handle the lock period and the current day. It also cleans up some unused components from the `FixedStaking` view.

> _`Button` not disabled_
> _Users can stake and claim rewards_
> _Logic based on day_

### Walkthrough
*  Enable users to open the `FixedStakingModal` and stake their tokens by removing the `disabled` prop of the `Button` component in the `FixedStakingCard` and `FixedStakingRow` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-587cdcd0802c7d65cfa2a5c7fa308533abbc2688dca6daaff5656529f6b6be22L85-R85), [link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-8ca9d02451a4cbef48a7621a5975c3891edf7aa93fd656aa1623b0c7d4c340faL171-R171))
*  Enable users to open the `ClaimModal` and claim their rewards when the staking pool is unlocked by removing the `disabled` prop of the `Button` component in the `StakedPositionSection` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L199-R199))
*  Prevent users from unstaking their tokens when the staking pool is locked or the last day action is not valid by adding the `notAllowWithdrawal` variable as the `disabled` prop of the `IconButton` component in the `StakedPositionSection` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L221-R222))
*  Prevent users from staking more tokens when the staking pool is about to end by assigning the `disabled` prop of the `IconButton` component in the `StakedPositionSection` component to the expression `currentDay + lockPeriod > poolEndDay` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L237-R236))
*  Use the `useCurrentDay` hook to get the current day of the staking pool and use it for logic and display purposes in the `StakedPositionSection` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L18-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L171-R171))
*  Remove the `Message` and `MessageText` components from the imports and the `Message` component that displayed a warning about the staking deposits and withdrawals being paused from the `index.tsx` file as the issue was resolved and the staking functionality was restored ([link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-3eb11510dfd5657b2526a31767373a3b6cec75cfcb87c0580e9a7456b5ad1943L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8122/files?diff=unified&w=0#diff-3eb11510dfd5657b2526a31767373a3b6cec75cfcb87c0580e9a7456b5ad1943L78-L83))


