### PR TITLE
refactor: Use query in profile

### DIFF
--- a/apps/web/src/views/ProfileCreation/TeamSelection.tsx
+++ b/apps/web/src/views/ProfileCreation/TeamSelection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Card, CardBody, CommunityIcon, Flex, Heading, Text } from '@pancakeswap/uikit'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import shuffle from 'lodash/shuffle'
 import { getTeams } from 'state/teams/helpers'
 import { useTranslation } from '@pancakeswap/localization'
@@ -11,7 +11,7 @@ import useProfileCreation from './contexts/hook'
 const Team: React.FC<React.PropsWithChildren> = () => {
   const { teamId: currentTeamId, actions } = useProfileCreation()
   const { t } = useTranslation()
-  const { data: teams } = useSWR('teams', async () => getTeams())
+  const { data: teams } = useQuery(['teams'], async () => getTeams())
   const teamValues = useMemo(() => (teams ? shuffle(Object.values(teams)) : []), [teams])
   const handleTeamSelection = (value: string) => actions.setTeamId(parseInt(value, 10))
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 98b13ef</samp>

### Summary
🚀🛠️🗃️

<!--
1.  🚀 - This emoji conveys the idea of improved performance and speed, as well as launching a new feature or improvement.
2.  🛠️ - This emoji signifies that the code involves refactoring, fixing, or improving existing code or functionality, as well as building or crafting something.
3.  🗃️ - This emoji represents the concept of data, caching, or storage, as well as organizing or managing information.
-->
Refactor team data fetching and caching in `TeamSelection.tsx` using React Query. This enhances the team selection view's performance and reliability.

> _We're fetching and caching the team data_
> _With `useQuery` from React Query_
> _It makes our app run faster and smoother_
> _So heave away, me hearties, heave away_

### Walkthrough
* Migrate from useSWR to useQuery for fetching and caching team data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8351/files?diff=unified&w=0#diff-6dc6fa7310afebd8dd3f86cfb07e3c70aba7195bc9cbf49e0ac9677bb97541d4L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8351/files?diff=unified&w=0#diff-6dc6fa7310afebd8dd3f86cfb07e3c70aba7195bc9cbf49e0ac9677bb97541d4L14-R14))


