### PR TITLE
refactor: Use query in farms

### DIFF
--- a/apps/web/src/hooks/useFarm.ts
+++ b/apps/web/src/hooks/useFarm.ts
@@ -4,7 +4,7 @@ import { priceHelperTokens } from '@pancakeswap/farms/constants/common'
 import { Currency, ERC20Token } from '@pancakeswap/sdk'
 import { FeeAmount, Pool } from '@pancakeswap/v3-sdk'
 import { useMemo } from 'react'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 
 import { FAST_INTERVAL } from 'config/constants'
 import { getViemClients } from 'utils/viem'
@@ -32,8 +32,8 @@ export function useFarm({ currencyA, currencyB, feeAmount }: FarmParams) {
     return farm ?? null
   }, [chainId, currencyA, currencyB, feeAmount])
 
-  return useSWR(
-    chainId && farmConfig && [chainId, farmConfig.token0.symbol, farmConfig.token1.symbol, farmConfig.feeAmount],
+  return useQuery(
+    [chainId, farmConfig.token0.symbol, farmConfig.token1.symbol, farmConfig.feeAmount],
     async () => {
       if (!farmConfig) {
         throw new Error('Invalid farm config')
@@ -68,8 +68,9 @@ export function useFarm({ currencyA, currencyB, feeAmount }: FarmParams) {
       }
     },
     {
-      refreshInterval: FAST_INTERVAL * 3,
-      dedupingInterval: FAST_INTERVAL,
+      enabled: Boolean(chainId && farmConfig),
+      refetchInterval: FAST_INTERVAL * 3,
+      staleTime: FAST_INTERVAL,
     },
   )
 }

--- a/apps/web/src/state/farms/hooks.ts
+++ b/apps/web/src/state/farms/hooks.ts
@@ -2,7 +2,7 @@ import { SLOW_INTERVAL } from 'config/constants'
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { useAppDispatch } from 'state'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { useBCakeProxyContractAddress } from 'views/Farms/hooks/useBCakeProxyContractAddress'
 import { getMasterChefContract } from 'utils/contractHelpers'
 import { getFarmConfig } from '@pancakeswap/farms/constants'
@@ -25,23 +25,35 @@ import {
 
 export function useFarmsLength() {
   const { chainId } = useActiveChainId()
-  return useSWRImmutable(
-    chainId && supportedChainIdV2.includes(chainId) ? ['farmsLength', chainId] : null,
+  return useQuery(
+    ['farmsLength', chainId],
     async () => {
       const mc = getMasterChefContract(undefined, chainId)
       return Number(await mc.read.poolLength())
+    },
+    {
+      enabled: Boolean(chainId && supportedChainIdV2.includes(chainId)),
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
     },
   )
 }
 
 export function useFarmV2PublicAPI() {
   const { chainId } = useActiveChainId()
-  return useSWRImmutable(
-    chainId && supportedChainIdV2.includes(chainId) ? ['farm-v2-pubic-api', chainId] : null,
+  return useQuery(
+    ['farm-v2-pubic-api', chainId],
     async () => {
       return fetch(`https://farms-api.pancakeswap.com/${chainId}`)
         .then((res) => res.json())
         .then((res) => res.data)
+    },
+    {
+      enabled: Boolean(chainId && supportedChainIdV2.includes(chainId)),
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
     },
   )
 }
@@ -55,8 +67,8 @@ export const usePollFarmsWithUserData = () => {
     isLoading: isProxyContractLoading,
   } = useBCakeProxyContractAddress(account, chainId)
 
-  useSWRImmutable(
-    chainId && supportedChainIdV2.includes(chainId) ? ['publicFarmData', chainId] : null,
+  useQuery(
+    ['publicFarmData', chainId],
     async () => {
       const farmsConfig = await getFarmConfig(chainId)
       if (!farmsConfig) return
@@ -65,7 +77,11 @@ export const usePollFarmsWithUserData = () => {
       dispatch(fetchFarmsPublicDataAsync({ pids, chainId }))
     },
     {
-      refreshInterval: SLOW_INTERVAL,
+      enabled: Boolean(chainId && supportedChainIdV2.includes(chainId)),
+      refetchInterval: SLOW_INTERVAL,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
     },
   )
 
@@ -73,8 +89,8 @@ export const usePollFarmsWithUserData = () => {
     ? ['farmsWithUserData', account, proxyAddress, chainId]
     : ['farmsWithUserData', account, chainId]
 
-  useSWRImmutable(
-    account && chainId && !isProxyContractLoading ? name : null,
+  useQuery(
+    name,
     async () => {
       const farmsConfig = await getFarmConfig(chainId)
       if (!farmsConfig) return
@@ -83,7 +99,11 @@ export const usePollFarmsWithUserData = () => {
       dispatch(fetchFarmUserDataAsync(params))
     },
     {
-      refreshInterval: SLOW_INTERVAL,
+      enabled: Boolean(account && chainId && !isProxyContractLoading),
+      refetchInterval: SLOW_INTERVAL,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
     },
   )
 }

--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { bCakeSupportedChainId } from '@pancakeswap/farms'
 import { useBCakeFarmBoosterV3Contract, useMasterchefV3 } from 'hooks/useContract'
 import _toNumber from 'lodash/toNumber'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import { useContractRead } from 'wagmi'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { PRECISION_FACTOR, getUserMultiplier } from './multiplierAPI'
@@ -12,9 +12,9 @@ import { useUserLockedCakeStatus } from '../../../../hooks/useUserLockedCakeStat
 
 export const USER_ESTIMATED_MULTIPLIER = 2
 
-const SWR_SETTINGS_WITHOUT_REFETCH = {
-  errorRetryCount: 3,
-  errorRetryInterval: 3000,
+const QUERY_SETTINGS_WITHOUT_REFETCH = {
+  retry: 3,
+  retryDelay: 3000,
   keepPreviousData: true,
 }
 
@@ -35,21 +35,27 @@ export const useBakeV3farmCanBoost = (farmPid: number) => {
 export const useIsBoostedPool = (tokenId?: string) => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
-  const { data, mutate } = useSWR(
-    chainId && tokenId && tokenId !== 'undefined' && `v3/bcake/isBoostedPool/${chainId}/${tokenId}`,
+  const { data, refetch } = useQuery(
+    [`v3/bcake/isBoostedPool/${chainId}/${tokenId}`],
     () => farmBoosterV3Contract.read.isBoostedPool([BigInt(tokenId ?? 0)]),
-    SWR_SETTINGS_WITHOUT_REFETCH,
+    {
+      enabled: Boolean(chainId && tokenId && tokenId !== 'undefined'),
+      ...QUERY_SETTINGS_WITHOUT_REFETCH,
+    },
   )
-  return { isBoosted: data?.[0], pid: Number(data?.[1]), mutate }
+  return { isBoosted: data?.[0], pid: Number(data?.[1]), mutate: refetch }
 }
 
 export const useUserPositionInfo = (tokenId: string) => {
   const { chainId } = useActiveChainId()
   const masterChefV3 = useMasterchefV3()
-  const { data, mutate } = useSWR(
-    chainId && tokenId && `v3/masterChef/userPositionInfos/${chainId}/${tokenId}`,
+  const { data, refetch } = useQuery(
+    [`v3/masterChef/userPositionInfos/${chainId}/${tokenId}`],
     () => masterChefV3.read.userPositionInfos([BigInt(tokenId)]),
-    SWR_SETTINGS_WITHOUT_REFETCH,
+    {
+      enabled: Boolean(chainId && tokenId),
+      ...QUERY_SETTINGS_WITHOUT_REFETCH,
+    },
   )
   return {
     data: {
@@ -63,45 +69,54 @@ export const useUserPositionInfo = (tokenId: string) => {
       pid: data?.[7],
       boostMultiplier: _toNumber(new BN(data?.[8].toString()).div(PRECISION_FACTOR).toString()),
     },
-    updateUserPositionInfo: mutate,
+    updateUserPositionInfo: refetch,
   }
 }
 
 export const useUserBoostedPoolsTokenId = () => {
   const { account, chainId } = useAccountActiveChain()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
-  const { data, mutate } = useSWR(
-    chainId && account && `v3/bcake/userBoostedPools/${chainId}/${account}`,
+  const { data, refetch } = useQuery(
+    [`v3/bcake/userBoostedPools/${chainId}/${account}`],
     () => farmBoosterV3Contract.read.activedPositions([account]),
-    SWR_SETTINGS_WITHOUT_REFETCH,
+    {
+      enabled: Boolean(chainId && account),
+      ...QUERY_SETTINGS_WITHOUT_REFETCH,
+    },
   )
   return {
     pids: data?.map((tokenId) => Number(tokenId)) ?? [],
-    updateBoostedPoolsTokenId: mutate,
+    updateBoostedPoolsTokenId: refetch,
   }
 }
 
 export const useUserMultiplierBeforeBoosted = (tokenId?: string) => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
-  const { data, mutate } = useSWR(
-    chainId && tokenId && `v3/bcake/useUserMultiplierBeforeBoosted/${chainId}/${tokenId}`,
+  const { data, refetch } = useQuery(
+    [`v3/bcake/useUserMultiplierBeforeBoosted/${chainId}/${tokenId}`],
     () => getUserMultiplier({ address: farmBoosterV3Contract.address, tokenId, chainId }),
-    SWR_SETTINGS_WITHOUT_REFETCH,
+    {
+      enabled: Boolean(chainId && tokenId),
+      ...QUERY_SETTINGS_WITHOUT_REFETCH,
+    },
   )
   return {
     userMultiplierBeforeBoosted: data ?? 1,
-    updatedUserMultiplierBeforeBoosted: mutate,
+    updatedUserMultiplierBeforeBoosted: refetch,
   }
 }
 
 export const useUserMaxBoostedPositionLimit = () => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
-  const { data } = useSWR(
-    chainId && `v3/bcake/userMaxBoostedPositionLimit/${chainId}`,
+  const { data } = useQuery(
+    [`v3/bcake/userMaxBoostedPositionLimit/${chainId}`],
     () => farmBoosterV3Contract.read.MAX_BOOST_POSITION(),
-    SWR_SETTINGS_WITHOUT_REFETCH,
+    {
+      enabled: Boolean(chainId),
+      ...QUERY_SETTINGS_WITHOUT_REFETCH,
+    },
   )
   return Number(data)
 }

--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/useBoostMultiplier.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/useBoostMultiplier.ts
@@ -1,12 +1,12 @@
 import { useBCakeFarmBoosterContract, useMasterchef } from 'hooks/useContract'
 import BN from 'bignumber.js'
 import { useCallback } from 'react'
-import useSWR from 'swr'
 import _toNumber from 'lodash/toNumber'
 import { Address, useAccount } from 'wagmi'
 import { publicClient } from 'utils/wagmi'
 import { ChainId } from '@pancakeswap/chains'
 import { bCakeFarmBoosterABI } from 'config/abi/bCakeFarmBooster'
+import { useQuery } from '@tanstack/react-query'
 import { YieldBoosterState } from './useYieldBoosterState'
 
 const PRECISION_FACTOR = new BN('1000000000000') // 1e12
@@ -119,7 +119,7 @@ export default function useBoostMultiplier({ pid, boosterState, proxyAddress }):
 
   const cacheName = shouldGetFromSC ? `proxy${pid}` : should1X ? `user${pid}` : `public${pid}`
 
-  const { data } = useSWR(['boostMultiplier', cacheName], getMultiplier)
+  const { data } = useQuery(['boostMultiplier', cacheName], getMultiplier)
 
   return data || 0
 }

--- a/apps/web/src/views/Farms/components/YieldBooster/hooks/useFarmBoosterConstants.ts
+++ b/apps/web/src/views/Farms/components/YieldBooster/hooks/useFarmBoosterConstants.ts
@@ -1,44 +1,51 @@
-import useSWRImmutable from 'swr/immutable'
 import { getBCakeFarmBoosterAddress } from 'utils/addressHelpers'
 import { useMemo } from 'react'
-import { FetchStatus } from 'config/constants/types'
 import BigNumber from 'bignumber.js'
 import { publicClient } from 'utils/wagmi'
 import { ChainId } from '@pancakeswap/chains'
 import { bCakeFarmBoosterABI } from 'config/abi/bCakeFarmBooster'
+import { useQuery } from '@tanstack/react-query'
 
 const useFarmBoosterConstants = () => {
   const bCakeFarmBoosterAddress = getBCakeFarmBoosterAddress()
 
-  const { data, status } = useSWRImmutable('farmBoosterConstants', async () => {
-    return publicClient({ chainId: ChainId.BSC }).multicall({
-      contracts: [
-        {
-          address: bCakeFarmBoosterAddress,
-          abi: bCakeFarmBoosterABI,
-          functionName: 'cA',
-        },
-        {
-          address: bCakeFarmBoosterAddress,
-          abi: bCakeFarmBoosterABI,
-          functionName: 'CA_PRECISION',
-        },
-        {
-          address: bCakeFarmBoosterAddress,
-          abi: bCakeFarmBoosterABI,
-          functionName: 'cB',
-        },
-      ],
-      allowFailure: false,
-    })
-  })
+  const { data, status } = useQuery(
+    ['farmBoosterConstants'],
+    async () => {
+      return publicClient({ chainId: ChainId.BSC }).multicall({
+        contracts: [
+          {
+            address: bCakeFarmBoosterAddress,
+            abi: bCakeFarmBoosterABI,
+            functionName: 'cA',
+          },
+          {
+            address: bCakeFarmBoosterAddress,
+            abi: bCakeFarmBoosterABI,
+            functionName: 'CA_PRECISION',
+          },
+          {
+            address: bCakeFarmBoosterAddress,
+            abi: bCakeFarmBoosterABI,
+            functionName: 'cB',
+          },
+        ],
+        allowFailure: false,
+      })
+    },
+    {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  )
   return useMemo(() => {
     return {
       constants: data && {
         cA: new BigNumber(data[0].toString()).div(new BigNumber(data[1].toString())).toNumber(),
         cB: new BigNumber(data[2].toString()).toNumber(),
       },
-      isLoading: status !== FetchStatus.Fetched,
+      isLoading: status !== 'success',
     }
   }, [data, status])
 }

--- a/apps/web/src/views/Farms/hooks/useFarmCProxyAddress.ts
+++ b/apps/web/src/views/Farms/hooks/useFarmCProxyAddress.ts
@@ -1,13 +1,17 @@
-import useSWR from 'swr'
 import { ChainId } from '@pancakeswap/chains'
 import { fetchCProxyAddress } from 'state/farms/fetchFarmUser'
 import { farmFetcher } from 'state/farms'
 import { Address } from 'wagmi'
+import { useQuery } from '@tanstack/react-query'
 
 export const useFarmCProxyAddress = (account?: string, chainId?: number) => {
   const multiCallChainId = farmFetcher.isTestnet(chainId) ? ChainId.BSC_TESTNET : ChainId.BSC
-  const { data } = useSWR(account && chainId && ['cProxyAddress', account, chainId], async () =>
-    fetchCProxyAddress(account as Address, multiCallChainId),
+  const { data } = useQuery(
+    ['cProxyAddress', account, chainId],
+    async () => fetchCProxyAddress(account as Address, multiCallChainId),
+    {
+      enabled: Boolean(account && chainId),
+    },
   )
 
   return {

--- a/apps/web/src/views/Farms/hooks/useFirstTimeCrossFarming.ts
+++ b/apps/web/src/views/Farms/hooks/useFirstTimeCrossFarming.ts
@@ -1,7 +1,7 @@
-import useSWRImmutable from 'swr/immutable'
 import { getCrossFarmingSenderContract } from 'utils/contractHelpers'
 import { useMemo } from 'react'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { useQuery } from '@tanstack/react-query'
 
 export const useFirstTimeCrossFarming = (vaultPid: number | undefined) => {
   const { account, chainId } = useAccountActiveChain()
@@ -9,13 +9,19 @@ export const useFirstTimeCrossFarming = (vaultPid: number | undefined) => {
     return vaultPid && chainId ? getCrossFarmingSenderContract(null, chainId) : null
   }, [chainId, vaultPid])
 
-  const { data, mutate } = useSWRImmutable(
-    account && crossFarmingAddress && ['isFirstTimeCrossFarming', account, chainId],
+  const { data, refetch } = useQuery(
+    ['isFirstTimeCrossFarming', account, chainId],
     async () => {
       const firstTimeDeposit = await crossFarmingAddress.read.is1st([account])
       return !firstTimeDeposit
     },
+    {
+      enabled: Boolean(account && crossFarmingAddress),
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
   )
 
-  return { isFirstTime: data, refresh: mutate }
+  return { isFirstTime: data, refresh: refetch }
 }

--- a/apps/web/src/views/Farms/hooks/useUserBoosterStatus.ts
+++ b/apps/web/src/views/Farms/hooks/useUserBoosterStatus.ts
@@ -1,25 +1,31 @@
-import { FetchStatus } from 'config/constants/types'
 import { useBCakeFarmBoosterContract } from 'hooks/useContract'
-import useSWR from 'swr'
-import useSWRImmutable from 'swr/immutable'
 import { Address } from 'wagmi'
+import { useQuery } from '@tanstack/react-query'
 
 export const useUserBoosterStatus = (account: Address) => {
   const farmBoosterContract = useBCakeFarmBoosterContract()
-  const { data: MAX_BOOST_POOL, status: maxBoostStatus } = useSWRImmutable('maxBoostFarm', () =>
-    farmBoosterContract.read.MAX_BOOST_POOL(),
+  const { data: MAX_BOOST_POOL, status: maxBoostStatus } = useQuery(
+    ['maxBoostFarm'],
+    () => farmBoosterContract.read.MAX_BOOST_POOL(),
+    {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+    },
   )
   const {
     data: activatedPools,
     status,
-    mutate,
-  } = useSWR(account && ['activatedBoostFarm', [account]], () => farmBoosterContract.read.activedPools([account]))
+    refetch,
+  } = useQuery(['activatedBoostFarm', [account]], () => farmBoosterContract.read.activedPools([account]), {
+    enabled: Boolean(account),
+  })
 
   return {
     maxBoostCounts: MAX_BOOST_POOL ? Number(MAX_BOOST_POOL) : 0,
     activatedPoolsCounts: activatedPools?.length ?? 0,
     remainingCounts: (MAX_BOOST_POOL ? Number(MAX_BOOST_POOL) : 0) - (activatedPools?.length ?? 0),
-    isLoading: maxBoostStatus !== FetchStatus.Fetched || status !== FetchStatus.Fetched,
-    refreshActivePools: mutate,
+    isLoading: maxBoostStatus !== 'success' || status !== 'success',
+    refreshActivePools: refetch,
   }
 }

--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -6,11 +6,11 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { useMasterchefV3, useV3NFTPositionManagerContract } from 'hooks/useContract'
 import { useCallback } from 'react'
-import { mutate } from 'swr'
 import { calculateGasMargin } from 'utils'
 import { getViemClients, viemClients } from 'utils/viem'
 import { Address, hexToBigInt } from 'viem'
 import { useAccount, useSendTransaction, useWalletClient } from 'wagmi'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface FarmV3ActionContainerChildrenProps {
   attemptingTxn: boolean
@@ -32,6 +32,7 @@ const useFarmV3Actions = ({
   const { data: signer } = useWalletClient()
   const { chainId } = useActiveChainId()
   const { sendTransactionAsync } = useSendTransaction()
+  const queryClient = useQueryClient()
   const publicClient = viemClients[chainId as keyof typeof viemClients]
 
   const { loading, fetchWithCatchTxError } = useCatchTxError()
@@ -165,7 +166,7 @@ const useFarmV3Actions = ({
           {t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' })}
         </ToastDescriptionWithTx>,
       )
-      mutate((key) => Array.isArray(key) && key[0] === 'mcv3-harvest', undefined)
+      queryClient.invalidateQueries({ queryKey: ['mcv3-harvest'] })
     }
   }, [
     account,
@@ -177,6 +178,7 @@ const useFarmV3Actions = ({
     t,
     toastSuccess,
     tokenId,
+    queryClient,
   ])
 
   return {
@@ -194,6 +196,7 @@ export function useFarmsV3BatchHarvest() {
   const { address: account } = useAccount()
   const { sendTransactionAsync } = useSendTransaction()
   const { loading, fetchWithCatchTxError } = useCatchTxError()
+  const queryClient = useQueryClient()
 
   const masterChefV3Address = useMasterchefV3()?.address
   const onHarvestAll = useCallback(
@@ -228,10 +231,10 @@ export function useFarmsV3BatchHarvest() {
             {t('Your %symbol% earnings have been sent to your wallet!', { symbol: 'CAKE' })}
           </ToastDescriptionWithTx>,
         )
-        mutate((key) => Array.isArray(key) && key[0] === 'mcv3-harvest', undefined)
+        queryClient.invalidateQueries({ queryKey: ['mcv3-harvest'] })
       }
     },
-    [account, fetchWithCatchTxError, masterChefV3Address, sendTransactionAsync, signer, t, toastSuccess],
+    [account, fetchWithCatchTxError, masterChefV3Address, sendTransactionAsync, signer, t, toastSuccess, queryClient],
   )
 
   return {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d64c44</samp>

### Summary
🚀🔄🛠️

<!--
1.  🚀 - This emoji represents the improvement in performance and consistency of the data fetching and caching logic, as well as the reduction of dependencies and code complexity.
2.  🔄 - This emoji represents the migration from one library to another, and the adjustment of the syntax and options to match the new library.
3.  🛠️ - This emoji represents the optimization and refinement of the data fetching conditions and the loading and refetching states.
-->
The pull request refactors the data fetching logic in various hooks and components related to the Farms and YieldBooster features of the web app. It replaces the use of `useSWR` and `useSWRImmutable` hooks from the SWR library with the `useQuery` hook from the react-query library. This improves the data caching, invalidation, and consistency across the app, and reduces the dependency on the `bCakeSupportedChainId` constant. It also updates the query options and conditions to match the react-query syntax and the data availability.

> _To fetch data from contracts and APIs_
> _We used `useSWR` with some compromise_
> _But now we have switched_
> _To `useQuery` enriched_
> _With better caching and invalidation ties_

### Walkthrough
*  Replace `useSWR` and `useSWRImmutable` hooks with `useQuery` hook from react-query library to improve data fetching and caching ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL8),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dR31),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL65-R66),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL95-R98),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL222-R224),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dR241),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL361-R370),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL7-R7),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL15-R17),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL38-R46),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL49-R58),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL66-R72),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL73-R89),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL87-R106),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL101-R119),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ede3196b149e063595621e5b678466f9aa9f420982fdeb26f81b143783a6d758L4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ede3196b149e063595621e5b678466f9aa9f420982fdeb26f81b143783a6d758R9),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ede3196b149e063595621e5b678466f9aa9f420982fdeb26f81b143783a6d758L122-R122),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-e61bef8ab6031619f920ddb84567fedd560b80bcc4c7f76c821584e977921cf9L1-R41),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-e61bef8ab6031619f920ddb84567fedd560b80bcc4c7f76c821584e977921cf9L41-R48),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L1-R7),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L19-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L40-R42),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L1-R20),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L21-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-268ed8e0a610d7799118b655664a035c0e22e6ba106ec155b662a54bd5bd494eL1-R14),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L1-R4),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L12-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L1-R21),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L22-R28),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L9-R13),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R35),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L168-R169),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R181),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R199),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L231-R237))
*  Adjust query options to match react-query syntax and behavior, such as renaming `refreshInterval` to `refetchInterval`, `fallbackData` to `initialData`, `errorRetryCount` to `retry`, `errorRetryInterval` to `retryDelay`, and setting `keepPreviousData` to `true` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL95-R98),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL222-R224),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL361-R370),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL15-R17),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL38-R46),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL73-R89),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL87-R106),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL101-R119),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ede3196b149e063595621e5b678466f9aa9f420982fdeb26f81b143783a6d758L122-R122),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-e61bef8ab6031619f920ddb84567fedd560b80bcc4c7f76c821584e977921cf9L41-R48),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L19-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L21-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L12-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L22-R28))
*  Add `enabled` option to `useQuery` hook to conditionally run the query based on the availability of required variables or conditions ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL65-R66),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dR241),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL361-R370),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL38-R46),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL73-R89),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL87-R106),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L19-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L21-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L12-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L22-R28))
*  Add `refetchOnMount`, `refetchOnReconnect`, and `refetchOnWindowFocus` options to `useQuery` hook to prevent unnecessary refetching of data that does not change frequently ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL101-R119),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-e61bef8ab6031619f920ddb84567fedd560b80bcc4c7f76c821584e977921cf9L41-R48),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L21-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L12-R26))
*  Rename `mutate` function returned by `useSWR` hook to `refetch` function returned by `useQuery` hook, and use it to manually refetch the data for the query ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL49-R58),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL66-R72),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-ac12c5777e4b967f5e79d074360e3c376de3f29677eaf0d93eb8961179b5836aL73-R89),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-468ad065683a2b1ea008b7c53fefb2b290c8f66740076421b670ad2443d92a43L21-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-f05757e64d38fea86ce32eaa050a75b9bb25c5f4a83241225ef93deb0b5482c1L12-R26),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L22-R28),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L168-R169),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L231-R237))
*  Change `isLoading` variable to compare the `status` returned by `useQuery` hook with `'success'` instead of `FetchStatus.Fetched`, as the `status` is a string that indicates the query state ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-e61bef8ab6031619f920ddb84567fedd560b80bcc4c7f76c821584e977921cf9L41-R48),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-1a9fc5e8bf94ddb38539a9043b0b958b37c7565b0c9a10a994488edae5b7ca15L40-R42),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-bb964256c1e82452b27bfbe4e0f769736468d5aa4dde40bf4add91f35f394387L22-R28))
*  Declare `queryClient` variable by calling `useQueryClient` hook, and use it to access the query client instance, which can be used to invalidate or refetch queries ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L9-R13),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R35),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R199))
*  Add `queryClient` variable to the dependency array of `useCallback` hooks, as it is used inside the callback functions ([link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218R181),[link](https://github.com/pancakeswap/pancake-frontend/pull/8245/files?diff=unified&w=0#diff-2ef8dcff1b33f7bbd71889bed20d3b32d09d09645ee503d71773ac76ff1ee218L231-R237))


