### PR TITLE
chore: Shuffle zkevm node

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
+import shuffle from 'lodash/shuffle'
 import {
   arbitrum,
   polygonZkEvm,
@@ -111,9 +112,8 @@ export const PUBLIC_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
+    ...shuffle([process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '', ...polygonZkEvm.rpcUrls.public.http]),
     'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
-    process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '',
-    ...polygonZkEvm.rpcUrls.public.http,
     getPoktUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
   ].filter(Boolean),
   [ChainId.POLYGON_ZKEVM_TESTNET]: [

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -30,5 +30,5 @@ export const viemClients = CHAINS.reduce((prev, cur) => {
 }, {} as Record<ChainId, PublicClient>)
 
 export const getViemClients = ({ chainId }: { chainId?: ChainId }) => {
-  return viemClients[chainId]
+  return viemClients[chainId as ChainId]
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c38ffae</samp>

### Summary
🎨🔀🛡️

<!--
1.  🎨 - This emoji represents the improvement of code quality and readability by using a more specific type for the `chainId` parameter.
2.  🔀 - This emoji represents the shuffling of the Polygon ZK-EVM RPC URLs to achieve better load balancing and performance.
3.  🛡️ - This emoji represents the preservation of the security and compatibility of the ZK-EVM and Pokt nodes by keeping their order in the array.
-->
Improved load balancing for Polygon ZK-EVM RPCs and fixed TypeScript error in `getViemClients` function. Changed `nodes.ts` and `viem.ts` files.

> _To fix a TypeScript error_
> _We cast `chainId` to be surer_
> _But we also shuffled_
> _The URLs we muffled_
> _To balance the Polygon server_

### Walkthrough
* Import and use `shuffle` function to randomize RPC URLs for Polygon ZK-EVM chain ([link](https://github.com/pancakeswap/pancake-frontend/pull/8340/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecR2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8340/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL114-R116))
* Cast `chainId` parameter to `ChainId` type to fix TypeScript error in `getViemClients` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8340/files?diff=unified&w=0#diff-183d744228d84d3639e7b8c1f87acfe1fbea6a869359deb8313a0bb51c523c5cL33-R33))


