### PR TITLE
refactor: Use query in home

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -2,27 +2,15 @@ import { formatEther } from 'viem'
 import dayjs from 'dayjs'
 import { gql } from 'graphql-request'
 import { GetStaticProps } from 'next'
-import { SWRConfig } from 'swr'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { getCakeVaultAddress } from 'utils/addressHelpers'
 import { getCakeContract } from 'utils/contractHelpers'
 import { getBlocksFromTimestamps } from 'utils/getBlocksFromTimestamps'
 import { bitQueryServerClient, infoServerClient } from 'utils/graphql'
 import Home from '../views/Home'
 
-const IndexPage = ({ totalTx30Days, addressCount30Days, tvl }) => {
-  return (
-    <SWRConfig
-      value={{
-        fallback: {
-          totalTx30Days,
-          addressCount30Days,
-          tvl,
-        },
-      }}
-    >
-      <Home />
-    </SWRConfig>
-  )
+const IndexPage = () => {
+  return <Home />
 }
 
 // Values fetched from TheGraph and BitQuery jan 24, 2022
@@ -32,6 +20,8 @@ const addressCount = 4425459
 const tvl = 6082955532.115718
 
 export const getStaticProps: GetStaticProps = async () => {
+  const queryClient = new QueryClient()
+
   const totalTxQuery = gql`
     query TotalTransactions($block: Block_height) {
       pancakeFactory(block: $block) {
@@ -122,8 +112,14 @@ export const getStaticProps: GetStaticProps = async () => {
     }
   }
 
+  queryClient.setQueryData(['totalTx30Days'], results.totalTx30Days)
+  queryClient.setQueryData(['tvl'], results.tvl)
+  queryClient.setQueryData(['addressCount30Days'], results.addressCount30Days)
+
   return {
-    props: results,
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
     revalidate: 60 * 60 * 24 * 30, // 30 days
   }
 }

--- a/apps/web/src/utils/apr.ts
+++ b/apps/web/src/utils/apr.ts
@@ -4,7 +4,7 @@ import { BLOCKS_PER_YEAR } from 'config'
 import lpAprs56 from 'config/constants/lpAprs/56.json'
 import lpAprs1 from 'config/constants/lpAprs/1.json'
 
-const getLpApr = (chainId: number) => {
+const getLpApr = (chainId?: number) => {
   switch (chainId) {
     case ChainId.BSC:
       return lpAprs56
@@ -43,20 +43,22 @@ const BIG_NUMBER_NAN = new BigNumber(NaN)
 
 /**
  * Get farm APR value in %
+ * @param chainId
  * @param poolWeight allocationPoint / totalAllocationPoint
  * @param cakePriceUsd Cake price in USD
  * @param poolLiquidityUsd Total pool liquidity in USD
  * @param farmAddress Farm Address
+ * @param regularCakePerBlock
  * @returns Farm Apr
  */
 export const getFarmApr = (
-  chainId: number,
-  poolWeight: BigNumber | null,
+  chainId: number | undefined,
+  poolWeight: BigNumber | null | undefined,
   cakePriceUsd: BigNumber | null,
-  poolLiquidityUsd: BigNumber | null,
+  poolLiquidityUsd: BigNumber | null | undefined,
   farmAddress: string | null,
   regularCakePerBlock: number,
-): { cakeRewardsApr: number; lpRewardsApr: number } => {
+): { cakeRewardsApr: number | null; lpRewardsApr: number } => {
   const yearlyCakeRewardAllocation = poolWeight
     ? poolWeight.times(BLOCKS_PER_YEAR * regularCakePerBlock)
     : new BigNumber(NaN)
@@ -64,11 +66,13 @@ export const getFarmApr = (
     .times(cakePriceUsd || BIG_NUMBER_NAN)
     .div(poolLiquidityUsd || BIG_NUMBER_NAN)
     .times(100)
-  let cakeRewardsAprAsNumber = null
+  let cakeRewardsAprAsNumber: number | null = null
   if (!cakeRewardsApr.isNaN() && cakeRewardsApr.isFinite()) {
     cakeRewardsAprAsNumber = cakeRewardsApr.toNumber()
   }
-  const lpRewardsApr = (getLpApr(chainId)[farmAddress?.toLowerCase()] || getLpApr(chainId)[farmAddress]) ?? 0 // can get both checksummed or lowercase
+  const lpRewardsApr = farmAddress
+    ? (getLpApr(chainId)[farmAddress?.toLowerCase()] || getLpApr(chainId)[farmAddress]) ?? 0
+    : 0 // can get both checksummed or lowercase
   return { cakeRewardsApr: cakeRewardsAprAsNumber, lpRewardsApr }
 }
 

--- a/apps/web/src/utils/verifyBscNetwork.ts
+++ b/apps/web/src/utils/verifyBscNetwork.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
 
 export const verifyBscNetwork = (chainId?: number) => {
-  return chainId && (chainId === ChainId.BSC || chainId === ChainId.BSC_TESTNET)
+  return Boolean(chainId && (chainId === ChainId.BSC || chainId === ChainId.BSC_TESTNET))
 }

--- a/apps/web/src/utils/verifyBscNetwork.ts
+++ b/apps/web/src/utils/verifyBscNetwork.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
 
-export const verifyBscNetwork = (chainId: number) => {
-  return chainId === ChainId.BSC || chainId === ChainId.BSC_TESTNET
+export const verifyBscNetwork = (chainId?: number) => {
+  return chainId && (chainId === ChainId.BSC || chainId === ChainId.BSC_TESTNET)
 }

--- a/apps/web/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useIsRenderLotteryBanner.tsx
@@ -1,23 +1,35 @@
-import useSWR from 'swr'
 import { fetchCurrentLotteryId, fetchLottery } from 'state/lottery/helpers'
-import { FetchStatus } from 'config/constants/types'
-import { immutableMiddleware } from 'hooks/useSWRContract'
 import { FAST_INTERVAL, SLOW_INTERVAL } from 'config/constants'
+import { useQuery } from '@tanstack/react-query'
 
 const useIsRenderLotteryBanner = () => {
-  const { data: currentLotteryId, status: currentLotteryIdStatus } = useSWR(
+  const { data: currentLotteryId, status: currentLotteryIdStatus } = useQuery(
     ['currentLotteryId'],
     fetchCurrentLotteryId,
-    { refreshInterval: SLOW_INTERVAL, use: [immutableMiddleware] },
+    {
+      refetchInterval: SLOW_INTERVAL,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
   )
 
-  const { status: currentLotteryStatus } = useSWR(
-    currentLotteryId ? ['currentLottery'] : null,
-    async () => fetchLottery(currentLotteryId.toString()),
-    { refreshInterval: FAST_INTERVAL, use: [immutableMiddleware] },
+  const { status: currentLotteryStatus } = useQuery(
+    ['currentLottery'],
+    async () => {
+      if (!currentLotteryId) return undefined
+      return fetchLottery(currentLotteryId.toString())
+    },
+    {
+      enabled: Boolean(currentLotteryId),
+      refetchInterval: FAST_INTERVAL,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
   )
 
-  return currentLotteryIdStatus === FetchStatus.Fetched && currentLotteryStatus === FetchStatus.Fetched
+  return currentLotteryIdStatus === 'success' && currentLotteryStatus === 'success'
 }
 
 export default useIsRenderLotteryBanner

--- a/apps/web/src/views/Home/components/CakeDataRow.tsx
+++ b/apps/web/src/views/Home/components/CakeDataRow.tsx
@@ -9,11 +9,11 @@ import { SLOW_INTERVAL } from 'config/constants'
 import { useEffect, useState } from 'react'
 import { useCakePrice } from 'hooks/useCakePrice'
 import { styled } from 'styled-components'
-import useSWR from 'swr'
 import { getCakeVaultAddress } from 'utils/addressHelpers'
 import { publicClient } from 'utils/wagmi'
 import { useCakeEmissionPerBlock } from 'views/Home/hooks/useCakeEmissionPerBlock'
 import { erc20ABI } from 'wagmi'
+import { useQuery } from '@tanstack/react-query'
 
 const StyledColumn = styled(Flex)<{ noMobileBorder?: boolean; noDesktopBorder?: boolean }>`
   flex-direction: column;
@@ -81,8 +81,8 @@ const CakeDataRow = () => {
       burnedBalance: 0,
       circulatingSupply: 0,
     },
-  } = useSWR(
-    loadData ? ['cakeDataRow'] : null,
+  } = useQuery(
+    ['cakeDataRow'],
     async () => {
       const [totalSupply, burned, totalLockedAmount] = await publicClient({ chainId: ChainId.BSC }).multicall({
         contracts: [
@@ -111,7 +111,8 @@ const CakeDataRow = () => {
       }
     },
     {
-      refreshInterval: SLOW_INTERVAL,
+      enabled: Boolean(loadData),
+      refetchInterval: SLOW_INTERVAL,
     },
   )
   const cakePriceBusd = useCakePrice()

--- a/apps/web/src/views/Home/components/CommunitySection/LotteryCardContent.tsx
+++ b/apps/web/src/views/Home/components/CommunitySection/LotteryCardContent.tsx
@@ -7,7 +7,7 @@ import { styled } from 'styled-components'
 import { fetchLottery, fetchCurrentLotteryId } from 'state/lottery/helpers'
 import { getBalanceAmount } from '@pancakeswap/utils/formatBalance'
 import { SLOW_INTERVAL } from 'config/constants'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 
 const StyledLink = styled(NextLinkFromReactRouter)`
   width: 100%;
@@ -24,14 +24,22 @@ const LotteryCardContent = () => {
   const { observerRef, isIntersecting } = useIntersectionObserver()
   const [loadData, setLoadData] = useState(false)
   const cakePriceBusd = useCakePrice()
-  const { data: currentLotteryId } = useSWRImmutable(loadData ? ['currentLotteryId'] : null, fetchCurrentLotteryId, {
-    refreshInterval: SLOW_INTERVAL,
+  const { data: currentLotteryId } = useQuery(['currentLotteryId'], fetchCurrentLotteryId, {
+    enabled: Boolean(loadData),
+    refetchInterval: SLOW_INTERVAL,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
   })
-  const { data: currentLottery } = useSWRImmutable(
-    currentLotteryId ? ['currentLottery'] : null,
+  const { data: currentLottery } = useQuery(
+    ['currentLottery'],
     async () => fetchLottery(currentLotteryId?.toString() ?? ''),
     {
-      refreshInterval: SLOW_INTERVAL,
+      enabled: Boolean(loadData),
+      refetchInterval: SLOW_INTERVAL,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
     },
   )
 

--- a/apps/web/src/views/Home/components/CommunitySection/PredictionCardContent.tsx
+++ b/apps/web/src/views/Home/components/CommunitySection/PredictionCardContent.tsx
@@ -6,9 +6,9 @@ import { formatLocalisedCompactNumber } from '@pancakeswap/utils/formatBalance'
 import { useIntersectionObserver } from '@pancakeswap/hooks'
 import { getTotalWon } from 'state/predictions/helpers'
 import { useCakePrice } from 'hooks/useCakePrice'
-import useSWR from 'swr'
 import { SLOW_INTERVAL } from 'config/constants'
 import { useBNBPrice } from 'hooks/useBNBPrice'
+import { useQuery } from '@tanstack/react-query'
 
 const StyledLink = styled(NextLinkFromReactRouter)`
   width: 100%;
@@ -33,8 +33,9 @@ const PredictionCardContent = () => {
   const bnbBusdPrice = useBNBPrice({ enabled: loadData })
   const cakePrice = useCakePrice({ enabled: loadData })
 
-  const { data } = useSWR(loadData ? ['prediction', 'tokenWon'] : null, getTotalWon, {
-    refreshInterval: SLOW_INTERVAL,
+  const { data } = useQuery(['prediction', 'tokenWon'], getTotalWon, {
+    enabled: Boolean(loadData),
+    refetchInterval: SLOW_INTERVAL,
   })
 
   const bnbWonInUsd = bnbBusdPrice.multipliedBy(data?.totalWonBNB || 0).toNumber()

--- a/apps/web/src/views/Home/components/MetricsSection/index.tsx
+++ b/apps/web/src/views/Home/components/MetricsSection/index.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Flex, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import Image from 'next/legacy/image'
 import { styled } from 'styled-components'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import aptosBallRocket from '../../images/aptos-ball-rocket.png'
 import bnbBallRocket from '../../images/bnb-ball-rocket.png'
 import ethBallRocket from '../../images/eth-ball-rocket.png'
@@ -52,9 +52,9 @@ const AptosBallRocket = styled.div`
 
 const Stats = () => {
   const { t } = useTranslation()
-  const { data: tvl } = useSWRImmutable('tvl')
-  const { data: txCount } = useSWRImmutable('totalTx30Days')
-  const { data: addressCount } = useSWRImmutable('addressCount30Days')
+  const { data: tvl = 0 } = useQuery<number>(['tvl'], { enabled: false })
+  const { data: txCount = 0 } = useQuery<number>(['totalTx30Days'], { enabled: false })
+  const { data: addressCount = 0 } = useQuery<number>(['addressCount30Days'], { enabled: false })
   const { isMobile, isSm, isMd, isXxl } = useMatchBreakpoints()
 
   return (

--- a/apps/web/src/views/Home/hooks/useAllArticle.ts
+++ b/apps/web/src/views/Home/hooks/useAllArticle.ts
@@ -1,6 +1,6 @@
-import useSWR from 'swr'
-import { ArticleType } from '../utils/transformArticle'
+import { useQuery } from '@tanstack/react-query'
 import { getArticle } from './getArticle'
+import { ArticleType } from '../utils/transformArticle'
 
 interface AllArticleType {
   isFetching: boolean
@@ -8,9 +8,9 @@ interface AllArticleType {
 }
 
 export const useAllNewsArticle = (): AllArticleType => {
-  const { data: articlesData, isLoading } = useSWR(
+  const { data: articlesData, isLoading } = useQuery(
     ['/allNews'],
-    () =>
+    async () =>
       getArticle({
         url: '/articles',
         urlParamsObject: {
@@ -27,10 +27,8 @@ export const useAllNewsArticle = (): AllArticleType => {
         },
       }),
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
 
@@ -49,8 +47,8 @@ export const useAllNewsArticle = (): AllArticleType => {
 }
 
 export const useLatestArticle = (): AllArticleType => {
-  const { data: articlesData, isLoading } = useSWR(
-    ['/lastetArticle'],
+  const { data: articlesData, isLoading } = useQuery(
+    ['/latestArticle'],
     () =>
       getArticle({
         url: '/articles',
@@ -61,10 +59,8 @@ export const useLatestArticle = (): AllArticleType => {
         },
       }),
     {
-      revalidateOnFocus: false,
-      revalidateIfStale: false,
-      revalidateOnReconnect: false,
-      revalidateOnMount: true,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   )
 

--- a/apps/web/src/views/Home/hooks/useGetTopFarmsByApr.tsx
+++ b/apps/web/src/views/Home/hooks/useGetTopFarmsByApr.tsx
@@ -5,34 +5,43 @@ import { useAppDispatch } from 'state'
 import { fetchFarmsPublicDataAsync } from 'state/farms'
 import { getFarmApr } from 'utils/apr'
 import orderBy from 'lodash/orderBy'
-import { FetchStatus } from 'config/constants/types'
 import { getFarmConfig } from '@pancakeswap/farms/constants'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useFarmsV3 } from 'state/farmsV3/hooks'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 
 const useGetTopFarmsByApr = (isIntersecting: boolean) => {
   const dispatch = useAppDispatch()
   const { data: farms, regularCakePerBlock } = useFarms()
   const { data: farmsV3, isLoading } = useFarmsV3()
-  const [topFarms, setTopFarms] = useState<{ lpSymbol: string; apr: number; lpRewardsApr: number; version: 2 | 3 }[]>(
-    () => [null, null, null, null, null],
-  )
+  const [topFarms, setTopFarms] = useState<
+    ({
+      lpSymbol: string
+      apr: number | null
+      lpRewardsApr: number
+      version: 2 | 3
+    } | null)[]
+  >(() => [null, null, null, null, null])
   const cakePriceBusd = useCakePrice()
   const { chainId } = useActiveChainId()
 
-  const { status: fetchStatus, isValidating } = useSWR(
-    isIntersecting && chainId && [chainId, 'fetchTopFarmsByApr'],
+  const { status: fetchStatus, isFetching } = useQuery(
+    [chainId, 'fetchTopFarmsByApr'],
     async () => {
+      if (!chainId) return undefined
       const farmsConfig = await getFarmConfig(chainId)
-      const activeFarms = farmsConfig.filter((farm) => farm.pid !== 0)
-      return dispatch(fetchFarmsPublicDataAsync({ pids: activeFarms.map((farm) => farm.pid), chainId }))
+      const activeFarms = farmsConfig?.filter((farm) => farm.pid !== 0)
+      return dispatch(fetchFarmsPublicDataAsync({ pids: activeFarms?.map((farm) => farm.pid) ?? [], chainId }))
     },
-    { revalidateOnFocus: false, revalidateOnReconnect: false },
+    {
+      enabled: Boolean(isIntersecting && chainId),
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
   )
 
   useEffect(() => {
-    if (fetchStatus === FetchStatus.Fetched && farms?.length > 0 && !isLoading) {
+    if (fetchStatus === 'success' && farms?.length > 0 && !isLoading) {
       const farmsWithPrices = farms.filter(
         (farm) =>
           farm.lpTotalInQuoteToken &&
@@ -42,7 +51,9 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
           farm.multiplier !== '0X',
       )
       const farmsWithApr = farmsWithPrices.map((farm) => {
-        const totalLiquidity = farm.lpTotalInQuoteToken.times(farm.quoteTokenPriceBusd)
+        const totalLiquidity = farm?.quoteTokenPriceBusd
+          ? farm?.lpTotalInQuoteToken?.times(farm.quoteTokenPriceBusd)
+          : undefined
         const { cakeRewardsApr, lpRewardsApr } = getFarmApr(
           chainId,
           farm.poolWeight,
@@ -58,17 +69,21 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
         .filter((f) => f.multiplier !== '0X' && 'cakeApr' in f)
         .map((f) => ({
           ...f,
-          apr: +f.cakeApr,
+          apr: f.cakeApr ? +f.cakeApr : Number.NaN,
           // lpRewardsApr missing
           lpRewardsApr: 0,
           version: 3 as const,
         }))
 
-      const sortedByApr = orderBy([...farmsWithApr, ...activeFarmV3], (farm) => farm.apr + farm.lpRewardsApr, 'desc')
+      const sortedByApr = orderBy(
+        [...farmsWithApr, ...activeFarmV3],
+        (farm) => (farm.apr !== null ? farm.apr + farm.lpRewardsApr : farm.lpRewardsApr),
+        'desc',
+      )
       setTopFarms(sortedByApr.slice(0, 5))
     }
   }, [cakePriceBusd, chainId, farms, farmsV3.farmsWithPrice, fetchStatus, isLoading, regularCakePerBlock])
-  return { topFarms, fetched: fetchStatus === FetchStatus.Fetched && !isValidating, chainId }
+  return { topFarms, fetched: fetchStatus === 'success' && !isFetching, chainId }
 }
 
 export default useGetTopFarmsByApr

--- a/packages/farms/constants/index.ts
+++ b/packages/farms/constants/index.ts
@@ -3,8 +3,8 @@ import { isStableFarm, SerializedFarmConfig, supportedChainIdV2 } from '..'
 
 let logged = false
 
-export const getFarmConfig = async (chainId: ChainId) => {
-  if (supportedChainIdV2.includes(chainId as number)) {
+export const getFarmConfig = async (chainId?: ChainId) => {
+  if (chainId && supportedChainIdV2.includes(chainId as number)) {
     const chainName = getChainName(chainId)
     try {
       return (await import(`/${chainName}.ts`)).default.filter(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 329e64e</samp>

### Summary
🔄🚀🎣

<!--
1.  🔄 This emoji represents the replacement or substitution of one library or tool with another, such as SWR with React Query. It can also imply a change in the direction or orientation of something, such as the data fetching and caching logic.
2.  🚀 This emoji represents the improvement or enhancement of something, such as the performance, user experience, or stability of the data fetching and caching. It can also imply a launch or deployment of something, such as the new React Query API or the server-side rendering and hydration.
3.  🎣 This emoji represents the use of hooks or custom hooks, such as the `useQuery` hook from React Query or the `useFarmsWithBalance` hook. It can also imply the fetching or retrieving of data or resources, such as the cake data, the lottery data, or the top pools by APR.
-->
The pull request replaces the SWR library with React Query for data fetching and caching in the web app. It updates several components and hooks that use SWR to use React Query instead, with appropriate options and conditions. It also removes the SWR dependency from the `index.tsx` file and uses server-side rendering and hydration for better performance and user experience.

> _Sing, O Muse, of the valiant pull request_
> _That from SWR to React Query moved_
> _The data fetching and caching logic_
> _Of many a component well-improved._

### Walkthrough
*  Migrate from SWR to React Query for data fetching and caching (all changes)
*  Replace the import of `SWRConfig` from `swr` with the import of `dehydrate` and `QueryClient` from `@tanstack/react-query` in `index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL5-R5))
*  Remove the `SWRConfig` wrapper from the `IndexPage` component and render the `Home` component directly in `index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL12-R13))
*  Move the `tvl` function inside the `getStaticProps` function and create a new `queryClient` instance using `QueryClient` in `index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdR23-R24))
*  Set the query data for `totalTx30Days`, `tvl`, and `addressCount30Days` using `queryClient.setQueryData` and return the `dehydratedState` of the `queryClient` as props in `getStaticProps` in `index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-56c2a44281dd7a9c64dd0cb2da5245897c3df4a1465bf94684d279f59f5a77fdL125-R122))
*  Replace the import of `useSWR` from `swr` with the import of `useQuery` from `@tanstack/react-query` in `useIsRenderLotteryBanner.tsx`, `CakeDataRow.tsx`, `PredictionCardContent.tsx`, `useAllArticle.ts`, `useFarmsWithBalance.tsx`, `useGetTopFarmsByApr.tsx`, and `useGetTopPoolsByApr.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-23dc6d33aa8e53c9eec2d72c4e6017699be8eba57cca14b36a9c7b4639a1e3ffL1-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-b1c146fc65b699595e9b2073c40588e1b171497779ea663ccc13a86f8300937eL12-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-413567f1660e2ebe00f10e81aa88b7a26f80cf7f8d4aecd0b38efba588992ca2L9-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL1-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-d08d17d289fdf87589feaf9122a004620a29e5fb23a9113ba307faa4c2c3a2f9L5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-d08d17d289fdf87589feaf9122a004620a29e5fb23a9113ba307faa4c2c3a2f9R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-25a3237e73b74e02af8206bd7f6d47ac2cf9c7d1a6bafae86a6c0489cf3e9d27L8-R11), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-7b882aa086321ede43c692effc6f3ad2e06129de2403e9307742c314417504a7L13-R15))
*  Replace the import of `useSWRImmutable` from `swr/immutable` with the import of `useQuery` from `@tanstack/react-query` in `LotteryCardContent.tsx` and `MetricsSection/index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-4ff12c73ec3223f1e54309aea2cbbb74a8749128757eb7fa7fab956fe80f3cb5L10-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-cda12b23cd0cd526f330ba3a431e557d9eaef2fef93065496a35af6aa2864ff2L5-R5))
*  Replace the `useSWR` or `useSWRImmutable` hooks with the `useQuery` hooks, with the same keys, in `CakeDataRow.tsx`, `LotteryCardContent.tsx`, `PredictionCardContent.tsx`, `useAllArticle.ts`, `useFarmsWithBalance.tsx`, `useGetTopFarmsByApr.tsx`, and `useGetTopPoolsByApr.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-b1c146fc65b699595e9b2073c40588e1b171497779ea663ccc13a86f8300937eL84-R85), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-4ff12c73ec3223f1e54309aea2cbbb74a8749128757eb7fa7fab956fe80f3cb5L27-R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-413567f1660e2ebe00f10e81aa88b7a26f80cf7f8d4aecd0b38efba588992ca2L36-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL11-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL52-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-d08d17d289fdf87589feaf9122a004620a29e5fb23a9113ba307faa4c2c3a2f9L82-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-25a3237e73b74e02af8206bd7f6d47ac2cf9c7d1a6bafae86a6c0489cf3e9d27L24-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-7b882aa086321ede43c692effc6f3ad2e06129de2403e9307742c314417504a7L23-R23))
*  Add the `enabled` option to the `useQuery` hooks, to conditionally enable or disable the queries based on the dependencies, in `CakeDataRow.tsx`, `LotteryCardContent.tsx`, `PredictionCardContent.tsx`, `useAllArticle.ts`, `useFarmsWithBalance.tsx`, `useGetTopFarmsByApr.tsx`, and `useGetTopPoolsByApr.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-b1c146fc65b699595e9b2073c40588e1b171497779ea663ccc13a86f8300937eL114-R115), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-4ff12c73ec3223f1e54309aea2cbbb74a8749128757eb7fa7fab956fe80f3cb5L27-R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-413567f1660e2ebe00f10e81aa88b7a26f80cf7f8d4aecd0b38efba588992ca2L36-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL11-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL52-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-d08d17d289fdf87589feaf9122a004620a29e5fb23a9113ba307faa4c2c3a2f9L104-R105), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-25a3237e73b74e02af8206bd7f6d47ac2cf9c7d1a6bafae86a6c0489cf3e9d27L31-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-7b882aa086321ede43c692effc6f3ad2e06129de2403e9307742c314417504a7L33-R36))
*  Add or modify the options to disable refetching on reconnect, mount, or window focus in the `useQuery` hooks, in `LotteryCardContent.tsx`, `useAllArticle.ts`, `useGetTopFarmsByApr.tsx`, and `useGetTopPoolsByApr.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-4ff12c73ec3223f1e54309aea2cbbb74a8749128757eb7fa7fab956fe80f3cb5L27-R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL11-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL30-R31), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL52-R51), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-57a06bbc632f71fd2bd639e55eb1d2fd0033285406a08d0e117d06043f77320fL64-R63), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-25a3237e73b74e02af8206bd7f6d47ac2cf9c7d1a6bafae86a6c0489cf3e9d27L31-R38), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-7b882aa086321ede43c692effc6f3ad2e06129de2403e9307742c314417504a7L33-R36))
*  Add the `enabled: false` option to the `useQuery` hooks for `tvl`, `totalTx30Days`, and `addressCount30Days` in `MetricsSection/index.tsx`, to disable the queries on the client-side, as the data is already fetched and hydrated on the server-side ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-cda12b23cd0cd526f330ba3a431e557d9eaef2fef93065496a35af6aa2864ff2L55-R57))
*  Replace the `fetchStatus` and `isValidating` variables with `fetchStatus` and `isFetching` variables, and compare the `fetchStatus` variable to `'success'` instead of `FetchStatus.Fetched`, in `useGetTopFarmsByApr.tsx` and `useGetTopPoolsByApr.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-25a3237e73b74e02af8206bd7f6d47ac2cf9c7d1a6bafae86a6c0489cf3e9d27L71-R74), [link](https://github.com/pancakeswap/pancake-frontend/pull/8310/files?diff=unified&w=0#diff-7b882aa086321ede43c692effc6f3ad2e06129de2403e9307742c314417504a7L43-R49))


