### PR TITLE
fix: Potential np3 v3 boost farm query hook

### DIFF
--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -361,10 +361,10 @@ const useV3BoostedFarm = (pids: number[]) => {
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
 
   const { data } = useQuery(
-    ['v3/boostedFarm', chainId, pids.join('-')],
+    ['v3/boostedFarm', chainId, pids?.join('-')],
     () => getV3FarmBoosterWhiteList({ farmBoosterContract: farmBoosterV3Contract, chainId, pids }),
     {
-      enabled: Boolean(chainId && pids.length > 0 && bCakeSupportedChainId.includes(chainId)),
+      enabled: Boolean(chainId && pids?.length > 0 && bCakeSupportedChainId.includes(chainId)),
       retry: 3,
       retryDelay: 3000,
       keepPreviousData: true,

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -356,7 +356,7 @@ export function useFarmsV3WithPositionsAndBooster(options: UseFarmsOptions = {})
   }
 }
 
-const useV3BoostedFarm = (pids: number[]) => {
+const useV3BoostedFarm = (pids?: number[]) => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
 
@@ -364,7 +364,7 @@ const useV3BoostedFarm = (pids: number[]) => {
     ['v3/boostedFarm', chainId, pids?.join('-')],
     () => getV3FarmBoosterWhiteList({ farmBoosterContract: farmBoosterV3Contract, chainId, pids }),
     {
-      enabled: Boolean(chainId && pids?.length > 0 && bCakeSupportedChainId.includes(chainId)),
+      enabled: Boolean(chainId && pids && pids.length > 0 && bCakeSupportedChainId.includes(chainId)),
       retry: 3,
       retryDelay: 3000,
       keepPreviousData: true,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ffb0a92</samp>

### Summary
🐛🌐🪝

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request and the optional chaining operator.
2.  🌐 - This emoji represents a network or chain-related change, which is relevant to the bug that occurs when switching to unsupported chains.
3.  🪝 - This emoji represents a hook, which is the React feature that the `useV3BoostedFarm` function uses to manage state and side effects.
-->
Added optional chaining to `pids` in `useV3BoostedFarm` hook to prevent farm page crash on unsupported chains. This hook is defined in `apps/web/src/state/farmsV3/hooks.ts`.

> _`pids` may be null_
> _Optional chaining saves us_
> _Winter bug is fixed_

### Walkthrough
*  Prevent farm page crash on unsupported chains by adding optional chaining to `pids` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8288/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL364-R367), )


