### PR TITLE
fix: native token unwrap

### DIFF
--- a/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
@@ -89,21 +89,17 @@ export class PancakeSwapTrade implements Command {
         if (this.type === TradeType.EXACT_OUTPUT) {
           minAmountOut = minAmountOut.subtract(minAmountOut.multiply(feeBips))
         }
-
-        // The remaining tokens that need to be sent to the user after the fee is taken will be caught
-        // by this if-else clause.
-        if (outputIsNative) {
-          planner.addCommand(CommandType.UNWRAP_WETH, [
-            this.options.recipient,
-            BigInt(minAmountOut.quotient.toString()),
-          ])
-        } else {
-          planner.addCommand(CommandType.SWEEP, [
-            sampleTrade.outputAmount.currency.wrapped.address,
-            this.options.recipient,
-            BigInt(minAmountOut.quotient.toString()),
-          ])
-        }
+      }
+      // The remaining tokens that need to be sent to the user after the fee is taken will be caught
+      // by this if-else clause.
+      if (outputIsNative) {
+        planner.addCommand(CommandType.UNWRAP_WETH, [this.options.recipient, BigInt(minAmountOut.quotient.toString())])
+      } else {
+        planner.addCommand(CommandType.SWEEP, [
+          sampleTrade.outputAmount.currency.wrapped.address,
+          this.options.recipient,
+          BigInt(minAmountOut.quotient.toString()),
+        ])
       }
 
       if ((inputIsNative && this.type === TradeType.EXACT_OUTPUT) || SwapRouter.riskOfPartialFill(trades)) {

--- a/packages/universal-router-sdk/test/__snapshots__/trade.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/trade.test.ts.snap
@@ -442,6 +442,26 @@ exports[`PancakeSwap StableSwap Through Universal Router, BSC Network Only > mul
     ]
   },
   {
+    "command": "SWEEP",
+    "args": [
+      {
+        "type": "address",
+        "name": "token",
+        "value": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d"
+      },
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "952380952"
+      }
+    ]
+  },
+  {
     "command": "UNWRAP_WETH",
     "args": [
       {
@@ -1404,6 +1424,21 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode a single exactI
         "value": true
       }
     ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "949999999"
+      }
+    ]
   }
 ]
 `;
@@ -1539,6 +1574,21 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode a single exactI
         "value": true
       }
     ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "949999999"
+      }
+    ]
   }
 ]
 `;
@@ -1601,6 +1651,21 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode a single exactI
         "value": true
       }
     ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "949999999"
+      }
+    ]
   }
 ]
 `;
@@ -1638,6 +1703,21 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode exactInput USDT
         "type": "bool",
         "name": "payerIsUser",
         "value": true
+      }
+    ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "947624999"
       }
     ]
   }
@@ -1729,6 +1809,21 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode exactOutput USD
         "type": "bool",
         "name": "payerIsUser",
         "value": true
+      }
+    ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "1000000000000000000"
       }
     ]
   }
@@ -1864,6 +1959,21 @@ exports[`PancakeSwap Universal Router Trade > v3 > should encode a exactOutput U
         "type": "bool",
         "name": "payerIsUser",
         "value": true
+      }
+    ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "1000000000000000000"
       }
     ]
   }
@@ -2041,6 +2151,21 @@ exports[`PancakeSwap Universal Router Trade > v3 > should encode a single exactI
         "value": true
       }
     ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "949999999"
+      }
+    ]
   }
 ]
 `;
@@ -2170,6 +2295,21 @@ exports[`PancakeSwap Universal Router Trade > v3 > should encode a single exactI
         "value": true
       }
     ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "949999999"
+      }
+    ]
   }
 ]
 `;
@@ -2253,6 +2393,21 @@ exports[`PancakeSwap Universal Router Trade > v3 > should encode a single exactO
         "type": "bool",
         "name": "payerIsUser",
         "value": true
+      }
+    ]
+  },
+  {
+    "command": "UNWRAP_WETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "1000000000000000000"
       }
     ]
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2472de9</samp>

### Summary
🐛🚑💰

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🚑 - This emoji represents a hotfix, which is a type of urgent bug fix that is applied to a live or production system. The change was merged into the master branch, which suggests that it was a hotfix for a critical issue.
3.  💰 - This emoji represents money or tokens, which is the subject of the change. The change affects how the output tokens are calculated and sent to the user after the fee is deducted.
-->
Fixed a bug in `pancakeswap.ts` that caused incorrect output token amounts when using feeOnTransfer option. Moved the closing brace of an if block to include the if-else clause for sending the remaining tokens to the user.

> _`feeOnTransfer` bug_
> _sending tokens after fee_
> _fixed in autumn chill_

### Walkthrough
* Fix feeOnTransfer bug for non-native output tokens by moving closing brace of if block ([link](https://github.com/pancakeswap/pancake-frontend/pull/8212/files?diff=unified&w=0#diff-566cd8974b99b34b5fdc1c4a109c3da8754c475cba38788149605d459e291b05L92-R103))


