### PR TITLE
fix: isPoolTickInRange null

### DIFF
--- a/apps/web/src/utils/isPoolTickInRange.ts
+++ b/apps/web/src/utils/isPoolTickInRange.ts
@@ -1,7 +1,7 @@
 import { Pool } from '@pancakeswap/v3-sdk'
 
 const isPoolTickInRange = (pool: Pool | undefined, tickLower: number | undefined, tickUpper: number | undefined) => {
-  if (typeof pool === 'undefined') return false
+  if (!pool) return false
   const below = typeof tickLower === 'number' ? pool.tickCurrent < tickLower : undefined
   const above = typeof tickUpper === 'number' ? pool.tickCurrent >= tickUpper : undefined
   return typeof below === 'boolean' && typeof above === 'boolean' ? !below && !above : false


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 11eece6</samp>

### Summary
:recycle::art::wrench:

<!--
1.  :recycle: - This emoji represents the refactoring and improvement of the code quality, as it implies that the code was cleaned up and reused more efficiently.
2.  :art: - This emoji represents the simplification and conciseness of the code, as it implies that the code was made more elegant and expressive.
3.  :wrench: - This emoji represents the fixing of a potential bug or inconsistency, as it implies that the code was adjusted or tweaked to work better.
-->
Simplified the `isPoolTickInRange` function in `apps/web/src/utils/isPoolTickInRange.ts` to use a falsy check for the `pool` parameter. This was part of a code quality improvement for the utils folder.

> _`isPoolTickInRange`_
> _Falsy check simplifies code_
> _Autumn of refactor_

### Walkthrough
*  Simplify the falsy check for the `pool` parameter in the `isPoolTickInRange` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8203/files?diff=unified&w=0#diff-ef21ba2444addc925ac8b43ece27293ef3b7cfe4c41c054c68ccf36015108633L4-R4))


