### PR TITLE
chore: Move axl to finished pools

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -50,15 +50,6 @@ export const livePools: SerializedPool[] = [
     version: 3,
   },
   {
-    sousId: 360,
-    stakingToken: bscTokens.cake,
-    earningToken: bscTokens.axl,
-    contractAddress: '0x32f0414a4e970a3edd9e7db367A43348F25D74cD',
-    poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.05358',
-    version: 3,
-  },
-  {
     sousId: 359,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.wncg,
@@ -85,6 +76,15 @@ export const livePools: SerializedPool[] = [
 
 // known finished pools
 const finishedPools = [
+  {
+    sousId: 360,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.axl,
+    contractAddress: '0x32f0414a4e970a3edd9e7db367A43348F25D74cD',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.05358',
+    version: 3,
+  },
   {
     sousId: 357,
     stakingToken: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 229fc61</samp>

### Summary
🏊🏁💰

<!--
1.  🏊 - This emoji represents a pool, and is used to indicate that the pull request is related to the pool arrays.
2.  🏁 - This emoji represents the end of a race or a competition, and is used to indicate that the pool has finished and the winners have been determined.
3.  💰 - This emoji represents money or wealth, and is used to indicate that the users can claim or unstake their tokens from the pool.
-->
Move a finished pool from active to finished in `packages/pools/src/constants/pools/56.ts`. This improves the accuracy and usability of the pools feature on the website.

> _`sousId` three-sixty_
> _moved to finished pools array_
> _autumn harvest time_

### Walkthrough
*  Move the pool with sousId 360 from active to finished pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/8360/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bL53-L61), [link](https://github.com/pancakeswap/pancake-frontend/pull/8360/files?diff=unified&w=0#diff-21a68ca608a542b99be691600781000b07789bfe32d5765d6c2290c46107331bR80-R88))


