### PR TITLE
chore: add price helper for aptos new farm

### DIFF
--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -40,7 +40,7 @@ const farms: SerializedFarmConfig[] = [
   // * By order of release
   {
     pid: 20,
-    lpSymbol: 'amAPT-APT',
+    lpSymbol: 'amAPT-APT LP',
     lpAddress:
       '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::amapt_token::AmnisApt, 0x1::aptos_coin::AptosCoin>',
     token: mainnetTokens.amapt,

--- a/apps/aptos/config/constants/priceHelperLps/farms/1.ts
+++ b/apps/aptos/config/constants/priceHelperLps/farms/1.ts
@@ -6,6 +6,12 @@ import { mainnetTokens } from 'config/constants/tokens'
 const priceHelperLps: Omit<SerializedFarmConfig, 'pid'>[] = [
   {
     pid: null,
+    lpSymbol: 'amAPT-APT LP',
+    quoteToken: APT[ChainId.MAINNET],
+    token: mainnetTokens.amapt,
+  },
+  {
+    pid: null,
     lpSymbol: 'APT-stAPT LP',
     quoteToken: APT[ChainId.MAINNET],
     token: mainnetTokens.stapt,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 51436df</samp>

### Summary
🔄📈🚫

<!--
1.  🔄 - This emoji signifies that something was changed or updated, such as the lpSymbol of the amAPT-APT liquidity pool.
2.  📈 - This emoji signifies that something was added or improved, such as the priceHelperLps array that now includes the amAPT-APT LP as a source of price information.
3.  🚫 - This emoji signifies that something was removed or excluded, such as the pid of the amAPT-APT LP that was set to null since it is not a farmable pool.
-->
Updated the configuration of the amAPT-APT liquidity pool in the Aptos app. Added the LP suffix to the lpSymbol and included the LP as a price source for the amAPT token.

> _`amAPT-APT` LP_
> _now has suffix and price_
> _autumn harvest time_

### Walkthrough
* Update the lpSymbol of the amAPT-APT liquidity pool to include the LP suffix ([link](https://github.com/pancakeswap/pancake-frontend/pull/8177/files?diff=unified&w=0#diff-823c0cf898674c10b06daf39fe7d05e2bb2aed321b3173fe510dfc30c584f592L43-R43))
* Add the amAPT-APT LP as a price source for the amAPT token in the `priceHelperLps` array ([link](https://github.com/pancakeswap/pancake-frontend/pull/8177/files?diff=unified&w=0#diff-4cdf7dfa5308d65e5936220f90001313adf3880410840edc9c576c6edddab9c9R9-R14))


