### PR TITLE
chore: fix roi calculator for position manager

### DIFF
--- a/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
+++ b/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
@@ -346,6 +346,7 @@ export const AddLiquidity = memo(function AddLiquidity({
                   isAprLoading={aprDataInfo.isLoading}
                   lpSymbol={`${currencyA.symbol}-${currencyB.symbol} LP`}
                   totalAssetsInUsd={totalAssetsInUsd}
+                  totalStakedInUsd={totalStakedInUsd}
                   userLpAmounts={userLpAmounts}
                   totalSupplyAmounts={totalSupplyAmounts}
                   precision={precision}

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -12,6 +12,7 @@ interface Props {
   apr: AprResult
   isAprLoading: boolean
   lpSymbol: string
+  totalStakedInUsd: number
   totalAssetsInUsd: number
   userLpAmounts?: bigint
   totalSupplyAmounts?: bigint
@@ -28,9 +29,10 @@ export const AprButton = memo(function YieldInfo({
   id,
   apr,
   isAprLoading,
-  totalAssetsInUsd,
+  totalStakedInUsd,
   lpSymbol,
   userLpAmounts,
+  totalSupplyAmounts,
   precision,
 }: Props) {
   const { t } = useTranslation()
@@ -43,8 +45,8 @@ export const AprButton = memo(function YieldInfo({
   )
 
   const tokenPrice = useMemo(
-    () => totalAssetsInUsd / (Number(((userLpAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0),
-    [userLpAmounts, precision, totalAssetsInUsd],
+    () => totalStakedInUsd / (Number(((totalSupplyAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0),
+    [totalSupplyAmounts, precision, totalStakedInUsd],
   )
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     <>

--- a/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
@@ -157,6 +157,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
           autoCompound={autoCompound}
           withCakeReward={withCakeReward}
           totalAssetsInUsd={totalAssetsInUsd}
+          totalStakedInUsd={totalStakedInUsd}
           lpSymbol={`${currencyA.symbol}-${currencyB.symbol} LP`}
           totalSupplyAmounts={totalSupplyAmounts}
           userLpAmounts={userLpAmounts}

--- a/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
+++ b/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
@@ -12,6 +12,7 @@ interface Props {
   withCakeReward?: boolean
   lpSymbol: string
   autoCompound?: boolean
+  totalStakedInUsd: number
   totalAssetsInUsd: number
   onAprClick?: () => void
   userLpAmounts?: bigint
@@ -29,6 +30,7 @@ export const YieldInfo = memo(function YieldInfo({
   lpSymbol,
   userLpAmounts,
   totalSupplyAmounts,
+  totalStakedInUsd,
   precision,
 }: Props) {
   const { t } = useTranslation()
@@ -49,6 +51,7 @@ export const YieldInfo = memo(function YieldInfo({
           lpSymbol={lpSymbol}
           totalAssetsInUsd={totalAssetsInUsd}
           totalSupplyAmounts={totalSupplyAmounts}
+          totalStakedInUsd={totalStakedInUsd}
           userLpAmounts={userLpAmounts}
           precision={precision}
         />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4189791</samp>

### Summary
📈💵🔄

<!--
1.  📈 - This emoji represents the improvement in the APR calculation accuracy by using the total staked value in USD instead of the token balance.
2.  💵 - This emoji represents the addition of the total staked value in USD to the APR tooltip, which gives more information to the user about the staking rewards.
3.  🔄 - This emoji represents the change in the data source for the token price and supply, which are now derived from the total staked value in USD instead of the token balance.
-->
Updated the APR calculation and display for the `DuoTokenVaultCard` component. The changes use the total staked value in USD to improve the accuracy and clarity of the APR tooltip.

> _Sing, O Muse, of the valiant coder who improved the APR_
> _By passing `totalStakedInUsd` from the `DuoTokenVaultCard` to the `AprButton`_
> _Like Hephaestus, the skillful craftsman, who forged the weapons of the gods_
> _He updated the `AprButton` to use the staked value for the `YieldInfo` component_

### Walkthrough
*  Add `totalStakedInUsd` prop to `AprButton` and `YieldInfo` components to display the total value of the staked tokens in USD ([link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-abe038ea9bc6a7a5c23336bcccad09a2fced1dda9b4d5af8e0820b8469c11af5R15))
*  Pass `totalStakedInUsd` prop from `DuoTokenVaultCard` to `AprButton` using the `vault` object data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-62d07e5ee0952ee8018188d3e18edf692d4453d27be50e50823df140c2c93840R160))
*  Use `totalStakedInUsd` prop to calculate the token price and supply in `AprButton` and replace the previous logic that used `totalAssetsInUsd` and `userLpAmounts` props ([link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766L31-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766L46-R49))
*  Pass `totalStakedInUsd` prop from `YieldInfo` to `AprButton` and display it in the tooltip of the APR button ([link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-abe038ea9bc6a7a5c23336bcccad09a2fced1dda9b4d5af8e0820b8469c11af5R33), [link](https://github.com/pancakeswap/pancake-frontend/pull/8304/files?diff=unified&w=0#diff-abe038ea9bc6a7a5c23336bcccad09a2fced1dda9b4d5af8e0820b8469c11af5R54))


