### PR TITLE
fix: Remove keepPreviousData flag from farm v3 public

### DIFF
--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -94,7 +94,6 @@ export const useFarmsV3Public = () => {
     {
       enabled: Boolean(farmFetcherV3.isChainSupported(chainId)),
       refetchInterval: FAST_INTERVAL * 3,
-      keepPreviousData: true,
       initialData: fallback,
     },
   )


### PR DESCRIPTION
Disabled when in swr

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b30ac9a</samp>

### Summary
🔄🚀🎨

<!--
1.  🔄 This emoji represents the idea of refreshing or updating data, which is what the removal of the `keepPreviousData` option enables. It could also be used to indicate a refactor or improvement of existing code.
2.  🚀 This emoji represents the idea of speed or performance, which is one of the goals of the refactor. It could also be used to indicate a new feature or enhancement.
3.  🎨 This emoji represents the idea of design or user interface, which is another aspect of the refactor. It could also be used to indicate a change in the appearance or style of the page.
-->
Removed `keepPreviousData` option from `useQuery` hook in `useFarmsV3Public` to fix stale data issues on farms page. This is part of a performance and UX improvement refactor.

> _`useQuery` changes_
> _Farms always fresh and sorted_
> _A crisp autumn harvest_

### Walkthrough
* Remove `keepPreviousData` option from `useQuery` hook to avoid stale data in farms page (`[link](https://github.com/pancakeswap/pancake-frontend/pull/8309/files?diff=unified&w=0#diff-716013767f1a29e7e7f8acbb3357272a9d0bb6ad05de8e45872df4835b46077dL97)`)


