### PR TITLE
refactor(uikit): remove next-seo

### DIFF
--- a/apps/aptos/pages/404.tsx
+++ b/apps/aptos/pages/404.tsx
@@ -1,5 +1,10 @@
 import { NotFound } from '@pancakeswap/uikit'
+import { NextSeo } from 'next-seo'
 
-const NotFoundPage = () => <NotFound />
+const NotFoundPage = () => (
+  <NotFound>
+    <NextSeo title="404" />
+  </NotFound>
+)
 
 export default NotFoundPage

--- a/apps/blog/pages/404.tsx
+++ b/apps/blog/pages/404.tsx
@@ -1,5 +1,10 @@
 import { NotFound } from '@pancakeswap/uikit'
+import { NextSeo } from 'next-seo'
 
-const NotFoundPage = () => <NotFound />
+const NotFoundPage = () => (
+  <NotFound>
+    <NextSeo title="404" />
+  </NotFound>
+)
 
 export default NotFoundPage

--- a/apps/blog/pages/articles/[slug].tsx
+++ b/apps/blog/pages/articles/[slug].tsx
@@ -8,6 +8,7 @@ import { InferGetStaticPropsType, GetStaticProps } from 'next'
 import { getArticle, getSingleArticle } from 'hooks/getArticle'
 import PageMeta from 'components/PageMeta'
 import { filterTagArray } from 'utils/filterTagArray'
