### PR TITLE
refactor: Use query in menu

### DIFF
--- a/apps/web/src/components/Menu/UserMenu/CakeBenefitsCard.tsx
+++ b/apps/web/src/components/Menu/UserMenu/CakeBenefitsCard.tsx
@@ -14,7 +14,6 @@ import {
 import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 
 import { VaultPosition } from 'utils/cakePool'
-import { FetchStatus } from 'config/constants/types'
 import { useTranslation } from '@pancakeswap/localization'
 import { styled } from 'styled-components'
 import useCakeBenefits from './hooks/useCakeBenefits'
@@ -146,9 +145,9 @@ const CakeBenefitsCard: React.FC<React.PropsWithChildren<CakeBenefitsCardProps>>
     },
   )
 
-  return cakeBenefitsFetchStatus === FetchStatus.Fetched ? (
+  return cakeBenefitsFetchStatus === 'success' ? (
     <>
-      {[VaultPosition.None, VaultPosition.Flexible].includes(cakeBenefits?.lockPosition) ? (
+      {cakeBenefits && [VaultPosition.None, VaultPosition.Flexible].includes(cakeBenefits?.lockPosition) ? (
         <>
           <Flex flexDirection="row" alignItems="center">
             <Tag variant="secondary" mr="auto">
@@ -174,7 +173,7 @@ const CakeBenefitsCard: React.FC<React.PropsWithChildren<CakeBenefitsCardProps>>
             </MessageText>
           </Message>
         </>
-      ) : [VaultPosition.LockedEnd, VaultPosition.AfterBurning].includes(cakeBenefits?.lockPosition) ? (
+      ) : cakeBenefits && [VaultPosition.LockedEnd, VaultPosition.AfterBurning].includes(cakeBenefits?.lockPosition) ? (
         <>
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
             <Tag variant="failure" mr="auto">

--- a/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
+++ b/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
@@ -1,6 +1,6 @@
 import { useAccount } from 'wagmi'
 import BigNumber from 'bignumber.js'
-import useSWR from 'swr'
+import { useQuery } from '@tanstack/react-query'
 import { useIfoCreditAddressContract } from 'hooks/useContract'
 import { ChainId } from '@pancakeswap/chains'
 import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
@@ -28,67 +28,69 @@ const useCakeBenefits = () => {
   const cakeVaultAddress = getCakeVaultAddress()
   const currentBscBlock = useChainCurrentBlock(ChainId.BSC)
 
-  const { data, status } = useSWR(account && currentBscBlock && ['cakeBenefits', account], async () => {
-    const [userInfo, currentPerformanceFee, currentOverdueFee, sharePrice] = await bscClient.multicall({
-      contracts: [
-        {
-          address: cakeVaultAddress,
-          abi: cakeVaultV2ABI,
-          functionName: 'userInfo',
-          args: [account],
-        },
-        {
-          address: cakeVaultAddress,
-          abi: cakeVaultV2ABI,
-          functionName: 'calculatePerformanceFee',
-          args: [account],
-        },
-        {
-          address: cakeVaultAddress,
-          abi: cakeVaultV2ABI,
-          functionName: 'calculateOverdueFee',
-          args: [account],
-        },
-        {
-          address: cakeVaultAddress,
-          abi: cakeVaultV2ABI,
-          functionName: 'getPricePerFullShare',
-        },
-      ],
-      allowFailure: false,
-    })
+  const { data, status } = useQuery(
+    ['cakeBenefits', account],
+    async () => {
+      if (!account) return undefined
+      const [userInfo, currentPerformanceFee, currentOverdueFee, sharePrice] = await bscClient.multicall({
+        contracts: [
+          {
+            address: cakeVaultAddress,
+            abi: cakeVaultV2ABI,
+            functionName: 'userInfo',
+            args: [account],
+          },
+          {
+            address: cakeVaultAddress,
+            abi: cakeVaultV2ABI,
+            functionName: 'calculatePerformanceFee',
+            args: [account],
+          },
+          {
+            address: cakeVaultAddress,
+            abi: cakeVaultV2ABI,
+            functionName: 'calculateOverdueFee',
+            args: [account],
+          },
+          {
+            address: cakeVaultAddress,
+            abi: cakeVaultV2ABI,
+            functionName: 'getPricePerFullShare',
+          },
+        ],
+        allowFailure: false,
+      })
+      const userContractResponse = {
+        shares: userInfo[0],
+        lastDepositedTime: userInfo[1],
+        cakeAtLastUserAction: userInfo[2],
+        lastUserActionTime: userInfo[3],
+        lockStartTime: userInfo[4],
+        lockEndTime: userInfo[5],
+        userBoostedShare: userInfo[6],
+        locked: userInfo[7],
+        lockedAmount: userInfo[8],
+      }
 
-    const userContractResponse = {
-      shares: userInfo[0],
-      lastDepositedTime: userInfo[1],
-      cakeAtLastUserAction: userInfo[2],
-      lastUserActionTime: userInfo[3],
-      lockStartTime: userInfo[4],
-      lockEndTime: userInfo[5],
-      userBoostedShare: userInfo[6],
-      locked: userInfo[7],
-      lockedAmount: userInfo[8],
-    }
-
-    const currentPerformanceFeeAsBigNumber = new BigNumber(currentPerformanceFee.toString())
-    const currentOverdueFeeAsBigNumber = new BigNumber(currentOverdueFee.toString())
-    const sharePriceAsBigNumber = sharePrice ? new BigNumber(sharePrice.toString()) : BIG_ZERO
-    const userBoostedSharesAsBignumber = new BigNumber(userContractResponse.userBoostedShare.toString())
-    const userSharesAsBignumber = new BigNumber(userContractResponse.shares.toString())
-    const lockPosition = getVaultPosition({
-      userShares: userSharesAsBignumber,
-      locked: userContractResponse.locked,
-      lockEndTime: userContractResponse.lockEndTime.toString(),
-    })
-    const lockedCake = [VaultPosition.None, VaultPosition.Flexible].includes(lockPosition)
-      ? '0.00'
-      : convertSharesToCake(
-          userSharesAsBignumber,
-          sharePriceAsBigNumber,
-          undefined,
-          undefined,
-          currentOverdueFeeAsBigNumber.plus(currentPerformanceFeeAsBigNumber).plus(userBoostedSharesAsBignumber),
-        ).cakeAsNumberBalance.toLocaleString('en', { maximumFractionDigits: 3 })
+      const currentPerformanceFeeAsBigNumber = new BigNumber(currentPerformanceFee.toString())
+      const currentOverdueFeeAsBigNumber = new BigNumber(currentOverdueFee.toString())
+      const sharePriceAsBigNumber = sharePrice ? new BigNumber(sharePrice.toString()) : BIG_ZERO
+      const userBoostedSharesAsBignumber = new BigNumber(userContractResponse.userBoostedShare.toString())
+      const userSharesAsBignumber = new BigNumber(userContractResponse.shares.toString())
+      const lockPosition = getVaultPosition({
+        userShares: userSharesAsBignumber,
+        locked: userContractResponse.locked,
+        lockEndTime: userContractResponse.lockEndTime.toString(),
+      })
+      const lockedCake = [VaultPosition.None, VaultPosition.Flexible].includes(lockPosition)
+        ? '0.00'
+        : convertSharesToCake(
+            userSharesAsBignumber,
+            sharePriceAsBigNumber,
+            undefined,
+            undefined,
+            currentOverdueFeeAsBigNumber.plus(currentPerformanceFeeAsBigNumber).plus(userBoostedSharesAsBignumber),
+          ).cakeAsNumberBalance.toLocaleString('en', { maximumFractionDigits: 3 })
 
     let iCake = ''
     let vCake = { vaultScore: '0', totalScore: '0' }
@@ -98,36 +100,40 @@ const useCakeBenefits = () => {
       const credit = await ifoCreditAddressContract.read.getUserCredit([account])
       iCake = getBalanceNumber(new BigNumber(credit.toString())).toLocaleString('en', { maximumFractionDigits: 3 })
 
-      const eligiblePools = await getActivePools(ChainId.BSC, currentBscBlock)
-      const poolAddresses = eligiblePools.map(({ contractAddress }) => contractAddress)
+        const eligiblePools: any = await getActivePools(ChainId.BSC, currentBscBlock)
+        const poolAddresses = eligiblePools.map(({ contractAddress }) => contractAddress)
 
-      const [cakeVaultBalance, total] = await getScores(
-        PANCAKE_SPACE,
-        [cakePoolBalanceStrategy('v1'), createTotalStrategy(poolAddresses, 'v1')],
-        ChainId.BSC.toString(),
-        [account],
-        Number(currentBscBlock),
-      )
-      vCake = {
-        vaultScore: cakeVaultBalance[account]
-          ? cakeVaultBalance[account].toLocaleString('en', { maximumFractionDigits: 3 })
-          : '0',
-        totalScore: total[account] ? total[account].toLocaleString('en', { maximumFractionDigits: 3 }) : '0',
+        const [cakeVaultBalance, total] = await getScores(
+          PANCAKE_SPACE,
+          [cakePoolBalanceStrategy('v1'), createTotalStrategy(poolAddresses, 'v1')],
+          ChainId.BSC.toString(),
+          [account],
+          Number(currentBscBlock),
+        )
+        vCake = {
+          vaultScore: cakeVaultBalance[account]
+            ? cakeVaultBalance[account].toLocaleString('en', { maximumFractionDigits: 3 })
+            : '0',
+          totalScore: total[account] ? total[account].toLocaleString('en', { maximumFractionDigits: 3 }) : '0',
+        }
       }
-    }
 
-    return {
-      lockedCake,
-      lockPosition,
-      lockedEndTime: new Date(parseInt(userContractResponse.lockEndTime.toString()) * 1000).toLocaleString(locale, {
-        month: 'short',
-        year: 'numeric',
-        day: 'numeric',
-      }),
-      iCake,
-      vCake,
-    }
-  })
+      return {
+        lockedCake,
+        lockPosition,
+        lockedEndTime: new Date(parseInt(userContractResponse.lockEndTime.toString()) * 1000).toLocaleString(locale, {
+          month: 'short',
+          year: 'numeric',
+          day: 'numeric',
+        }),
+        iCake,
+        vCake,
+      }
+    },
+    {
+      enabled: Boolean(account && currentBscBlock),
+    },
+  )
 
   return { data, status }
 }

--- a/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
+++ b/apps/web/src/components/Menu/UserMenu/hooks/useCakeBenefits.ts
@@ -92,13 +92,13 @@ const useCakeBenefits = () => {
             currentOverdueFeeAsBigNumber.plus(currentPerformanceFeeAsBigNumber).plus(userBoostedSharesAsBignumber),
           ).cakeAsNumberBalance.toLocaleString('en', { maximumFractionDigits: 3 })
 
-    let iCake = ''
-    let vCake = { vaultScore: '0', totalScore: '0' }
-    if (lockPosition === VaultPosition.Locked) {
-      // @ts-ignore
-      // TODO: Fix viem
-      const credit = await ifoCreditAddressContract.read.getUserCredit([account])
-      iCake = getBalanceNumber(new BigNumber(credit.toString())).toLocaleString('en', { maximumFractionDigits: 3 })
+      let iCake = ''
+      let vCake = { vaultScore: '0', totalScore: '0' }
+      if (lockPosition === VaultPosition.Locked) {
+        // @ts-ignore
+        // TODO: Fix viem
+        const credit = await ifoCreditAddressContract.read.getUserCredit([account])
+        iCake = getBalanceNumber(new BigNumber(credit.toString())).toLocaleString('en', { maximumFractionDigits: 3 })
 
         const eligiblePools: any = await getActivePools(ChainId.BSC, currentBscBlock)
         const poolAddresses = eligiblePools.map(({ contractAddress }) => contractAddress)

--- a/apps/web/src/components/Menu/hooks/useCompetitionStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useCompetitionStatus.ts
@@ -1,15 +1,23 @@
-import useSWRImmutable from 'swr/immutable'
 import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { SmartContractPhases, LIVE, REGISTRATION } from 'config/constants/trading-competition/phases'
 import { useTradingCompetitionContractMoD } from 'hooks/useContract'
 
 export const useCompetitionStatus = () => {
   const tradingCompetitionContract = useTradingCompetitionContractMoD()
 
-  const { data: state } = useSWRImmutable('competitionStatus', async () => {
-    const competitionStatus = await tradingCompetitionContract.read.currentStatus()
-    return SmartContractPhases[competitionStatus].state
-  })
+  const { data: state } = useQuery(
+    ['competitionStatus'],
+    async () => {
+      const competitionStatus = await tradingCompetitionContract.read.currentStatus()
+      return SmartContractPhases[competitionStatus].state
+    },
+    {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  )
 
   return useMemo(() => {
     if (state === REGISTRATION) {

--- a/apps/web/src/components/Menu/hooks/useIfoStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useIfoStatus.ts
@@ -1,4 +1,4 @@
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { ifoV7ABI } from '@pancakeswap/ifos'
 
@@ -8,8 +8,8 @@ import { useActiveIfoConfig } from 'hooks/useIfoConfig'
 export const useIfoStatus = () => {
   const { activeIfo } = useActiveIfoConfig()
 
-  const { data = { startTime: 0, endTime: 0 } } = useSWRImmutable(
-    activeIfo ? ['ifo', 'currentIfo_timestamps', activeIfo.chainId] : null,
+  const { data = { startTime: 0, endTime: 0 } } = useQuery(
+    ['ifo', 'currentIfo_timestamps', activeIfo?.chainId],
     async () => {
       const client = publicClient({ chainId: activeIfo?.chainId })
       if (!client || !activeIfo?.chainId) {
@@ -38,6 +38,12 @@ export const useIfoStatus = () => {
         startTime: startTimeResponse.status === 'success' ? Number(startTimeResponse.result) : 0,
         endTime: endTimeResponse.status === 'success' ? Number(endTimeResponse.result) : 0,
       }
+    },
+    {
+      enabled: Boolean(activeIfo),
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   )
 

--- a/apps/web/src/components/Menu/hooks/usePotteryStatus.ts
+++ b/apps/web/src/components/Menu/hooks/usePotteryStatus.ts
@@ -1,13 +1,21 @@
-import useSWRImmutable from 'swr/immutable'
-import { fetchLastVaultAddress } from 'state/pottery/fetchPottery'
+import { useQuery } from '@tanstack/react-query'
 import { getPotteryVaultContract } from 'utils/contractHelpers'
+import { fetchLastVaultAddress } from 'state/pottery/fetchPottery'
 
 export const usePotteryStatus = () => {
-  const { data: potteryStatus } = useSWRImmutable('potteryLastStatus', async () => {
-    const lastVaultAddress = await fetchLastVaultAddress()
-    const potteryVaultContract = getPotteryVaultContract(lastVaultAddress)
-    return potteryVaultContract.read.getStatus()
-  })
+  const { data: potteryStatus } = useQuery(
+    ['potteryLastStatus'],
+    async () => {
+      const lastVaultAddress = await fetchLastVaultAddress()
+      const potteryVaultContract = getPotteryVaultContract(lastVaultAddress)
+      return potteryVaultContract.read.getStatus()
+    },
+    {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  )
 
   return potteryStatus
 }

--- a/apps/web/src/components/Menu/hooks/useVotingStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useVotingStatus.ts
@@ -1,4 +1,4 @@
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 import { ProposalState, Proposal } from 'state/types'
 import request, { gql } from 'graphql-request'
 import { SNAPSHOT_API } from 'config/constants/endpoints'
@@ -20,16 +20,24 @@ export const getCoreProposal = async (type: ProposalState): Promise<Proposal[]> 
 }
 
 export const useVotingStatus = () => {
-  const { data: votingStatus = null } = useSWRImmutable('anyActiveSoonCoreProposals', async () => {
-    const activeProposals = await getCoreProposal(ProposalState.ACTIVE)
-    if (activeProposals.length) {
-      return 'vote_now'
-    }
-    const soonProposals = await getCoreProposal(ProposalState.PENDING)
-    if (soonProposals.length) {
-      return 'soon'
-    }
-    return null
-  })
+  const { data: votingStatus = null } = useQuery(
+    ['anyActiveSoonCoreProposals'],
+    async () => {
+      const activeProposals = await getCoreProposal(ProposalState.ACTIVE)
+      if (activeProposals.length) {
+        return 'vote_now'
+      }
+      const soonProposals = await getCoreProposal(ProposalState.PENDING)
+      if (soonProposals.length) {
+        return 'soon'
+      }
+      return null
+    },
+    {
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    },
+  )
   return votingStatus
 }

--- a/apps/web/src/views/Pools/components/RevenueSharing/JoinRevenueModal/VCakeModal.tsx
+++ b/apps/web/src/views/Pools/components/RevenueSharing/JoinRevenueModal/VCakeModal.tsx
@@ -7,7 +7,6 @@ import useVCake from 'views/Pools/hooks/useVCake'
 import JoinRevenueModal from 'views/Pools/components/RevenueSharing/JoinRevenueModal'
 import useCakeBenefits from 'components/Menu/UserMenu/hooks/useCakeBenefits'
 import { VaultPosition } from 'utils/cakePool'
-import { FetchStatus } from 'config/constants/types'
 
 const VCakeModal = () => {
   const { account, chainId } = useAccountActiveChain()
@@ -20,7 +19,7 @@ const VCakeModal = () => {
       account &&
       chainId === ChainId.BSC &&
       isInitialization === false &&
-      cakeBenefitsFetchStatus === FetchStatus.Fetched &&
+      cakeBenefitsFetchStatus === 'success' &&
       cakeBenefits?.lockPosition === VaultPosition.Locked
     ) {
       setOpen(true)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b1f246</samp>

### Summary
🔄🚀🧹

<!--
1.  🔄 - This emoji represents a refactoring change that does not affect the functionality or appearance of the code, but improves its quality, readability, or performance.
2.  🚀 - This emoji represents a performance improvement that makes the code run faster, more efficiently, or more reliably.
3.  🧹 - This emoji represents a cleanup change that removes unused, redundant, or obsolete code, or fixes minor issues or errors.
-->
This pull request refactors the data fetching logic in the `CakeBenefitsCard` component and related hooks to use `@tanstack/react-query` instead of `swr` for better performance and consistency. It also fixes a minor bug in the `VCakeModal` component by using the correct status property from `react-query`.

> _Sing, O Muse, of the swift and skillful coder_
> _Who reforged the `CakeBenefitsCard` with a new hook_
> _And replaced the old `useSWRImmutable` with `useQuery`_
> _The mighty tool of `@tanstack/react-query`, the data-fetcher._

### Walkthrough
*  Refactor data fetching hooks to use `useQuery` from `@tanstack/react-query` instead of `useSWR` or `useSWRImmutable` from `swr` in `./apps/web/src/components/Menu/UserMenu/CakeBenefitsCard.tsx` and related files ([link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-63041b14c34f602e12d36358e672648bd3df5ea97d5d810cb40d4d447bf98887L17), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-615c30d6c6f61b444636d64d6a14f50985cc9c40098057c21eaa564896f85851L3-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-615c30d6c6f61b444636d64d6a14f50985cc9c40098057c21eaa564896f85851L31-R135), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5de9c99ed38f8177e9b6d4d888180047abf9e4556f4a5e8cec18a78cb875191eL1-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5de9c99ed38f8177e9b6d4d888180047abf9e4556f4a5e8cec18a78cb875191eL9-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-0f05e5a73dcb15ee200123fa6e5b7ffdd661277ff279dcbef72db0abfba33d06L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-0f05e5a73dcb15ee200123fa6e5b7ffdd661277ff279dcbef72db0abfba33d06L11-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-310fe1e1da5263ffbaa8d3de40d87fac63006cb2892569e02e0b61ad6d0cc623L1-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5c33a712b9cf1a9800f100e63814ecb03b982256675c38ee072b6cb437f9d790L1-R1), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5c33a712b9cf1a9800f100e63814ecb03b982256675c38ee072b6cb437f9d790L23-R41))
* Add conditions to enable queries only when necessary and disable refetching on mount, reconnect, or window focus events for performance improvement ([link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5de9c99ed38f8177e9b6d4d888180047abf9e4556f4a5e8cec18a78cb875191eL9-R20), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-0f05e5a73dcb15ee200123fa6e5b7ffdd661277ff279dcbef72db0abfba33d06L11-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-0f05e5a73dcb15ee200123fa6e5b7ffdd661277ff279dcbef72db0abfba33d06R42-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-5c33a712b9cf1a9800f100e63814ecb03b982256675c38ee072b6cb437f9d790L23-R41))
* Replace the use of `FetchStatus.Fetched` with `'success'` to check the query status in `./apps/web/src/components/Menu/UserMenu/CakeBenefitsCard.tsx` and `./apps/web/src/views/Pools/components/RevenueSharing/JoinRevenueModal/VCakeModal.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-63041b14c34f602e12d36358e672648bd3df5ea97d5d810cb40d4d447bf98887L149-R150), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-63041b14c34f602e12d36358e672648bd3df5ea97d5d810cb40d4d447bf98887L177-R176), [link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-8a34db6069bb8d099c35f681aa36d9c33d33b8f24587142609d25d0be3a45362L23-R23))
* Add a null check for `cakeBenefits` before accessing its `lockPosition` property in `./apps/web/src/components/Menu/UserMenu/CakeBenefitsCard.tsx` to prevent a possible runtime error ([link](https://github.com/pancakeswap/pancake-frontend/pull/8410/files?diff=unified&w=0#diff-63041b14c34f602e12d36358e672648bd3df5ea97d5d810cb40d4d447bf98887L177-R176))


