### PR TITLE
fix: Responsive on increase veCake card

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockCake/Staking.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCake/Staking.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Grid, Heading } from '@pancakeswap/uikit'
+import { Grid, Heading, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { StyledCard } from './styled'
 import { LockCakeForm } from '../LockCakeForm'
 import { LockWeeksForm } from '../LockWeeksForm'
 
 export const Staking = () => {
   const { t } = useTranslation()
+  const { isDesktop } = useMatchBreakpoints()
   return (
     <StyledCard innerCardProps={{ padding: '24px' }}>
       <Heading scale="md">{t('Increase your veCAKE')}</Heading>
-      <Grid gridTemplateColumns="1fr 1fr" mt={32} gridColumnGap="24px">
+      <Grid gridTemplateColumns={isDesktop ? '1fr 1fr' : '1fr'} mt={32} gridColumnGap="24px" gridRowGap="24px">
         <LockCakeForm />
         <LockWeeksForm />
       </Grid>

--- a/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
@@ -86,10 +86,11 @@ const CakeInput: React.FC<{
         unit={balance}
       />
       {!disabled && balance ? (
-        <FlexGap justifyContent="space-between" flexWrap={isDesktop ? 'nowrap' : 'wrap'} gap="4px" width="100%">
+        <FlexGap justifyContent="space-between" flexWrap="wrap" gap="4px" width="100%">
           {percentShortcuts.map((p) => {
             return (
               <Button
+                key={p}
                 style={{ flex: 1 }}
                 scale={isDesktop ? 'sm' : 'xs'}
                 variant={p === percent ? 'primary' : 'tertiary'}

--- a/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
@@ -51,7 +51,7 @@ const WeekInput: React.FC<{
         unit={t('Weeks')}
       />
       {disabled ? null : (
-        <FlexGap justifyContent="space-between" flexWrap={isDesktop ? 'nowrap' : 'wrap'} gap="4px" width="100%">
+        <FlexGap justifyContent="space-between" flexWrap="wrap" gap="4px" width="100%">
           {weeks.map((week) => (
             <Button
               key={week}

--- a/apps/web/src/views/CakeStaking/components/LockedVeCakeStatus.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockedVeCakeStatus.tsx
@@ -59,7 +59,7 @@ export const LockedVeCakeStatus: React.FC<{
       />
     )
   return (
-    <Box maxWidth={['100%', '369px']}>
+    <Box maxWidth={['100%', '100%', '369px']} width="100%">
       <Card isActive>
         <CardHeader>
           <RowBetween>

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { SortArrowIcon, Text } from '@pancakeswap/uikit'
+import { SortArrowIcon, Text, Th } from '@pancakeswap/uikit'
 import { useState } from 'react'
 import styled from 'styled-components'
 import { SortButton } from 'views/V3Info/components/SortButton'
@@ -55,28 +55,36 @@ export const TableHeader: React.FC<{
 
   return (
     <THeader>
-      <Text color="secondary" textTransform="uppercase" fontWeight={600} ml={selectable ? 44 : 0}>
-        {t('gauges')}
-      </Text>
-      <Touchable>
-        <Text color="secondary" textTransform="uppercase" fontWeight={600}>
-          {t('votes')}
+      <Th style={{ textAlign: 'left' }}>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600} ml={selectable ? 44 : 0}>
+          {t('gauges')}
         </Text>
-        <SortButton scale="sm" variant="subtle" onClick={onVoteSort} className={getSortClassName(voteSort)}>
-          <SortArrowIcon />
-        </SortButton>
-      </Touchable>
-      <Touchable>
-        <Text color="secondary" textTransform="uppercase" fontWeight={600}>
-          {t('boost')}
+      </Th>
+      <Th>
+        <Touchable>
+          <Text color="secondary" textTransform="uppercase" fontWeight={600}>
+            {t('votes')}
+          </Text>
+          <SortButton scale="sm" variant="subtle" onClick={onVoteSort} className={getSortClassName(voteSort)}>
+            <SortArrowIcon />
+          </SortButton>
+        </Touchable>
+      </Th>
+      <Th>
+        <Touchable>
+          <Text color="secondary" textTransform="uppercase" fontWeight={600}>
+            {t('boost')}
+          </Text>
+          <SortButton scale="sm" variant="subtle" onClick={onBoostSort} className={getSortClassName(boostSort)}>
+            <SortArrowIcon />
+          </SortButton>
+        </Touchable>
+      </Th>
+      <Th>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600} textAlign="right">
+          {t('caps')}
         </Text>
-        <SortButton scale="sm" variant="subtle" onClick={onBoostSort} className={getSortClassName(boostSort)}>
-          <SortArrowIcon />
-        </SortButton>
-      </Touchable>
-      <Text color="secondary" textTransform="uppercase" fontWeight={600} textAlign="right">
-        {t('caps')}
-      </Text>
+      </Th>
     </THeader>
   )
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
@@ -2,6 +2,7 @@ import orderBy from 'lodash/orderBy'
 import uniqBy from 'lodash/uniqBy'
 import { useMemo, useState } from 'react'
 import styled from 'styled-components'
+import { space, SpaceProps } from 'styled-system'
 import { GaugeVoting } from 'views/GaugesVoting/hooks/useGaugesVoting'
 import { SortBy, SortField, TableHeader } from './TableHeader'
 import { ExpandRow, TableRow } from './TableRow'
@@ -13,14 +14,22 @@ const Scrollable = styled.div.withConfig({ shouldForwardProp: (prop) => !['expan
   height: ${({ expanded }) => (expanded ? 'auto' : '192px')};
 `
 
-export const GaugesTable: React.FC<{
-  scrollStyle?: React.CSSProperties
-  totalGaugesWeight: number
-  data?: GaugeVoting[]
-  selectable?: boolean
-  selectRows?: GaugeVoting[]
-  onRowSelect?: (hash: GaugeVoting['hash']) => void
-}> = ({ scrollStyle, data, totalGaugesWeight, selectable, selectRows, onRowSelect }) => {
+const Table = styled.table`
+  width: 100%;
+
+  ${space}
+`
+
+export const GaugesTable: React.FC<
+  {
+    scrollStyle?: React.CSSProperties
+    totalGaugesWeight: number
+    data?: GaugeVoting[]
+    selectable?: boolean
+    selectRows?: GaugeVoting[]
+    onRowSelect?: (hash: GaugeVoting['hash']) => void
+  } & SpaceProps
+> = ({ scrollStyle, data, totalGaugesWeight, selectable, selectRows, onRowSelect, ...props }) => {
   const [expanded, setExpanded] = useState(false)
   const [sortKey, setSortKey] = useState<SortField | undefined>()
   const [sortBy, setSortBy] = useState<SortBy | undefined>()
@@ -37,7 +46,7 @@ export const GaugesTable: React.FC<{
   }
 
   return (
-    <>
+    <Table {...props}>
       <TableHeader onSort={handleSort} selectable={selectable} />
       <Scrollable expanded={expanded} style={scrollStyle}>
         {sortedData?.map((row) => (
@@ -52,6 +61,6 @@ export const GaugesTable: React.FC<{
         ))}
       </Scrollable>
       <ExpandRow onCollapse={() => setExpanded(!expanded)} />
-    </>
+    </Table>
   )
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/TableHeader.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Text } from '@pancakeswap/uikit'
+import { Text, Th } from '@pancakeswap/uikit'
 import { THeader } from '../styled'
 
 export const TableHeader: React.FC<{
@@ -8,20 +8,26 @@ export const TableHeader: React.FC<{
   const { t } = useTranslation()
   return (
     <THeader style={{ borderTop: 'none' }}>
-      <Text color="secondary" textTransform="uppercase" fontWeight={600}>
-        {t('gauges')}({count})
-      </Text>
-      <Text color="secondary" textTransform="uppercase" fontWeight={600}>
-        {t('current votes')}
-      </Text>
-
-      <Text color="secondary" textTransform="uppercase" fontWeight={600}>
-        {t('preview votes')}
-      </Text>
-
-      <Text color="secondary" textTransform="uppercase" fontWeight={600} textAlign="right">
-        {t('My veCake %')}
-      </Text>
+      <Th style={{ textAlign: 'left' }}>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600}>
+          {t('gauges')}({count})
+        </Text>
+      </Th>
+      <Th>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600}>
+          {t('current votes')}
+        </Text>
+      </Th>
+      <Th>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600}>
+          {t('preview votes')}
+        </Text>
+      </Th>
+      <Th>
+        <Text color="secondary" textTransform="uppercase" fontWeight={600} textAlign="right">
+          {t('My veCake %')}
+        </Text>
+      </Th>
     </THeader>
   )
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/styled.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/styled.tsx
@@ -19,6 +19,8 @@ export const Row = css`
 
 export const THeader = styled.thead`
   ${Row}
+
+  padding: 0;
 `
 
 export const TRow = styled.tr`

--- a/apps/web/src/views/GaugesVoting/index.tsx
+++ b/apps/web/src/views/GaugesVoting/index.tsx
@@ -96,7 +96,7 @@ const GaugesVoting = () => {
               <WeightsPieChart totalGaugesWeight={Number(totalGaugesWeight)} data={gauges} />
             </div>
           </Grid>
-          <GaugesTable data={gauges} totalGaugesWeight={Number(totalGaugesWeight)} />
+          <GaugesTable mt="1.5em" data={gauges} totalGaugesWeight={Number(totalGaugesWeight)} />
         </Card>
         <Box mt="80px">
           <Heading as="h2" scale="xl" mb="24px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6ecfce1</samp>

### Summary
📱🎨♻️

<!--
1.  📱 - This emoji represents the changes that improve the responsiveness and layout of the components on different screen sizes and devices.
2.  🎨 - This emoji represents the changes that enhance the styling and appearance of the components using the UI kit and the styled components.
3.  ♻️ - This emoji represents the changes that refactor the code and improve the semantic and visual structure of the components.
-->
This pull request improves the responsiveness and styling of the cake staking and gauges voting features. It uses custom hooks, UI kit components, and styled components to adjust the layout and appearance of various components. It also fixes some React warnings and removes unnecessary conditions. The main files affected are `Staking.tsx`, `GaugesTable/index.tsx`, and `LockCakeForm.tsx`.

> _Sing, O Muse, of the glorious deeds of the developers_
> _Who with skill and wisdom improved the cake staking feature_
> _They made the `LockCakeForm` and the `LockWeeksForm` responsive_
> _And wrapped the buttons with `flexWrap` like a nimble weaver_

### Walkthrough
*  Import and use `useMatchBreakpoints` hook to make `Staking` component responsive ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-c60b72b7170b74ed6d4056df0262b652a22bb0998e73d4f7d9db0a7daa231a50L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-c60b72b7170b74ed6d4056df0262b652a22bb0998e73d4f7d9db0a7daa231a50L9-R13))
*  Remove `isDesktop` condition and add `key` prop to make `LockCakeForm` and `LockWeeksForm` components wrap buttons on smaller screens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-748e847901e3090db86324bb7fd2efc288b6c65ac6a74ef4cc88a1a59c505c36L89-R93), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-64ddb2e1e44c6e415b155a11662c74ada277c86c4f1e81485bb1d731076923b2L54-R54))
*  Adjust `width` and `maxWidth` props to make `LockedVeCakeStatus` component fill space on smaller screens ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-01ed07375da1f63ba8cbddacd7c4baaea5a047d301f640111e52708ac9531aceL62-R62))
*  Import and use `space` function and `SpaceProps` type to apply margin and padding styles to `GaugesTable` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cR5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cL16-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-d978657963a2d4ae2b8e9d1bc08548263f6c44d3f60c193190ef02236a111df1L99-R99))
*  Replace `div` element with styled `table` element and render `TableHeader` and `ExpandRow` components inside it in `GaugesTable` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cL16-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cL40-R49), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cL55-R64))
*  Import and use `Th` component and apply text alignment styles to table headers in `TableHeader` components for `GaugesTable` and `VoteTable` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-1e19294b710179d62409777fc1c830d24ad1429ea32b6d06a0b169215b305232L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-1e19294b710179d62409777fc1c830d24ad1429ea32b6d06a0b169215b305232L58-R87), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-4ebeada21ef3e9c14567c898737462002f13b8a4bfc35d7c910203e087ddc109L2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-4ebeada21ef3e9c14567c898737462002f13b8a4bfc35d7c910203e087ddc109L11-R30))
*  Remove default padding from `tr` element in `THeader` styled component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8404/files?diff=unified&w=0#diff-0ac4893d32da8d149689cd782801f7d9bfa06df5d6d109cf3d981b9fab68b074R22-R23))


