### PR TITLE
feat: add prod did.json in prep for web notifications launch

### DIFF
--- a/apps/web/public/.well-known/did.json
+++ b/apps/web/public/.well-known/did.json
@@ -9,7 +9,7 @@
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "X25519",
-        "x": "cFtgeR4nO7VgNETG8eZ8KxyMFVCZfaZTdmJH6zrWDUk"
+        "x": "KxjJ6SoCsM4Q_IZSWLvWaP6Ss3uZ2GBuE6v5K3Pe_2E"
       }
     },
     {
@@ -19,7 +19,7 @@
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",
-        "x": "cxLt0Q1TZBiknNj4QqDuphhi6ikjT1vlK7u_fzbQbsU"
+        "x": "AXXZDrwjTXDQpGeCvj63WM_n7jX3XSDXgaSA6a2NrLk"
       }
     }
   ],

--- a/apps/web/public/.well-known/did.json
+++ b/apps/web/public/.well-known/did.json
@@ -1,0 +1,28 @@
+{
+  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/jws-2020/v1"],
+  "id": "did:web:pancakeswap.finance",
+  "verificationMethod": [
+    {
+      "id": "did:web:pancakeswap.finance#wc-notify-subscribe-key",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:pancakeswap.finance",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "X25519",
+        "x": "cFtgeR4nO7VgNETG8eZ8KxyMFVCZfaZTdmJH6zrWDUk"
+      }
+    },
+    {
+      "id": "did:web:pancakeswap.finance#wc-notify-authentication-key",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:pancakeswap.finance",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "cxLt0Q1TZBiknNj4QqDuphhi6ikjT1vlK7u_fzbQbsU"
+      }
+    }
+  ],
+  "keyAgreement": ["did:web:pancakeswap.finance#wc-notify-subscribe-key"],
+  "authentication": ["did:web:pancakeswap.finance#wc-notify-authentication-key"]
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 52e2887</samp>

### Summary
📄🔔💱

<!--
1.  📄 - This emoji represents a document or file, and can be used to indicate that a new DID document was added to the web app.
2.  🔔 - This emoji represents a bell or notification, and can be used to indicate that the web app supports the WalletConnect Notify protocol, which enables push notifications from connected wallets.
3.  💱 - This emoji represents a currency exchange or swap, and can be used to indicate that the web app is a decentralized exchange platform that allows users to swap tokens and interact with smart contracts.
-->
Added a DID document to the web app's public folder to enable push notifications from WalletConnect wallets. The DID document describes the web app's decentralized identifier and its verification methods.

> _`DID document`_
> _WalletConnect Notify_
> _Pushes from wallets_

### Walkthrough
* Add a DID document to enable WalletConnect Notify protocol ([link](https://github.com/pancakeswap/pancake-frontend/pull/8451/files?diff=unified&w=0#diff-8fb20c287d9f64663eea50168ecea60f96fd71c9b6890de5d27ec846f5aa6f8fR1-R28))