+import { NextSeo } from 'next-seo'
 
 export async function getStaticPaths() {
   return {
@@ -84,7 +85,11 @@ export const getStaticProps = (async ({ params, previewData }) => {
 const ArticlePage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({ fallback }) => {
   const router = useRouter()
   if (!router.isFallback && !fallback?.['/article']?.title) {
-    return <NotFound />
+    return (
+      <NotFound>
+        <NextSeo title="404" />
+      </NotFound>
+    )
   }
 
   const { title, description, imgUrl } = fallback['/article']

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -1,6 +1,11 @@
 import { NotFound } from '@pancakeswap/uikit'
+import { NextSeo } from 'next-seo'
 
-const NotFoundPage = () => <NotFound />
+const NotFoundPage = () => (
+  <NotFound>
+    <NextSeo title="404" />
+  </NotFound>
+)
 
 NotFoundPage.chains = []
 

--- a/apps/web/src/pages/_error.tsx
+++ b/apps/web/src/pages/_error.tsx
@@ -14,8 +14,13 @@
 import { captureUnderscoreErrorException } from '@sentry/nextjs'
 import NextErrorComponent, { ErrorProps } from 'next/error'
 import { NotFound } from '@pancakeswap/uikit'
+import { NextSeo } from 'next-seo'
 
-const CustomErrorComponent = (props: ErrorProps) => <NotFound statusCode={props.statusCode} />
+const CustomErrorComponent = (props: ErrorProps) => (
+  <NotFound statusCode={props.statusCode}>
+    <NextSeo title="404" />
+  </NotFound>
+)
 
 CustomErrorComponent.getInitialProps = async (contextData) => {
   // In case this is running in a serverless function, await this in order to give Sentry

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -447,7 +447,11 @@ export default function PoolPage() {
   const isOwnNFT = isStakedInMCv3 || ownsNFT
 
   if (!isLoading && poolState === PoolState.NOT_EXISTS) {
-    return <NotFound />
+    return (
+      <NotFound>
+        <NextSeo title="404" />
+      </NotFound>
+    )
   }
 
   const farmingTips =

--- a/apps/web/src/views/Voting/Proposal/Overview.tsx
+++ b/apps/web/src/views/Voting/Proposal/Overview.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 import { useTranslation } from '@pancakeswap/localization'
 import Container from 'components/Layout/Container'
 import PageLoader from 'components/Loader/PageLoader'
+import { NextSeo } from 'next-seo'
 import { FetchStatus } from 'config/constants/types'
 import { isCoreProposal } from '../helpers'
 import { ProposalStateTag, ProposalTypeTag } from '../components/Proposals/tags'
@@ -39,7 +40,11 @@ const Overview = () => {
   const isPageLoading = votesLoadingStatus === FetchStatus.Fetching || proposalLoadingStatus === FetchStatus.Fetching
 
   if (!proposal && error) {
-    return <NotFound />
+    return (
+      <NotFound>
+        <NextSeo title="404" />
+      </NotFound>
+    )
   }
 
   if (isFallback || !proposal) {

--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -89,7 +89,6 @@
     "jest-styled-components": "^7.0.8",
     "js-cookie": "*",
     "next": "*",
-    "next-seo": "*",
     "next-themes": "^0.2.1",
     "polished": "^4.2.2",
     "react": "^18.2.0",
@@ -117,7 +116,6 @@
   "peerDependencies": {
     "js-cookie": "*",
     "next": "*",
-    "next-seo": "*",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-device-detect": "*",

--- a/packages/uikit/src/components/NotFound/NotFound.tsx
+++ b/packages/uikit/src/components/NotFound/NotFound.tsx
@@ -1,7 +1,7 @@
 import { styled } from "styled-components";
-import { NextSeo } from "next-seo";
-import { useTranslation } from "@pancakeswap/localization";
 import Link from "next/link";
+import { ReactNode } from "react";
+import { useTranslation } from "@pancakeswap/localization";
 import { LogoIcon } from "../Svg";
 import { Heading } from "../Heading";
 import { Text } from "../Text";
@@ -15,12 +15,12 @@ const StyledNotFound = styled.div`
   justify-content: center;
 `;
 
-const NotFound = ({ statusCode = 404 }: { statusCode?: number }) => {
+const NotFound = ({ statusCode = 404, children }: { statusCode?: number; children: ReactNode }) => {
   const { t } = useTranslation();
 
   return (
     <>
-      <NextSeo title="404" />
+      {children}
       <StyledNotFound>
         <LogoIcon width="64px" mb="8px" />
         <Heading scale="xxl">{statusCode}</Heading>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1676,9 +1676,6 @@ importers:
       next:
         specifier: '*'
         version: 13.4.2(@babel/core@7.21.3)(react-dom@18.2.0)(react@18.2.0)
-      next-seo:
-        specifier: '*'
-        version: 5.15.0(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
@@ -20857,6 +20854,7 @@ packages:
       next: 13.4.2(@babel/core@7.22.17)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /next-themes@0.2.1(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e746a39</samp>

### Summary
🏷️🚫📰

<!--
1.  🏷️ - This emoji represents the addition of the `NextSeo` component to set the page titles for different apps and pages. It also implies the removal of the unused `next-seo` package from `uikit`.
2.  🚫 - This emoji represents the 404 pages that are customized and rendered when a resource is not found or does not exist. It also implies the wrapping of the `NotFound` component with the `NextSeo` component to set the title for these pages.
3.  📰 - This emoji represents the `blog` app that is updated with the `NextSeo` component to set the page titles for the article pages and the 404 pages. It also implies the content and layout of the blog pages.
-->
Added `NextSeo` component to set page titles for various pages in the `blog`, `web`, and `aptos` apps. Removed `next-seo` package from `uikit` and refactored `NotFound` component to accept custom content.

> _We're setting titles with `NextSeo` on every page_
> _We're wrapping `NotFound` with it when there's nothing to display_
> _We're heaving away the `next-seo` package from `uikit`_
> _We're saving some bytes and avoiding conflicts with it_

### Walkthrough
*  Remove `NextSeo` component from `NotFound` component in `uikit` package and render `children` prop instead ([link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-19a86d9fdecfa605242f459debb823997382d049b803ba7c93aac4ca0470c2adL2-R4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-19a86d9fdecfa605242f459debb823997382d049b803ba7c93aac4ca0470c2adL18-R23))
*  Remove `next-seo` package from `uikit` package dependencies and devDependencies ([link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-cb0a1990ba52670ab2c56f831e950ca6447a9ca43ab7028565a66d0defd034d6L92),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-cb0a1990ba52670ab2c56f831e950ca6447a9ca43ab7028565a66d0defd034d6L120))
*  Import and use `NextSeo` component in `aptos`, `blog`, and `web` apps to set the title of the 404 page or the specific page when not found or error occurs ([link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-8526861bb317ffb66ef385b4f5c34737c7d8ef224a79e59ef066d40af55ae10dL2-R8),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-227e7b13e1887d504f620cf54c5e4c7a4635c6a752a6f6dd6b373cd2695c55efL2-R8),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-956a5360205f9116704a061c4caf856a85557ef36b0d9e99469fc249f09c0da6R11),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-956a5360205f9116704a061c4caf856a85557ef36b0d9e99469fc249f09c0da6L87-R92),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-73a9476fd843199582d0449dbe9de05f37fb46f013c480f04836314e0354a0baL2-R8),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-17d0c35dc481e812a5f04e8e7ddde01ebc2dec83ef5486877ec906c8d04d1430L17-R23),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL450-R454),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-559412beee23ad2e20b0a3d049e9f980328b8c3c2f44b2798b12329c94bfa135R11),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-559412beee23ad2e20b0a3d049e9f980328b8c3c2f44b2798b12329c94bfa135L42-R47))
*  Wrap `NotFound` component with `NextSeo` component in `aptos`, `blog`, and `web` apps and pass the desired title as a prop ([link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-956a5360205f9116704a061c4caf856a85557ef36b0d9e99469fc249f09c0da6L87-R92),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-17d0c35dc481e812a5f04e8e7ddde01ebc2dec83ef5486877ec906c8d04d1430L17-R23),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL450-R454),[link](https://github.com/pancakeswap/pancake-frontend/pull/8181/files?diff=unified&w=0#diff-559412beee23ad2e20b0a3d049e9f980328b8c3c2f44b2798b12329c94bfa135L42-R47))


