### PR TITLE
chore: list farm on BSC and ETH

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 99,
+    lpAddress: '0x4BBA1018b967e59220b22Ca03f68821A3276c9a6',
+    token0: bscTokens.eth,
+    token1: bscTokens.btcb,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 98,
     lpAddress: '0xbF72B6485E4b31601aFe7B0a1210Be2004D2B1d6',
     token0: bscTokens.usdt,

--- a/packages/farms/constants/eth.ts
+++ b/packages/farms/constants/eth.ts
@@ -49,6 +49,13 @@ export const farmsV3 = defineFarmV3Configs([
   },
   // Keep those farms on top
   {
+    pid: 43,
+    lpAddress: '0x3a1b97Fc25fA45832F588ED3bFb2A0f74ddBD4F8',
+    token0: ethereumTokens.wstETH,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 42,
     lpAddress: '0x73b9aDC00794260616C51C41997cE0245b3FA012',
     token0: ethereumTokens.meme,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 56ea47e</samp>

### Summary
🌾🌉🧮

<!--
1.  🌾 - This emoji represents the concept of farming, which is the term used for staking liquidity provider tokens and earning rewards in decentralized finance. It also matches the name of the `farmsV3` array, which contains the farm constants.
2.  🌉 - This emoji represents the concept of bridging, which is the term used for transferring tokens across different blockchains or networks. The new farms involve tokens that are wrapped or pegged versions of native tokens on other networks, such as ETH, BTC, and stETH. The bridge emoji also suggests the idea of connecting different ecosystems and creating more liquidity and opportunities for users.
3.  🧮 - This emoji represents the concept of fees, which is an important factor for users to consider when choosing which farm to stake in. The new farms have different fee amounts, which affect the swap fee and the reward rate of the farms. The abacus emoji also suggests the idea of calculating and comparing the potential returns and risks of the farms.
-->
This pull request adds two new farms to the `farmsV3` arrays in the `bsc.ts` and `eth.ts` files, which enable users to stake liquidity provider tokens for wrapped versions of ETH and BTC on different networks. The new farms have different fee amounts and reward rates.

> _New farms on `bsc` and `eth`_
> _Stake wrapped tokens for rewards_
> _Autumn harvest time_

### Walkthrough
*  Add two new farms to the `farmsV3` arrays for the Binance Smart Chain and Ethereum networks ([link](https://github.com/pancakeswap/pancake-frontend/pull/8367/files?diff=unified&w=0#diff-9e450d0474e6b664d46d9fefef8b01d8c419db2fcf3f6f4f9488691f10b3279dR51-R57), [link](https://github.com/pancakeswap/pancake-frontend/pull/8367/files?diff=unified&w=0#diff-1061ed839e27418db7270f395760f2b46f58d641b76b0d42c3c637a01797617bR52-R58))


