### PR TITLE
refactor: Use query in user

### DIFF
--- a/apps/web/src/state/user/hooks/index.tsx
+++ b/apps/web/src/state/user/hooks/index.tsx
@@ -287,9 +287,9 @@ export function useFeeDataWithGasPrice(chainIdOverride?: number): {
   }
 
   return {
-    gasPrice: data?.gasPrice || undefined,
-    maxFeePerGas: data?.maxFeePerGas || undefined,
-    maxPriorityFeePerGas: data?.maxPriorityFeePerGas || undefined,
+    gasPrice: data?.gasPrice ?? undefined,
+    maxFeePerGas: data?.maxFeePerGas ?? undefined,
+    maxPriorityFeePerGas: data?.maxPriorityFeePerGas ?? undefined,
   }
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9ac0e76</samp>

### Summary
🪄🔄🚀

<!--
1.  🪄 - This emoji can be used to represent the magic of the useQuery hook, which simplifies the data fetching and caching logic and provides useful features like loading and error states, refetching, and stale-while-revalidate.
2.  🔄 - This emoji can be used to represent the refetching and updating of the data, which happens automatically when the user switches between tabs or changes the network. It also indicates that the data is always fresh and consistent with the BSC provider and the API.
3.  🚀 - This emoji can be used to represent the performance and speed improvements that result from using the useQuery hook, which reduces the number of unnecessary requests and renders and optimizes the data fetching and caching strategies. It also suggests that the app is ready to launch and scale.
-->
Refactor user state hooks to use `useQuery` for better data fetching and caching. Fix null values issue with `ethers`.

> _`useQuery` hook_
> _fetches and caches the data_
> _no more null values_

### Walkthrough
*  Refactor state management from SWR to React Query for data fetching and caching ([link](https://github.com/pancakeswap/pancake-frontend/pull/8409/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL9-R10), [link](https://github.com/pancakeswap/pancake-frontend/pull/8409/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL305-R308), [link](https://github.com/pancakeswap/pancake-frontend/pull/8409/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL315-R316), [link](https://github.com/pancakeswap/pancake-frontend/pull/8409/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL379-R396))
*  Fix gas price fields to return undefined instead of null when data is not available ([link](https://github.com/pancakeswap/pancake-frontend/pull/8409/files?diff=unified&w=0#diff-7acbe01a6b7a8f36fbe0de10452d115ec58939c08c443ae16188bc4feb5921deL289-R290))

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Replaced `useSWR` with `useQuery` from `@tanstack/react-query` for fetching data.
- Updated options and parameters for `useQuery`.
- Refactored the code to improve readability and maintainability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->