### PR TITLE
chore: Use logo components from internal widgets

### DIFF
--- a/apps/web/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanel/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, memo, useCallback } from 'react'
 import { Currency, Pair, Token, Percent, CurrencyAmount } from '@pancakeswap/sdk'
 import { Button, Text, useModal, Flex, Box, CopyButton, Loading, Skeleton, ArrowDropDownIcon } from '@pancakeswap/uikit'
-import { Swap as SwapUI } from '@pancakeswap/widgets-internal'
+import { Swap as SwapUI, CurrencyLogo, DoubleCurrencyLogo } from '@pancakeswap/widgets-internal'
 import { styled } from 'styled-components'
 import { safeGetAddress } from 'utils'
 import { useTranslation } from '@pancakeswap/localization'
@@ -16,7 +16,6 @@ import { FiatLogo } from 'components/Logo/CurrencyLogo'
 import { useAccount } from 'wagmi'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import CurrencySearchModal from '../SearchModal/CurrencySearchModal'
-import { CurrencyLogo, DoubleCurrencyLogo } from '../Logo'
 
 import AddToWalletButton from '../AddToWallet/AddToWalletButton'
 

--- a/apps/web/src/components/CurrencyInputPanel/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanel/index.tsx
@@ -102,7 +102,7 @@ const CurrencyInputPanel = memo(function CurrencyInputPanel({
   const tokenAddress = token ? safeGetAddress(token.address) : null
 
   const amountInDollar = useStablecoinPriceAmount(
-    showUSDPrice ? currency : undefined,
+    showUSDPrice ? currency ?? undefined : undefined,
     Number.isFinite(+value) ? +value : undefined,
     {
       hideIfPriceImpactTooHigh: true,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7db7225</samp>

### Summary
🔄🎨🗑️

<!--
1.  🔄 - This emoji conveys the idea of refactoring or changing something without altering its functionality or behavior. It could be used to indicate that the `CurrencyInputPanel` component was modified to use different components for rendering the currency logos, but still has the same props and logic as before.
2.  🎨 - This emoji conveys the idea of improving the UI or design of something, or adding some flair or style. It could be used to indicate that the `CurrencyInputPanel` component now uses the `CurrencyLogo` and `DoubleCurrencyLogo` components, which have a more consistent and polished appearance than the previous local imports.
3.  🗑️ - This emoji conveys the idea of removing or deleting something that is no longer needed or used. It could be used to indicate that the unused local imports of `CurrencyLogo` and `DoubleCurrencyLogo` were removed from the `CurrencyInputPanel` component.
-->
Refactored a component to use shared widgets and removed unused code. Simplified the `CurrencyInputPanel` component by replacing custom logo rendering with imported components from `@pancakeswap/widgets-internal` and deleting unnecessary imports.

> _Oh we're the coders of the `pancakeswap` crew_
> _And we refactor components old and new_
> _We use the `widgets-internal` package too_
> _Heave away, me hearties, heave away_

### Walkthrough
*  Replace local `CurrencyLogo` and `DoubleCurrencyLogo` components with imports from `@pancakeswap/widgets-internal` package (`[link](https://github.com/pancakeswap/pancake-frontend/pull/8290/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L4-R4)`, `[link](https://github.com/pancakeswap/pancake-frontend/pull/8290/files?diff=unified&w=0#diff-41960731c9cdaaa1d6465c8816fb5d667d9cfb85be04b039cc6fe8f8359bad93L19)`)


