### PR TITLE
fix: More from collection pagination wrong

### DIFF
--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/MoreFromThisCollection.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/MoreFromThisCollection.tsx
@@ -90,60 +90,64 @@ const MoreFromThisCollection: React.FC<React.PropsWithChildren<MoreFromThisColle
     },
   )
 
-  let nftsToShow = useMemo(() => {
-    return shuffle(
+  const nftsToShow = useMemo(() => {
+    let shuffled = shuffle(
       allPancakeBunnyNfts
         ? allPancakeBunnyNfts.filter((nft) => nft.name !== currentTokenName)
         : collectionNfts?.filter((nft) => nft.name !== currentTokenName && nft.marketData?.isTradable),
     )
-  }, [allPancakeBunnyNfts, collectionNfts, currentTokenName])
+
+    if (isPBCollection) {
+      // PancakeBunnies should display 1 card per bunny id
+      shuffled = shuffled.reduce((nftArray, current) => {
+        const bunnyId = current.attributes[0].value
+        if (!nftArray.find((nft) => nft.attributes[0].value === bunnyId)) {
+          nftArray.push(current)
+        }
+        return nftArray
+      }, [])
+    }
+    return shuffled.slice(0, 12)
+  }, [allPancakeBunnyNfts, collectionNfts, currentTokenName, isPBCollection])
+
+  const [slidesPerView, maxPageIndex] = useMemo(() => {
+    let slides
+    let extraPages = 1
+    if (isMd) {
+      slides = 2
+    } else if (isLg) {
+      slides = 3
+    } else {
+      slides = 4
+    }
+    if (nftsToShow.length % slides === 0) {
+      extraPages = 0
+    }
+    const maxPage = Math.max(Math.floor(nftsToShow.length / slides) + extraPages, 1)
+    return [slides, maxPage]
+  }, [isMd, isLg, nftsToShow?.length])
 
   if (!nftsToShow || nftsToShow.length === 0) {
     return null
   }
 
-  let slidesPerView = 4
-  let maxPageIndex = 3
-
-  if (isMd) {
-    slidesPerView = 2
-    maxPageIndex = 6
-  }
-
-  if (isLg) {
-    slidesPerView = 3
-    maxPageIndex = 4
-  }
-
-  if (isPBCollection) {
-    // PancakeBunnies should display 1 card per bunny id
-    nftsToShow = nftsToShow.reduce((nftArray, current) => {
-      const bunnyId = current.attributes[0].value
-      if (!nftArray.find((nft) => nft.attributes[0].value === bunnyId)) {
-        nftArray.push(current)
-      }
-      return nftArray
-    }, [])
-  }
-  nftsToShow = nftsToShow.slice(0, 12)
-
   const nextSlide = () => {
     if (activeIndex < maxPageIndex - 1) {
       setActiveIndex((index) => index + 1)
-      swiperRef.slideNext()
+      swiperRef?.slideNext()
     }
   }
 
   const previousSlide = () => {
     if (activeIndex > 0) {
       setActiveIndex((index) => index - 1)
-      swiperRef.slidePrev()
+      swiperRef?.slidePrev()
     }
   }
 
   const goToSlide = (index: number) => {
     setActiveIndex(index / slidesPerView)
-    swiperRef.slideTo(index)
+    swiperRef?.slideTo(index)
   }
 
   const updateActiveIndex = ({ activeIndex: newActiveIndex }) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7b58e0</samp>

### Summary
🔄🖼️🚫

<!--
1.  🔄 - This emoji represents the refactoring of the logic for calculating the slides and the pagination, which is a kind of code improvement or optimization.
2.  🖼️ - This emoji represents the carousel component itself, which displays NFTs as images or artworks in a swiper.
3.  🚫 - This emoji represents the error handling for the swiper reference, which prevents the component from crashing or malfunctioning if the reference is null or undefined.
-->
Refactor and enhance the carousel component for more NFTs from the same collection. The file `MoreFromThisCollection.tsx` contains the updated logic for slides, pagination, and error handling. This improves the user experience and the code quality of the NFT market view.

> _Sing, O Muse, of the skillful coder who improved the carousel_
> _That shows the wondrous works of art, the NFTs immortal_
> _He refactored the logic of the slides and pagination_
> _And added error handling for the swiper's invocation_

### Walkthrough
*  Refactor the logic for computing the carousel items and pagination ([link](https://github.com/pancakeswap/pancake-frontend/pull/8162/files?diff=unified&w=0#diff-bb35d87c160e2c07803c2fd73ea2de189aa98830d49f7884896f404a45eb3bd9L93-R137))
* Add optional chaining operators to the `swiperRef` object before calling its methods ([link](https://github.com/pancakeswap/pancake-frontend/pull/8162/files?diff=unified&w=0#diff-bb35d87c160e2c07803c2fd73ea2de189aa98830d49f7884896f404a45eb3bd9L140-R144), [link](https://github.com/pancakeswap/pancake-frontend/pull/8162/files?diff=unified&w=0#diff-bb35d87c160e2c07803c2fd73ea2de189aa98830d49f7884896f404a45eb3bd9L146-R150))


