### PR TITLE
chore: Direct to dedicated domain on mobile for pp

### DIFF
--- a/apps/games/components/Game/Community/Banner/index.tsx
+++ b/apps/games/components/Game/Community/Banner/index.tsx
@@ -13,6 +13,7 @@ import { Autoplay, Navigation } from 'swiper/modules'
 import { GameCard } from 'components/Game/Community/Banner/GameCard'
 import { Decorations } from 'components/Game/Decorations'
 import { useGamesConfig } from 'hooks/useGamesConfig'
+import { getGameLink } from 'utils/getGameLink'
 
 const StyledBackground = styled(Box)`
   position: relative;
@@ -77,7 +78,7 @@ const StyledSwiperContainer = styled(Box)`
 export const Banner = () => {
   const { t } = useTranslation()
   const { theme } = useTheme()
-  const { isDesktop } = useMatchBreakpoints()
+  const { isDesktop, isMobile } = useMatchBreakpoints()
   const [_, setSwiper] = useState<SwiperClass | undefined>(undefined)
 
   const config = useGamesConfig()
@@ -139,7 +140,7 @@ export const Banner = () => {
                 >
                   {games.map((game) => (
                     <SwiperSlide key={game.id}>
-                      <NextLink passHref href={`/project/${game.id}`}>
+                      <NextLink passHref href={getGameLink({ gameId: game.id, isMobile })}>
                         <GameCard game={game} />
                       </NextLink>
                     </SwiperSlide>

--- a/apps/games/components/Game/Home/Game.tsx
+++ b/apps/games/components/Game/Home/Game.tsx
@@ -8,6 +8,7 @@ import { Carousel } from 'components/Game/Home/Carousel'
 import { CarouselView } from 'components/Game/Home/CarouselView'
 import { TrendingTags, StyledTag } from 'components/Game/Home/TrendingTags'
 import { StyledTextLineClamp } from 'components/Game/StyledTextLineClamp'
+import { useGameLink } from 'hooks/useGameLink'
 
 const StyledGameContainer = styled(Flex)<{ isHorizontal: boolean }>`
   width: 100%;
@@ -97,11 +98,7 @@ export const Game: React.FC<React.PropsWithChildren<GameProps>> = ({ isLatest, g
   const previewCarouseData: PostersItemData = useMemo(() => carouselData[carouselId], [carouselId, carouselData])
 
   const isHorizontal: boolean = useMemo(() => game.posters.layout === PostersLayout.Horizontal, [game])
-  const gameLink = useMemo(
-    () =>
-      game.id === 'pancake-protectors' && !isDesktop ? 'https://protectors.pancakeswap.finance' : `/project/${game.id}`,
-    [isDesktop, game.id],
-  )
+  const gameLink = useGameLink(game.id)
 
   return (
     <StyledGameContainer isHorizontal={isHorizontal}>

--- a/apps/games/components/Game/Home/Game.tsx
+++ b/apps/games/components/Game/Home/Game.tsx
@@ -97,6 +97,11 @@ export const Game: React.FC<React.PropsWithChildren<GameProps>> = ({ isLatest, g
   const previewCarouseData: PostersItemData = useMemo(() => carouselData[carouselId], [carouselId, carouselData])
 
   const isHorizontal: boolean = useMemo(() => game.posters.layout === PostersLayout.Horizontal, [game])
+  const gameLink = useMemo(
+    () =>
+      game.id === 'pancake-protectors' && !isDesktop ? 'https://protectors.pancakeswap.finance' : `/project/${game.id}`,
+    [isDesktop, game.id],
+  )
 
   return (
     <StyledGameContainer isHorizontal={isHorizontal}>
@@ -219,11 +224,7 @@ export const Game: React.FC<React.PropsWithChildren<GameProps>> = ({ isLatest, g
                     )}
                   </Flex>
                 </Flex>
-                <Link
-                  width="100% !important"
-                  href={`/project/${game.id}`}
-                  mb={['32px', '32px', '32px', '32px', '32px', '49px']}
-                >
+                <Link width="100% !important" href={gameLink} mb={['32px', '32px', '32px', '32px', '32px', '49px']}>
                   <Button width="100%">
                     <Text bold color="white">
                       {t('Play Now')}

--- a/apps/games/hooks/useGameLink.ts
+++ b/apps/games/hooks/useGameLink.ts
@@ -1,0 +1,10 @@
+import { useMatchBreakpoints } from '@pancakeswap/uikit'
+import { useMemo } from 'react'
+
+import { getGameLink } from 'utils/getGameLink'
+
+export function useGameLink(gameId: string) {
+  const { isMobile } = useMatchBreakpoints()
+
+  return useMemo(() => getGameLink({ gameId, isMobile }), [isMobile, gameId])
+}

--- a/apps/games/utils/getGameLink.ts
+++ b/apps/games/utils/getGameLink.ts
@@ -1,0 +1,3 @@
+export function getGameLink({ gameId, isMobile }: { gameId: string; isMobile?: boolean }) {
+  return gameId === 'pancake-protectors' && isMobile ? 'https://protectors.pancakeswap.finance' : `/project/${gameId}`
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3cb31e1</samp>

### Summary
🥞📱🪝

<!--
1.  🥞 - This emoji represents the Pancake Protectors game, which is the main feature of this pull request.
2.  📱 - This emoji represents the mobile support that is added to the game, allowing users to play it on their phones or tablets.
3.  🪝 - This emoji represents the `useMemo` hook that is used to optimize the game URL generation, avoiding unnecessary re-renders.
-->
Add mobile support for Pancake Protectors game. Use `useMemo` to generate game URL in `Game.tsx`.

> _`useMemo` to escape the doom_
> _Link to the game of your choice_
> _Mobile warriors, join the fight_
> _Pancake Protectors, raise your voice_

### Walkthrough
*  Create a `gameLink` variable to hold the URL for the game based on the device type and the game id ([link](https://github.com/pancakeswap/pancake-frontend/pull/8370/files?diff=unified&w=0#diff-4d88fdb79ab1a37f22978aed083dd6defe294333ec9d31ff69623e8e5d71dc5aR100-R104))
*  Use the `gameLink` variable as the href attribute of the Link component in `Game.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8370/files?diff=unified&w=0#diff-4d88fdb79ab1a37f22978aed083dd6defe294333ec9d31ff69623e8e5d71dc5aL222-R227))


