### PR TITLE
feat: add GRAI-USDC (0.05%) merkl notice

### DIFF
--- a/apps/web/src/config/merkl.ts
+++ b/apps/web/src/config/merkl.ts
@@ -20,4 +20,9 @@ export const MERKL_POOLS: MerklPool[] = [
     address: '0x4D4c8F2f30e0224889ab578283A844e10B57e0F8',
     link: 'https://merkl.angle.money/?times=active%2Cfuture%2C&phrase=ethx&chains=1%2C',
   },
+  {
+    chainId: ChainId.POLYGON_ZKEVM,
+    address: '0x39aCc7cf02af19A1eB0e3628bA0F5C48f44beBF3',
+    link: 'https://merkl.angle.money/?times=active%2Cfuture%2C&phrase=grai&chains=1101%2C',
+  },
 ]

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -9,7 +9,7 @@ import {
   LinkExternal,
   Message,
   MessageText,
-  InfoFilledIcon,
+  VerifiedIcon,
 } from '@pancakeswap/uikit'
 import { FarmWidget } from '@pancakeswap/widgets-internal'
 import ConnectWalletButton from 'components/ConnectWalletButton'
@@ -179,8 +179,8 @@ const MerklWarning: React.FC<{
 }> = ({ merklLink }) => {
   return (
     <StyleMerklWarning>
-      <Message variant="warning" icon={<InfoFilledIcon color="#D67E0A" />}>
-        <MessageText>
+      <Message variant="primary" icon={<VerifiedIcon color="#7645D9" />}>
+        <MessageText color="#7645D9">
           <MerklNotice.Content merklLink={merklLink} linkColor="currentColor" />
         </MessageText>
       </Message>

--- a/packages/widgets-internal/farm/components/MerklNotice/index.tsx
+++ b/packages/widgets-internal/farm/components/MerklNotice/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "@pancakeswap/localization";
-import { Box, LinkExternal, Placement, Text, TooltipText, WarningIcon, useTooltip } from "@pancakeswap/uikit";
+import { Box, InfoFilledIcon, LinkExternal, Placement, Text, TooltipText, useTooltip } from "@pancakeswap/uikit";
 import { isMobile } from "react-device-detect";
 import styled from "styled-components";
 
@@ -57,7 +57,7 @@ const MerklNotice: React.FC<MerklNoticeProps> = ({
     <>
       <TooltipText ref={targetRef} display="inline">
         <Text lineHeight={0}>
-          <WarningIcon color="warning" width={size} height={size} />
+          <InfoFilledIcon color="#6532CD" width={size} height={size} />
         </Text>
       </TooltipText>
       {tooltipVisible ? tooltip : null}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58c1627</samp>

### Summary
🌾🛡️🎨

<!--
1.  🌾 - This emoji represents the addition of a new farm to the `merklFarms` array, as well as the farming theme of the Angle protocol.
2.  🛡️ - This emoji represents the verification and security features of the Merkl proofs, as well as the shield icon used by Angle.
3.  🎨 - This emoji represents the style and design changes to the Merkl notice message and tooltip, as well as the artistic aspect of the Angle brand.
-->
This pull request adds support for a new farm on the Polygon ZK-EVM chain and updates the Merkl notice UI in the farm action panel and widget. The UI changes use a new icon and color scheme to match the Angle protocol brand and improve the verification experience.

> _To access a new farm on Polygon_
> _We added an entry to `merklFarms`_
> _We also changed the style_
> _Of the notice and tooltip a while_
> _To match Angle's verification icon_

### Walkthrough
*  Add new farm entry for Polygon ZK-EVM chain in `merklFarms` array ([link](https://github.com/pancakeswap/pancake-frontend/pull/8201/files?diff=unified&w=0#diff-26e2f02c2fa11d6079fe5936f22ec31f75a1269ecf1a9569ed161aae14153250R23-R27))
*  Use `VerifiedIcon` instead of `InfoFilledIcon` for Merkl notice message in `ActionPanel` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8201/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L12-R12))
*  Change message variant, icon color, and text color of Merkl notice message in `ActionPanel` component to match Angle branding ([link](https://github.com/pancakeswap/pancake-frontend/pull/8201/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L182-R183))
*  Use `InfoFilledIcon` instead of `WarningIcon` for Merkl notice tooltip in `MerklNotice` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8201/files?diff=unified&w=0#diff-f4ec63297299d4fb00e44783f068762542b0f74eb955ada9caf20febd689e764L2-R2))
*  Change icon color of Merkl notice tooltip in `MerklNotice` component to match message icon color ([link](https://github.com/pancakeswap/pancake-frontend/pull/8201/files?diff=unified&w=0#diff-f4ec63297299d4fb00e44783f068762542b0f74eb955ada9caf20febd689e764L60-R60))


