### PR TITLE
chore: position manager roi calculator decimals

### DIFF
--- a/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
+++ b/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
@@ -70,6 +70,7 @@ interface Props {
   precision?: bigint
   strategyInfoUrl?: string
   learnMoreAboutUrl?: string
+  lpTokenDecimals?: number
 }
 
 const StyledCurrencyInput = styled(CurrencyInput)`
@@ -108,6 +109,7 @@ export const AddLiquidity = memo(function AddLiquidity({
   totalStakedInUsd,
   strategyInfoUrl,
   learnMoreAboutUrl,
+  lpTokenDecimals,
 }: Props) {
   const [valueA, setValueA] = useState('')
   const [valueB, setValueB] = useState('')
@@ -350,6 +352,7 @@ export const AddLiquidity = memo(function AddLiquidity({
                   userLpAmounts={userLpAmounts}
                   totalSupplyAmounts={totalSupplyAmounts}
                   precision={precision}
+                  lpTokenDecimals={lpTokenDecimals}
                 />
               </RowBetween>
             </Flex>

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -25,6 +25,9 @@ const AprText = styled(Text)`
   cursor: pointer;
 `
 
+const lpTokenDecimals = 8
+const tokenBalanceMuitplier = new BigNumber(10).pow(lpTokenDecimals)
+
 export const AprButton = memo(function YieldInfo({
   id,
   apr,
@@ -40,7 +43,10 @@ export const AprButton = memo(function YieldInfo({
   const { address: account } = useAccount()
   const cakePriceBusd = useCakePrice()
   const tokenBalance = useMemo(
-    () => new BigNumber(Number(((userLpAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0),
+    () =>
+      new BigNumber(Number(((userLpAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0).times(
+        tokenBalanceMuitplier,
+      ),
     [userLpAmounts, precision],
   )
 
@@ -87,7 +93,7 @@ export const AprButton = memo(function YieldInfo({
       pid={Number(id)}
       linkLabel=""
       stakingTokenBalance={tokenBalance}
-      stakingTokenDecimals={0}
+      stakingTokenDecimals={lpTokenDecimals}
       stakingTokenSymbol={lpSymbol}
       stakingTokenPrice={tokenPrice}
       earningTokenPrice={cakePriceBusd.toNumber()}

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -1,5 +1,14 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, RoiCalculatorModal, Skeleton, Text, useModal, useTooltip } from '@pancakeswap/uikit'
+import {
+  Flex,
+  RoiCalculatorModal,
+  Skeleton,
+  Text,
+  useModal,
+  useTooltip,
+  IconButton,
+  CalculateIcon,
+} from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { useCakePrice } from 'hooks/useCakePrice'
 import { memo, useMemo } from 'react'
@@ -107,12 +116,17 @@ export const AprButton = memo(function YieldInfo({
   )
 
   return (
-    <Flex flexDirection="row" justifyContent="flex-end" alignItems="center">
+    <Flex flexDirection="row" justifyContent="center" alignItems="center">
       {apr && !isAprLoading ? (
-        <AprText color="success" ref={targetRef} bold onClick={onPresentApyModal}>
-          {`${apr.combinedApr}%`}
-          {tooltipVisible && tooltip}
-        </AprText>
+        <>
+          <AprText color="success" ref={targetRef} bold onClick={onPresentApyModal}>
+            {`${apr.combinedApr}%`}
+            {tooltipVisible && tooltip}
+          </AprText>
+          <IconButton variant="text" scale="sm" onClick={onPresentApyModal}>
+            <CalculateIcon mt="3px" color="textSubtle" ml="3px" width="20px" />
+          </IconButton>
+        </>
       ) : (
         <Skeleton width={50} height={20} />
       )}

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -17,6 +17,7 @@ interface Props {
   userLpAmounts?: bigint
   totalSupplyAmounts?: bigint
   precision?: bigint
+  lpTokenDecimals?: number
 }
 
 const AprText = styled(Text)`
@@ -24,9 +25,6 @@ const AprText = styled(Text)`
   text-decoration: dotted underline;
   cursor: pointer;
 `
