### PR TITLE
fix: mmTrade query-key

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/containers/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/MMCommitButton.tsx
@@ -49,8 +49,8 @@ export function MMCommitButton({ mmOrderBookTrade, mmRFQTrade, mmQuoteExpiryRema
   )
 
   const allowance = usePermit2Allowance(
+    mmTradeInfo?.routerAddress,
     mmTradeInfo?.slippageAdjustedAmounts[Field.INPUT],
-    undefined,
     isChainSupported(chainId) ? getUniversalRouterAddress(chainId) : undefined,
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1192da2</samp>

### Summary
🛣️📝⛽

<!--
1.  🛣️ - This emoji represents the router address, which is the new first argument for the hook. It also suggests the idea of routing or swapping tokens, which is the feature that permit2 enables.
2. 📝 - This emoji represents the permit2 function, which is a way of signing an approval for a token transfer without sending a separate transaction. It also suggests the idea of writing or signing something, which is what permit2 does.
3. ⛽ - This emoji represents the gas-saving aspect of permit2, which reduces the number of transactions and the amount of gas required to swap tokens. It also suggests the idea of fuel or energy, which is what gas is in the Ethereum context.
-->
Updated `usePermit2Allowance` hook to take router address as argument. This enables gas-saving swaps using permit2.

> _`usePermit2Allowance`_
> _Router address is the key_
> _Autumn leaves save gas_

### Walkthrough
* Update the `usePermit2Allowance` hook to take the router address as the first argument ([link](https://github.com/pancakeswap/pancake-frontend/pull/8257/files?diff=unified&w=0#diff-8f34a50e0f749c46ec808140acc35a83485914a682dede7cb7522dc900b729d4L52-R53))


