### PR TITLE
perf: (swap): Don't request all token highlights when in bsc

### DIFF
--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -136,7 +136,7 @@ export const usePoolTransactionsSWR = (address: string): Transaction[] | undefin
 
 // Tokens hooks
 
-export const useAllTokenHighLight = (enable: boolean, targetChainName?: MultiChainNameExtend): TokenData[] => {
+export const useAllTokenHighLight = (options: { enable?: boolean; targetChainName?: MultiChainNameExtend }): TokenData[] => {
   const chainNameByQuery = useChainNameByQuery()
   const chainName = targetChainName ?? chainNameByQuery
   const [t24h, t48h, t7d, t14d] = getDeltaTimestamps()

--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -136,7 +136,13 @@ export const usePoolTransactionsSWR = (address: string): Transaction[] | undefin
 
 // Tokens hooks
 
-export const useAllTokenHighLight = (options: { enable?: boolean; targetChainName?: MultiChainNameExtend }): TokenData[] => {
+export const useAllTokenHighLight = ({
+  enable,
+  targetChainName,
+}: {
+  enable?: boolean
+  targetChainName?: MultiChainNameExtend
+}): TokenData[] => {
   const chainNameByQuery = useChainNameByQuery()
   const chainName = targetChainName ?? chainNameByQuery
   const [t24h, t48h, t7d, t14d] = getDeltaTimestamps()

--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -136,14 +136,14 @@ export const usePoolTransactionsSWR = (address: string): Transaction[] | undefin
 
 // Tokens hooks
 
-export const useAllTokenHighLight = (targetChainName?: MultiChainNameExtend): TokenData[] => {
+export const useAllTokenHighLight = (enable: boolean, targetChainName?: MultiChainNameExtend): TokenData[] => {
   const chainNameByQuery = useChainNameByQuery()
   const chainName = targetChainName ?? chainNameByQuery
   const [t24h, t48h, t7d, t14d] = getDeltaTimestamps()
   const { blocks } = useBlockFromTimeStampSWR([t24h, t48h, t7d, t14d], undefined, undefined, chainName)
   const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
   const { data, isLoading } = useSWRImmutable(
-    blocks && chainName && [`info/token/data/${type}`, chainName],
+    enable && blocks && chainName && [`info/token/data/${type}`, chainName],
     () => fetchAllTokenData(chainName, blocks ?? []),
     SWR_SETTINGS_WITHOUT_REFETCH,
   )

--- a/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
+++ b/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
@@ -23,7 +23,10 @@ export const useTokenHighLightList = () => {
   const { chainId } = useActiveChainId()
   const chainWhiteList = useChainWhiteList(chainId)
   const allTokensFromWhiteList = useTokenDatasSWR(chainWhiteList || [], false)
-  const allTokensFromChain = useAllTokenHighLight(!chainWhiteList, multiChainName[chainId])
+  const allTokensFromChain = useAllTokenHighLight({
+    enable: !chainWhiteList,
+    targetChainName: multiChainName[chainId],
+  })
   const tokenAddresses: string[] = useMemo(
     () => allTokensFromChain?.map(({ address }) => address) || [],
     [allTokensFromChain],

--- a/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
+++ b/apps/web/src/views/Swap/components/HotTokenList/useList.tsx
@@ -9,34 +9,33 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ChainId } from '@pancakeswap/chains'
 import { parseV3TokenData, parseV2TokenData } from './utils'
 
-export const useBSCWhiteList = () => {
+export const useChainWhiteList = (chainId?: number) => {
   const listsByUrl = useAtomValue(selectorByUrlsAtom)
-  const lists = listsByUrl[PANCAKE_EXTENDED]
-  const list = lists?.current
   const whiteList = useMemo(() => {
+    const list = listsByUrl[PANCAKE_EXTENDED]?.current
     return list ? list.tokens.map((t) => t.address.toLowerCase()) : []
-  }, [list])
+  }, [listsByUrl])
+  if (chainId !== ChainId.BSC) return null
   return whiteList
 }
 
-// TODO: refactor -> remove chain specific logic
 export const useTokenHighLightList = () => {
   const { chainId } = useActiveChainId()
-  const bscWhiteList = useBSCWhiteList()
-  const allTokensFromBSC = useTokenDatasSWR(chainId === ChainId.BSC ? bscWhiteList : [], false)
-  const allTokensFromETH = useAllTokenHighLight(multiChainName[chainId])
+  const chainWhiteList = useChainWhiteList(chainId)
+  const allTokensFromWhiteList = useTokenDatasSWR(chainWhiteList || [], false)
+  const allTokensFromChain = useAllTokenHighLight(!chainWhiteList, multiChainName[chainId])
   const tokenAddresses: string[] = useMemo(
-    () => allTokensFromETH?.map(({ address }) => address) || [],
-    [allTokensFromETH],
+    () => allTokensFromChain?.map(({ address }) => address) || [],
+    [allTokensFromChain],
   )
-  const allV3TokensFromV3 = useTokensData(chainId === ChainId.BSC ? bscWhiteList : tokenAddresses, chainId)
+  const allV3TokensFromV3 = useTokensData(chainWhiteList || tokenAddresses, chainId)
 
   const tokens = useMemo(() => {
     return {
-      v2Tokens: (chainId === ChainId.BSC ? allTokensFromBSC : allTokensFromETH)?.map(parseV2TokenData),
+      v2Tokens: (allTokensFromWhiteList || allTokensFromChain)?.map(parseV2TokenData),
       v3Tokens: allV3TokensFromV3?.map(parseV3TokenData) ?? [],
     }
-  }, [allTokensFromBSC, allTokensFromETH, allV3TokensFromV3, chainId])
+  }, [allTokensFromWhiteList, allTokensFromChain, allV3TokensFromV3])
 
   return tokens
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b776ccd</samp>

### Summary
🔧🌐🚀

<!--
1.  🔧 - This emoji represents refactoring or fixing something, which is what the `useTokenHighLightList` hook did by removing the chain-specific logic and using a more generic hook.
2.  🌐 - This emoji represents the web or the internet, which is related to the `useChainWhiteList` hook that returns the white list for different chains based on the web3 provider.
3.  🚀 - This emoji represents speed or performance, which is what the `enable` parameter did by optimizing token data fetching based on the chain.
-->
Optimized token data fetching and refactored white list logic for swap view. Added `enable` parameter to `useAllTokenHighLight` and `useSWRImmutable` hooks and extracted `useChainWhiteList` hook from `useTokenHighLightList` hook.

> _We break the chains of logic, we seek the white list of doom_
> _We use the hooks of power, we optimize our fetching gloom_
> _We don't care about the others, we only serve the BSC_
> _We are the `useTokenHighLightList`, we are the metal beast_

### Walkthrough
*  Refactor token white list logic to use a generic hook that returns the white list for BSC or null for other chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/8178/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292L139-R139), [link](https://github.com/pancakeswap/pancake-frontend/pull/8178/files?diff=unified&w=0#diff-f2387797bca27b530d156fa7f58d5addb1dc1d2ff995c1bb9b5dd10be464b292L146-R146), [link](https://github.com/pancakeswap/pancake-frontend/pull/8178/files?diff=unified&w=0#diff-a420fe77bc6f87e86140728bc74cdd16fc8cb65c4f93f833a34b3ce398215be9L12-R38))


