### PR TITLE
refactor: Enable ssr for react-query and use it in teams pages

### DIFF
--- a/apps/web/src/Providers.tsx
+++ b/apps/web/src/Providers.tsx
@@ -2,7 +2,7 @@ import { ModalProvider, light, dark, UIKitProvider } from '@pancakeswap/uikit'
 import { Provider } from 'react-redux'
 import { SWRConfig } from 'swr'
 import { LanguageProvider } from '@pancakeswap/localization'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fetchStatusMiddleware } from 'hooks/useSWRContract'
 import { Store } from '@reduxjs/toolkit'
 import { ThemeProvider as NextThemeProvider, useTheme as useNextTheme } from 'next-themes'
@@ -22,31 +22,32 @@ const StyledUIKitProvider: React.FC<React.PropsWithChildren> = ({ children, ...p
   )
 }
 
-const Providers: React.FC<React.PropsWithChildren<{ store: Store; children: React.ReactNode }>> = ({
-  children,
-  store,
-}) => {
+const Providers: React.FC<
+  React.PropsWithChildren<{ store: Store; children: React.ReactNode; dehydratedState: any }>
+> = ({ children, store, dehydratedState }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <WagmiConfig config={wagmiConfig}>
-        <Provider store={store}>
-          <NextThemeProvider>
-            <StyledUIKitProvider>
-              <LanguageProvider>
-                <SWRConfig
-                  value={{
-                    use: [fetchStatusMiddleware],
-                  }}
-                >
-                  <HistoryManagerProvider>
-                    <ModalProvider>{children}</ModalProvider>
-                  </HistoryManagerProvider>
-                </SWRConfig>
-              </LanguageProvider>
-            </StyledUIKitProvider>
-          </NextThemeProvider>
-        </Provider>
-      </WagmiConfig>
+      <Hydrate state={dehydratedState}>
+        <WagmiConfig config={wagmiConfig}>
+          <Provider store={store}>
+            <NextThemeProvider>
+              <StyledUIKitProvider>
+                <LanguageProvider>
+                  <SWRConfig
+                    value={{
+                      use: [fetchStatusMiddleware],
+                    }}
+                  >
+                    <HistoryManagerProvider>
+                      <ModalProvider>{children}</ModalProvider>
+                    </HistoryManagerProvider>
+                  </SWRConfig>
+                </LanguageProvider>
+              </StyledUIKitProvider>
+            </NextThemeProvider>
+          </Provider>
+        </WagmiConfig>
+      </Hydrate>
     </QueryClientProvider>
   )
 }

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -58,7 +58,7 @@ function MPGlobalHooks() {
   return null
 }
 
