### PR TITLE
fix(smart-router): Add default exports path

### DIFF
--- a/.changeset/dirty-zoos-rule.md
+++ b/.changeset/dirty-zoos-rule.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': patch
+---
+
+Add smart-router exports default path

--- a/packages/smart-router/package.json
+++ b/packages/smart-router/package.json
@@ -51,6 +51,11 @@
   },
   "exports": {
     "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/evm/index.d.ts",
+      "import": "./dist/evm.mjs",
+      "require": "./dist/evm.js"
+    },
     "./evm": {
       "types": "./dist/evm/index.d.ts",
       "import": "./dist/evm.mjs",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3be8b41</samp>

### Summary
📝📦🚀

<!--
1.  📝 - This emoji represents the addition of a markdown file to the `.changeset` folder, which is a documentation-related change.
2.  📦 - This emoji represents the addition of a new property to the `package.json` file, which is a packaging-related change.
3.  🚀 - This emoji represents the update to export the smart router as a standalone package, which is a feature-related change.
-->
This pull request updates the `@pancakeswap/smart-router` package to export it as a standalone package with default paths for types, import and require. It also adds a changeset file to document the patch update.

> _`smart-router` package_
> _exports its types and functions_
> _autumn of refactor_

### Walkthrough
*  Add a patch update and a changelog entry for the `@pancakeswap/smart-router` package (.changeset/dirty-zoos-rule.md)
*  Enable importing or requiring the `@pancakeswap/smart-router` package by its name and provide TypeScript types ([link](https://github.com/pancakeswap/pancake-frontend/pull/8342/files?diff=unified&w=0#diff-6d0b8c7b73a5587b6dd0c7536b5691aa4a5c66ad365351ada5fdd9a1f169a990R54-R58))


