### PR TITLE
refactor: Use query in profile

### DIFF
--- a/apps/web/src/views/Profile/components/PancakeCollectibles.tsx
+++ b/apps/web/src/views/Profile/components/PancakeCollectibles.tsx
@@ -1,7 +1,6 @@
 import { Grid, Heading, PageHeader } from '@pancakeswap/uikit'
-import useSWR from 'swr'
 import dynamic from 'next/dynamic'
-import { FetchStatus } from 'config/constants/types'
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from '@pancakeswap/localization'
 import { Collection } from 'state/nftMarket/types'
 import Page from 'components/Layout/Page'
@@ -15,7 +14,7 @@ const CollectionCardWithVolume = dynamic(
 
 const PancakeCollectibles = () => {
   const { t } = useTranslation()
-  const { data: collections, status } = useSWR<Collection[]>(['pancakeCollectibles'])
+  const { data: collections, status } = useQuery<Collection[]>(['pancakeCollectibles'])
 
   return (
     <>
@@ -25,7 +24,7 @@ const PancakeCollectibles = () => {
         </Heading>
       </PageHeader>
       <Page>
-        {status !== FetchStatus.Fetched ? (
+        {status !== 'success' ? (
           <PageLoader />
         ) : (
           <>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1543219</samp>

### Summary
🧹🔄🚀

<!--
1.  🧹 - This emoji represents the removal of unused imports and code, as well as the refactoring of `getStaticProps` to use `@tanstack/react-query`. It conveys the idea of cleaning up and improving the code quality.
2.  🔄 - This emoji represents the replacement of `swr` with `@tanstack/react-query` for data fetching and updating. It conveys the idea of changing and updating the data fetching logic and dependencies.
3.  🚀 - This emoji represents the improvement of the performance and consistency of the data fetching logic by using `useQuery`. It conveys the idea of speeding up and enhancing the user experience.
-->
Refactored the profile and pancake collectibles pages to use `@tanstack/react-query` instead of `swr` for data fetching and caching. This improves the query data handling, serialization, and performance, and reduces the dependencies of the files.

> _Oh we're the coders of the pancake ship_
> _And we work with queries and hooks_
> _We've switched from `useSWR` to `useQuery`_
> _To improve our data fetching looks_

### Walkthrough
*  Replace `useSWR` and `useSWRImmutable` hooks with `useQuery` hook from `@tanstack/react-query` to fetch and update profile and achievements data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-d3a63e10677e970afdb0dcc3874a4347abb445a549ee72a7d8e4e3478f5b1f4bL5-R5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-d3a63e10677e970afdb0dcc3874a4347abb445a549ee72a7d8e4e3478f5b1f4bL23-R30), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-d3a63e10677e970afdb0dcc3874a4347abb445a549ee72a7d8e4e3478f5b1f4bL37-R37), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-d3a63e10677e970afdb0dcc3874a4347abb445a549ee72a7d8e4e3478f5b1f4bL45-R54), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-d3a63e10677e970afdb0dcc3874a4347abb445a549ee72a7d8e4e3478f5b1f4bL62-R88))
* Simplify `PancakeCollectiblesPage` component to only render `PancakeCollectiblesPageRouter` component and pass `dehydratedState` prop with serialized query data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-91918428291c6b84832f06979d737fce8b7878f64cf77071fd1ebc451ecf96f3L12-R24))
* Use `queryClient` and `dehydrate` to create and serialize query data for `pancakeCollectibles` key in `getStaticProps` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-91918428291c6b84832f06979d737fce8b7878f64cf77071fd1ebc451ecf96f3L56-R54), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-91918428291c6b84832f06979d737fce8b7878f64cf77071fd1ebc451ecf96f3L67-R61))
* Remove unused imports of `InferGetStaticPropsType` and `SWRConfig` from `pancake-collectibles.tsx` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-91918428291c6b84832f06979d737fce8b7878f64cf77071fd1ebc451ecf96f3L1-R2))
* Use `useQuery` hook to fetch collections data in `PancakeCollectibles` component and use `success` status instead of `Fetched` status ([link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-773d8311b919a88117cfe32e0bb542d26df055344701f20f7cae027fb6454cb5L2-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-773d8311b919a88117cfe32e0bb542d26df055344701f20f7cae027fb6454cb5L18-R17), [link](https://github.com/pancakeswap/pancake-frontend/pull/8395/files?diff=unified&w=0#diff-773d8311b919a88117cfe32e0bb542d26df055344701f20f7cae027fb6454cb5L28-R27))




<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Replaced `useSWR` with `useQuery` from `@tanstack/react-query` in `PancakeCollectibles.tsx`, `pancake-collectibles.tsx`, and `hooks.ts` files.
- Removed unused imports.
- Updated the code to use the new `useQuery` API.
- Replaced `useSWRImmutable` with `useQuery` in the `useProfile` and `useAchievementsForAddress` hooks.
- Updated the code to handle the new `useQuery` API in the `useProfile` and `useAchievementsForAddress` hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->