### PR TITLE
fix: Untransformed variables in translations

### DIFF
--- a/packages/localization/src/Provider.tsx
+++ b/packages/localization/src/Provider.tsx
@@ -106,7 +106,7 @@ export const LanguageProvider: React.FC<React.PropsWithChildren> = ({ children }
           return reduce(
             omitBy(data, isUndefinedOrNull),
             (result, dataValue, dataKey) => {
-              if (dataValue) {
+              if (dataValue !== undefined && dataValue !== null) {
                 return result.replace(getRegExpForDataKey(dataKey), dataValue.toString())
               }
               return result


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at edc50cf</samp>

### Summary
🐛🛠️🌐

<!--
1.  🐛 - This emoji represents a bug or an issue that needs to be fixed. It can be used to indicate that the change is part of a bug fix or a solution to a problem.
2.  🛠️ - This emoji represents a tool or a repair. It can be used to indicate that the change is part of a refactoring or an improvement to the code quality or functionality.
3.  🌐 - This emoji represents the globe or the world. It can be used to indicate that the change is related to localization or internationalization, or that it affects multiple languages or regions.
-->
Fixed a bug in the localization provider that caused some translations to miss data values. Changed the logic for checking the existence of data values in `Provider.tsx`.

> _`dataValue` checked_
> _not falsey, but undefined_
> _autumn bug is fixed_

### Walkthrough
* Fix issue #2419 where some translations were missing data values by checking for `undefined` and `null` instead of falsey values in `Provider.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8470/files?diff=unified&w=0#diff-91251395c6bcf055b988c7385d7fefb63bcbb114e2abe938dd9c7ec3835c589fL109-R109))


