### PR TITLE
fix(Games): Fix carouseImage width

### DIFF
--- a/apps/games/components/Game/Home/Carousel.tsx
+++ b/apps/games/components/Game/Home/Carousel.tsx
@@ -126,7 +126,7 @@ interface CarouselProps {
 }
 
 const breakPoints: { [index: number]: { slidesPerView: number } } = {
-  370: {
+  320: {
     slidesPerView: 3,
   },
   920: {

--- a/apps/games/components/Game/Home/Carousel.tsx
+++ b/apps/games/components/Game/Home/Carousel.tsx
@@ -58,10 +58,15 @@ const StyledCarouselImage = styled(Box)<{
   ${({ theme }) => theme.mediaQueries.xl} {
     margin-top: 0;
     width: ${({ isHorizontal }) => (isHorizontal ? '157px' : '93%')};
+    height: ${({ isHorizontal }) => (isHorizontal ? '104px' : '210px')};
 
     &:after {
       display: none;
     }
+  }
+
+  ${({ theme }) => theme.mediaQueries.xxl} {
+    height: ${({ isHorizontal }) => (isHorizontal ? '104px' : '143px')};
   }
 `
 

--- a/apps/games/components/Game/Home/Carousel.tsx
+++ b/apps/games/components/Game/Home/Carousel.tsx
@@ -57,7 +57,7 @@ const StyledCarouselImage = styled(Box)<{
 
   ${({ theme }) => theme.mediaQueries.xl} {
     margin-top: 0;
-    width: ${({ isHorizontal }) => (isHorizontal ? '157px' : '96px')};
+    width: ${({ isHorizontal }) => (isHorizontal ? '157px' : '93%')};
 
     &:after {
       display: none;
@@ -168,7 +168,7 @@ export const Carousel: React.FC<React.PropsWithChildren<CarouselProps>> = ({
         breakpoints={breakPoints}
       >
         {carouselData.map((carousel, index) => (
-          <SwiperSlide key={carousel.image}>
+          <SwiperSlide key={carousel.image} style={{ width: '100%' }}>
             <StyledCarouselImage
               isActive={carouselId === index}
               imgUrl={carousel.image}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b515c59</samp>

### Summary
🖼️📱🔄

<!--
1.  🖼️ - This emoji can be used to indicate that the carousel image size and aspect ratio have been improved.
2.  📱 - This emoji can be used to indicate that the carousel component is more responsive and adapts to different screen sizes and orientations.
3.  🔄 - This emoji can be used to indicate that the carousel component uses the SwiperSlide component to enable smooth and circular scrolling of the images.
-->
Improve responsiveness and layout of game home carousel. Adjust `Carousel.tsx` to use different widths for `carousel image` and `SwiperSlide` based on screen size and orientation.

> _The game home page had a carousel_
> _But its layout was not very swell_
> _So they tweaked the `SwiperSlide`_
> _And the image's width and height_
> _To make it responsive and look well_

### Walkthrough
*  Adjust the width of the carousel image to 93% of the parent container when the screen size is extra large and the carousel is not horizontal ([link](https://github.com/pancakeswap/pancake-frontend/pull/8421/files?diff=unified&w=0#diff-3b42584ed590ae9be5f6eafcbda1ad417bdfcd2b7379b0dd633c656ec08aaa92L60-R60))
*  Set the width of the SwiperSlide component to 100% of the parent container to prevent shrinking or overflowing when the carousel is horizontal and the screen size is extra large ([link](https://github.com/pancakeswap/pancake-frontend/pull/8421/files?diff=unified&w=0#diff-3b42584ed590ae9be5f6eafcbda1ad417bdfcd2b7379b0dd633c656ec08aaa92L171-R171))




Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/d4c1bc2d-9236-4198-9310-0b37df27c64c)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/dd1bbe51-336d-421f-a15e-6ced5bdb548a)
