### PR TITLE
chore: Adjust the subgraph and scrollToTop placement

### DIFF
--- a/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
@@ -151,7 +151,7 @@ export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = (
     <Box
       position="fixed"
       bottom="calc(55px + env(safe-area-inset-bottom))"
-      right="5%"
+      right="18px"
       ref={targetRef}
       data-test="subgraph-health-indicator"
     >

--- a/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
+++ b/packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx
@@ -7,7 +7,7 @@ import { ArrowUpIcon } from "../Svg";
 const FixedContainer = styled.div`
   position: fixed;
   right: 18px;
-  bottom: calc(82px + env(safe-area-inset-bottom));
+  bottom: calc(110px + env(safe-area-inset-bottom));
 `;
 
 const ScrollToTopButtonV2 = () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 919e587</samp>

### Summary
📏📐🖥️

<!--
1.  📏 - This emoji can be used to represent the change in the `right` property of the `SubgraphHealthIndicator` component, as it implies a measurement or adjustment of the horizontal alignment of the element.
2.  📐 - This emoji can be used to represent the change in the `bottom` property of the `FixedContainer` styled component, as it implies a measurement or adjustment of the vertical alignment of the element.
3.  🖥️ - This emoji can be used to represent the overall purpose of the changes, which is to improve the responsiveness and layout of the components on smaller screens. Alternatively, one could use 📱 to emphasize the mobile aspect of the changes.
-->
Adjusted the positioning and spacing of `SubgraphHealthIndicator` and `ScrollToTopButtonV2` components to improve the layout and avoid overlaps with `SettingsMenu` on smaller screens. Modified `apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx` and `packages/uikit/src/components/ScrollToTopButton/ScrollToTopButtonV2.tsx`.

> _`SubgraphHealthIndicator`_
> _Aligns with `ScrollToTopButtonV2`_
> _No overlap in spring_

### Walkthrough
*  Adjust the position and spacing of the `SubgraphHealthIndicator` and the `ScrollToTopButtonV2` components to avoid overlapping with the `SettingsMenu` component on smaller screens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8272/files?diff=unified&w=0#diff-01767be7d913cf9d5ceedd0001d1059d2c61ed0c348ad41a8fb3dbed6b445cdcL154-R154), [link](https://github.com/pancakeswap/pancake-frontend/pull/8272/files?diff=unified&w=0#diff-0123f57616bd1d0fd7e4c6afda8c3d200c1f887fa2d12482570bfc44671816feL10-R10))
  * Change the `right` property of the `SubgraphHealthIndicator` component from `5%` to `18px` in `SubgraphHealthIndicator.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8272/files?diff=unified&w=0#diff-01767be7d913cf9d5ceedd0001d1059d2c61ed0c348ad41a8fb3dbed6b445cdcL154-R154))
  * Change the `bottom` property of the `FixedContainer` styled component from `82px` to `110px` in `ScrollToTopButtonV2.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8272/files?diff=unified&w=0#diff-0123f57616bd1d0fd7e4c6afda8c3d200c1f887fa2d12482570bfc44671816feL10-R10))



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/e1efb1ef-5f7e-416c-92e6-f8043d38b662)
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/e6f6af95-d7ea-4d96-b232-a8dcac44edfe)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/6070bf09-6eed-4a94-b893-85c686baabaa)
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/ec2effbd-da1e-45d2-8d93-374b08b8608c)

