### PR TITLE
chore: Default to use nodies

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -1,5 +1,4 @@
 import { ChainId } from '@pancakeswap/chains'
-import shuffle from 'lodash/shuffle'
 import {
   arbitrum,
   polygonZkEvm,
@@ -112,7 +111,8 @@ export const PUBLIC_NODES = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.public.http,
   [ChainId.POLYGON_ZKEVM]: [
-    ...shuffle([process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '', ...polygonZkEvm.rpcUrls.public.http]),
+    process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '',
+    ...polygonZkEvm.rpcUrls.public.http,
     'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
     getPoktUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
   ].filter(Boolean),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 609166a</samp>

### Summary
🗑️🔀🧪

<!--
1.  🗑️ for removing an unused import
2.  🔀 for changing the RPC URL order
3.  🧪 for enabling custom testing
-->
Updated the RPC URL configuration for Polygon ZK-EVM in `nodes.ts` to facilitate testing. Removed an unnecessary import.

> _To test Polygon ZK-EVM_
> _They changed the RPC URL scheme_
> _They removed an import_
> _That was not of import_
> _And hoped for a bug-free regime_

### Walkthrough
* Change the order of RPC URLs for Polygon ZK-EVM chain to prefer the environment variable ([link](https://github.com/pancakeswap/pancake-frontend/pull/8349/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL115-R115))
* Remove unused `shuffle` import from `lodash` in `nodes.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8349/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL2))


