### PR TITLE
fix: Nft collection pagination wrong

### DIFF
--- a/apps/web/src/views/Nft/market/Collections/index.tsx
+++ b/apps/web/src/views/Nft/market/Collections/index.tsx
@@ -172,14 +172,6 @@ const Collectible = () => {
     }
   }, [isMobile, page])
 
-  useEffect(() => {
-    let extraPages = 1
-    if (collections.length % ITEMS_PER_PAGE === 0) {
-      extraPages = 0
-    }
-    setMaxPage(Math.max(Math.floor(collections.length / ITEMS_PER_PAGE) + extraPages, 1))
-  }, [collections])
-
   const sortedCollections = useMemo(() => {
     return orderBy(
       collections,
@@ -195,6 +187,14 @@ const Collectible = () => {
       sortDirection ? 'desc' : 'asc',
     ).filter((collection) => !DELIST_COLLECTIONS[collection.address])
   }, [collections, sortField, sortDirection])
+
+  useEffect(() => {
+    let extraPages = 1
+    if (sortedCollections.length % ITEMS_PER_PAGE === 0) {
+      extraPages = 0
+    }
+    setMaxPage(Math.max(Math.floor(sortedCollections.length / ITEMS_PER_PAGE) + extraPages, 1))
+  }, [sortedCollections])
 
   return (
     <>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 66b524e</samp>

### Summary
🐛🔎📊

<!--
1.  🐛 - This emoji represents a bug fix, as the previous pagination logic was not working correctly with the sorted and filtered collections array.
2.  🔎 - This emoji represents a search or filter feature, as the pull request enhances the collections view by allowing users to sort and filter the collections by various criteria.
3.  📊 - This emoji represents a data or analytics feature, as the pull request improves the display and navigation of the collections data.
-->
This pull request fixes a bug in the collections view pagination by using the correct array of collections. This affects the file `apps/web/src/views/Nft/market/Collections/index.tsx`.

> _Oh, we're the coders of the sea, and we work on the UI_
> _We update the pagination logic for the `collections` view_
> _We use the sorted and filtered array, and we make it work our way_
> _And we sing this shanty as we push the code review_

### Walkthrough
* Remove unnecessary hook that calculates max page number based on original collections array ([link](https://github.com/pancakeswap/pancake-frontend/pull/8161/files?diff=unified&w=0#diff-956895ae1e8fc8321026802b54e8f38fc3c6e6a5f6655450a6eb2707db0f5f6cL175-L182))
* Add new hook that calculates max page number based on sorted and filtered collections array ([link](https://github.com/pancakeswap/pancake-frontend/pull/8161/files?diff=unified&w=0#diff-956895ae1e8fc8321026802b54e8f38fc3c6e6a5f6655450a6eb2707db0f5f6cR191-R198))


