### PR TITLE
chore: fix bCake boosted tag issue

### DIFF
--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -359,15 +359,16 @@ export function useFarmsV3WithPositionsAndBooster(options: UseFarmsOptions = {})
 const useV3BoostedFarm = (pids?: number[]) => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
+  const enabled = Boolean(chainId && pids && pids.length > 0 && bCakeSupportedChainId.includes(chainId))
 
   const { data } = useQuery(
     ['v3/boostedFarm', chainId, pids?.join('-')],
     () => getV3FarmBoosterWhiteList({ farmBoosterContract: farmBoosterV3Contract, chainId, pids }),
     {
-      enabled: Boolean(chainId && pids && pids.length > 0 && bCakeSupportedChainId.includes(chainId)),
+      enabled,
       retry: 3,
       retryDelay: 3000,
-      keepPreviousData: true,
+      keepPreviousData: enabled,
     },
   )
 

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -359,16 +359,14 @@ export function useFarmsV3WithPositionsAndBooster(options: UseFarmsOptions = {})
 const useV3BoostedFarm = (pids?: number[]) => {
   const { chainId } = useActiveChainId()
   const farmBoosterV3Contract = useBCakeFarmBoosterV3Contract()
-  const enabled = Boolean(chainId && pids && pids.length > 0 && bCakeSupportedChainId.includes(chainId))
 
   const { data } = useQuery(
     ['v3/boostedFarm', chainId, pids?.join('-')],
     () => getV3FarmBoosterWhiteList({ farmBoosterContract: farmBoosterV3Contract, chainId, pids }),
     {
-      enabled,
+      enabled: Boolean(chainId && pids && pids.length > 0 && bCakeSupportedChainId.includes(chainId)),
       retry: 3,
       retryDelay: 3000,
-      keepPreviousData: enabled,
     },
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6ead628</samp>

### Summary
🚀🌐🪄

<!--
1.  🚀 - This emoji represents the addition of a new feature or enhancement, which is the bCake booster feature in this case.
2.  🌐 - This emoji represents the optimization of the data fetching logic, which involves interacting with the web or network layer of the application.
3.  🪄 - This emoji represents the data processing or manipulation, which involves transforming or filtering the data from the query hook.
-->
Add feature flag and optimize data fetching for bCake booster. Use `enabled` to toggle `useQuery` and data processing in `./apps/web/src/state/farmsV3/hooks.ts`.

> _The bCake booster is unleashed by the flag of doom_
> _`useQuery` hooks the data with a blazing zoom_
> _The farms are boosted by the logic of the beast_
> _`enabled` controls the fate of the harvest feast_

### Walkthrough
*  Introduce a new variable `enabled` to check the bCake booster feature support ([link](https://github.com/pancakeswap/pancake-frontend/pull/8308/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dR362))


