### PR TITLE
fix: Pool boosted UI

### DIFF
--- a/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
+++ b/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
@@ -12,7 +12,7 @@ export const useBoostedPoolApr = ({ contractAddress, chainId }: UseBoostedPoolAp
   const client = getViemClients({ chainId })
 
   const { data } = useQuery(
-    ['boostedPoolsApr', chainId],
+    ['boostedPoolsApr', client, contractAddress, chainId],
     () => {
       if (client) {
         return getBoostedPoolApr({

--- a/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
+++ b/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
@@ -12,7 +12,7 @@ export const useBoostedPoolApr = ({ contractAddress, chainId }: UseBoostedPoolAp
   const client = getViemClients({ chainId })
 
   const { data } = useQuery(
-    ['boostedPoolsApr', client, contractAddress, chainId],
+    ['boostedPoolsApr', contractAddress, chainId],
     () => {
       if (client) {
         return getBoostedPoolApr({

--- a/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
+++ b/apps/web/src/views/Pools/hooks/useBoostedPoolApr.ts
@@ -12,7 +12,7 @@ export const useBoostedPoolApr = ({ contractAddress, chainId }: UseBoostedPoolAp
   const client = getViemClients({ chainId })
 
   const { data } = useQuery(
-    ['boostedPoolsApr'],
+    ['boostedPoolsApr', chainId],
     () => {
       if (client) {
         return getBoostedPoolApr({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1546279</samp>

### Summary
🔄🔗🚀

<!--
1.  🔄 - This emoji represents the refetching of the query when the network changes, as well as the possible variation of the APR values.
2.  🔗 - This emoji represents the chainId parameter, which identifies the network that the user is connected to, and the query key, which is composed of the chainId and other arguments.
3.  🚀 - This emoji represents the boosted pools, which offer higher rewards and incentives for liquidity providers.
-->
Added `chainId` to query key for fetching boosted pool APRs. This allows the query to update the APRs based on the network the user is connected to.

> _`useQuery` changes_
> _`chainId` affects the APR_
> _Pools shift with seasons_

### Walkthrough
*  Add `chainId` parameter to query key of `useQuery` hook to refetch boosted pool APR when network changes ([link](https://github.com/pancakeswap/pancake-frontend/pull/8422/files?diff=unified&w=0#diff-fecd21c45f9d393643358542fcc35dc2f73d5edd2055bc61ee67c7e84aaff089L15-R15))


