### PR TITLE
chore: add GA4 for blog

### DIFF
--- a/apps/blog/pages/_app.tsx
+++ b/apps/blog/pages/_app.tsx
@@ -78,11 +78,11 @@ function MyApp({ Component, pageProps }: AppProps) {
         id="google-tag"
         dangerouslySetInnerHTML={{
           __html: `
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer', '${process.env.NEXT_PUBLIC_GTAG}');
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_NEW_GTM}');
           `,
         }}
       />

--- a/apps/blog/pages/_app.tsx
+++ b/apps/blog/pages/_app.tsx
@@ -82,7 +82,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_NEW_GTM}');
+})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM}');
           `,
         }}
       />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b3a361</samp>

### Summary
🔄📊📝

<!--
1.  🔄 This emoji means "repeat" or "change" and can be used to indicate that something was modified or replaced with something else. In this case, the GTM ID was changed to a different value.
2. 📊 This emoji means "chart" or "data" and can be used to indicate that something relates to analytics, statistics, or tracking. In this case, the GTM ID is used for tracking and analytics purposes for the blog app.
3. 📝 This emoji means "memo" or "write" and can be used to indicate that something relates to content, documentation, or blogging. In this case, the GTM ID is used for the blog app, which is a subdomain for content creation.
-->
Changed the Google Tag Manager ID for the blog app to use a separate container. This enables independent tracking and analytics for the `apps/blog` subdomain.

> _`GTM` container_
> _changed for blog subdomain_
> _autumn analytics_

### Walkthrough
*  Change the Google Tag Manager ID for the blog app to use a different container ([link](https://github.com/pancakeswap/pancake-frontend/pull/8280/files?diff=unified&w=0#diff-57987834d6cc63fdef4401b3d012aef6b9a5a41a260faf4ddb1365873785997bL81-R85))


