### PR TITLE
fix: Show gauges list on mobile

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/GaugeTokenImage.tsx
+++ b/apps/web/src/views/GaugesVoting/components/GaugeTokenImage.tsx
@@ -4,12 +4,17 @@ import { GaugeALMConfig, GaugeConfig, GaugeType, GaugeV2Config, GaugeV3Config } 
 import { useMemo } from 'react'
 import { Address } from 'viem'
 
-const GaugeSingleTokenImage = () => {
-  return <img src="/images/cake-staking/token-vecake.png" alt="ve-cake" width="32px" height="32px" />
+type Props = {
+  size?: number
 }
 
-const GaugeDoubleTokenImage: React.FC<{ gaugeConfig: GaugeV2Config | GaugeV3Config | GaugeALMConfig }> = ({
+const GaugeSingleTokenImage = ({ size = 32 }: Props) => {
+  return <img src="/images/cake-staking/token-vecake.png" alt="ve-cake" width={size} height={size} />
+}
+
+const GaugeDoubleTokenImage: React.FC<{ gaugeConfig: GaugeV2Config | GaugeV3Config | GaugeALMConfig } & Props> = ({
   gaugeConfig,
+  size = 32,
 }) => {
   const currency0 = useMemo<Token | undefined>(() => {
     if (gaugeConfig.token0Address)
@@ -22,17 +27,19 @@ const GaugeDoubleTokenImage: React.FC<{ gaugeConfig: GaugeV2Config | GaugeV3Conf
     return undefined
   }, [gaugeConfig.chainId, gaugeConfig.token1Address])
 
-  return <DoubleCurrencyLogo size={32} currency0={currency0} currency1={currency1} />
+  return <DoubleCurrencyLogo size={size} currency0={currency0} currency1={currency1} />
 }
 
-export const GaugeTokenImage: React.FC<{
-  gauge?: GaugeConfig
-}> = ({ gauge }) => {
+export const GaugeTokenImage: React.FC<
+  {
+    gauge?: GaugeConfig
+  } & Props
+> = ({ gauge, size }) => {
   if (!gauge) return null
 
   if (gauge?.type === GaugeType.VeCakePool) {
-    return <GaugeSingleTokenImage />
+    return <GaugeSingleTokenImage size={size} />
   }
 
-  return <GaugeDoubleTokenImage gaugeConfig={gauge} />
+  return <GaugeDoubleTokenImage gaugeConfig={gauge} size={size} />
 }

--- a/apps/web/src/views/GaugesVoting/components/NetworkBadge/NetworkBadge.tsx
+++ b/apps/web/src/views/GaugesVoting/components/NetworkBadge/NetworkBadge.tsx
@@ -62,6 +62,10 @@ const Badge = styled.div.withConfig({ shouldForwardProp: (prop) => prop !== 'sca
   gap: ${({ scale }) => (scale === 'sm' ? '4px' : '8px')};
 `
 
+const BadgeText = styled(Text)<{ scale?: Scale }>`
+  font-size: ${({ scale }) => (scale === 'sm' ? '14px' : '16px')};
+`
+
 export const NetworkBadge: React.FC<{
   color?: NetworkLogoTheme
   chainId?: number
@@ -85,9 +89,9 @@ export const NetworkBadge: React.FC<{
       }}
     >
       <NetworkLogo type={color} chainId={chainId} />
-      <Text color={textColor} bold>
+      <BadgeText color={textColor} bold scale={scale}>
         {short ? shortName : longName}
-      </Text>
+      </BadgeText>
     </Badge>
   )
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/List.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/List.tsx
@@ -1,0 +1,99 @@
+import { SpaceProps } from 'styled-system'
+import { Text, Flex, FlexGap, Tag, PaginationButton } from '@pancakeswap/uikit'
+import styled from 'styled-components'
+import { CSSProperties, useEffect, useMemo, useState } from 'react'
+import { Address } from 'viem'
+
+import { GAUGE_TYPE_NAMES, GaugeType } from 'config/constants/types'
+import { GaugeVoting } from 'views/GaugesVoting/hooks/useGaugesVoting'
+import { useGaugeConfig } from 'views/GaugesVoting/hooks/useGaugePair'
+import { feeTierPercent } from 'views/V3Info/utils'
+
+import { GaugeTokenImage } from '../../GaugeTokenImage'
+import { NetworkBadge } from '../../NetworkBadge'
+
+const ListContainer = styled(Flex)`
+  margin-left: -32px;
+  margin-right: -32px;
+`
+
+const ListItemContainer = styled(FlexGap)`
+  padding: 0.875em;
+  border-bottom: 1px solid ${(props) => props.theme.colors.cardBorder};
+`
+
+type ListProps = {
+  pageSize?: number
+  scrollStyle?: CSSProperties
+  totalGaugesWeight: number
+  data?: GaugeVoting[]
+  selectable?: boolean
+  selectRows?: GaugeVoting[]
+  onRowSelect?: (hash: GaugeVoting['hash']) => void
+} & SpaceProps
+
+export function GaugesList({
+  pageSize = 5,
+  scrollStyle,
+  data,
+  totalGaugesWeight,
+  selectable,
+  selectRows,
+  onRowSelect,
+  ...props
+}: ListProps) {
+  const [page, setPage] = useState(1)
+  const maxPage = useMemo(() => (data && data.length ? Math.ceil(data.length / pageSize) : 1), [data, pageSize])
+
+  useEffect(() => {
+    if (maxPage > page) {
+      setPage(1)
+    }
+  }, [maxPage])
+
+  const dataDisplay = useMemo(() => data?.slice((page - 1) * pageSize, page * pageSize), [data, page])
+  const list = dataDisplay?.map((item) => <ListItem key={item.pid} data={item} />)
+
+  return (
+    <ListContainer {...props} flexDirection="column">
+      {list}
+      <PaginationButton showMaxPageText maxPage={maxPage} currentPage={page} setCurrentPage={setPage} />
+    </ListContainer>
+  )
+}
+
+type ListItemProps = {
+  data: GaugeVoting
+  selectable?: boolean
+  selected?: boolean
+  onSelect?: (hash: GaugeVoting['hash']) => void
+  totalGaugesWeight?: number
+}
+
+export function ListItem({ data, totalGaugesWeight, selected, selectable, onSelect }: ListItemProps) {
+  const pool = useGaugeConfig(data?.pairAddress as Address, Number(data?.chainId || undefined))
+
+  return (
+    <ListItemContainer gap="1em" flexDirection="column">
+      <Flex justifyContent="space-between" flex="1">
+        <FlexGap gap="0.25em" flexWrap="wrap">
+          <GaugeTokenImage gauge={pool} size={24} />
+          <Text fontWeight={600} fontSize={16}>
+            {pool?.pairName}
+          </Text>
+        </FlexGap>
+        <FlexGap gap="0.25em" justifyContent="flex-end" flexWrap="wrap">
+          <NetworkBadge chainId={Number(data?.chainId)} scale="sm" />
+          {pool?.type === GaugeType.V3 ? (
+            <Tag outline variant="secondary" scale="sm">
+              {feeTierPercent(pool.feeTier)}
+            </Tag>
+          ) : null}
+          <Tag variant="secondary" scale="sm">
+            {pool ? GAUGE_TYPE_NAMES[pool.type] : ''}
+          </Tag>
+        </FlexGap>
+      </Flex>
+    </ListItemContainer>
+  )
+}

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
@@ -20,6 +20,8 @@ const Table = styled.table`
   ${space}
 `
 
+export * from './List'
+
 export const GaugesTable: React.FC<
   {
     scrollStyle?: React.CSSProperties

--- a/apps/web/src/views/GaugesVoting/index.tsx
+++ b/apps/web/src/views/GaugesVoting/index.tsx
@@ -20,7 +20,7 @@ import { MyVeCakeBalance } from './components/MyVeCakeBalance'
 import { RemainVeCakeBalance } from './components/RemainVeCakeBalance'
 import { CurrentEpoch } from './components/CurrentEpoch'
 import { WeightsPieChart } from './components/WeightsPieChart'
-import { GaugesTable, VoteTable } from './components/Table'
+import { GaugesTable, VoteTable, GaugesList } from './components/Table'
 import { useGaugesVoting } from './hooks/useGaugesVoting'
 import { useGaugesTotalWeight } from './hooks/useGaugesTotalWeight'
 
@@ -96,7 +96,11 @@ const GaugesVoting = () => {
               <WeightsPieChart totalGaugesWeight={Number(totalGaugesWeight)} data={gauges} />
             </div>
           </Grid>
-          <GaugesTable mt="1.5em" data={gauges} totalGaugesWeight={Number(totalGaugesWeight)} />
+          {isDesktop ? (
+            <GaugesTable mt="1.5em" data={gauges} totalGaugesWeight={Number(totalGaugesWeight)} />
+          ) : (
+            <GaugesList mt="1.5em" data={gauges} totalGaugesWeight={Number(totalGaugesWeight)} />
+          )}
         </Card>
         <Box mt="80px">
           <Heading as="h2" scale="xl" mb="24px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eb12a9f</samp>

### Summary
📱📊🎨

<!--
1.  📱 - This emoji represents the improvement of the mobile responsiveness and user experience of the voting interface by using the new `GaugesList` component.
2.  📊 - This emoji represents the creation of the new `GaugesList` component that renders a list of gauges with their relevant information and tags.
3.  🎨 - This emoji represents the adjustment of the token image and network badge components to improve the layout and design of the gauges voting view.
-->
Improved the responsiveness and design of the gauges voting view by creating new components and props for the token images, network badges, and gauges list. Refactored the `GaugesTable` component to export the new `GaugesList` component from the same folder.

> _`GaugesList` component_
> _shows voting options on mobile_
> _cutting edge design_

### Walkthrough
*  Add `GaugesList` component to render a paginated list of gauges with token images, names, network badges, and tags on mobile devices ([link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-a668b2f710e56c990040f3ef0d53d456ce7a8ffec58b57cdbea2e55076167eebR1-R99), [link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-3ecb78652d928e1cdf8696b97b3bdc5040ab71013a4e690f94b6a77b44cf5e8cR23-R24), [link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-d978657963a2d4ae2b8e9d1bc08548263f6c44d3f60c193190ef02236a111df1L23-R23), [link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-d978657963a2d4ae2b8e9d1bc08548263f6c44d3f60c193190ef02236a111df1L99-R103))
*  Modify `GaugeTokenImage` component and its subcomponents to accept a `size` prop that determines the width and height of the token images ([link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-4bb2d2b4d086eaf23b088567858d94b674decc139f1ed76380f654f1184f6ebaL7-R17), [link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-4bb2d2b4d086eaf23b088567858d94b674decc139f1ed76380f654f1184f6ebaL25-R44))
*  Create `BadgeText` styled component to customize the font size of the text inside the `NetworkBadge` component based on a `scale` prop ([link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-bff8cda7d7e2d8d1c04b71fc9e674078d5f82fa8383472dbb7701a1d9e445295R65-R68), [link](https://github.com/pancakeswap/pancake-frontend/pull/8405/files?diff=unified&w=0#diff-bff8cda7d7e2d8d1c04b71fc9e674078d5f82fa8383472dbb7701a1d9e445295L88-R94))


