### PR TITLE
fix: (affiliate-program): DefaultLink hook cache refetch not work and move to react-query

### DIFF
--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/LoginButton.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/LoginButton.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react'
 import { SiweMessage } from 'siwe'
-import { useSWRConfig } from 'swr'
 import { useAccount } from 'wagmi'
 import { useSignMessage } from '@pancakeswap/wagmi'
 import { getCookie } from 'cookies-next'
@@ -8,11 +7,12 @@ import { Button } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
+import { useQueryClient } from '@tanstack/react-query'
 
 const LoginButton = () => {
   const { t } = useTranslation()
   const { address } = useAccount()
-  const { mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { signMessageAsync } = useSignMessage()
   const { chainId } = useActiveChainId()
   const [isLoading, setIsLoading] = useState(false)
@@ -45,7 +45,7 @@ const LoginButton = () => {
         const { status } = await response.json()
 
         if (status === 'success') {
-          await mutate(['/auth-affiliate', address, cookie])
+          await queryClient.invalidateQueries(['affiliates-program', 'auth-affiliate', address, cookie])
         }
       }
     } catch (error) {

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/LoginButton.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/LoginButton.tsx
@@ -2,11 +2,9 @@ import { useState, useMemo } from 'react'
 import { SiweMessage } from 'siwe'
 import { useAccount } from 'wagmi'
 import { useSignMessage } from '@pancakeswap/wagmi'
-import { getCookie } from 'cookies-next'
 import { Button } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
 import { useQueryClient } from '@tanstack/react-query'
 
 const LoginButton = () => {
@@ -16,7 +14,6 @@ const LoginButton = () => {
   const { signMessageAsync } = useSignMessage()
   const { chainId } = useActiveChainId()
   const [isLoading, setIsLoading] = useState(false)
-  const cookie = getCookie(AFFILIATE_SID)
 
   const isReady = useMemo(() => address && chainId && !isLoading, [isLoading, address, chainId])
 
@@ -45,7 +42,7 @@ const LoginButton = () => {
         const { status } = await response.json()
 
         if (status === 'success') {
-          await queryClient.invalidateQueries(['affiliates-program', 'auth-affiliate', address, cookie])
+          await queryClient.invalidateQueries(['affiliates-program', 'auth-affiliate', address])
         }
       }
     } catch (error) {

--- a/apps/web/src/views/AffiliatesProgram/hooks/useAffiliateClaimList.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useAffiliateClaimList.tsx
@@ -1,20 +1,18 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import qs from 'qs'
 import useAuthAffiliate from 'views/AffiliatesProgram/hooks/useAuthAffiliate'
 import useAuthAffiliateExist from 'views/AffiliatesProgram/hooks/useAuthAffiliateExist'
 import { UserClaimListResponse, MAX_PER_PAGE } from 'views/AffiliatesProgram/hooks/useUserClaimList'
 import { FAST_INTERVAL } from 'config/constants'
+import { useQuery } from '@tanstack/react-query'
 
 const useAffiliateClaimList = ({ currentPage }) => {
   const { address } = useAccount()
   const { isAffiliate } = useAuthAffiliate()
   const { isAffiliateExist } = useAuthAffiliateExist()
 
-  const { data, isLoading, mutate } = useSWR(
-    address &&
-      isAffiliateExist &&
-      isAffiliate && ['/affiliate-claim-list', isAffiliateExist, isAffiliate, address, currentPage],
+  const { data, isLoading, refetch } = useQuery(
+    ['affiliates-program', 'affiliate-claim-list', isAffiliateExist, isAffiliate, address, currentPage],
     async () => {
       try {
         const skip = currentPage === 1 ? 0 : (currentPage - 1) * MAX_PER_PAGE
@@ -36,7 +34,8 @@ const useAffiliateClaimList = ({ currentPage }) => {
       }
     },
     {
-      refreshInterval: FAST_INTERVAL * 3,
+      enabled: Boolean(address && isAffiliateExist && isAffiliate),
+      refetchInterval: FAST_INTERVAL * 3,
       keepPreviousData: true,
     },
   )
@@ -44,7 +43,7 @@ const useAffiliateClaimList = ({ currentPage }) => {
   return {
     data,
     isFetching: isLoading,
-    mutate,
+    mutate: refetch,
   }
 }
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliate.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliate.tsx
@@ -78,7 +78,7 @@ const useAuthAffiliate = (): AffiliateInfoType => {
   const cookie = getCookie(AFFILIATE_SID)
 
   const { data, refetch } = useQuery(
-    ['affiliates-program', 'auth-affiliate', address, cookie],
+    ['affiliates-program', 'auth-affiliate', address],
     async () => {
       try {
         const response = await fetch(`/api/affiliates-program/affiliate-info`)

--- a/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliate.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliate.tsx
@@ -1,7 +1,7 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import { getCookie, deleteCookie } from 'cookies-next'
 import { AFFILIATE_SID } from 'pages/api/affiliates-program/affiliate-login'
+import { useQuery } from '@tanstack/react-query'
 
 export interface FeeType {
   affiliateAddress: string
@@ -77,31 +77,37 @@ const useAuthAffiliate = (): AffiliateInfoType => {
   const { address } = useAccount()
   const cookie = getCookie(AFFILIATE_SID)
 
-  const { data, mutate } = useSWR(address && cookie !== '' && ['/auth-affiliate', address, cookie], async () => {
-    try {
-      const response = await fetch(`/api/affiliates-program/affiliate-info`)
-      const result: AffiliateInfoResponse = await response.json()
-      if (result.status === 'error') {
-        deleteCookie(AFFILIATE_SID, { sameSite: true })
-      }
+  const { data, refetch } = useQuery(
+    ['affiliates-program', 'auth-affiliate', address, cookie],
+    async () => {
+      try {
+        const response = await fetch(`/api/affiliates-program/affiliate-info`)
+        const result: AffiliateInfoResponse = await response.json()
+        if (result.status === 'error') {
+          deleteCookie(AFFILIATE_SID, { sameSite: true })
+        }
 
-      return {
-        isAffiliate: result.status === 'success',
-        affiliate: result.affiliate,
+        return {
+          isAffiliate: result.status === 'success',
+          affiliate: result.affiliate,
+        }
+      } catch (error) {
+        console.error(`Fetch Affiliate Exist Error: ${error}`)
+        return {
+          isAffiliate: false,
+          affiliate: initAffiliateData,
+        }
       }
-    } catch (error) {
-      console.error(`Fetch Affiliate Exist Error: ${error}`)
-      return {
-        isAffiliate: false,
-        affiliate: initAffiliateData,
-      }
-    }
-  })
+    },
+    {
+      enabled: Boolean(address && cookie !== ''),
+    },
+  )
 
   return {
     isAffiliate: (data?.isAffiliate && !!address) ?? false,
     affiliate: data?.affiliate ?? initAffiliateData,
-    refresh: mutate,
+    refresh: refetch,
   }
 }
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliateExist.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useAuthAffiliateExist.tsx
@@ -1,6 +1,6 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import qs from 'qs'
+import { useQuery } from '@tanstack/react-query'
 
 interface AuthAffiliateExistResponse {
   exist: boolean
@@ -9,8 +9,8 @@ interface AuthAffiliateExistResponse {
 const useAuthAffiliateExist = () => {
   const { address } = useAccount()
 
-  const { data: isAffiliateExist } = useSWR(
-    address && ['/affiliate-exist', address],
+  const { data: isAffiliateExist } = useQuery(
+    ['affiliates-program', 'affiliate-exist', address],
     async () => {
       try {
         const queryString = qs.stringify({ address })
@@ -23,10 +23,9 @@ const useAuthAffiliateExist = () => {
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
+      enabled: !!address,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useLeaderboard.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useLeaderboard.tsx
@@ -1,7 +1,7 @@
-import useSWRImmutable from 'swr/immutable'
 import BigNumber from 'bignumber.js'
 import { useCakePrice } from 'hooks/useCakePrice'
 import { MetricDetail } from 'views/AffiliatesProgram/hooks/useAuthAffiliate'
+import { useQuery } from '@tanstack/react-query'
 
 export interface ListType {
   address: string
@@ -18,8 +18,8 @@ interface Leaderboard {
 const useLeaderboard = (): Leaderboard => {
   const cakePriceBusd = useCakePrice()
 
-  const { data, isLoading } = useSWRImmutable(
-    cakePriceBusd.gt(0) && ['/affiliate-program-leaderboard', cakePriceBusd],
+  const { data, isLoading } = useQuery(
+    ['affiliates-program', 'affiliate-program-leaderboard', cakePriceBusd],
     async () => {
       const response = await fetch(`/api/affiliates-program/leader-board`)
       const result = await response.json()
@@ -31,6 +31,11 @@ const useLeaderboard = (): Leaderboard => {
         }
       })
       return list
+    },
+    {
+      enabled: cakePriceBusd.gt(0),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useUserClaimList.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useUserClaimList.tsx
@@ -1,8 +1,8 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import qs from 'qs'
 import useUserExist from 'views/AffiliatesProgram/hooks/useUserExist'
 import { FAST_INTERVAL } from 'config/constants'
+import { useQuery } from '@tanstack/react-query'
 
 export type ClaimStatus = 'PENDING' | 'APPROVED' | 'REJECTED'
 
@@ -29,8 +29,8 @@ const useUserClaimList = ({ currentPage }) => {
   const { address } = useAccount()
   const { isUserExist } = useUserExist()
 
-  const { data, isLoading, mutate } = useSWR(
-    address && isUserExist && ['/user-claim-list', isUserExist, address, currentPage],
+  const { data, isLoading, refetch } = useQuery(
+    ['affiliates-program', 'user-claim-list', isUserExist, address, currentPage],
     async () => {
       try {
         const skip = currentPage === 1 ? 0 : (currentPage - 1) * MAX_PER_PAGE
@@ -51,7 +51,8 @@ const useUserClaimList = ({ currentPage }) => {
       }
     },
     {
-      refreshInterval: FAST_INTERVAL * 3,
+      enabled: Boolean(address && isUserExist),
+      refetchInterval: FAST_INTERVAL * 3,
       keepPreviousData: true,
     },
   )
@@ -59,7 +60,7 @@ const useUserClaimList = ({ currentPage }) => {
   return {
     data,
     isFetching: isLoading,
-    mutate,
+    mutate: refetch,
   }
 }
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useUserExist.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useUserExist.tsx
@@ -1,4 +1,4 @@
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import { useAccount } from 'wagmi'
 import qs from 'qs'
 
@@ -9,8 +9,8 @@ interface UserExistResponse {
 const useUserExist = () => {
   const { address } = useAccount()
 
-  const { data: isUserExist, isLoading } = useSWR(
-    address && ['/user-exist', address],
+  const { data: isUserExist, isLoading } = useQuery(
+    ['affiliates-program', 'user-exist', address],
     async () => {
       try {
         const queryString = qs.stringify({ address })
@@ -23,10 +23,9 @@ const useUserExist = () => {
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
+      enabled: !!address,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0ad8285</samp>

### Summary
🔄🚀🛠️

<!--
1.  🔄 - This emoji represents the refactoring of the data fetching logic using a different library or hook, which implies a change in the implementation but not the functionality.
2.  🚀 - This emoji represents the improvement of the performance, consistency, and error handling of the data fetching and caching, which implies a positive impact on the user experience and the app efficiency.
3.  🛠️ - This emoji represents the adjustment of the query options and the use of utility functions, which implies a fine-tuning of the data fetching behavior and the code quality.
-->
The pull request refactors the data fetching logic for various components and hooks in the `AffiliatesProgram` view, using the `useQuery` hook from `@tanstack/react-query` instead of the `useSWR` hook. This improves the performance, consistency, and error handling of the data fetching and caching across the app. The pull request also imports some utility functions from external libraries to simplify the code.

> _To fetch data with more speed and grace_
> _We replaced `useSWR` with `useQuery`_
> _From `react-query` we took_
> _Some hooks and options to cook_
> _A better caching and error handling base_

### Walkthrough
*  Replace `useSWR` hook with `useQuery` hook for data fetching and caching in various hooks ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ea466405378cb17c3e020769042ee68ad5f5f276852383f92e0c709956b789b7L14-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-4bcef3f8e01bcdc502a427e1b19ade7229e38f42066e52a8b3e76ece6c836e39L80-R105), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-3fc1def9923120efdb4072d887f42f09f36649508b285e1b897d9543f25e3eccL12-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL12-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-40a6d3e2fc2ef9520f5600bb29da2dfafa581ec4a241bd977560aa8bbb549f31L32-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-662fbc716d907bc4cf509afe6f1ae5913230be5e21242a6e7bf224e1ab64d825L12-R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-70e8e399d97015e40102cdd4792f44dbe497f0b8032c58a230fa24b665e7228eL15-R33))
*  Import `useQuery` hook from `@tanstack/react-query` and `nanoid` function from `@reduxjs/toolkit` in various hooks ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ea466405378cb17c3e020769042ee68ad5f5f276852383f92e0c709956b789b7R8-R9), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-4bcef3f8e01bcdc502a427e1b19ade7229e38f42066e52a8b3e76ece6c836e39R5-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-3fc1def9923120efdb4072d887f42f09f36649508b285e1b897d9543f25e3eccR4-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-40a6d3e2fc2ef9520f5600bb29da2dfafa581ec4a241bd977560aa8bbb549f31R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-70e8e399d97015e40102cdd4792f44dbe497f0b8032c58a230fa24b665e7228eR4))
*  Import `useQueryClient` hook from `@tanstack/react-query` in `useDefaultLinkId` hook to access query client instance ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL2-R2))
*  Add `enabled` option to `useQuery` hook to conditionally enable or disable queries based on variables in various hooks ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ea466405378cb17c3e020769042ee68ad5f5f276852383f92e0c709956b789b7L38-R46), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-3fc1def9923120efdb4072d887f42f09f36649508b285e1b897d9543f25e3eccL25-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL31-R41), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-40a6d3e2fc2ef9520f5600bb29da2dfafa581ec4a241bd977560aa8bbb549f31L53-R62), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-662fbc716d907bc4cf509afe6f1ae5913230be5e21242a6e7bf224e1ab64d825L25-R29))
*  Rename `mutate` function to `refetch` in various hooks to use consistent naming of `useQuery` hook method for manual refetching ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ea466405378cb17c3e020769042ee68ad5f5f276852383f92e0c709956b789b7L38-R46), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-4bcef3f8e01bcdc502a427e1b19ade7229e38f42066e52a8b3e76ece6c836e39L104-R111), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-40a6d3e2fc2ef9520f5600bb29da2dfafa581ec4a241bd977560aa8bbb549f31L53-R62))
*  Replace `revalidateOnFocus`, `revalidateIfStale`, `revalidateOnReconnect`, and `revalidateOnMount` options with `refetchOnFocus`, `refetchOnReconnect`, and `refetchOnMount` options in various hooks to use consistent naming and behavior of `useQuery` hook options for automatic refetching ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-3fc1def9923120efdb4072d887f42f09f36649508b285e1b897d9543f25e3eccL25-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL31-R41), [link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-662fbc716d907bc4cf509afe6f1ae5913230be5e21242a6e7bf224e1ab64d825L25-R29))
*  Replace `mutate` function with `queryClient.invalidateQueries` method in `useDefaultLinkId` hook to invalidate and refetch query when `randomNanoId` variable changes ([link](https://github.com/pancakeswap/pancake-frontend/pull/8183/files?diff=unified&w=0#diff-ba8f2b8604de2c2503e1be6f65ae6a7dc9b953923fd7d16db3be7a05d287e90cL23-R25))


