### PR TITLE
refactor: Use query in voting

### DIFF
--- a/apps/web/src/pages/voting/proposal/[id].tsx
+++ b/apps/web/src/pages/voting/proposal/[id].tsx
@@ -1,21 +1,13 @@
 // eslint-disable-next-line camelcase
-import { SWRConfig, unstable_serialize } from 'swr'
 import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
 import { NextSeo } from 'next-seo'
 import { getProposal } from 'state/voting/helpers'
 import { ProposalState } from 'state/types'
 import Overview from 'views/Voting/Proposal/Overview'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 
-const ProposalPage = ({ fallback = {} }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  return (
-    <SWRConfig
-      value={{
-        fallback,
-      }}
-    >
-      <Overview />
-    </SWRConfig>
-  )
+const ProposalPage = () => {
+  return <Overview />
 }
 
 export const getStaticPaths: GetStaticPaths = () => {
@@ -26,8 +18,8 @@ export const getStaticPaths: GetStaticPaths = () => {
 }
 
 ProposalPage.Meta = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
-  if (props.id && props.fallback[unstable_serialize(['proposal', props.id])]) {
-    const proposal = props.fallback[unstable_serialize(['proposal', props.id])]
+  if (props.id && props.dehydratedState?.queries?.[0]?.state?.data) {
+    const proposal = props.dehydratedState?.queries?.[0]?.state?.data
     return (
       <NextSeo
         openGraph={{
@@ -40,6 +32,7 @@ ProposalPage.Meta = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
 }
 
 export const getStaticProps = (async ({ params }) => {
+  const queryClient = new QueryClient()
   const { id } = params
   if (typeof id !== 'string') {
     return {
@@ -48,7 +41,7 @@ export const getStaticProps = (async ({ params }) => {
   }
 
   try {
-    const fetchedProposal = await getProposal(id)
+    const fetchedProposal = await queryClient.fetchQuery(['voting', 'proposal', id], () => getProposal(id))
     if (!fetchedProposal) {
       return {
         notFound: true,
@@ -57,9 +50,7 @@ export const getStaticProps = (async ({ params }) => {
     }
     return {
       props: {
-        fallback: {
-          [unstable_serialize(['proposal', id])]: fetchedProposal,
-        },
+        dehydratedState: dehydrate(queryClient),
         id,
       },
       revalidate:
@@ -70,7 +61,7 @@ export const getStaticProps = (async ({ params }) => {
   } catch (error) {
     return {
       props: {
-        fallback: {},
+        dehydratedState: dehydrate(queryClient),
         id,
       },
       revalidate: 60,

--- a/apps/web/src/pages/voting/proposal/[id].tsx
+++ b/apps/web/src/pages/voting/proposal/[id].tsx
@@ -19,14 +19,17 @@ export const getStaticPaths: GetStaticPaths = () => {
 
 ProposalPage.Meta = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
   if (props.id && props.dehydratedState?.queries?.[0]?.state?.data) {
-    const proposal = props.dehydratedState?.queries?.[0]?.state?.data
-    return (
-      <NextSeo
-        openGraph={{
-          description: proposal.title,
-        }}
-      />
-    )
+    // @ts-ignore
+    const { title } = props.dehydratedState?.queries?.[0]?.state?.data
+    if (title) {
+      return (
+        <NextSeo
+          openGraph={{
+            description: title,
+          }}
+        />
+      )
+    }
   }
   return null
 }

--- a/apps/web/src/pages/voting/proposal/[id].tsx
+++ b/apps/web/src/pages/voting/proposal/[id].tsx
@@ -20,7 +20,7 @@ export const getStaticPaths: GetStaticPaths = () => {
 ProposalPage.Meta = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
   if (props.id && props.dehydratedState?.queries?.[0]?.state?.data) {
     // @ts-ignore
-    const { title } = props.dehydratedState?.queries?.[0]?.state?.data
+    const title = props.dehydratedState?.queries?.[0]?.state?.data?.ttile
     if (title) {
       return (
         <NextSeo

--- a/apps/web/src/views/Voting/Proposal/Overview.tsx
+++ b/apps/web/src/views/Voting/Proposal/Overview.tsx
@@ -1,7 +1,7 @@
 import { ArrowBackIcon, Box, Button, Flex, Heading, NotFound, ReactMarkdown } from '@pancakeswap/uikit'
 import { getAllVotes, getProposal } from 'state/voting/helpers'
 import { useAccount } from 'wagmi'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { ProposalState } from 'state/types'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -9,7 +9,6 @@ import { useTranslation } from '@pancakeswap/localization'
 import Container from 'components/Layout/Container'
 import PageLoader from 'components/Loader/PageLoader'
 import { NextSeo } from 'next-seo'
-import { FetchStatus } from 'config/constants/types'
 import { isCoreProposal } from '../helpers'
 import { ProposalStateTag, ProposalTypeTag } from '../components/Proposals/tags'
 import Layout from '../components/Layout'
@@ -28,16 +27,26 @@ const Overview = () => {
     status: proposalLoadingStatus,
     data: proposal,
     error,
-  } = useSWRImmutable(id ? ['proposal', id] : null, () => getProposal(id))
+  } = useQuery(['voting', 'proposal', id], () => getProposal(id), {
+    enabled: Boolean(id),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
 
   const {
     status: votesLoadingStatus,
     data: votes,
-    mutate: refetch,
-  } = useSWRImmutable(proposal ? ['proposal', proposal, 'votes'] : null, async () => getAllVotes(proposal))
+    refetch,
+  } = useQuery(['voting', 'proposal', proposal, 'votes'], async () => getAllVotes(proposal), {
+    enabled: Boolean(proposal),
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  })
   const hasAccountVoted = account && votes && votes.some((vote) => vote.voter.toLowerCase() === account.toLowerCase())
 
-  const isPageLoading = votesLoadingStatus === FetchStatus.Fetching || proposalLoadingStatus === FetchStatus.Fetching
+  const isPageLoading = votesLoadingStatus === 'loading' || proposalLoadingStatus === 'loading'
 
   if (!proposal && error) {
     return (

--- a/apps/web/src/views/Voting/components/Proposals/Proposals.tsx
+++ b/apps/web/src/views/Voting/components/Proposals/Proposals.tsx
@@ -2,10 +2,9 @@ import { Box, Breadcrumbs, Card, Flex, Heading, Text } from '@pancakeswap/uikit'
 import Link from 'next/link'
 import { useTranslation } from '@pancakeswap/localization'
 import Container from 'components/Layout/Container'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import { ProposalState, ProposalType } from 'state/types'
 import { getProposals } from 'state/voting/helpers'
-import { FetchStatus } from 'config/constants/types'
 import { useSessionStorage } from 'hooks/useSessionStorage'
 import { filterProposalsByState, filterProposalsByType } from '../../helpers'
 import ProposalsLoading from './ProposalsLoading'
@@ -27,7 +26,9 @@ const Proposals = () => {
 
   const { proposalType, filterState } = state
 
-  const { status, data } = useSWR(['proposals', filterState], async () => getProposals(1000, 0, filterState))
+  const { data, status } = useQuery(['voting', 'proposals', filterState], async () =>
+    getProposals(1000, 0, filterState),
+  )
 
   const handleProposalTypeChange = (newProposalType: ProposalType) => {
     setState((prevState) => ({
@@ -58,18 +59,14 @@ const Proposals = () => {
       </Heading>
       <Card>
         <TabMenu proposalType={proposalType} onTypeChange={handleProposalTypeChange} />
-        <Filters
-          filterState={filterState}
-          onFilterChange={handleFilterChange}
-          isLoading={status !== FetchStatus.Fetched}
-        />
-        {status !== FetchStatus.Fetched && <ProposalsLoading />}
-        {status === FetchStatus.Fetched &&
+        <Filters filterState={filterState} onFilterChange={handleFilterChange} isLoading={status !== 'success'} />
+        {status !== 'success' && <ProposalsLoading />}
+        {status === 'success' &&
           filteredProposals.length > 0 &&
           filteredProposals.map((proposal) => {
             return <ProposalRow key={proposal.id} proposal={proposal} />
           })}
-        {status === FetchStatus.Fetched && filteredProposals.length === 0 && (
+        {status === 'success' && filteredProposals.length === 0 && (
           <Flex alignItems="center" justifyContent="center" p="32px">
             <Heading as="h5">{t('No proposals found')}</Heading>
           </Flex>

--- a/apps/web/src/views/Voting/hooks/useGetVotingPower.tsx
+++ b/apps/web/src/views/Voting/hooks/useGetVotingPower.tsx
@@ -1,7 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { useAccount, Address } from 'wagmi'
-import { FetchStatus } from 'config/constants/types'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { getActivePools } from 'utils/calls'
 import { bscTokens } from '@pancakeswap/tokens'
 import { publicClient } from 'utils/wagmi'
@@ -21,39 +20,48 @@ interface State {
 
 const useGetVotingPower = (block?: number): State & { isLoading: boolean; isError: boolean } => {
   const { address: account } = useAccount()
-  const { data, status, error } = useSWRImmutable(account ? [account, block, 'votingPower'] : null, async () => {
-    const blockNumber = block ? BigInt(block) : await publicClient({ chainId: ChainId.BSC }).getBlockNumber()
-    const eligiblePools = await getActivePools(ChainId.BSC, Number(blockNumber))
-    const poolAddresses: Address[] = eligiblePools
-      .filter((pair) => pair.stakingToken.address.toLowerCase() === bscTokens.cake.address.toLowerCase())
-      .map(({ contractAddress }) => contractAddress)
+  const { data, status, error } = useQuery(
+    [account, block, 'votingPower'],
+    async () => {
+      const blockNumber = block ? BigInt(block) : await publicClient({ chainId: ChainId.BSC }).getBlockNumber()
+      const eligiblePools = await getActivePools(ChainId.BSC, Number(blockNumber))
+      const poolAddresses: Address[] = eligiblePools
+        .filter((pair) => pair.stakingToken.address.toLowerCase() === bscTokens.cake.address.toLowerCase())
+        .map(({ contractAddress }) => contractAddress)
 
-    const {
-      cakeBalance,
-      cakeBnbLpBalance,
-      cakePoolBalance,
-      total,
-      poolsBalance,
-      cakeVaultBalance,
-      ifoPoolBalance,
-      lockedCakeBalance,
-      lockedEndTime,
-    } = await getVotingPower(account, poolAddresses, blockNumber)
-    return {
-      cakeBalance,
-      cakeBnbLpBalance,
-      cakePoolBalance,
-      poolsBalance,
-      cakeVaultBalance,
-      ifoPoolBalance,
-      total,
-      lockedCakeBalance,
-      lockedEndTime,
-    }
-  })
+      const {
+        cakeBalance,
+        cakeBnbLpBalance,
+        cakePoolBalance,
+        total,
+        poolsBalance,
+        cakeVaultBalance,
+        ifoPoolBalance,
+        lockedCakeBalance,
+        lockedEndTime,
+      } = await getVotingPower(account, poolAddresses, blockNumber)
+      return {
+        cakeBalance,
+        cakeBnbLpBalance,
+        cakePoolBalance,
+        poolsBalance,
+        cakeVaultBalance,
+        ifoPoolBalance,
+        total,
+        lockedCakeBalance,
+        lockedEndTime,
+      }
+    },
+    {
+      enabled: Boolean(account),
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+    },
+  )
   if (error) console.error(error)
 
-  return { ...data, isLoading: status !== FetchStatus.Fetched, isError: status === FetchStatus.Failed }
+  return { ...data, isLoading: status !== 'success', isError: status === 'error' }
 }
 
 export default useGetVotingPower


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5efffcc</samp>

### Summary
🔄🌐🎨

<!--
1.  🔄 This emoji can be used to indicate that the code refactored or updated some existing logic or functionality, without adding new features or breaking changes. It can also imply that the code improved the performance or efficiency of the codebase.
2.  🌐 This emoji can be used to indicate that the code involved some network or web-related functionality, such as fetching data, caching, or making API calls. It can also imply that the code enhanced the user experience or accessibility of the web app.
3.  🎨 This emoji can be used to indicate that the code improved the UI or design of the web app, such as adding animations, transitions, or styles. It can also imply that the code followed some best practices or conventions for UI development.
-->
Refactored proposals data fetching and caching with `useQuery` hook. Improved query UI status handling.

> _Oh we're the coders of the sea, and we work with hooks and queries_
> _We fetch and cache the data well, with `useQuery` from tanstack_
> _Heave away, me hearties, heave away_
> _We've refactored all the code, and improved the proposals mode_

### Walkthrough
*  Refactor data fetching and caching to use react-query instead of SWR ([link](https://github.com/pancakeswap/pancake-frontend/pull/8283/files?diff=unified&w=0#diff-ce1f97c61dd843ad944775e2cb810ba25ba4a191c3bfc7671769ec50ff8d3beaL5-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8283/files?diff=unified&w=0#diff-ce1f97c61dd843ad944775e2cb810ba25ba4a191c3bfc7671769ec50ff8d3beaL30-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/8283/files?diff=unified&w=0#diff-ce1f97c61dd843ad944775e2cb810ba25ba4a191c3bfc7671769ec50ff8d3beaL61-R69))


