### PR TITLE
chore: use api from zkevm usd price

### DIFF
--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -48,7 +48,7 @@ export function useStablecoinPrice(
       if (!currency) {
         return undefined
       }
-      const tokenAddress = currency.isNative ? currency.wrapped.address : currency.address
+      const tokenAddress = currency.wrapped.address
       const result = await fetchTokenUSDValue(currency.chainId, [tokenAddress])
       return result[tokenAddress]
     },

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -42,7 +42,7 @@ export function useStablecoinPrice(
     (currency?.chainId === ChainId.ETHEREUM || currency?.chainId === ChainId.POLYGON_ZKEVM) && shouldEnabled
 
   // we don't have too many AMM pools on ethereum yet, try to get it from api
-  const { data: priceFromLlama, isLoading } = useSWRImmutable<string>(
+  const { data: priceFromLlama, isLoading } = useSWRImmutable<string | undefined>(
     currency && enableLlama && ['fiat-price-llama', currency],
     async () => {
       if (!currency) {
@@ -50,7 +50,7 @@ export function useStablecoinPrice(
       }
       const tokenAddress = currency.wrapped.address
       const result = await fetchTokenUSDValue(currency.chainId, [tokenAddress])
-      return result[tokenAddress]
+      return result.get(tokenAddress)
     },
     {
       dedupingInterval: 30_000,

--- a/apps/web/src/hooks/useBUSDPrice.ts
+++ b/apps/web/src/hooks/useBUSDPrice.ts
@@ -1,4 +1,4 @@
-import { Currency, CurrencyAmount, Price, WETH9, TradeType } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, Price, TradeType } from '@pancakeswap/sdk'
 import { ChainId } from '@pancakeswap/chains'
 import { CAKE, STABLE_COIN } from '@pancakeswap/tokens'
 import { useMemo } from 'react'
@@ -8,6 +8,7 @@ import { useCakePrice } from 'hooks/useCakePrice'
 import { getFullDecimalMultiplier } from '@pancakeswap/utils/getFullDecimalMultiplier'
 import { SmartRouterTrade } from '@pancakeswap/smart-router/evm'
 import { computeTradePriceBreakdown } from 'views/Swap/V3Swap/utils/exchange'
+import { fetchTokenUSDValue } from 'utils/llamaPrice'
 import { warningSeverity } from 'utils/exchange'
 import { useActiveChainId } from './useActiveChainId'
 import { useBestAMMTrade } from './useBestAMMTrade'
@@ -37,18 +38,19 @@ export function useStablecoinPrice(
 
   const shouldEnabled = currency && stableCoin && enabled && currentChainId === chainId && !isCake && !isStableCoin
 
-  const enableLlama = currency?.chainId === ChainId.ETHEREUM && shouldEnabled
+  const enableLlama =
+    (currency?.chainId === ChainId.ETHEREUM || currency?.chainId === ChainId.POLYGON_ZKEVM) && shouldEnabled
 
   // we don't have too many AMM pools on ethereum yet, try to get it from api
   const { data: priceFromLlama, isLoading } = useSWRImmutable<string>(
-    currency && enableLlama && ['fiat-price-ethereum', currency],
+    currency && enableLlama && ['fiat-price-llama', currency],
     async () => {
-      const address = currency?.isToken ? currency.address : WETH9[ChainId.ETHEREUM]?.address
-      return fetch(`https://coins.llama.fi/prices/current/ethereum:${address}`) // <3 llama
-        .then((res) => res.json())
-        .then(
-          (res) => res?.coins?.[`ethereum:${address}`]?.confidence > 0.9 && res?.coins?.[`ethereum:${address}`]?.price,
-        )
+      if (!currency) {
+        return undefined
+      }
+      const tokenAddress = currency.isNative ? currency.wrapped.address : currency.address
+      const result = await fetchTokenUSDValue(currency.chainId, [tokenAddress])
+      return result[tokenAddress]
     },
     {
       dedupingInterval: 30_000,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b4dffb</samp>

### Summary
🔄💲🌐

<!--
1.  🔄 - This emoji conveys the idea of updating or changing something, which is what the hook did to use a new function and handle different tokens.
2.  💲 - This emoji represents money or currency, which is relevant for the hook that fetches the USD value of tokens.
3.  🌐 - This emoji symbolizes the world or the internet, which is related to the hook that supports different chains and native and wrapped tokens.
-->
Updated the `useStablecoinPrice` hook to support cross-chain tokens and native tokens. Removed unused import from `useBUSDPrice.ts`.

> _From the depths of the `useStablecoinPrice` hook_
> _We summon the power of the `fetchUSDValue` function_
> _No matter the chain or the token we seek_
> _We crush the `WETH9` import with our destruction_

### Walkthrough
*  Modify `useStablecoinPrice` hook to support both Ethereum and Polygon ZK-EVM chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/8350/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaL40-R53))
  - Replace `WETH9` import with `fetchTokenUSDValue` utility function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8350/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaL1-R1),[link](https://github.com/pancakeswap/pancake-frontend/pull/8350/files?diff=unified&w=0#diff-5b34b1fc6cf61851f079c808fdf2ae746784a9471f898b9cac7f8ead870489aaR11))


