### PR TITLE
feat: update doc links

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockedVeCakeStatus.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockedVeCakeStatus.tsx
@@ -33,6 +33,18 @@ import { StyledLockedCard } from './styled'
 
 dayjs.extend(relativeTime)
 
+const LearnMore = () => {
+  const { t } = useTranslation()
+  return (
+    <Link
+      href="https://docs.pancakeswap.finance/products/vecake/migrate-from-cake-pool#10ffc408-be58-4fa8-af56-be9f74d03f42"
+      color="text"
+    >
+      {t('Learn More >>')}
+    </Link>
+  )
+}
+
 export const LockedVeCakeStatus: React.FC<{
   status: CakeLockStatus
 }> = ({ status }) => {
@@ -145,12 +157,7 @@ const LockedInfo = () => {
                     'Position migrated from CAKE Pool can not be extended or topped up. To extend or add more CAKE, set up a native veCAKE position.',
                   )}
                 </Text>
-                <Link
-                  href="https://docs.pancakeswap.finance/vecake/migrate-from-cake-pool#10ffc408-be58-4fa8-af56-be9f74d03f42"
-                  color="text"
-                >
-                  {t('Learn More >>')}
-                </Link>
+                <LearnMore />
               </AutoColumn>
             </Message>
           )}
@@ -190,9 +197,7 @@ const FromProxyTooltip: React.FC<{
   return (
     <>
       {t('%amount% veCAKE from CAKE Pool migrated position.', { amount: proxyCake })}
-      <Link href="https://docs.pancakeswap.finance/vecake/migrate-from-cake-pool#10ffc408-be58-4fa8-af56-be9f74d03f42">
-        {t('Learn More')} {'>>'}
-      </Link>
+      <LearnMore />
     </>
   )
 }
@@ -215,9 +220,7 @@ const ProxyUnlockTooltip: React.FC<{
           expiredAt: formatTime(Number(dayjs.unix(proxyUnlockTime))),
         },
       )}
-      <Link href="https://docs.pancakeswap.finance/vecake/migrate-from-cake-pool#10ffc408-be58-4fa8-af56-be9f74d03f42">
-        {t('Learn More')} {'>>'}
-      </Link>
+      <LearnMore />
     </>
   )
 }

--- a/apps/web/src/views/CakeStaking/components/NewCakeStakingCard.tsx
+++ b/apps/web/src/views/CakeStaking/components/NewCakeStakingCard.tsx
@@ -31,7 +31,7 @@ export const NewCakeStakingCard: React.FC = () => {
   const { t } = useTranslation()
   return (
     <AtomBox display="flex" alignItems="center">
-      <Link href="https://docs.pancakeswap.finance/vecake/how-to-get-vecake">
+      <Link href="https://docs.pancakeswap.finance/products/vecake/how-to-get-vecake">
         <SpeechBubbleBox>
           <Button variant="subtle" endIcon={<HelpIcon color="white" width="24px" />}>
             {t('New to CAKE Staking')}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5fb118a</samp>

### Summary
🔗📚♻️

<!--
1.  🔗 - This emoji represents the update to the link URL, as it is related to linking or connecting different web pages.
2.  📚 - This emoji represents the creation of the `LearnMore` component, as it is related to documentation or learning resources.
3.  ♻️ - This emoji represents the refactoring of the duplicated code into a reusable component, as it is related to recycling or improving existing code.
-->
This pull request refactors the code for rendering the veCAKE status in the CakeStaking view and fixes a broken link to the veCAKE documentation. It introduces a new `LearnMore` component and updates the `NewCakeStakingCard` component.

> _Oh we're the crew of the veCAKE ship, and we code with skill and pride_
> _We always keep our docs up to date, and our links are verified_
> _We don't repeat ourselves in our code, we use `LearnMore` instead_
> _So heave away, me hearties, heave away, and raise the veCAKE flag overhead_

### Walkthrough
* Create and reuse a `LearnMore` component to render a link to the documentation about veCAKE and the migration from CAKE pool ([link](https://github.com/pancakeswap/pancake-frontend/pull/8424/files?diff=unified&w=0#diff-01ed07375da1f63ba8cbddacd7c4baaea5a047d301f640111e52708ac9531aceR36-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/8424/files?diff=unified&w=0#diff-01ed07375da1f63ba8cbddacd7c4baaea5a047d301f640111e52708ac9531aceL148-R160), [link](https://github.com/pancakeswap/pancake-frontend/pull/8424/files?diff=unified&w=0#diff-01ed07375da1f63ba8cbddacd7c4baaea5a047d301f640111e52708ac9531aceL193-R200), [link](https://github.com/pancakeswap/pancake-frontend/pull/8424/files?diff=unified&w=0#diff-01ed07375da1f63ba8cbddacd7c4baaea5a047d301f640111e52708ac9531aceL218-R223)) in `LockedVeCakeStatus.tsx`


