### PR TITLE
fix: split amount by mix-route

### DIFF
--- a/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
@@ -215,8 +215,8 @@ async function addMixedSwap(
 
   for (const route of trade.routes) {
     const { inputAmount, outputAmount, pools } = route
-    const amountIn: bigint = SmartRouter.maximumAmountIn(trade, options.slippageTolerance).quotient
-    const amountOut: bigint = SmartRouter.minimumAmountOut(trade, options.slippageTolerance).quotient
+    const amountIn: bigint = SmartRouter.maximumAmountIn(trade, options.slippageTolerance, inputAmount).quotient
+    const amountOut: bigint = SmartRouter.minimumAmountOut(trade, options.slippageTolerance, outputAmount).quotient
 
     // flag for whether the trade is single hop or not
     const singleHop = pools.length === 1


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dfa9113</samp>

### Summary
🔄📈🌈

<!--
1.  🔄 This emoji represents the change in the logic of the methods, as they now use a different parameter to calculate the slippage tolerance. It also implies that the methods are related to swapping tokens, which is the main functionality of the SmartRouter.
2.  📈 This emoji represents the improvement in the accuracy of the swap amounts and the reduction of the risk of failed transactions, which are positive outcomes for the users of the SmartRouter. It also implies that the methods are related to optimizing the swap rates and minimizing the slippage.
3.  🌈 This emoji represents the introduction of the mixed swaps feature, which allows the users to swap between different input and output tokens using multiple routes. It also implies that the methods are related to supporting a variety of tokens and routes, which enhances the flexibility and diversity of the SmartRouter.
-->
Modified `SmartRouter` methods to use route amount for slippage tolerance calculation. This improves swap accuracy and enables mixed swaps.

> _`SmartRouter` adapts_
> _Slippage based on route amount_
> _Autumn leaves fall fast_

### Walkthrough
*  Modify `maximumAmountIn` and `minimumAmountOut` methods of `SmartRouter` class to take `routeAmount` parameter and calculate slippage tolerance based on it ([link](https://github.com/pancakeswap/pancake-frontend/pull/8149/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L218-R223))


