### PR TITLE
chore: Default to use pokt on polygon

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -14,12 +14,6 @@ import { getNodeRealUrl } from 'utils/node/nodeReal'
 import { getPoktUrl } from 'utils/node/pokt'
 import { opbnbTestnet, linea, opbnb } from './chains'
 
-const POLYGON_ZKEVM_NODES = [
-  'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
-  getPoktUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
-  ...polygonZkEvm.rpcUrls.public.http,
-]
-
 const ARBITRUM_NODES = [
   ...arbitrum.rpcUrls.public.http,
   'https://arbitrum-one.publicnode.com',
@@ -50,7 +44,11 @@ export const SERVER_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_ONE]: ARBITRUM_NODES,
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
-  [ChainId.POLYGON_ZKEVM]: POLYGON_ZKEVM_NODES,
+  [ChainId.POLYGON_ZKEVM]: [
+    'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
+    getPoktUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+    ...polygonZkEvm.rpcUrls.public.http,
+  ],
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     'https://polygon-zkevm-testnet.rpc.thirdweb.com',
     ...polygonZkEvmTestnet.rpcUrls.public.http,
@@ -112,7 +110,9 @@ export const PUBLIC_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
-    ...POLYGON_ZKEVM_NODES,
+    getPoktUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+    'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
+    ...polygonZkEvm.rpcUrls.public.http,
     getNodeRealUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
   ],
   [ChainId.POLYGON_ZKEVM_TESTNET]: [


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cbd19a0</samp>

### Summary
🔄🚀🛠️

<!--
1.  🔄 - This emoji can be used to indicate that the order or sequence of something was changed or swapped, as in the case of the POLYGON_ZKEVM_NODES array.
2.  🚀 - This emoji can be used to suggest that the change was made to improve the performance, speed, or reliability of something, as in the case of the Pokt URL providing a better service for the Polygon ZK-EVM network.
3.  🛠️ - This emoji can be used to imply that the change was part of a fix, update, or improvement of something, as in the case of the pull request to update the network configuration and enhance the user experience.
-->
Changed the order of `POLYGON_ZKEVM_NODES` to use Pokt URL first. This improves the reliability and scalability of the Polygon ZK-EVM network for the app.

> _`POLYGON_ZKEVM_NODES`_
> _Switch Pokt and ZKEVM URLs - kireji_
> _Better service in fall - kigo_

### Walkthrough
*  Prioritize the Pokt URL over the ZKEVM URL for the Polygon ZK-EVM network to improve reliability and scalability ([link](https://github.com/pancakeswap/pancake-frontend/pull/8324/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL18-R19))


