### PR TITLE
chore: list new farms for base

### DIFF
--- a/packages/farms/constants/base.ts
+++ b/packages/farms/constants/base.ts
@@ -4,6 +4,27 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 11,
+    lpAddress: '0x25DEe2707979055245A18AE6a415bb7b1435Eb06',
+    token0: baseTokens.usdbc,
+    token1: baseTokens.axlusdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
+    pid: 10,
+    lpAddress: '0x72AB388E2E2F6FaceF59E3C3FA2C4E29011c2D38',
+    token0: baseTokens.weth,
+    token1: baseTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
+    pid: 9,
+    lpAddress: '0x0D486753B99b1e0548d3505D8B797c673b58Cad3',
+    token0: baseTokens.weth,
+    token1: baseTokens.usdbc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 8,
     lpAddress: '0x0D486753B99b1e0548d3505D8B797c673b58Cad3',
     token0: baseTokens.tbtc,

--- a/packages/farms/constants/base.ts
+++ b/packages/farms/constants/base.ts
@@ -19,7 +19,7 @@ export const farmsV3 = defineFarmV3Configs([
   },
   {
     pid: 9,
-    lpAddress: '0x0D486753B99b1e0548d3505D8B797c673b58Cad3',
+    lpAddress: '0xF6C0A374a483101e04EF5F7Ac9Bd15d9142BAC95',
     token0: baseTokens.weth,
     token1: baseTokens.usdbc,
     feeAmount: FeeAmount.LOWEST,

--- a/packages/tokens/src/8453.ts
+++ b/packages/tokens/src/8453.ts
@@ -16,4 +16,11 @@ export const baseTokens = {
   usdbc: new ERC20Token(ChainId.BASE, '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA', 6, 'USDbC', 'USD Base Coin'),
   dai: new ERC20Token(ChainId.BASE, '0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb', 18, 'DAI', 'Dai Stablecoin'),
   tbtc: new ERC20Token(ChainId.BASE, '0x236aa50979D5f3De3Bd1Eeb40E81137F22ab794b', 18, 'tBTC', 'Base tBTC v2'),
+  axlusdc: new ERC20Token(
+    ChainId.BASE,
+    '0xEB466342C4d449BC9f53A865D5Cb90586f405215',
+    6,
+    'axlUSDC',
+    'Axelar Wrapped USDC',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f02cce6</samp>

### Summary
🌾🌉💱

<!--
1.  🌾 - This emoji represents the addition of new farms, as farms are a common symbol of agriculture and yield.
2.  🌉 - This emoji represents the cross-chain nature of the Axelar network and the new tokens, as bridges are a common symbol of connecting different networks and platforms.
3.  💱 - This emoji represents the swap fee and the liquidity pool pairs, as exchange is a common symbol of trading and swapping different currencies and tokens.
-->
This pull request adds support for three new liquidity pools and one new token from the Axelar network on the PancakeSwap frontend. It updates the `farmsV3` array in `base.ts` and the `baseTokens` object in `8453.ts` with the relevant information for the new farms and token.

> _`farmsV3` expands_
> _with Axelar's cross-chain pairs_
> _autumn harvest grows_

### Walkthrough
*  Add three new farms for WETH/USDC, WETH/USDBC, and axlUSDC/USDBC pairs to the farmsV3 array ([link](https://github.com/pancakeswap/pancake-frontend/pull/8165/files?diff=unified&w=0#diff-6c70dc184340ad173580d8acefe2b446a8f066fe4ff0f71deb7b9069e414c7b6R7-R27))
*  Add axlUSDC token information to the baseTokens object in `packages/tokens/src/8453.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8165/files?diff=unified&w=0#diff-b60fe1f065ba116f678f7137ce43ea3b162f13570dbc5455f1293a772473c931R19-R25))


