### PR TITLE
chore: Add subgraph endpoints to chains

### DIFF
--- a/.changeset/clean-mayflies-do.md
+++ b/.changeset/clean-mayflies-do.md
@@ -1,0 +1,6 @@
+---
+'@pancakeswap/chains': minor
+'routing-api': patch
+---
+
+Add subgraph endpoints to chains

--- a/apis/routing/src/constants.ts
+++ b/apis/routing/src/constants.ts
@@ -17,20 +17,3 @@ export const SUPPORTED_CHAINS = [
 ] as const
 
 export type SupportedChainId = (typeof SUPPORTED_CHAINS)[number]
-
-export const V3_SUBGRAPH_URLS: Record<SupportedChainId, string> = {
-  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
-  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
-  [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
-  [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
-  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
-  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
-  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exchange-v3-linea',
-  [ChainId.LINEA_TESTNET]:
-    'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v3',
-}

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -1,10 +1,10 @@
-import { ChainId } from '@pancakeswap/chains'
+import { ChainId, V3_SUBGRAPHS } from '@pancakeswap/chains'
 import { OnChainProvider, SubgraphProvider } from '@pancakeswap/smart-router/evm'
 import { createPublicClient, http } from 'viem'
 import { bsc, bscTestnet, goerli, mainnet } from 'viem/chains'
 import { GraphQLClient } from 'graphql-request'
 
-import { V3_SUBGRAPH_URLS, SupportedChainId } from './constants'
+import { SupportedChainId } from './constants'
 
 const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE]
 requireCheck.forEach((node) => {
@@ -50,19 +50,19 @@ export const viemProviders: OnChainProvider = ({ chainId }: { chainId?: ChainId 
 }
 
 export const v3SubgraphClients: Record<SupportedChainId, GraphQLClient> = {
-  [ChainId.ETHEREUM]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ETHEREUM], { fetch }),
-  [ChainId.POLYGON_ZKEVM]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.POLYGON_ZKEVM], { fetch }),
-  [ChainId.ZKSYNC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ZKSYNC], { fetch }),
-  [ChainId.LINEA_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.LINEA_TESTNET], { fetch }),
-  [ChainId.GOERLI]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.GOERLI], { fetch }),
-  [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC], { fetch }),
-  [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BSC_TESTNET], { fetch }),
-  [ChainId.ARBITRUM_ONE]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.ARBITRUM_ONE], { fetch }),
-  [ChainId.LINEA]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.LINEA], { fetch }),
-  [ChainId.SCROLL_SEPOLIA]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.SCROLL_SEPOLIA], { fetch }),
-  [ChainId.BASE_TESTNET]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BASE_TESTNET], { fetch }),
-  [ChainId.BASE]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.BASE], { fetch }),
-  [ChainId.OPBNB]: new GraphQLClient(V3_SUBGRAPH_URLS[ChainId.OPBNB], { fetch }),
+  [ChainId.ETHEREUM]: new GraphQLClient(V3_SUBGRAPHS[ChainId.ETHEREUM], { fetch }),
+  [ChainId.POLYGON_ZKEVM]: new GraphQLClient(V3_SUBGRAPHS[ChainId.POLYGON_ZKEVM], { fetch }),
+  [ChainId.ZKSYNC]: new GraphQLClient(V3_SUBGRAPHS[ChainId.ZKSYNC], { fetch }),
+  [ChainId.LINEA_TESTNET]: new GraphQLClient(V3_SUBGRAPHS[ChainId.LINEA_TESTNET], { fetch }),
+  [ChainId.GOERLI]: new GraphQLClient(V3_SUBGRAPHS[ChainId.GOERLI], { fetch }),
+  [ChainId.BSC]: new GraphQLClient(V3_SUBGRAPHS[ChainId.BSC], { fetch }),
+  [ChainId.BSC_TESTNET]: new GraphQLClient(V3_SUBGRAPHS[ChainId.BSC_TESTNET], { fetch }),
+  [ChainId.ARBITRUM_ONE]: new GraphQLClient(V3_SUBGRAPHS[ChainId.ARBITRUM_ONE], { fetch }),
+  [ChainId.LINEA]: new GraphQLClient(V3_SUBGRAPHS[ChainId.LINEA], { fetch }),
+  [ChainId.SCROLL_SEPOLIA]: new GraphQLClient(V3_SUBGRAPHS[ChainId.SCROLL_SEPOLIA], { fetch }),
+  [ChainId.BASE_TESTNET]: new GraphQLClient(V3_SUBGRAPHS[ChainId.BASE_TESTNET], { fetch }),
+  [ChainId.BASE]: new GraphQLClient(V3_SUBGRAPHS[ChainId.BASE], { fetch }),
+  [ChainId.OPBNB]: new GraphQLClient(V3_SUBGRAPHS[ChainId.OPBNB], { fetch }),
 } as const
 
 export const v3SubgraphProvider: SubgraphProvider = ({ chainId = ChainId.BSC }: { chainId?: ChainId }) => {

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@pancakeswap/chains'
+import { ChainId, V3_SUBGRAPHS, V2_SUBGRAPHS } from '@pancakeswap/chains'
 
 export const GRAPH_API_PROFILE = 'https://api.thegraph.com/subgraphs/name/pancakeswap/profile'
 export const GRAPH_API_PREDICTION_BNB = 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2'
@@ -46,18 +46,7 @@ export const ACCESS_RISK_API = 'https://red.alert.pancakeswap.com/red-api'
 
 export const CELER_API = 'https://api.celerscan.com/scan'
 
-export const INFO_CLIENT_WITH_CHAIN = {
-  [ChainId.BSC]: INFO_CLIENT,
-  [ChainId.ETHEREUM]: INFO_CLIENT_ETH,
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-polygon-zkevm/version/latest',
-  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
-  [ChainId.ZKSYNC]: ' https://api.studio.thegraph.com/query/45376/exchange-v2-zksync/version/latest',
-  [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
-  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exhange-v2',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v2',
-}
+export const INFO_CLIENT_WITH_CHAIN = V2_SUBGRAPHS
 
 export const BLOCKS_CLIENT_WITH_CHAIN = {
   [ChainId.BSC]: BLOCKS_CLIENT,
@@ -72,26 +61,7 @@ export const BLOCKS_CLIENT_WITH_CHAIN = {
 
 export const ASSET_CDN = 'https://assets.pancakeswap.finance'
 
-export const V3_SUBGRAPH_URLS = {
-  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
-  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
-  [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
-  [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
-  [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
-  [ChainId.POLYGON_ZKEVM_TESTNET]: null,
-  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
-  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync-testnet/version/latest',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exchange-v3-linea',
-  [ChainId.LINEA_TESTNET]:
-    'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
-  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v3',
-  [ChainId.OPBNB_TESTNET]: null,
-  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
-} satisfies Record<ChainId, string | null>
+export const V3_SUBGRAPH_URLS = V3_SUBGRAPHS
 
 export const TRADING_REWARD_API = 'https://pancake-trading-fee-rebate-api.pancakeswap.com/api/v1'
 

--- a/packages/chains/src/index.test.ts
+++ b/packages/chains/src/index.test.ts
@@ -11,6 +11,8 @@ test('exports', () => {
       "getChainName",
       "getLlamaChainName",
       "getChainIdByChainName",
+      "V3_SUBGRAPHS",
+      "V2_SUBGRAPHS",
     ]
   `)
 })

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -1,3 +1,4 @@
 export * from './chainId'
 export * from './chainNames'
 export * from './utils'
+export * from './subgraphs'

--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -1,0 +1,35 @@
+import { ChainId } from './chainId'
+
+export const V3_SUBGRAPHS = {
+  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
+  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
+  [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
+  [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
+  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
+  [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
+  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/v0.0.0',
+  [ChainId.POLYGON_ZKEVM_TESTNET]: null,
+  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
+  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync-testnet/version/latest',
+  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exchange-v3-linea',
+  [ChainId.LINEA_TESTNET]:
+    'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
+  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
+  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
+  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v3',
+  [ChainId.OPBNB_TESTNET]: null,
+  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
+} satisfies Record<ChainId, string | null>
+
+export const V2_SUBGRAPHS = {
+  [ChainId.BSC]: 'https://proxy-worker-api.pancakeswap.com/bsc-exchange',
+  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth',
+  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-polygon-zkevm/version/latest',
+  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
+  [ChainId.ZKSYNC]: ' https://api.studio.thegraph.com/query/45376/exchange-v2-zksync/version/latest',
+  [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
+  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
+  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exhange-v2',
+  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
+  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v2',
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ff4f9c</samp>

### Summary
📦🗑️♻️

<!--
1.  📦 for adding a new package dependency and exporting new constants from the chains package.
2.  🗑️ for removing an unused constant from the routing-api package.
3.  ♻️ for refactoring the web package to use the subgraph constants from the chains package.
-->
This pull request adds subgraph endpoints for Uniswap V2 and V3 to the `chains` package and refactors the `routing-api` and `web` packages to use them. This improves the consistency and maintainability of the subgraph clients across the packages.

> _Sing, O Muse, of the skillful pull request_
> _That brought subgraph endpoints to the chains_
> _And made the routing-api and web_
> _Rejoice in the shared and consistent `V3_SUBGRAPHS`._

### Walkthrough
*  Add subgraph endpoints to the chains package and use them in the routing-api and web packages ([link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-8786384944542db4fe96f36d8432fed62723899c0ad7bd8440721e984c244d49R1-R6))
  * Define and export V3_SUBGRAPHS and V2_SUBGRAPHS constants in `subgraphs.ts` that contain the subgraph URLs for each chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-ae8591973194929337c2d5168deab036fd9d5fac8bd597889c0843755632136cR1-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-cb6590dddd8646cdd5e3677cb1e05aa883274f7c7fd77fcd5645ac87bbf5713dR4), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-9970c58ceb6b4b9f1ef347162b34fcfaf5355466cbf4dcdffcd0669a8a53bf55R14-R15))
  * Import V3_SUBGRAPHS and V2_SUBGRAPHS from the chains package and use them to create GraphQL clients for each chain in `provider.ts` of the routing-api package ([link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L7-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-0a6975d7fb0faf3791a56dd786d9226fdbcb013af80d0f985783e06573fa2df0L53-R65))
  * Import V3_SUBGRAPHS and V2_SUBGRAPHS from the chains package and use them to fetch data from the subgraphs in `endpoints.ts` of the web package ([link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L49-R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-7238357db46da6bb48ca41841457ac0e832ee21fb8fd76a6b3c9dbf701ce8c62L75-R64))
  * Remove the unused V3_SUBGRAPH_URLS constant from `constants.ts` of the routing-api package ([link](https://github.com/pancakeswap/pancake-frontend/pull/8187/files?diff=unified&w=0#diff-43579c3e0a273c113f43cdf93068a199e594bf2376548191ec9e4f63e01bde3aL20-L36))


