### PR TITLE
fix: Blog image problem

### DIFF
--- a/apps/blog/types.ts
+++ b/apps/blog/types.ts
@@ -40,7 +40,7 @@ export interface ResponseArticleDataType {
       data: CategoriesType[]
     }
     image: {
-      data: ArticleImageType
+      data: ArticleImageType[]
     }
     newsOutBoundLink: string
     newsFromPlatform: string

--- a/apps/blog/utils/transformArticle.ts
+++ b/apps/blog/utils/transformArticle.ts
@@ -32,7 +32,7 @@ export const transformArticle = (article: ResponseArticleDataType): ArticleDataT
     description: article?.attributes?.description ?? '',
     newsFromPlatform: article?.attributes?.newsFromPlatform ?? '',
     newsOutBoundLink: article?.attributes?.newsOutBoundLink ?? '',
-    imgUrl: article?.attributes?.image?.data?.attributes?.url ?? '',
+    imgUrl: article?.attributes?.image?.data?.[0]?.attributes?.url ?? '',
     categories: article.attributes?.categories?.data?.map((i) => i.attributes.name),
   }
 }

--- a/apps/web/src/views/Home/types.ts
+++ b/apps/web/src/views/Home/types.ts
@@ -40,7 +40,7 @@ export interface ResponseArticleDataType {
       data: CategoriesType[]
     }
     image: {
-      data: ArticleImageType
+      data: ArticleImageType[]
     }
     newsOutBoundLink: string
     newsFromPlatform: string

--- a/apps/web/src/views/Home/utils/transformArticle.ts
+++ b/apps/web/src/views/Home/utils/transformArticle.ts
@@ -32,7 +32,7 @@ export const transformArticle = (article: ResponseArticleDataType): ArticleDataT
     description: article?.attributes?.description ?? '',
     newsFromPlatform: article?.attributes?.newsFromPlatform ?? '',
     newsOutBoundLink: article?.attributes?.newsOutBoundLink ?? '',
-    imgUrl: article?.attributes?.image?.data?.attributes?.url ?? '',
+    imgUrl: article?.attributes?.image?.data?.[0]?.attributes?.url ?? '',
     categories: article.attributes?.categories?.data?.map((i) => i.attributes.name),
   }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1fd5680</samp>

### Summary
📷🔄🚚

<!--
1.  📷 - This emoji represents the change from a single image object to an array of image objects for each article. It conveys the idea of multiple images or photos for each article in the blog feature.
2.  🔄 - This emoji represents the change from accessing the whole image object to accessing the first element of the image array for each article. It conveys the idea of transforming or adapting the data to match the new interface and display the first image of each article in the blog feature.
3.  🚚 - This emoji represents the change of applying the same changes to the home feature of the PancakeSwap frontend. It conveys the idea of moving or transferring the changes from one feature to another to keep them consistent and aligned.
-->
The `image` property of the `ResponseArticleDataType` interface was changed to support multiple images for each article in the blog and home features of the PancakeSwap frontend. The `transformArticle` functions in both features were updated accordingly to display the first image of each article.

> _`image` now an array_
> _Multiple photos per article_
> _Autumn leaves of change_

### Walkthrough
*  Change the `image` property of the `ResponseArticleDataType` interface to accept an array of `ArticleImageType` instead of a single object, to support multiple images for each article in the blog feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-be86497777a3b318bd86840a83b8e55239456255e2cb4a24e33da363cb90304cL43-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-d02a7ba2d5d8f5d28099403f9f327900546a4463be02547e8a27ba39fbd6e83dL43-R43))
*  Update the `transformArticle` function to access the first element of the `image.data` array instead of the whole object, to display the first image of each article in the blog feature ([link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-dd5151d886e1c520d3df4db0026868c1ebe300ced3a0997af9c61043b7e9f448L35-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-bc4be424bbf11ff4e1a6f3aefc286a21792fc4770702442cd33cd6ba16c6247bL35-R35))
*  Apply the same changes to the `apps/web/src/views/Home` files, to keep the interface and function consistent across the blog and home features ([link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-d02a7ba2d5d8f5d28099403f9f327900546a4463be02547e8a27ba39fbd6e83dL43-R43), [link](https://github.com/pancakeswap/pancake-frontend/pull/8128/files?diff=unified&w=0#diff-bc4be424bbf11ff4e1a6f3aefc286a21792fc4770702442cd33cd6ba16c6247bL35-R35))


