### PR TITLE
chore: Don't set swiper in game

### DIFF
--- a/apps/games/components/Game/Home/Games.tsx
+++ b/apps/games/components/Game/Home/Games.tsx
@@ -1,5 +1,5 @@
 import { styled, useTheme } from 'styled-components'
-import { useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import dayjs from 'dayjs'
 import { GameType } from '@pancakeswap/games'
 import { useTranslation } from '@pancakeswap/localization'
@@ -8,7 +8,6 @@ import { StyledTextLineClamp } from 'components/Game/StyledTextLineClamp'
 
 import 'swiper/css'
 import { Swiper, SwiperSlide } from 'swiper/react'
-import type { Swiper as SwiperClass } from 'swiper/types'
 
 const StyledCard = styled(Box)<{ picked?: boolean }>`
   position: relative;
@@ -104,7 +103,6 @@ interface GamesProps {
 export const Games: React.FC<React.PropsWithChildren<GamesProps>> = ({ otherGames, pickedGameId, setPickedGameId }) => {
   const { t } = useTranslation()
   const { isDark } = useTheme()
-  const [_, setSwiper] = useState<SwiperClass | undefined>(undefined)
 
   const getTime = useCallback((timestamp: number) => {
     const timeToMilliseconds = timestamp * 1000
@@ -115,7 +113,6 @@ export const Games: React.FC<React.PropsWithChildren<GamesProps>> = ({ otherGame
     <StyledSwiper
       slidesPerView={1}
       spaceBetween={10}
-      onSwiper={setSwiper}
       navigation={{
         prevEl: '.prev',
         nextEl: '.next',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 62c8428</samp>

### Summary
🧹🔄🎮

<!--
1.  🧹 - This emoji conveys the idea of cleaning up or simplifying the code, which is the main purpose of this pull request.
2.  🔄 - This emoji conveys the idea of updating or refreshing the code, which is another aspect of this pull request since it makes the `Swiper` component more consistent and aligned with the `activeIndex` state variable.
3.  🎮 - This emoji conveys the idea of games, which is the domain of the `Games` component and the `Swiper` component that displays the games.
-->
Simplify state management of `Swiper` component in `Games` component. Remove unused state variable and prop and use `activeIndex` to control the active game.

> _`Swiper` simpler now_
> _No more unused state or prop_
> _Cutting like winter_

### Walkthrough
*  Remove unused state variable and prop for Swiper component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8397/files?diff=unified&w=0#diff-8cc47931d7b1bf3ec2c4bf09005c411f5fd8f5019d90590dbc4010ebee003811L107), [link](https://github.com/pancakeswap/pancake-frontend/pull/8397/files?diff=unified&w=0#diff-8cc47931d7b1bf3ec2c4bf09005c411f5fd8f5019d90590dbc4010ebee003811L118))


