### PR TITLE
fix: roi calc

### DIFF
--- a/apps/web/src/utils/isPoolTickInRange.ts
+++ b/apps/web/src/utils/isPoolTickInRange.ts
@@ -1,6 +1,7 @@
 import { Pool } from '@pancakeswap/v3-sdk'
 
-const isPoolTickInRange = (pool: Pool, tickLower: number, tickUpper: number) => {
+const isPoolTickInRange = (pool: Pool | undefined, tickLower: number, tickUpper: number) => {
+  if (typeof pool === 'undefined') return false
   const below = pool && typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
   const above = pool && typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
   return typeof below === 'boolean' && typeof above === 'boolean' ? !below && !above : false

--- a/apps/web/src/utils/isPoolTickInRange.ts
+++ b/apps/web/src/utils/isPoolTickInRange.ts
@@ -1,9 +1,9 @@
 import { Pool } from '@pancakeswap/v3-sdk'
 
-const isPoolTickInRange = (pool: Pool | undefined, tickLower: number, tickUpper: number) => {
+const isPoolTickInRange = (pool: Pool | undefined, tickLower: number | undefined, tickUpper: number | undefined) => {
   if (typeof pool === 'undefined') return false
-  const below = pool && typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
-  const above = pool && typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
+  const below = typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
+  const above = typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
   return typeof below === 'boolean' && typeof above === 'boolean' ? !below && !above : false
 }
 

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -7,7 +7,7 @@ import {
   useAmountsByUsdValue,
 } from '@pancakeswap/widgets-internal/roi'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { encodeSqrtRatioX96, parseProtocolFees, Pool, FeeCalculator } from '@pancakeswap/v3-sdk'
+import { encodeSqrtRatioX96, parseProtocolFees, Pool, FeeCalculator, Tick } from '@pancakeswap/v3-sdk'
 import { useCallback, useMemo, useState } from 'react'
 import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
@@ -159,12 +159,23 @@ export function AprCalculator({
   const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || (inverted ? aprAmountA : aprAmountB)
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
   const inRange = isPoolTickInRange(pool, tickLower, tickUpper)
+  const allTicks = useMemo(
+    () =>
+      data?.map(
+        ({ tick, liquidityNet }) => new Tick({ index: parseInt(tick), liquidityNet, liquidityGross: liquidityNet }),
+      ),
+    [data],
+  )
+  const mostActiveLiquidity = useMemo(
+    () => allTicks && sqrtRatioX96 && FeeCalculator.getLiquidityFromSqrtRatioX96(allTicks, sqrtRatioX96),
+    [allTicks, sqrtRatioX96],
+  )
   const { apr } = useRoi({
     tickLower,
     tickUpper,
     sqrtRatioX96,
     fee: feeAmount,
-    mostActiveLiquidity: pool?.liquidity,
+    mostActiveLiquidity,
     amountA: validAmountA,
     amountB: validAmountB,
     compoundOn: false,

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -87,7 +87,7 @@ export function AprCalculator({
     formState,
   )
   const router = useRouter()
-  const poolAddress = useMemo(() => pool && Pool.getAddress(pool.token0, pool.token1, pool.fee), [pool])
+  const poolAddress = useMemo(() => (pool ? Pool.getAddress(pool.token0, pool.token1, pool.fee) : undefined), [pool])
 
   const prices = usePairTokensPrice(poolAddress, priceSpan, baseCurrency?.chainId)
   const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount)
@@ -158,7 +158,7 @@ export function AprCalculator({
   const validAmountA = amountA || (inverted ? tokenAmount1 : tokenAmount0) || (inverted ? aprAmountB : aprAmountA)
   const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || (inverted ? aprAmountA : aprAmountB)
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
-  const inRange = isPoolTickInRange(pool, tickLower, tickUpper)
+  const inRange = isPoolTickInRange(pool ?? undefined, tickLower ?? 0, tickUpper ?? 0)
   const allTicks = useMemo(
     () =>
       data?.map(
@@ -263,8 +263,8 @@ export function AprCalculator({
           query: {
             ...router.query,
             currency: [
-              position.amountA ? currencyId(position.amountA.currency) : undefined,
-              position.amountB ? currencyId(position.amountB.currency) : undefined,
+              position.amountA ? currencyId(position.amountA.currency) : '',
+              position.amountB ? currencyId(position.amountB.currency) : '',
               feeAmount ? feeAmount.toString() : '',
             ],
           },
@@ -355,7 +355,7 @@ export function AprCalculator({
         priceSpan={priceSpan}
         onPriceSpanChange={setPriceSpan}
         onApply={onApply}
-        isFarm={hasFarmApr}
+        isFarm={Boolean(hasFarmApr)}
         cakeAprFactor={positionFarmAprFactor}
         cakePrice={cakePrice.toFixed(3)}
       />

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -7,7 +7,7 @@ import {
   useAmountsByUsdValue,
 } from '@pancakeswap/widgets-internal/roi'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { encodeSqrtRatioX96, parseProtocolFees, Pool, FeeCalculator, Tick } from '@pancakeswap/v3-sdk'
+import { encodeSqrtRatioX96, parseProtocolFees, Pool, FeeCalculator } from '@pancakeswap/v3-sdk'
 import { useCallback, useMemo, useState } from 'react'
 import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
@@ -159,23 +159,12 @@ export function AprCalculator({
   const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || (inverted ? aprAmountA : aprAmountB)
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
   const inRange = isPoolTickInRange(pool ?? undefined, tickLower ?? undefined, tickUpper ?? undefined)
-  const allTicks = useMemo(
-    () =>
-      data?.map(
-        ({ tick, liquidityNet }) => new Tick({ index: parseInt(tick), liquidityNet, liquidityGross: liquidityNet }),
-      ),
-    [data],
-  )
-  const mostActiveLiquidity = useMemo(
-    () => allTicks && sqrtRatioX96 && FeeCalculator.getLiquidityFromSqrtRatioX96(allTicks, sqrtRatioX96),
-    [allTicks, sqrtRatioX96],
-  )
   const { apr } = useRoi({
     tickLower,
     tickUpper,
     sqrtRatioX96,
     fee: feeAmount,
-    mostActiveLiquidity,
+    mostActiveLiquidity: pool?.liquidity,
     amountA: validAmountA,
     amountB: validAmountB,
     compoundOn: false,

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -158,7 +158,7 @@ export function AprCalculator({
   const validAmountA = amountA || (inverted ? tokenAmount1 : tokenAmount0) || (inverted ? aprAmountB : aprAmountA)
   const validAmountB = amountB || (inverted ? tokenAmount0 : tokenAmount1) || (inverted ? aprAmountA : aprAmountB)
   const [amount0, amount1] = inverted ? [validAmountB, validAmountA] : [validAmountA, validAmountB]
-  const inRange = isPoolTickInRange(pool ?? undefined, tickLower ?? 0, tickUpper ?? 0)
+  const inRange = isPoolTickInRange(pool ?? undefined, tickLower ?? undefined, tickUpper ?? undefined)
   const allTicks = useMemo(
     () =>
       data?.map(

--- a/packages/widgets-internal/roi/RoiCalculator.tsx
+++ b/packages/widgets-internal/roi/RoiCalculator.tsx
@@ -55,9 +55,9 @@ export type RoiCalculatorProps = {
       time: Date;
       value: number;
     }[];
-    maxPrice: number;
-    minPrice: number;
-    averagePrice: number;
+    maxPrice?: number;
+    minPrice?: number;
+    averagePrice?: number;
   };
   ticks?: TickData[];
   price?: Price<Token, Token>;

--- a/packages/widgets-internal/roi/RoiCalculator.tsx
+++ b/packages/widgets-internal/roi/RoiCalculator.tsx
@@ -1,5 +1,5 @@
 import { Currency, CurrencyAmount, Price, Token, ZERO, Percent, ZERO_PERCENT } from "@pancakeswap/sdk";
-import { FeeAmount, FeeCalculator, Tick, TickMath, sqrtRatioX96ToPrice } from "@pancakeswap/v3-sdk";
+import { FeeAmount, FeeCalculator, TickMath, sqrtRatioX96ToPrice } from "@pancakeswap/v3-sdk";
 import { useTranslation } from "@pancakeswap/localization";
 import { useCallback, useMemo, useState } from "react";
 import BigNumber from "bignumber.js";
@@ -170,17 +170,6 @@ export function RoiCalculator({
 
     return currencyA.wrapped.sortsBefore(currencyB.wrapped) ? accuratePrice : accuratePrice.invert();
   }, [sqrtRatioX96, currencyA, currencyB]);
-  const ticks = useMemo(
-    () =>
-      ticksRaw?.map(
-        ({ tick, liquidityNet }) => new Tick({ index: parseInt(tick), liquidityNet, liquidityGross: liquidityNet })
-      ),
-    [ticksRaw]
-  );
-  const mostActiveLiquidity = useMemo(
-    () => ticks && sqrtRatioX96 && FeeCalculator.getLiquidityFromSqrtRatioX96(ticks, sqrtRatioX96),
-    [ticks, sqrtRatioX96]
-  );
 
   const priceRange = usePriceRange({
     feeAmount,
@@ -287,7 +276,7 @@ export function RoiCalculator({
       tickUpper: priceRange?.tickUpper,
       volume24H,
       sqrtRatioX96,
-      mostActiveLiquidity,
+      mostActiveLiquidity: liquidity,
       fee: feeAmount,
       protocolFee,
       compoundEvery: compoundingIndexToFrequency[compoundIndex],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 557813a</samp>

### Summary
📈🔧🚀

<!--
1.  📈 This emoji conveys the idea of improvement or enhancement, which is what the APR calculation for V3 pools achieved by using tick data.
2.  🔧 This emoji suggests the idea of fixing or adjusting something, which is what the refactoring of the code did by using the `Tick` type and memoizing some computations.
3.  🚀 This emoji implies the idea of speed or performance, which is what the changes aimed to improve by using more efficient data and calculations.
-->
Improved and optimized the APR calculator for V3 pools using `Tick` data.

> _Oh we're the savvy sailors of the V3 pools_
> _We use the `Tick` data to find the best tools_
> _We memoize our maths to make our code run fast_
> _And we calculate the APR with every contrast_

### Walkthrough
* Import `Tick` type from `@pancakeswap/v3-sdk` to create ticks array from data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8197/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L10-R10))
* Memoize `allTicks` and `mostActiveLiquidity` variables to avoid unnecessary computations and improve performance ([link](https://github.com/pancakeswap/pancake-frontend/pull/8197/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1R162-R172))
* Use `mostActiveLiquidity` instead of `pool?.liquidity` to calculate ROI with more accuracy based on current price and tick data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8197/files?diff=unified&w=0#diff-11372967482ecb262dc9c61cfcc4c28c7ac992e7a9bad352f6fce19f1940bdb1L167-R178))


