### PR TITLE
refactor: Use query in liquidity

### DIFF
--- a/.changeset/polite-steaks-raise.md
+++ b/.changeset/polite-steaks-raise.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': patch
+---
+
+refactor: Add undefined type to public provider

--- a/apps/web/src/hooks/useV3Pools.ts
+++ b/apps/web/src/hooks/useV3Pools.ts
@@ -3,7 +3,7 @@ import { SmartRouter, V3Pool } from '@pancakeswap/smart-router/evm'
 import { Tick } from '@pancakeswap/v3-sdk'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import useSWRImmutable from 'swr/immutable'
+import { useQuery } from '@tanstack/react-query'
 
 import { POOLS_FAST_REVALIDATE, POOLS_SLOW_REVALIDATE } from 'config/pools'
 import { v3Clients } from 'utils/graphql'
@@ -45,7 +45,7 @@ export function useV3CandidatePools(
   const {
     data,
     isLoading: ticksLoading,
-    isValidating: ticksValidating,
+    isFetching: ticksValidating,
   } = useV3PoolsWithTicks(candidatePoolsWithoutTicks, {
     key,
     blockNumber,
@@ -140,8 +140,8 @@ export function useV3PoolsWithTicks(
     return POOLS_SLOW_REVALIDATE[chainId] || 0
   }, [pools])
 
-  const poolsWithTicks = useSWRImmutable(
-    key && pools && enabled ? ['v3_pool_ticks', key] : null,
+  const poolsWithTicks = useQuery(
+    ['v3_pool_ticks', key],
     async () => {
       if (!pools) {
         throw new Error('Invalid pools to get ticks')
@@ -170,9 +170,12 @@ export function useV3PoolsWithTicks(
       }
     },
     {
-      refreshInterval,
-      errorRetryCount: 3,
-      revalidateOnFocus: false,
+      enabled: Boolean(key && pools && enabled),
+      refetchInterval: refreshInterval,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      retry: 3,
     },
   )
 

--- a/apps/web/src/hooks/useV3Pools.ts
+++ b/apps/web/src/hooks/useV3Pools.ts
@@ -3,7 +3,6 @@ import { SmartRouter, V3Pool } from '@pancakeswap/smart-router/evm'
 import { Tick } from '@pancakeswap/v3-sdk'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
 
 import { POOLS_FAST_REVALIDATE, POOLS_SLOW_REVALIDATE } from 'config/pools'
 import { v3Clients } from 'utils/graphql'

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -60,7 +60,6 @@ import { memo, ReactNode, useCallback, useMemo, useState } from 'react'
 import { useSingleCallResult } from 'state/multicall/hooks'
 import { useIsTransactionPending, useTransactionAdder } from 'state/transactions/hooks'
 import { styled } from 'styled-components'
-import useSWRImmutable from 'swr/immutable'
 import { calculateGasMargin, getBlockExploreLink } from 'utils'
 import currencyId from 'utils/currencyId'
 import { formatCurrencyAmount, formatPrice } from 'utils/formatCurrencyAmount'
@@ -82,6 +81,7 @@ import { useMerklInfo } from 'hooks/useMerkl'
 import Link from 'next/link'
 import { isUserRejected } from 'utils/sentry'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
+import { useQuery } from '@tanstack/react-query'
 
 export const BodyWrapper = styled(Card)`
   border-radius: 24px;
@@ -877,8 +877,8 @@ function PositionHistory_({
   const [isExpanded, setIsExpanded] = useState(false)
   const { chainId } = useActiveChainId()
   const client = v3Clients[chainId as ChainId]
-  const { data, isLoading } = useSWRImmutable(
-    client && tokenId && ['positionHistory', chainId, tokenId],
+  const { data, isLoading } = useQuery(
+    ['positionHistory', chainId, tokenId],
     async () => {
       const result = await client.request<PositionHistoryResult>(
         gql`
@@ -922,8 +922,10 @@ function PositionHistory_({
       })
     },
     {
-      revalidateOnMount: true,
-      refreshInterval: 30_000,
+      enabled: Boolean(client && tokenId),
+      refetchInterval: 30_000,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   )
 

--- a/packages/smart-router/evm/v3-router/providers/multicallSwapProvider.ts
+++ b/packages/smart-router/evm/v3-router/providers/multicallSwapProvider.ts
@@ -37,7 +37,11 @@ export type PancakeMulticallConfig = {
 export class PancakeMulticallProvider extends IMulticallProvider<PancakeMulticallConfig> {
   static abi = IMulticallABI
 
-  constructor(protected chainId: ChainId, protected provider: PublicClient, protected gasLimitPerCall = 1_000_000) {
+  constructor(
+    protected chainId: ChainId,
+    protected provider: PublicClient | undefined,
+    protected gasLimitPerCall = 1_000_000,
+  ) {
     super()
     this.provider = provider
   }

--- a/packages/smart-router/evm/v3-router/types/providers.ts
+++ b/packages/smart-router/evm/v3-router/types/providers.ts
@@ -44,6 +44,6 @@ export interface QuoteProvider<C = any> {
   getConfig?: () => C
 }
 
-export type OnChainProvider = ({ chainId }: { chainId?: ChainId }) => PublicClient
+export type OnChainProvider = ({ chainId }: { chainId?: ChainId }) => PublicClient | undefined
 
 export type SubgraphProvider = ({ chainId }: { chainId?: ChainId }) => GraphQLClient | undefined


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 238674b</samp>

### Summary
🔧🚀🐛

<!--
1.  🔧 - This emoji represents a change that fixes or improves something, such as a bug, a performance issue, or a dependency. In this case, the emoji could be used to indicate the change in the return types of the provider functions, which fixes a potential type error and handles an edge case.
2.  🚀 - This emoji represents a change that adds a new feature, enhances an existing one, or boosts the speed or quality of something. In this case, the emoji could be used to indicate the change in the custom hooks that use `react-query`, which enhances the data fetching and caching functionality of the v3 pools data.
3.  🐛 - This emoji represents a change that fixes a bug, a mistake, or a typo. In this case, the emoji could be used to indicate the change in the data fetching logic for the v3 liquidity position page, which fixes a potential bug in the gas estimation function and adds error handling and refresh options. It also removes an unused import, which could be considered a minor mistake.
-->
The pull request improves the data fetching and caching for the v3 pools and liquidity pages using `react-query`, and adds error handling and refresh options. It also fixes some minor issues in the v3 router types and functions.

> _`OnChainProvider` and `SubgraphProvider` return `undefined`_
> _When the chain id is not supported by the client_
> _We use `react-query` to fetch and cache the v3 pools_
> _And handle the errors and refreshes with skill and will_

### Walkthrough
*  Replace `useSWRImmutable` hook with `useQuery` hook from `react-query` library for data fetching and caching in `useV3PoolsWithTicks` and `PositionHistory_` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL143-R143), [link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL173-R177), [link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL866-R867), [link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL911-R914))
*  Rename `isValidating` property to `isFetching` in `useV3PoolsWithTicks` hook to match `useQuery` convention ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL48-R47))
*  Use memoized `viemClients` object instead of `getViemClients` function to pass on-chain client to `useV3CandidatePoolsWithoutTicks` hook ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL102-R101))
*  Use optional chaining operator to handle undefined on-chain client in `estimateGas` function for removing liquidity ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL353-R353))
*  Add `undefined` as possible return value for `OnChainProvider` and `SubgraphProvider` types in `providers.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-af970447e91def4d88a80070b0ac3acc54fe8635121580383bd18b2cdffbc2fdL43-R43))
*  Remove unused `useSWRImmutable` import from `useV3Pools.ts` and `liquidity/[tokenId].tsx` files ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-eed1c540944d691d26bcf3b5a7bb5ec231453cada2da879997e7a3ac73aa582bL5-R8), [link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bL63))
*  Add `useQuery` import to `liquidity/[tokenId].tsx` file ([link](https://github.com/pancakeswap/pancake-frontend/pull/8431/files?diff=unified&w=0#diff-d541d696a78f40e25e2fb5e5596eee09f23c12573229e2734b5bdfc1ef40b22bR83))

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding the undefined type to the public provider in the `OnChainProvider` type.

### Detailed summary:
- Added undefined type to the `OnChainProvider` type in `packages/smart-router/evm/v3-router/types/providers.ts`
- Updated the constructor in `packages/smart-router/evm/v3-router/providers/multicallSwapProvider.ts` to accept `PublicClient` as optional
- Replaced `isValidating` with `isFetching` in `apps/web/src/hooks/useV3Pools.ts`
- Replaced `useSWRImmutable` with `useQuery` in `apps/web/src/hooks/useV3Pools.ts` and `apps/web/src/pages/liquidity/[tokenId].tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->