### PR TITLE
refactor: Use query in pools

### DIFF
--- a/apps/web/src/hooks/useCallWithGasPrice.ts
+++ b/apps/web/src/hooks/useCallWithGasPrice.ts
@@ -68,11 +68,14 @@ export function useCallWithGasPrice() {
         ? GetFunctionArgs<TAbi, _FunctionName>['args']
         : never,
     >(
-      contract: { abi: TAbi; account: Account; chain: Chain; address: Address },
+      contract: { abi: TAbi; account: Account | undefined; chain: Chain | undefined; address: Address } | null,
       methodName: InferFunctionName<TAbi, TFunctionName>,
       methodArgs?: Args extends never ? undefined : Args,
       overrides?: Omit<CallParameters, 'chain' | 'to' | 'data'>,
     ): Promise<SendTransactionResult> => {
+      if (!contract) {
+        throw new Error('No valid contract')
+      }
       if (!walletClient) {
         throw new Error('No valid wallet connect')
       }

--- a/apps/web/src/hooks/useUserCakeLockStatus.ts
+++ b/apps/web/src/hooks/useUserCakeLockStatus.ts
@@ -1,6 +1,6 @@
 import { useAccount } from 'wagmi'
 import { ChainId } from '@pancakeswap/chains'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { useCakeVaultContract } from 'hooks/useContract'
 import { useActiveChainId } from './useActiveChainId'
 
@@ -9,12 +9,19 @@ export const useUserCakeLockStatus = () => {
   const { chainId } = useActiveChainId()
   const cakeVaultContract = useCakeVaultContract()
 
-  const { data: userCakeLockStatus = null } = useSWRImmutable(
-    account && chainId === ChainId.BSC ? ['userCakeLockStatus', account] : null,
+  const { data: userCakeLockStatus = null } = useQuery(
+    ['userCakeLockStatus', account],
     async () => {
+      if (!account) return undefined
       const [, , , , , lockEndTime, , locked] = await cakeVaultContract.read.userInfo([account])
       const lockEndTimeStr = lockEndTime.toString()
       return locked && (lockEndTimeStr === '0' || Date.now() > parseInt(lockEndTimeStr) * 1000)
+    },
+    {
+      enabled: Boolean(account && chainId === ChainId.BSC),
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
     },
   )
   return userCakeLockStatus

--- a/apps/web/src/views/Pools/components/LockedPool/Buttons/ConvertToFlexibleButton.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Buttons/ConvertToFlexibleButton.tsx
@@ -11,8 +11,8 @@ import { useVaultPoolContract } from 'hooks/useContract'
 import { useAppDispatch } from 'state'
 import { fetchCakeVaultUserData } from 'state/pools'
 import { VaultKey } from 'state/types'
-import { useSWRConfig } from 'swr'
 import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useQueryClient } from '@tanstack/react-query'
 
 const ConvertToFlexibleButton: React.FC<React.PropsWithChildren<ButtonProps>> = (props) => {
   const dispatch = useAppDispatch()
@@ -23,10 +23,11 @@ const ConvertToFlexibleButton: React.FC<React.PropsWithChildren<ButtonProps>> = 
   const vaultPoolContract = useVaultPoolContract(VaultKey.CakeVault)
   const { callWithGasPrice } = useCallWithGasPrice()
   const { t } = useTranslation()
-  const { mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { toastSuccess } = useToast()
 
   const handleUnlock = useCallback(async () => {
+    if (!account || !chainId) return
     const callOptions = {
       gas: vaultPoolConfig[VaultKey.CakeVault].gasLimit,
     }
@@ -44,9 +45,19 @@ const ConvertToFlexibleButton: React.FC<React.PropsWithChildren<ButtonProps>> = 
         </ToastDescriptionWithTx>,
       )
       dispatch(fetchCakeVaultUserData({ account, chainId }))
-      mutate(['userCakeLockStatus', account])
+      queryClient.invalidateQueries(['userCakeLockStatus', account])
     }
-  }, [t, toastSuccess, account, callWithGasPrice, dispatch, fetchWithCatchTxError, vaultPoolContract, mutate, chainId])
+  }, [
+    t,
+    toastSuccess,
+    account,
+    callWithGasPrice,
+    dispatch,
+    fetchWithCatchTxError,
+    vaultPoolContract,
+    queryClient,
+    chainId,
+  ])
 
   return (
     <Button width="100%" disabled={pendingTx} onClick={handleUnlock} variant="secondary" {...props}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9765a60</samp>

### Summary
🍰🚀🛠️

<!--
1.  🍰 - This emoji represents the cake vault and cake lock features, which are the main focus of the pull request. It also conveys a sense of reward and satisfaction for the users who participate in these features.
2.  🚀 - This emoji represents the performance and speed improvements that the pull request brings to the data layer. It also suggests that the features are ready to launch and scale.
3.  🛠️ - This emoji represents the refactoring and migration work that the pull request involves. It also indicates that the codebase is being maintained and updated with the latest tools and best practices.
-->
The pull request migrates the data fetching and caching logic for several features related to the cake vault, the IFO, and the revenue sharing pool from SWR to React Query. This improves the performance, consistency, and flexibility of the data layer. The affected files are `useUserCakeLockStatus.ts`, `hooks.ts`, `ConvertToFlexibleButton.tsx`, `useLockedPool.tsx`, `useRevenueSharingPool.ts`, and `useVCake.tsx`.

> _We are the masters of the query_
> _We unleash the power of React_
> _We slay the beast of SWR_
> _We rise with the speed of React Query_

### Walkthrough
*  Replace `useSWRImmutable` and `useSWR` hooks with `useQuery` hooks from `@tanstack/react-query` for data fetching and caching ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-4aeb98498895aaba2e636c60fc2413bb749fe9fe46d57e9ba722844ce49fc298L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-4aeb98498895aaba2e636c60fc2413bb749fe9fe46d57e9ba722844ce49fc298L12-R13), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-4aeb98498895aaba2e636c60fc2413bb749fe9fe46d57e9ba722844ce49fc298R19-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-dec744b5aefc78d651a73cf7b57304f462558a101a9a6b6bbaa2892a470cb315L7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-dec744b5aefc78d651a73cf7b57304f462558a101a9a6b6bbaa2892a470cb315R14), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-dec744b5aefc78d651a73cf7b57304f462558a101a9a6b6bbaa2892a470cb315L172-R225), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-33d54a8e725a275963a0662215cf3b0fb9b06e2f8556a36b0c7919d45b0cd8b9L1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-33d54a8e725a275963a0662215cf3b0fb9b06e2f8556a36b0c7919d45b0cd8b9R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-33d54a8e725a275963a0662215cf3b0fb9b06e2f8556a36b0c7919d45b0cd8b9L34-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-12b0d82dd5bbc2690c3048d72d9692034bcbe3a8e7423f06f8837824432965bfL1-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-12b0d82dd5bbc2690c3048d72d9692034bcbe3a8e7423f06f8837824432965bfL15-R33))
  *  Add options objects to `useQuery` hooks to specify enabling conditions, refetch intervals, and refetching behavior on mount, window focus, and reconnect events ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-4aeb98498895aaba2e636c60fc2413bb749fe9fe46d57e9ba722844ce49fc298R19-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-dec744b5aefc78d651a73cf7b57304f462558a101a9a6b6bbaa2892a470cb315L172-R225), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-33d54a8e725a275963a0662215cf3b0fb9b06e2f8556a36b0c7919d45b0cd8b9L34-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-12b0d82dd5bbc2690c3048d72d9692034bcbe3a8e7423f06f8837824432965bfL15-R33))
  *  Make `isInitialization` property optional in `UseVCake` interface to handle undefined data from `useQuery` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-12b0d82dd5bbc2690c3048d72d9692034bcbe3a8e7423f06f8837824432965bfL1-R7))
*  Replace `useSWRConfig` hook with `useQueryClient` hook from `@tanstack/react-query` for query cache manipulation ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-ece2beb279ac1cd56b0141ddb850c03f6a06fdc61b663d98f73c24075e7a6327L14-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-ece2beb279ac1cd56b0141ddb850c03f6a06fdc61b663d98f73c24075e7a6327L26-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dL3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dR19), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dL66-R66))
  *  Replace `mutate` function with `invalidateQueries` method to invalidate and refetch query cache for given keys ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-ece2beb279ac1cd56b0141ddb850c03f6a06fdc61b663d98f73c24075e7a6327L47-R59), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dL90-R90), [link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dL102-R102))
  *  Pass `queryClient` instance as dependency to `useCallback` hook that handles locking of CAKE tokens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8334/files?diff=unified&w=0#diff-b1faeb5eb903235f5eba5f23d8c1ffb89ce7134601e787d66b533ab5e883c78dL102-R102))


