### PR TITLE
chore(GaugesVoting): Adjust bunny position on mobile

### DIFF
--- a/apps/web/src/views/GaugesVoting/index.tsx
+++ b/apps/web/src/views/GaugesVoting/index.tsx
@@ -74,10 +74,9 @@ const GaugesVoting = () => {
               </Text>
             </Box>
           </Flex>
-
-          <Box>
+          <Flex justifyContent="flex-end">
             <img src="/images/gauges-voting/landing-bunny.png" alt="bunny" width="218px" />
-          </Box>
+          </Flex>
         </Flex>
       </StyledPageHeader>
       <Page style={{ paddingTop: 0, marginTop: '-18px' }}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2b4c18f</samp>

### Summary
🐰📦➡️

<!--
1.  🐰 (bunny)
2.  📦 (flex container)
3.  ➡️ (flex-end)
-->
Moved the bunny image to the right on the gauges voting landing page. This improves the layout and responsiveness of `apps/web/src/views/GaugesVoting/index.tsx`.

> _`bunny` hops right_
> _flex container adjusts_
> _autumn of gauges_

### Walkthrough
* Added a new view component for the gauges voting feature in `apps/web/src/views/GaugesVoting/index.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8467/files?diff=unified&w=0#diff-d978657963a2d4ae2b8e9d1bc08548263f6c44d3f60c193190ef02236a111df1L77-R79))



Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/82d9a41c-a3ac-40d2-9ab1-6da3a1bbdeed)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/acd85820-3db5-4174-94c8-ba443a3c5365)
