### PR TITLE
refactor: Use query for block hooks

### DIFF
--- a/apps/web/src/hooks/useRefreshEffect.ts
+++ b/apps/web/src/hooks/useRefreshEffect.ts
@@ -1,6 +1,6 @@
 import { FAST_INTERVAL, SLOW_INTERVAL } from 'config/constants'
 import { DependencyList, EffectCallback, useEffect } from 'react'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import { useActiveChainId } from './useActiveChainId'
 
 type BlockEffectCallback = (blockNumber: number) => ReturnType<EffectCallback>
@@ -9,7 +9,7 @@ const EMPTY_ARRAY = []
 
 export function useFastRefreshEffect(effect: BlockEffectCallback, deps?: DependencyList) {
   const { chainId } = useActiveChainId()
-  const { data = 0 } = useSWR(chainId && [FAST_INTERVAL, 'blockNumber', chainId])
+  const { data = 0 } = useQuery<number>([FAST_INTERVAL, 'blockNumber', chainId], { enabled: false })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(effect.bind(null, data), [data, ...(deps || EMPTY_ARRAY)])
@@ -17,7 +17,7 @@ export function useFastRefreshEffect(effect: BlockEffectCallback, deps?: Depende
 
 export function useSlowRefreshEffect(effect: BlockEffectCallback, deps?: DependencyList) {
   const { chainId } = useActiveChainId()
-  const { data = 0 } = useSWR(chainId && [SLOW_INTERVAL, 'blockNumber', chainId])
+  const { data = 0 } = useQuery<number>([SLOW_INTERVAL, 'blockNumber', chainId], { enabled: false })
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(effect.bind(null, data), [data, ...(deps || EMPTY_ARRAY)])

--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -62,6 +62,7 @@ export const useCurrentBlock = (): number => {
     enabled: false,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
   return Number(currentBlock)
 }
@@ -90,6 +91,7 @@ export const useInitialBlock = (): number => {
     enabled: false,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
   return Number(initialBlock)
 }
@@ -100,6 +102,7 @@ export const useInitialBlockTimestamp = (): number => {
     enabled: false,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
   return Number(initialBlockTimestamp)
 }

--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -36,9 +36,10 @@ export const usePollBlockNumber = () => {
     ['blockNumberFetcher', chainId],
     async () => {
       queryClient.setQueryData(['blockNumber', chainId], Number(blockNumber))
+      return null
     },
     {
-      enabled: Boolean(chainId),
+      enabled: false,
       refetchOnMount: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,

--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -16,10 +16,10 @@ export const usePollBlockNumber = () => {
       queryClient.setQueryData(['blockNumber', chainId], Number(data))
     },
     onSuccess: (data) => {
-      if (!queryClient.getQueryCache().find(['initialBlockNumber', chainId])?.state?.data) {
+      if (!queryClient.getQueryCache().find<number>(['initialBlockNumber', chainId])?.state?.data) {
         queryClient.setQueryData(['initialBlockNumber', chainId], Number(data))
       }
-      if (!queryClient.getQueryCache().find(['initialBlockTimestamp', chainId])?.state?.data) {
+      if (!queryClient.getQueryCache().find<number>(['initialBlockTimestamp', chainId])?.state?.data) {
         const fetchInitialBlockTimestamp = async () => {
           const provider = viemClients[chainId as keyof typeof viemClients]
           if (provider) {

--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -1,31 +1,30 @@
 import { FAST_INTERVAL, SLOW_INTERVAL } from 'config/constants'
 // eslint-disable-next-line camelcase
-import useSWR, { useSWRConfig, unstable_serialize } from 'swr'
-import useSWRImmutable from 'swr/immutable'
 import { useBlockNumber, usePublicClient } from 'wagmi'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { viemClients } from 'utils/viem'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 const REFRESH_BLOCK_INTERVAL = 6000
 
 export const usePollBlockNumber = () => {
-  const { cache, mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { chainId } = useActiveChainId()
   const { data: blockNumber } = useBlockNumber({
     chainId,
     onBlock: (data) => {
-      mutate(['blockNumber', chainId], Number(data))
+      queryClient.setQueryData(['blockNumber', chainId], Number(data))
     },
     onSuccess: (data) => {
-      if (!cache.get(unstable_serialize(['initialBlockNumber', chainId]))?.data) {
-        mutate(['initialBlockNumber', chainId], Number(data))
+      if (!queryClient.getQueryCache().find(['initialBlockNumber', chainId])?.state?.data) {
+        queryClient.setQueryData(['initialBlockNumber', chainId], Number(data))
       }
-      if (!cache.get(unstable_serialize(['initialBlockTimestamp', chainId]))?.data) {
+      if (!queryClient.getQueryCache().find(['initialBlockTimestamp', chainId])?.state?.data) {
         const fetchInitialBlockTimestamp = async () => {
           const provider = viemClients[chainId as keyof typeof viemClients]
           if (provider) {
             const block = await provider.getBlock({ blockNumber: data })
-            mutate(['initialBlockTimestamp', chainId], Number(block.timestamp))
+            queryClient.setQueryData(['initialBlockTimestamp', chainId], Number(block.timestamp))
           }
         }
         fetchInitialBlockTimestamp()
@@ -33,74 +32,74 @@ export const usePollBlockNumber = () => {
     },
   })
 
-  useSWR(
-    chainId && ['blockNumberFetcher', chainId],
+  useQuery(
+    ['blockNumberFetcher', chainId],
     async () => {
-      mutate(['blockNumber', chainId], Number(blockNumber))
+      queryClient.setQueryData(['blockNumber', chainId], Number(blockNumber))
     },
     {
-      revalidateOnMount: false,
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
+      enabled: Boolean(chainId),
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
 
-  useSWR(
-    chainId && [FAST_INTERVAL, 'blockNumber', chainId],
-    async () => {
-      return Number(blockNumber)
-    },
-    {
-      refreshInterval: FAST_INTERVAL,
-    },
-  )
+  useQuery([FAST_INTERVAL, 'blockNumber', chainId], async () => Number(blockNumber), {
+    enabled: Boolean(chainId),
+    refetchInterval: FAST_INTERVAL,
+  })
 
-  useSWR(
-    chainId && [SLOW_INTERVAL, 'blockNumber', chainId],
-    async () => {
-      return Number(blockNumber)
-    },
-    {
-      refreshInterval: SLOW_INTERVAL,
-    },
-  )
+  useQuery([SLOW_INTERVAL, 'blockNumber', chainId], async () => Number(blockNumber), {
+    enabled: Boolean(chainId),
+    refetchInterval: SLOW_INTERVAL,
+  })
 }
 
 export const useCurrentBlock = (): number => {
   const { chainId } = useActiveChainId()
-  const { data: currentBlock = 0 } = useSWRImmutable(['blockNumber', chainId])
+  const { data: currentBlock = 0 } = useQuery<number>(['blockNumber', chainId], {
+    enabled: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  })
   return Number(currentBlock)
 }
 
 export const useChainCurrentBlock = (chainId: number): number => {
   const { chainId: activeChainId } = useActiveChainId()
   const provider = usePublicClient({ chainId })
-  const { data: currentBlock = 0 } = useSWR(
-    chainId ? (activeChainId === chainId ? ['blockNumber', chainId] : ['chainBlockNumber', chainId]) : null,
-    activeChainId !== chainId
-      ? async () => {
-          const blockNumber = await provider.getBlockNumber()
-          return Number(blockNumber)
-        }
-      : undefined,
-    activeChainId !== chainId
-      ? {
-          refreshInterval: REFRESH_BLOCK_INTERVAL,
-        }
-      : undefined,
+
+  const { data: currentBlock = 0 } = useQuery(
+    activeChainId === chainId ? ['blockNumber', chainId] : ['chainBlockNumber', chainId],
+    async () => {
+      const blockNumber = await provider.getBlockNumber()
+      return Number(blockNumber)
+    },
+    {
+      enabled: activeChainId !== chainId,
+      ...(activeChainId !== chainId && { refetchInterval: REFRESH_BLOCK_INTERVAL }),
+    },
   )
   return currentBlock
 }
 
 export const useInitialBlock = (): number => {
   const { chainId } = useActiveChainId()
-  const { data: initialBlock = 0 } = useSWRImmutable(['initialBlockNumber', chainId])
+  const { data: initialBlock = 0 } = useQuery<number>(['initialBlockNumber', chainId], {
+    enabled: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  })
   return Number(initialBlock)
 }
 
 export const useInitialBlockTimestamp = (): number => {
   const { chainId } = useActiveChainId()
-  const { data: initialBlockTimestamp = 0 } = useSWRImmutable(['initialBlockTimestamp', chainId])
+  const { data: initialBlockTimestamp = 0 } = useQuery<number>(['initialBlockTimestamp', chainId], {
+    enabled: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  })
   return Number(initialBlockTimestamp)
 }

--- a/apps/web/src/state/multicall/hooks.ts
+++ b/apps/web/src/state/multicall/hooks.ts
@@ -254,7 +254,7 @@ export function useSingleContractMultipleData<TAbi extends Abi | readonly unknow
   const queryClient = useQueryClient()
 
   return useMemo(() => {
-    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
+    const currentBlockNumber = queryClient.getQueryCache().find<number>(['blockNumber', chainId])?.state?.data
     return results.map((result) => toCallState(result, contract.abi, functionName, currentBlockNumber))
   }, [queryClient, chainId, results, contract.abi, functionName])
 }
@@ -315,7 +315,7 @@ export function useMultipleContractSingleData<TAbi extends Abi | readonly unknow
   const queryClient = useQueryClient()
 
   return useMemo(() => {
-    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
+    const currentBlockNumber = queryClient.getQueryCache().find<number>(['blockNumber', chainId])?.state?.data
     return results.map((result) => toCallState(result, abi, functionName, currentBlockNumber))
   }, [queryClient, chainId, results, abi, functionName])
 }
@@ -360,7 +360,7 @@ export function useSingleCallResult<TAbi extends Abi | readonly unknown[], TFunc
   const { chainId } = useActiveChainId()
 
   return useMemo(() => {
-    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
+    const currentBlockNumber = queryClient.getQueryCache().find<number>(['blockNumber', chainId])?.state?.data
     return toCallState(result, contract?.abi, functionName, currentBlockNumber)
   }, [queryClient, chainId, result, contract?.abi, functionName])
 }

--- a/apps/web/src/state/multicall/hooks.ts
+++ b/apps/web/src/state/multicall/hooks.ts
@@ -2,11 +2,7 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 import { multicallReducerAtom } from 'state/multicall/reducer'
-import {
-  // eslint-disable-next-line camelcase
-  unstable_serialize,
-  useSWRConfig,
-} from 'swr'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   Abi,
   Address,
@@ -255,12 +251,12 @@ export function useSingleContractMultipleData<TAbi extends Abi | readonly unknow
 
   const results = useCallsData(calls, options)
 
-  const { cache } = useSWRConfig()
+  const queryClient = useQueryClient()
 
   return useMemo(() => {
-    const currentBlockNumber = cache.get(unstable_serialize(['blockNumber', chainId]))?.data
+    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
     return results.map((result) => toCallState(result, contract.abi, functionName, currentBlockNumber))
-  }, [cache, chainId, results, contract.abi, functionName])
+  }, [queryClient, chainId, results, contract.abi, functionName])
 }
 
 const DEFAULT_OPTIONS = {
@@ -316,12 +312,12 @@ export function useMultipleContractSingleData<TAbi extends Abi | readonly unknow
   const results = useCallsData(calls, options?.blocksPerFetch ? { blocksPerFetch } : DEFAULT_OPTIONS)
   const { chainId } = useActiveChainId()
 
-  const { cache } = useSWRConfig()
+  const queryClient = useQueryClient()
 
   return useMemo(() => {
-    const currentBlockNumber = cache.get(unstable_serialize(['blockNumber', chainId]))?.data
+    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
     return results.map((result) => toCallState(result, abi, functionName, currentBlockNumber))
-  }, [cache, chainId, results, abi, functionName])
+  }, [queryClient, chainId, results, abi, functionName])
 }
 
 export type SingleCallParameters<
@@ -360,11 +356,11 @@ export function useSingleCallResult<TAbi extends Abi | readonly unknown[], TFunc
 
   const result = useCallsData(calls, options)[0]
 
-  const { cache } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { chainId } = useActiveChainId()
 
   return useMemo(() => {
-    const currentBlockNumber = cache.get(unstable_serialize(['blockNumber', chainId]))?.data
+    const currentBlockNumber = queryClient.getQueryCache().find(['blockNumber', chainId])?.state?.data
     return toCallState(result, contract?.abi, functionName, currentBlockNumber)
-  }, [cache, chainId, result, contract?.abi, functionName])
+  }, [queryClient, chainId, result, contract?.abi, functionName])
 }

--- a/apps/web/src/testUtils.tsx
+++ b/apps/web/src/testUtils.tsx
@@ -13,7 +13,8 @@ import { SWRConfig } from 'swr'
 import { vi } from 'vitest'
 import { WagmiConfig } from 'wagmi'
 import { useHydrateAtoms } from 'jotai/utils'
-import { wagmiConfig } from './utils/wagmi'
+import { wagmiConfig } from 'utils/wagmi'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const mockRouter: NextRouter = {
   basePath: '',
@@ -92,8 +93,15 @@ export const createSWRWrapper =
 
 export const createWagmiWrapper =
   () =>
-  ({ children }) =>
-    <WagmiConfig config={wagmiConfig}>{children}</WagmiConfig>
+  ({ children }) => {
+    const queryClient = new QueryClient()
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <WagmiConfig config={wagmiConfig}>{children}</WagmiConfig>
+      </QueryClientProvider>
+    )
+  }
 
 // re-export everything
 export * from '@testing-library/react'

--- a/apps/web/src/views/Swap/hooks/useRefreshBlockNumber.ts
+++ b/apps/web/src/views/Swap/hooks/useRefreshBlockNumber.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { useSWRConfig } from 'swr'
+import { useQueryClient } from '@tanstack/react-query'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 
 export const useRefreshBlockNumber = () => {
@@ -11,19 +11,19 @@ export const useRefreshBlockNumber = () => {
     }
   }, [isLoading])
 
-  const { mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { chainId } = useActiveChainId()
 
   useEffect(() => {
     if (!isLoading) return
 
-    mutate(['blockNumberFetcher', chainId])
+    queryClient.invalidateQueries(['blockNumberFetcher', chainId])
 
     // setTimeout is used to demonstrate the loading
     // because the real loading state occurs on multicall state
     // we don't know when the fetch is finished.
     setTimeout(() => setFetch(false), 500)
-  }, [mutate, isLoading, chainId])
+  }, [queryClient, isLoading, chainId])
 
   return { refreshBlockNumber, isLoading }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7102761</samp>

### Summary
🔄🚀🧪

<!--
1.  🔄 - This emoji represents the refactoring of the data fetching logic from `swr` to `react-query`, which is a major change in the web app's state management and caching strategy.
2.  🚀 - This emoji represents the performance improvement and consistency of the data fetching logic, which makes the web app faster and more reliable for the users.
3.  🧪 - This emoji represents the testing of the data fetching logic, which ensures the quality and correctness of the web app's functionality.
-->
The pull request refactors the web app to use `react-query` instead of `swr` for data fetching and caching. This improves the performance and consistency of the data fetching logic and the user interface. The pull request also updates the tests and the test utils to use `react-query`.

> _We're breaking free from the chains of SWR_
> _We're using react-query to fetch and cache_
> _We're refactoring our hooks for performance and consistency_
> _We're the masters of data in the web app_

### Walkthrough
*  Replace `useSWR` and `useSWRImmutable` hooks with `useQuery` from `react-query` for data fetching and caching, and update the return values and options accordingly ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L4-R5),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L39-R43),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L52-R61),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L64-R76),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L80-R94),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-c79cbea27ae83b9ca7588ee41b3973a2ed51214982e52a391635bdeddc56fb3dL12-R12),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-c79cbea27ae83b9ca7588ee41b3973a2ed51214982e52a391635bdeddc56fb3dL20-R20),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L36-R66),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L79-R83),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L98-R95),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L104-R106),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L258-R259),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L319-R320),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L363-R365))
*  Replace `useSWRConfig` hook with `useQueryClient` hook, and use `queryClient` to access and update the query cache ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L5-R6),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-d210780d2f00ca3e308e832b957b5e0979db31c17bee1b8018c31f511c0f1dbeL14-R15))
*  Replace `mutate` function from `swr` with `setQueryData` or `invalidateQueries` from `react-query`, and use `waitFor` from `@testing-library/react` to wait for query updates ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L52-R61),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L80-R94),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L36-R66),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-d210780d2f00ca3e308e832b957b5e0979db31c17bee1b8018c31f511c0f1dbeL20-R21))
*  Replace `unstable_serialize` function from `swr` with `find` method of the query cache, and use `queryKey` to identify the queries ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L3-R27),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L5-R6),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L258-R259),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L319-R320),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L363-R365))
*  Create custom hooks `useFastRefreshEffect`, `useSlowRefreshEffect`, `usePollBlockNumber`, `useSingleContractMultipleData`, `useMultipleContractSingleData`, and `useSingleCallResult` that use `react-query` to trigger callbacks or fetch data from the blockchain ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L39-R43),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-427703945ac63bb4cc1f51c61d8396902dab68ed708f2063d0c3c17aa8c1e285L64-R76),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-c79cbea27ae83b9ca7588ee41b3973a2ed51214982e52a391635bdeddc56fb3dL12-R12),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-c79cbea27ae83b9ca7588ee41b3973a2ed51214982e52a391635bdeddc56fb3dL20-R20),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-5ceb9d5e2a50941c88f358e2afea0e55f90ea64191a679bd6c697fe2e177fc47L36-R66),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L258-R259),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L319-R320),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-7a4eeefc948227740fbecc58250c10947aa030e3e1355da62fa5e033e317d947L363-R365))
*  Create a query client and provide it to the test components with `QueryClientProvider` in `apps/web/src/testUtils.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-e072c2741885a61c81231587c78646fc3214ffbf008350db9617b159aad94454L16-R17),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-e072c2741885a61c81231587c78646fc3214ffbf008350db9617b159aad94454L95-R105))
*  Modify the `useRefreshBlockNumber` hook in `apps/web/src/views/Swap/hooks/useRefreshBlockNumber.ts` to allow the user to refresh the block number manually and show a loading indicator ([link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-d210780d2f00ca3e308e832b957b5e0979db31c17bee1b8018c31f511c0f1dbeL20-R21),[link](https://github.com/pancakeswap/pancake-frontend/pull/8253/files?diff=unified&w=0#diff-d210780d2f00ca3e308e832b957b5e0979db31c17bee1b8018c31f511c0f1dbeL26-R27))