-
-const lpTokenDecimals = 8 // the vault ABI from 3 party is difference, so we need to hardcode this, just for user can input the decimal points
-const tokenBalanceMultiplier = new BigNumber(10).pow(lpTokenDecimals)
 
 export const AprButton = memo(function YieldInfo({
   id,
@@ -37,17 +35,19 @@ export const AprButton = memo(function YieldInfo({
   userLpAmounts,
   totalSupplyAmounts,
   precision,
+  lpTokenDecimals = 0,
 }: Props) {
   const { t } = useTranslation()
 
   const { address: account } = useAccount()
   const cakePriceBusd = useCakePrice()
+  const tokenBalanceMultiplier = useMemo(() => new BigNumber(10).pow(lpTokenDecimals), [lpTokenDecimals])
   const tokenBalance = useMemo(
     () =>
       new BigNumber(Number(((userLpAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0).times(
         tokenBalanceMultiplier,
       ),
-    [userLpAmounts, precision],
+    [userLpAmounts, precision, tokenBalanceMultiplier],
   )
 
   const tokenPrice = useMemo(

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -25,7 +25,7 @@ const AprText = styled(Text)`
   cursor: pointer;
 `
 
-const lpTokenDecimals = 8 // the vault ABI from different 3 party is difference, so we need to hardcode this, just for user can input the decimal points
+const lpTokenDecimals = 8 // the vault ABI from 3 party is difference, so we need to hardcode this, just for user can input the decimal points
 const tokenBalanceMultiplier = new BigNumber(10).pow(lpTokenDecimals)
 
 export const AprButton = memo(function YieldInfo({

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -26,7 +26,7 @@ const AprText = styled(Text)`
 `
 
 const lpTokenDecimals = 8
-const tokenBalanceMuitplier = new BigNumber(10).pow(lpTokenDecimals)
+const tokenBalanceMultiplier = new BigNumber(10).pow(lpTokenDecimals)
 
 export const AprButton = memo(function YieldInfo({
   id,
@@ -45,7 +45,7 @@ export const AprButton = memo(function YieldInfo({
   const tokenBalance = useMemo(
     () =>
       new BigNumber(Number(((userLpAmounts ?? 0n) * 10000n) / (precision ?? 1n)) / 10000 ?? 0).times(
-        tokenBalanceMuitplier,
+        tokenBalanceMultiplier,
       ),
     [userLpAmounts, precision],
   )

--- a/apps/web/src/views/PositionManagers/components/AprButton.tsx
+++ b/apps/web/src/views/PositionManagers/components/AprButton.tsx
@@ -25,7 +25,7 @@ const AprText = styled(Text)`
   cursor: pointer;
 `
 
-const lpTokenDecimals = 8
+const lpTokenDecimals = 8 // the vault ABI from different 3 party is difference, so we need to hardcode this, just for user can input the decimal points
 const tokenBalanceMultiplier = new BigNumber(10).pow(lpTokenDecimals)
 
 export const AprButton = memo(function YieldInfo({

--- a/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
@@ -73,6 +73,7 @@ interface Props {
   userLpAmounts?: bigint
   totalSupplyAmounts?: bigint
   precision?: bigint
+  lpTokenDecimals?: number
 }
 
 export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
@@ -114,6 +115,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
   managerAddress,
   totalStakedInUsd,
   learnMoreAboutUrl,
+  lpTokenDecimals,
 }: PropsWithChildren<Props>) {
   const apr = useApr({
     currencyA,
@@ -162,6 +164,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
           totalSupplyAmounts={totalSupplyAmounts}
           userLpAmounts={userLpAmounts}
           precision={precision}
+          lpTokenDecimals={lpTokenDecimals}
         />
         <ManagerInfo mt="1.5em" id={manager.id} name={manager.name} strategy={strategy} />
         <LiquidityManagement
@@ -198,6 +201,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
           totalStakedInUsd={totalStakedInUsd}
           strategyInfoUrl={strategyInfoUrl}
           learnMoreAboutUrl={learnMoreAboutUrl}
+          lpTokenDecimals={lpTokenDecimals}
         />
         <ExpandableSection mt="1.5em">
           <VaultInfo

--- a/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
@@ -63,6 +63,7 @@ interface Props {
   isInCakeRewardDateRange: boolean
   strategyInfoUrl?: string
   learnMoreAboutUrl?: string
+  lpTokenDecimals?: number
 }
 
 export const LiquidityManagement = memo(function LiquidityManagement({
@@ -100,6 +101,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
   totalStakedInUsd,
   strategyInfoUrl,
   learnMoreAboutUrl,
+  lpTokenDecimals,
 }: Props) {
   const { t } = useTranslation()
   const [addLiquidityModalOpen, setAddLiquidityModalOpen] = useState(false)
@@ -188,6 +190,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
         totalStakedInUsd={totalStakedInUsd}
         strategyInfoUrl={strategyInfoUrl}
         learnMoreAboutUrl={learnMoreAboutUrl}
+        lpTokenDecimals={lpTokenDecimals}
       />
       <RemoveLiquidity
         isOpen={removeLiquidityModalOpen}

--- a/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
+++ b/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
@@ -18,6 +18,7 @@ interface Props {
   userLpAmounts?: bigint
   totalSupplyAmounts?: bigint
   precision?: bigint
+  lpTokenDecimals?: number
 }
 
 export const YieldInfo = memo(function YieldInfo({
@@ -32,6 +33,7 @@ export const YieldInfo = memo(function YieldInfo({
   totalSupplyAmounts,
   totalStakedInUsd,
   precision,
+  lpTokenDecimals,
 }: Props) {
   const { t } = useTranslation()
 
@@ -54,6 +56,7 @@ export const YieldInfo = memo(function YieldInfo({
           totalStakedInUsd={totalStakedInUsd}
           userLpAmounts={userLpAmounts}
           precision={precision}
+          lpTokenDecimals={lpTokenDecimals}
         />
       </RowBetween>
       <RowBetween>

--- a/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
@@ -188,6 +188,7 @@ export const PCSVaultCard = memo(function PCSVaultCard({
       precision={info?.precision}
       totalStakedInUsd={totalStakedInUsd}
       learnMoreAboutUrl={learnMoreAboutUrl}
+      lpTokenDecimals={info?.lpTokenDecimals}
     >
       {id}
     </DuoTokenVaultCard>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ac45bdb</samp>

### Summary
🐛🧮🌐

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this pull request.
2.  🧮 - This emoji represents a calculation or math-related change, which is relevant for the logic that adjusts the token decimals and balance.
3.  🌐 - This emoji represents a global or universal change, which is suitable for the introduction of a constant that affects all LP tokens.
-->
Fix bug in `AprButton` component for LP tokens with 8 decimals. Use a constant `lpTokenDecimals` to calculate the correct APR values.

> _There once was a bug in `AprButton`_
> _That made some LP tokens look rotten_
> _The fix was quite simple_
> _Just tweak a decimal_
> _And use `lpTokenDecimals` often_

### Walkthrough
* Fix the bug in the APR button component by using the correct number of decimals for the LP token ([link](https://github.com/pancakeswap/pancake-frontend/pull/8319/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766R28-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/8319/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766L43-R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/8319/files?diff=unified&w=0#diff-014052c22c59ed783ab1d38e23dd156aa3a09f5c04f3da501dad212570bef766L90-R96))


