### PR TITLE
refactor: Use query in trading reward

### DIFF
--- a/apps/web/src/views/TradingReward/hooks/useAllTradingRewardPair.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useAllTradingRewardPair.tsx
@@ -1,9 +1,9 @@
-import useSWR from 'swr'
 import BigNumber from 'bignumber.js'
 import { ChainId } from '@pancakeswap/chains'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
 import { getTradingRewardContract } from 'utils/contractHelpers'
 import { useTradingRewardContract, useTradingRewardTopTraderContract } from 'hooks/useContract'
+import { useQuery } from '@tanstack/react-query'
 
 export enum RewardStatus {
   ALL = '0',
@@ -148,8 +148,8 @@ const useAllTradingRewardPair = ({ status, type }: UseAllTradingRewardPairProps)
   const tradingRewardTopTradersContract = useTradingRewardTopTraderContract({ chainId: ChainId.BSC })
   const contract = type === RewardType.CAKE_STAKERS ? tradingRewardContract : tradingRewardTopTradersContract
 
-  const { data: allPairs, isLoading } = useSWR(
-    status && type && ['/all-activated-trading-reward-pair', status, type],
+  const { data: allPairs, isLoading } = useQuery(
+    ['tradingReward', 'all-activated-trading-reward-pair', status, type],
     async () => {
       try {
         const campaignsResponse = await fetch(`${TRADING_REWARD_API}/campaign/status/${status}/type/${type}`)
@@ -176,11 +176,10 @@ const useAllTradingRewardPair = ({ status, type }: UseAllTradingRewardPairProps)
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
-      fallbackData: initialAllTradingRewardState,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      initialData: initialAllTradingRewardState,
+      enabled: Boolean(status && type),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useAllUserCampaignInfo.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useAllUserCampaignInfo.tsx
@@ -1,4 +1,3 @@
-import useSWR from 'swr'
 import BigNumber from 'bignumber.js'
 import { useAccount } from 'wagmi'
 import { SLOW_INTERVAL } from 'config/constants'
@@ -10,6 +9,7 @@ import { ChainId } from '@pancakeswap/chains'
 import { publicClient } from 'utils/wagmi'
 import { Address } from 'viem'
 import { RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQuery } from '@tanstack/react-query'
 
 interface UserCampaignInfoResponse {
   id: string
@@ -49,8 +49,8 @@ const useAllUserCampaignInfo = ({ campaignIds, type }: UseAllUserCampaignInfoPro
       ? getTradingRewardAddress(ChainId.BSC)
       : getTradingRewardTopTradesAddress(ChainId.BSC)
 
-  const { data: allUserCampaignInfoData, isLoading } = useSWR(
-    campaignIds.length > 0 && account && type && ['/all-campaign-id-info', account, campaignIds, type],
+  const { data: allUserCampaignInfoData, isLoading } = useQuery(
+    ['tradingReward', 'all-campaign-id-info', account, campaignIds, type],
     async () => {
       try {
         const allUserCampaignInfo = await Promise.all(
@@ -136,8 +136,9 @@ const useAllUserCampaignInfo = ({ campaignIds, type }: UseAllUserCampaignInfoPro
       }
     },
     {
-      refreshInterval: SLOW_INTERVAL,
-      fallbackData: [],
+      refetchInterval: SLOW_INTERVAL,
+      initialData: [],
+      enabled: Boolean(campaignIds.length > 0 && account),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useAllUserCampaignInfo.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useAllUserCampaignInfo.tsx
@@ -138,7 +138,7 @@ const useAllUserCampaignInfo = ({ campaignIds, type }: UseAllUserCampaignInfoPro
     {
       refetchInterval: SLOW_INTERVAL,
       initialData: [],
-      enabled: Boolean(campaignIds.length > 0 && account),
+      enabled: Boolean(campaignIds.length > 0 && account && type),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useCampaignIdInfo.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useCampaignIdInfo.tsx
@@ -1,8 +1,8 @@
-import useSWR from 'swr'
 import BigNumber from 'bignumber.js'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
 import { ChainId } from '@pancakeswap/chains'
 import { RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQuery } from '@tanstack/react-query'
 
 export interface CampaignVolume {
   pool: string
@@ -45,8 +45,8 @@ interface UseCampaignIdInfoProps {
 }
 
 const useCampaignIdInfo = ({ campaignId, type }: UseCampaignIdInfoProps): CampaignIdInfo => {
-  const { data: campaignIdInfo, isLoading } = useSWR(
-    campaignId && type && ['/campaign-id-info', campaignId, type],
+  const { data: campaignIdInfo, isLoading } = useQuery(
+    ['tradingReward', 'campaign-id-info', campaignId, type],
     async () => {
       try {
         const response = await fetch(`${TRADING_REWARD_API}/campaign/campaignId/${campaignId}/address/0x/type/${type}`)
@@ -76,11 +76,10 @@ const useCampaignIdInfo = ({ campaignId, type }: UseCampaignIdInfoProps): Campai
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
-      fallbackData: initialState,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      initialData: initialState,
+      enabled: Boolean(campaignId && type),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useClaimAllReward.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useClaimAllReward.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import BigNumber from 'bignumber.js'
-import { useSWRConfig } from 'swr'
 import { parseEther, encodePacked, keccak256 } from 'viem'
 import { useAccount } from 'wagmi'
 import { ChainId } from '@pancakeswap/chains'
@@ -12,6 +11,7 @@ import { useTradingRewardContract, useTradingRewardTopTraderContract } from 'hoo
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
 import { Qualification, RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface UseClaimAllRewardProps {
   campaignIds: Array<string>
@@ -24,7 +24,7 @@ export const useClaimAllReward = ({ campaignIds, unclaimData, qualification, typ
   const { t } = useTranslation()
   const { address: account } = useAccount()
   const { toastSuccess } = useToast()
-  const { mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { fetchWithCatchTxError, loading: isPending } = useCatchTxError()
   const tradingRewardContract = useTradingRewardContract({ chainId: ChainId.BSC })
   const tradingRewardTopTradersContract = useTradingRewardTopTraderContract({ chainId: ChainId.BSC })
@@ -61,7 +61,7 @@ export const useClaimAllReward = ({ campaignIds, unclaimData, qualification, typ
     )
 
     if (receipt?.status) {
-      await mutate(['/all-campaign-id-info', account, campaignIds])
+      await queryClient.invalidateQueries(['tradingReward', 'all-campaign-id-info', account, campaignIds])
       toastSuccess(
         t('Success!'),
         <ToastDescriptionWithTx txHash={receipt.transactionHash}>
@@ -75,7 +75,7 @@ export const useClaimAllReward = ({ campaignIds, unclaimData, qualification, typ
     campaignIds,
     contract,
     fetchWithCatchTxError,
-    mutate,
+    queryClient,
     qualification.minAmountUSD,
     t,
     toastSuccess,

--- a/apps/web/src/views/TradingReward/hooks/useRankList.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useRankList.tsx
@@ -1,7 +1,7 @@
-import useSWR from 'swr'
 import { useState } from 'react'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
 import { RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQuery } from '@tanstack/react-query'
 
 interface UseRankListProps {
   campaignId: string
@@ -39,8 +39,8 @@ export const useRankList = ({ campaignId, currentPage }: UseRankListProps): Rank
   const [lastCampaignId, setLastCampaignId] = useState('')
   const [topThreeTraders, setTopThreeTraders] = useState<RankListDetail[]>([])
 
-  const { data } = useSWR(
-    Number(campaignId) > 0 && currentPage && ['/trader-rank-list', campaignId, currentPage],
+  const { data } = useQuery(
+    ['tradingReward', 'trader-rank-list', campaignId, currentPage],
     async () => {
       try {
         setIsLoading(true)
@@ -79,9 +79,9 @@ export const useRankList = ({ campaignId, currentPage }: UseRankListProps): Rank
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
+      enabled: Boolean(Number(campaignId) > 0 && currentPage),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useRewardBreakdown.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useRewardBreakdown.tsx
@@ -1,10 +1,10 @@
-import useSWR from 'swr'
 import { ChainId } from '@pancakeswap/chains'
 import { useAccount } from 'wagmi'
 import { Token } from '@pancakeswap/swap-sdk-core'
 import { tradingRewardPairConfigChainMap } from 'views/TradingReward/config/pairs'
 import { UserCampaignInfoDetail } from 'views/TradingReward/hooks/useAllUserCampaignInfo'
 import { AllTradingRewardPairDetail } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQuery } from '@tanstack/react-query'
 
 interface UseRewardBreakdownProps {
   allUserCampaignInfo: UserCampaignInfoDetail[]
@@ -43,8 +43,8 @@ const useRewardBreakdown = ({
 }: UseRewardBreakdownProps): RewardBreakdown => {
   const { address: account } = useAccount()
 
-  const { data: rewardBreakdownList, isLoading } = useSWR(
-    ['/rewards-breakdown', allUserCampaignInfo, allTradingRewardPairData, account],
+  const { data: rewardBreakdownList, isLoading } = useQuery(
+    ['tradingReward', 'rewards-breakdown', allUserCampaignInfo, allTradingRewardPairData, account],
     async () => {
       try {
         const dataInfo = Object.keys(campaignPairs).map((campaignId) => {
@@ -95,7 +95,8 @@ const useRewardBreakdown = ({
       }
     },
     {
-      fallbackData: [],
+      initialData: [],
+      enabled: Boolean(account),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useTradingFeeClaimedRecord.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useTradingFeeClaimedRecord.tsx
@@ -1,7 +1,7 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import { RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
+import { useQuery } from '@tanstack/react-query'
 
 const initialState = {
   claimedRebate: false,
@@ -11,8 +11,8 @@ const initialState = {
 const useTradingFeeClaimedRecord = ({ type, campaignId }: { type: RewardType; campaignId: string }) => {
   const { address: account } = useAccount()
 
-  const { data } = useSWR(
-    account && type && ['/trading-fee-claimed-record', account],
+  const { data } = useQuery(
+    ['tradingReward', 'trading-fee-claimed-record', account],
     async () => {
       try {
         // campaignId & type will not affect API value
@@ -27,11 +27,10 @@ const useTradingFeeClaimedRecord = ({ type, campaignId }: { type: RewardType; ca
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
-      fallbackData: initialState,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      initialData: initialState,
+      enabled: Boolean(account && type),
     },
   )
 

--- a/apps/web/src/views/TradingReward/hooks/useUserTradeRank.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useUserTradeRank.tsx
@@ -1,7 +1,7 @@
-import useSWR from 'swr'
 import { useAccount } from 'wagmi'
 import { TRADING_REWARD_API } from 'config/constants/endpoints'
 import { RewardType } from 'views/TradingReward/hooks/useAllTradingRewardPair'
+import { useQuery } from '@tanstack/react-query'
 
 const initialState = {
   topTradersIndex: 0,
@@ -13,8 +13,8 @@ const initialState = {
 
 export const useUserTradeRank = ({ campaignId }: { campaignId: string }) => {
   const { address: account } = useAccount()
-  const { data, isLoading } = useSWR(
-    Number(campaignId) > 0 && account && ['/user-trade-rank', campaignId, account],
+  const { data, isLoading } = useQuery(
+    ['tradingReward', 'user-trade-rank', campaignId, account],
     async () => {
       try {
         const response = await fetch(
@@ -34,10 +34,10 @@ export const useUserTradeRank = ({ campaignId }: { campaignId: string }) => {
       }
     },
     {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
-      fallbackData: initialState,
+      enabled: Boolean(Number(campaignId) > 0 && account),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      initialData: initialState,
     },
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 045249e</samp>

### Summary
🎣🚀🛠️

<!--
1.  🎣 - This emoji represents the useQuery hook from react-query, which is a fishing hook that can be used to fetch and cache data from APIs. This emoji can be used to indicate that the code has been updated to use the react-query library for data fetching and caching.
2.  🚀 - This emoji represents the improved performance and usability of the TradingReward view, which can now fetch and display data faster and more reliably. This emoji can be used to indicate that the code has been optimized and enhanced for the user experience.
3.  🛠️ - This emoji represents the refactoring and alignment of the code with the react-query conventions, which makes the code more consistent and maintainable. This emoji can be used to indicate that the code has been improved and cleaned up.
-->
This pull request replaces the useSWR hook with the useQuery hook from the react-query library in several hooks that fetch and cache data for the TradingReward view. This improves the performance, consistency, and customizability of the data fetching and caching logic.

> _We're breaking free from the SWR curse_
> _We're using react-query to make it worse_
> _We're fetching and caching with no remorse_
> _We're the masters of the data source_

### Walkthrough
*  Replace `useSWR` hook with `useQuery` hook from `react-query` library in eight files to fetch and cache data from APIs with more features and flexibility ([link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f187845105d64b076ba7e7129a905f4d77507d629db001f8c337352d63b549ecL1),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f187845105d64b076ba7e7129a905f4d77507d629db001f8c337352d63b549ecR6),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f187845105d64b076ba7e7129a905f4d77507d629db001f8c337352d63b549ecL151-R152),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f8a9fdf18f27a98c3dc9809498f7ac448496e61fb8e4bf9853ac46101312e18cL1),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f8a9fdf18f27a98c3dc9809498f7ac448496e61fb8e4bf9853ac46101312e18cR12),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f8a9fdf18f27a98c3dc9809498f7ac448496e61fb8e4bf9853ac46101312e18cL52-R53),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08637e1bd97bb44a62b6ee1c5c4a341c22ef5fff2b1000b7815f70b5e5e70b9dL1-R5),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08637e1bd97bb44a62b6ee1c5c4a341c22ef5fff2b1000b7815f70b5e5e70b9dL48-R49),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-45433ee2c60fdc0d78f87bdc74046f0fc7d857d67a5dbcd7d6171d975406dde2L3),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-37412cdd57fd66e57a9366aad7e9beaa3c95e186573eeb179e5410966272750fL1-R4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-37412cdd57fd66e57a9366aad7e9beaa3c95e186573eeb179e5410966272750fL42-R43),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-6a187cb0f3a75fac83487276ae3dfd7294b1cdb23a64a1c399bb456808a82eeaL1),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-6a187cb0f3a75fac83487276ae3dfd7294b1cdb23a64a1c399bb456808a82eeaR7),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-6a187cb0f3a75fac83487276ae3dfd7294b1cdb23a64a1c399bb456808a82eeaL46-R47),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08dc7987ab25b7b5cd5f2cac4d0ef73b5200de112d1a8d3503704ecf3fd2f3b6L1-R4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08dc7987ab25b7b5cd5f2cac4d0ef73b5200de112d1a8d3503704ecf3fd2f3b6L14-R15),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-7daaf106864f93b18f65961b19005f1a0facbc3c4dfdd7f766e697d3824e5aefL1-R4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-7daaf106864f93b18f65961b19005f1a0facbc3c4dfdd7f766e697d3824e5aefL16-R17))
*  Modify the options passed to `useQuery` hook to use consistent and appropriate parameters for refetching, initial data, and query enabling in seven files ([link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f187845105d64b076ba7e7129a905f4d77507d629db001f8c337352d63b549ecL179-R182),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-f8a9fdf18f27a98c3dc9809498f7ac448496e61fb8e4bf9853ac46101312e18cL139-R141),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08637e1bd97bb44a62b6ee1c5c4a341c22ef5fff2b1000b7815f70b5e5e70b9dL79-R82),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-37412cdd57fd66e57a9366aad7e9beaa3c95e186573eeb179e5410966272750fL82-R84),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-6a187cb0f3a75fac83487276ae3dfd7294b1cdb23a64a1c399bb456808a82eeaL98-R99),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-08dc7987ab25b7b5cd5f2cac4d0ef73b5200de112d1a8d3503704ecf3fd2f3b6L30-R33),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-7daaf106864f93b18f65961b19005f1a0facbc3c4dfdd7f766e697d3824e5aefL37-R40))
*  Replace `useSWRConfig` hook with `useQueryClient` hook from `react-query` library in `useClaimAllReward.tsx` file to access the query client instance and invalidate or refetch the data cached by `useQuery` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-45433ee2c60fdc0d78f87bdc74046f0fc7d857d67a5dbcd7d6171d975406dde2R14),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-45433ee2c60fdc0d78f87bdc74046f0fc7d857d67a5dbcd7d6171d975406dde2L27-R27),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-45433ee2c60fdc0d78f87bdc74046f0fc7d857d67a5dbcd7d6171d975406dde2L64-R64),[link](https://github.com/pancakeswap/pancake-frontend/pull/8195/files?diff=unified&w=0#diff-45433ee2c60fdc0d78f87bdc74046f0fc7d857d67a5dbcd7d6171d975406dde2L78-R78))


