### PR TITLE
fix: Proposal total count

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
@@ -63,7 +63,7 @@ const CakeInput: React.FC<{
 
   const balance = (
     <Flex>
-      <Text textAlign="left" color="textSubtle" ml="4px">
+      <Text textAlign="left" color="textSubtle" ml="4px" fontSize="12px">
         {t('Balance: %balance%', { balance: formatBigInt(cakeBalance, 2) })}
       </Text>
     </Flex>

--- a/apps/web/src/views/CakeStaking/hooks/useGaugesVotingCount.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useGaugesVotingCount.ts
@@ -1,7 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
+import { SUPPORT_CAKE_STAKING } from 'config/constants/supportChains'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useGaugesVotingContract } from 'hooks/useContract'
 
 export const useGaugesVotingCount = (): bigint | undefined => {
+  const { chainId } = useActiveChainId()
   const gaugesVotingContract = useGaugesVotingContract()
 
   const { data } = useQuery(
@@ -16,6 +19,7 @@ export const useGaugesVotingCount = (): bigint | undefined => {
       }
     },
     {
+      enabled: Boolean(gaugesVotingContract && chainId && SUPPORT_CAKE_STAKING.includes(chainId)),
       keepPreviousData: true,
     },
   )

--- a/apps/web/src/views/CakeStaking/hooks/useLockAllowance.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useLockAllowance.ts
@@ -29,7 +29,10 @@ export const useLockApproveCallback = (amount: string) => {
     [amount, cakeToken?.decimals],
   )
 
-  const currencyAmount = cakeToken ? CurrencyAmount.fromRawAmount<Currency>(cakeToken, rawAmount.toString()) : undefined
+  const currencyAmount = useMemo(
+    () => (cakeToken ? CurrencyAmount.fromRawAmount<Currency>(cakeToken, rawAmount.toString()) : undefined),
+    [cakeToken, rawAmount],
+  )
 
   const { approvalState, approveCallback, currentAllowance } = useApproveCallback(
     currencyAmount,

--- a/apps/web/src/views/CakeStaking/hooks/useSnapshotProposalsCount.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useSnapshotProposalsCount.ts
@@ -3,22 +3,22 @@ import { SNAPSHOT_API } from 'config/constants/endpoints'
 import request, { gql } from 'graphql-request'
 
 const getSnapshotCount = async (space: string) => {
-  const response: { proposals: { id: string }[] } = await request(
+  const response: { space: { proposalsCount: number } } = await request(
     SNAPSHOT_API,
     gql`
-      query Proposals {
-        proposals(where: { space_in: "${space}" }) {
-          id
+      query ProposalsCount {
+        space(id: "${space}") {
+          proposalsCount
         }
       }
     `,
   )
-  return response.proposals.length ?? 0
+  return response.space.proposalsCount ?? 0
 }
 
 const SPACE_ID = 'cakevote.eth'
 
-export const useSnapshotVotingCount = (): number | undefined => {
+export const useSnapshotProposalsCount = (): number | undefined => {
   const { data } = useQuery(
     ['snapshotVotingCount', SPACE_ID],
     async () => {

--- a/apps/web/src/views/CakeStaking/hooks/useTotalIFOSold.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useTotalIFOSold.ts
@@ -7,6 +7,7 @@ export const useTotalIFOSold = () => {
   const [sold, setSold] = useState(0)
 
   useEffect(() => {
+    // FIXME: gauges ifo should totally of mainnet
     getTotalIFOSold(chainId).then(setSold)
   }, [chainId])
 

--- a/apps/web/src/views/CakeStaking/index.tsx
+++ b/apps/web/src/views/CakeStaking/index.tsx
@@ -23,13 +23,13 @@ import { CakeRewardsCard } from './components/CakeRewardsCard'
 import { LockCake } from './components/LockCake'
 import { NewCakeStakingCard } from './components/NewCakeStakingCard'
 import { useGaugesVotingCount } from './hooks/useGaugesVotingCount'
-import { useSnapshotVotingCount } from './hooks/useSnapshotVotingCount'
+import { useSnapshotProposalsCount } from './hooks/useSnapshotProposalsCount'
 import { useTotalIFOSold } from './hooks/useTotalIFOSold'
 
 const CakeStaking = () => {
   const { t } = useTranslation()
   const gaugesVotingCount = useGaugesVotingCount()
-  const snapshotVotingCount = useSnapshotVotingCount()
+  const snapshotProposalsCount = useSnapshotProposalsCount()
   const totalCakeDistributed = useCakeDistributed()
   const [cakeRewardModalVisible, setCakeRewardModalVisible] = useState(false)
   const totalIFOSold = useTotalIFOSold()
@@ -152,7 +152,7 @@ const CakeStaking = () => {
                 ml="4px"
               />
             }
-            dataText={`${snapshotVotingCount}`}
+            dataText={`${snapshotProposalsCount}`}
           />
           <BenefitCard
             type="ifo"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bfe0a09</samp>

### Summary
🎨🚀🛠️

<!--
1.  🎨 - This emoji represents a design or UI change, such as the font size reduction for the balance text.
2.  🚀 - This emoji represents a performance or optimization improvement, such as the use of `useMemo` to avoid unnecessary re-rendering.
3.  🛠️ - This emoji represents a bug fix or a refactor, such as the renaming and query change for the snapshot proposals count hook, the comment about the gauges ifo total, and the update of the cake staking view and the benefit card component.
-->
Updated the cake staking view and hooks to use the new snapshot API and the gauges voting contract. Fixed some UI and performance issues. Renamed some variables and files for clarity.

> _`useMemo` saves time_
> _cake staking gets proposals_
> _autumn leaves fall fast_

### Walkthrough
* Reduce balance text font size in lock cake form to fit UI ([link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-748e847901e3090db86324bb7fd2efc288b6c65ac6a74ef4cc88a1a59c505c36L66-R66))
* Move `useGaugesVotingCount` hook to hooks folder and add condition to enable query based on chain id and supported chains ([link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-a086bb3c32238c7f74674b0f4b3f7167f49eec8e7b0c572bf472be496f351bc0L2-R7), [link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-a086bb3c32238c7f74674b0f4b3f7167f49eec8e7b0c572bf472be496f351bc0R22))
* Wrap `currencyAmount` in `useMemo` hook to avoid unnecessary re-rendering in `useLockAllowance` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-c0388aa7b56bcf690e851bf45b535aa83ce5415fe4fffa27bde422fbf2805a9dL32-R35))
* Rename `useSnapshotVotingCount` hook to `useSnapshotProposalsCount` and use `proposalsCount` field from snapshot API instead of fetching and counting proposals manually ([link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-2b1df466fa9f4793e7036ea223a7511243df0311920f819afd2f859bd4418f1cL6-R21))
* Add comment to indicate that gauges ifo total should be based on mainnet data in `useTotalIFOSold` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-eb923f845d1ae47ea3b05e84b2e47a883e54320c16a8e1a54b4c4a2fd480cda4R10))
* Replace `useSnapshotVotingCount` hook by `useSnapshotProposalsCount` hook and rename `snapshotVotingCount` variable to `snapshotProposalsCount` in `CakeStaking` view and `BenefitCard` component (`apps/web/src/views/CakeStaking/index.tsx`, [link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-6f455b41f6d5e062b57aca894573c292fee3026627d7dcd3d0d0baca9e33509bL26-R26), [link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-6f455b41f6d5e062b57aca894573c292fee3026627d7dcd3d0d0baca9e33509bL32-R32), [link](https://github.com/pancakeswap/pancake-frontend/pull/8416/files?diff=unified&w=0#diff-6f455b41f6d5e062b57aca894573c292fee3026627d7dcd3d0d0baca9e33509bL155-R155))


