### PR TITLE
chore: hide single token display while it's duo

### DIFF
--- a/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
@@ -140,6 +140,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               onRemove={showRemoveLiquidityModal}
               token0PriceUSD={token0PriceUSD}
               token1PriceUSD={token1PriceUSD}
+              isSingleDepositToken={isSingleDepositToken}
               isSingleDepositToken0={isSingleDepositToken0}
             />
           </InnerCard>

--- a/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
+++ b/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
@@ -25,6 +25,7 @@ interface StakedAssetsProps {
   staked1Amount?: CurrencyAmount<Currency>
   token0PriceUSD?: number
   token1PriceUSD?: number
+  isSingleDepositToken?: boolean
   isSingleDepositToken0?: boolean
   price?: Price<Currency, Currency>
   onAdd?: () => void
@@ -41,6 +42,7 @@ export const StakedAssets = memo(function StakedAssets({
   token0PriceUSD,
   token1PriceUSD,
   isSingleDepositToken0,
+  isSingleDepositToken,
 }: StakedAssetsProps) {
   const { t } = useTranslation()
 
@@ -72,9 +74,11 @@ export const StakedAssets = memo(function StakedAssets({
           <Text color="text" fontSize="1.5em" bold>
             ~${totalAssetsInUsd.toFixed(2)}
           </Text>
-          <Text color="textSubtle" fontSize="0.75em">
-            (~{totalAssetInSingleDepositTokenAmount.toFixed(6)} {singleDepositSymbol})
-          </Text>
+          {isSingleDepositToken && (
+            <Text color="textSubtle" fontSize="0.75em">
+              (~{totalAssetInSingleDepositTokenAmount.toFixed(6)} {singleDepositSymbol})
+            </Text>
+          )}
         </Flex>
         <Flex flexDirection="row" justifyContent="flex-end">
           <ActionButton scale="md" onClick={onRemove}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 15ec2ba</samp>

### Summary
📦🪝🖼️

<!--
1.  📦 - This emoji represents adding a new prop to a component, which is a common way of enhancing or modifying its functionality or appearance.
2.  🪝 - This emoji represents using a custom hook to handle some logic or state related to a component, which is a common way of reusing or abstracting code in React.
3.  🖼️ - This emoji represents updating the UI or the presentation of a component, which is a common way of improving or changing the user experience or the design.
-->
This pull request adds support for pools with a single deposit token in the `PositionManagers` view. It modifies the `StakedAssets` and `LiquidityManagement` components to handle and display the value of the staked assets in the single deposit token.

> _`StakedAssets` shows_
> _single deposit token pools_
> _autumn leaves falling_

### Walkthrough
*  Add a new prop `isSingleDepositToken` to the `StakedAssets` component and pass it from the `LiquidityManagement` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8366/files?diff=unified&w=0#diff-5ab760c1e9d425a7ce00cb8474fd3fb6c5fa6379b752609436a0b2678061bba9R143), [link](https://github.com/pancakeswap/pancake-frontend/pull/8366/files?diff=unified&w=0#diff-a50beaeb766e2af9a03a6593bb5b1490b26b3299a89e659465bb8d850df32654R28))
*  Use the `isSingleDepositToken` prop in the `useStakedAssets` hook to calculate the value of the staked assets in the single deposit token if applicable ([link](https://github.com/pancakeswap/pancake-frontend/pull/8366/files?diff=unified&w=0#diff-a50beaeb766e2af9a03a6593bb5b1490b26b3299a89e659465bb8d850df32654R45))
*  Conditionally render the text that shows the value of the staked assets in the single deposit token in the `StakedAssets` component, hiding it for pools that do not have a single deposit token ([link](https://github.com/pancakeswap/pancake-frontend/pull/8366/files?diff=unified&w=0#diff-a50beaeb766e2af9a03a6593bb5b1490b26b3299a89e659465bb8d850df32654L75-R81))