-function MyApp(props: AppProps<{ initialReduxState: any }>) {
+function MyApp(props: AppProps<{ initialReduxState: any; dehydratedState: any }>) {
   const { pageProps, Component } = props
   const store = useStore(pageProps.initialReduxState)
 
@@ -80,7 +80,7 @@ function MyApp(props: AppProps<{ initialReduxState: any }>) {
         )}
       </Head>
       <DefaultSeo {...SEO} />
-      <Providers store={store}>
+      <Providers store={store} dehydratedState={pageProps.dehydratedState}>
         <PageMeta />
         {(Component as NextPageWithLayout).Meta && (
           // @ts-ignore

--- a/apps/web/src/pages/teams/index.tsx
+++ b/apps/web/src/pages/teams/index.tsx
@@ -1,29 +1,23 @@
-import { GetStaticProps, InferGetStaticPropsType } from 'next'
-import { SWRConfig } from 'swr'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { GetStaticProps } from 'next'
+import { teamsById } from 'utils/teamsById'
+import { getTeams } from 'state/teams/helpers'
 import Teams from '../../views/Teams'
-import { getTeams } from '../../state/teams/helpers'
-import { teamsById } from '../../utils/teamsById'
 
-const TeamsPage = ({ fallback }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  return (
-    <SWRConfig
-      value={{
-        fallback,
-      }}
-    >
-      <Teams />
-    </SWRConfig>
-  )
+const TeamsPage = () => {
+  return <Teams />
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const fetchedTeams = await getTeams()
-  if (!fetchedTeams) {
+  const queryClient = new QueryClient()
+
+  const fetchedTeams = await queryClient.fetchQuery(['teams'], getTeams)
+
+  if (fetchedTeams) {
+    await queryClient.prefetchQuery(['teams'], () => teamsById)
     return {
       props: {
-        fallback: {
-          teams: teamsById,
-        },
+        dehydratedState: dehydrate(queryClient),
       },
       revalidate: 1,
     }
@@ -31,11 +25,9 @@ export const getStaticProps: GetStaticProps = async () => {
 
   return {
     props: {
-      fallback: {
-        teams: fetchedTeams,
-      },
+      dehydratedState: dehydrate(queryClient),
+      revalidate: 60 * 60 * 12,
     },
-    revalidate: 60 * 60 * 12, // 12 hours
   }
 }
 

--- a/apps/web/src/state/teams/helpers.ts
+++ b/apps/web/src/state/teams/helpers.ts
@@ -35,7 +35,6 @@ export const getTeam = async (teamId: number): Promise<Team> => {
  * Gets on-chain data and merges it with the existing static list of teams
  */
 export const getTeams = async (): Promise<TeamsById> => {
-  console.info('mmmmmmmm')
   try {
     const profileContract = getProfileContract()
     const teamsById = fromPairs(teamsList.map((team) => [team.id, team]))

--- a/apps/web/src/state/teams/helpers.ts
+++ b/apps/web/src/state/teams/helpers.ts
@@ -35,6 +35,7 @@ export const getTeam = async (teamId: number): Promise<Team> => {
  * Gets on-chain data and merges it with the existing static list of teams
  */
 export const getTeams = async (): Promise<TeamsById> => {
+  console.info('mmmmmmmm')
   try {
     const profileContract = getProfileContract()
     const teamsById = fromPairs(teamsList.map((team) => [team.id, team]))

--- a/apps/web/src/testUtils.tsx
+++ b/apps/web/src/testUtils.tsx
@@ -46,7 +46,9 @@ export function renderWithProvider(
   function Wrapper({ children }) {
     return (
       <RouterContext.Provider value={{ ...mockRouter, ...router }}>
-        <Provider store={store}>{children}</Provider>
+        <Provider store={store} dehydratedState={{}}>
+          {children}
+        </Provider>
       </RouterContext.Provider>
     )
   }
@@ -63,7 +65,7 @@ export const createJotaiWrapper =
   (reduxState = undefined, testAtom, initState = undefined) =>
   ({ children }) =>
     (
-      <Provider store={makeStore(reduxState)}>
+      <Provider store={makeStore(reduxState)} dehydratedState={{}}>
         <JotaiProvider>
           {initState ? <HydrateAtoms initialValues={[[testAtom, initState]]}>{children}</HydrateAtoms> : children}
         </JotaiProvider>
@@ -73,7 +75,11 @@ export const createJotaiWrapper =
 export const createReduxWrapper =
   (initState = undefined) =>
   ({ children }) =>
-    <Provider store={makeStore(initState)}>{children}</Provider>
+    (
+      <Provider store={makeStore(initState)} dehydratedState={{}}>
+        {children}
+      </Provider>
+    )
 
 export const createSWRWrapper =
   (fallbackData = undefined) =>

--- a/apps/web/src/views/Teams/components/TeamCard.tsx
+++ b/apps/web/src/views/Teams/components/TeamCard.tsx
@@ -1,11 +1,10 @@
 import { styled } from 'styled-components'
 import { Card, CardHeader, CardBody, CommunityIcon, Heading, PrizeIcon, Text, Skeleton } from '@pancakeswap/uikit'
-import { FetchStatus } from 'config/constants/types'
-import useSWR from 'swr'
 import { getTeam } from 'state/teams/helpers'
 import { useTranslation } from '@pancakeswap/localization'
-import ComingSoon from './ComingSoon'
+import { useQuery } from '@tanstack/react-query'
 import IconStatBox from './IconStatBox'
+import ComingSoon from './ComingSoon'
 
 interface TeamCardProps {
   id: string
@@ -76,7 +75,7 @@ const StatRow = styled.div`
 const TeamCard: React.FC<React.PropsWithChildren<TeamCardProps>> = ({ id }) => {
   const { t } = useTranslation()
   const idNumber = Number(id)
-  const { data: team, status } = useSWR(['team', id], async () => getTeam(idNumber))
+  const { data: team, status } = useQuery(['team', id], async () => getTeam(idNumber))
 
   return (
     <Wrapper>
@@ -92,7 +91,7 @@ const TeamCard: React.FC<React.PropsWithChildren<TeamCardProps>> = ({ id }) => {
         </StyledCardHeader>
         <CardBody>
           <StatRow>
-            {status !== FetchStatus.Fetched ? (
+            {status !== 'success' ? (
               <Skeleton width="100px" />
             ) : (
               <IconStatBox icon={CommunityIcon} title={team.users} subtitle={t('Active Members')} />

--- a/apps/web/src/views/Teams/index.tsx
+++ b/apps/web/src/views/Teams/index.tsx
@@ -1,16 +1,15 @@
 import { AutoRenewIcon, Flex, Heading } from '@pancakeswap/uikit'
 import orderBy from 'lodash/orderBy'
-import useSWR from 'swr'
 import Page from 'components/Layout/Page'
-import { FetchStatus } from 'config/constants/types'
 import { useTranslation } from '@pancakeswap/localization'
+import { getTeams } from 'state/teams/helpers'
+import { useQuery } from '@tanstack/react-query'
 import TeamListCard from './components/TeamListCard'
 import TeamHeader from './components/TeamHeader'
-import { getTeams } from '../../state/teams/helpers'
 
 const Teams = () => {
   const { t } = useTranslation()
-  const { data, status } = useSWR('teams', async () => getTeams())
+  const { data, status } = useQuery(['teams'], async () => getTeams())
   const teamList = data ? Object.values(data) : []
   const topTeams = orderBy(teamList, ['points', 'id', 'name'], ['desc', 'asc', 'asc'])
 
@@ -19,7 +18,7 @@ const Teams = () => {
       <TeamHeader />
       <Flex alignItems="center" justifyContent="space-between" mb="32px">
         <Heading scale="xl">{t('Teams')}</Heading>
-        {status !== FetchStatus.Fetched && <AutoRenewIcon spin />}
+        {status !== 'success' && <AutoRenewIcon spin />}
       </Flex>
       {topTeams.map((team, index) => (
         <TeamListCard key={team.id} rank={index + 1} team={team} />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d1c816</samp>

### Summary
🚀🔄🧪

<!--
1.  🚀 This emoji represents the main feature of the pull request, which is adding server-side rendering and hydration support for react-query data. This is a significant improvement for the web app's performance and user experience.
2.  🔄 This emoji represents the change of replacing `swr` with `react-query` for fetching and rendering the teams data. This is a refactor that improves the data fetching logic and consistency.
3.  🧪 This emoji represents the change of modifying the test utils to pass an empty `dehydratedState` prop to the `Provider` component. This is a fix that prevents errors when testing components that use `useQuery`.
-->
The pull request replaces `swr` with `react-query` for data fetching and rendering in the web app. It adds server-side rendering and hydration support for the query data using `@tanstack/react-query`. It improves the performance, consistency, and user experience of the web app. It also fixes some testing errors and refactors some components. It adds a temporary debugging statement that should be removed.

> _We're fetching data with `react-query`_
> _We're rendering it on the server side_
> _We're heaving on the ropes with `Hydrate`_
> _We're sailing fast and smooth with the tide_

### Walkthrough
*  Replace `useSWR` hook with `useQuery` hook from `@tanstack/react-query` for fetching and caching team data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-14945e118468c1f09b2837620105931b76146775591e5366980fc7a0fd40bfd1L2-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-71d08d29838b88f5c217abcfd2bfe504fc32f9a8b57f85d263a7094adb30607eL3-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-71d08d29838b88f5c217abcfd2bfe504fc32f9a8b57f85d263a7094adb30607eL79-R78), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-71d08d29838b88f5c217abcfd2bfe504fc32f9a8b57f85d263a7094adb30607eL95-R94), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-6cd24cd853c0660a28b5acb35bac9c930b3cd54b6680e9d84601cceceeae8d7fL3-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-6cd24cd853c0660a28b5acb35bac9c930b3cd54b6680e9d84601cceceeae8d7fL22-R21))
*  Add `dehydratedState` prop to `MyApp` and `Providers` components to enable server-side rendering and hydration of query data using `dehydrate` and `Hydrate` functions from `@tanstack/react-query` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93L61-R61), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-a3569d521976a5ee9e97e2b2e005bf7423bc96bb49397b3adfb09cde5862bf93L83-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-35175c7cc24a0714ea91b73a8aa1ae17b35e974151d7c36281434b4522af0967L5-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-35175c7cc24a0714ea91b73a8aa1ae17b35e974151d7c36281434b4522af0967L25-R50))
*  Modify `getStaticProps` functions in `teams/[id].tsx` and `teams/index.tsx` to use `queryClient` from `@tanstack/react-query` to fetch and prefetch query data on the server-side and return `dehydratedState` prop instead of `fallback` prop ([link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-14945e118468c1f09b2837620105931b76146775591e5366980fc7a0fd40bfd1R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-14945e118468c1f09b2837620105931b76146775591e5366980fc7a0fd40bfd1L45-R45), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-14945e118468c1f09b2837620105931b76146775591e5366980fc7a0fd40bfd1L59-R53), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-475a60823d5f7b05e26e507843b7877b87db30f153c17176ee6cd5d40b382f86L1-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-475a60823d5f7b05e26e507843b7877b87db30f153c17176ee6cd5d40b382f86L34-R30))
*  Pass `dehydratedState` prop with an empty object to `Provider` component in `renderWithProvider`, `createJotaiWrapper`, and `createReduxWrapper` functions in `testUtils.tsx` to avoid errors when testing components that use `useQuery` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-e072c2741885a61c81231587c78646fc3214ffbf008350db9617b159aad94454L49-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-e072c2741885a61c81231587c78646fc3214ffbf008350db9617b159aad94454L66-R68), [link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-e072c2741885a61c81231587c78646fc3214ffbf008350db9617b159aad94454L76-R82))
*  Remove `console.info` statement from `getTeam` function in `teams/helpers.ts` as it is not related to the main purpose of the pull request and should be removed before merging ([link](https://github.com/pancakeswap/pancake-frontend/pull/8186/files?diff=unified&w=0#diff-ed210b6d01cfdf5c001dde86edb5b02066ad1d331818e894b07347238c3972afR38))


