### PR TITLE
fix: (swap): Recipient text two chars shown when no recipient

### DIFF
--- a/apps/aptos/components/Swap/SwapModalHeader.tsx
+++ b/apps/aptos/components/Swap/SwapModalHeader.tsx
@@ -135,7 +135,7 @@ export default function SwapModalHeader({
           {tradeInfoText}
         </Text>
       </AutoColumn>
-      {recipient !== null ? (
+      {recipient ? (
         <AutoColumn justify="flex-start" gap="sm" style={{ padding: '12px 0 0 0px' }}>
           <Text color="textSubtle">
             {recipientSentToText}

--- a/apps/web/src/views/Swap/components/SwapModalHeader.tsx
+++ b/apps/web/src/views/Swap/components/SwapModalHeader.tsx
@@ -147,7 +147,7 @@ export default function SwapModalHeader({
           {tradeInfoText}
         </Text>
       </AutoColumn>
-      {recipient !== null ? (
+      {recipient ? (
         <AutoColumn justify="flex-start" gap="sm" style={{ padding: '12px 0 0 0px' }}>
           <Text fontSize={12} color="textSubtle">
             {recipientSentToText}


### PR DESCRIPTION

<img width="356" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/9fd0c714-2a27-4d23-a865-26f58a0298c3">


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b507a44</samp>

### Summary
🔧🔄🧹

<!--
1.  🔧 - This emoji can be used to indicate a bug fix or a minor improvement, as the change simplifies the logic and makes the code more robust.
2.  🔄 - This emoji can be used to indicate a sync or an update, as the change aligns the aptos app code with the web app code and avoids divergence.
3.  🧹 - This emoji can be used to indicate a cleanup or a refactor, as the change removes unnecessary code and makes the code more readable.
-->
Simplify the condition to check the recipient address for the swap in `SwapModalHeader.tsx` files. This change affects both the web and the aptos apps, which share some code.

> _`recipient` truth_
> _simplifies the swap logic_
> _autumn of null checks_

### Walkthrough
*  Simplify the condition to check if the recipient address is provided for the swap by using the truthiness of the recipient value instead of comparing with null ([link](https://github.com/pancakeswap/pancake-frontend/pull/8158/files?diff=unified&w=0#diff-2ccdd802759f9e6514eea0300fc452144725489ca3a7a6d34efe0d83ed57272eL138-R138), [link](https://github.com/pancakeswap/pancake-frontend/pull/8158/files?diff=unified&w=0#diff-92e3624fedbc82a4851abdebcc5f3fe7073d78c8458ee9f5fe3ea6070b42b80aL150-R150)) in `SwapModalHeader.tsx` files of both web and aptos apps


