### PR TITLE
fix: chainName

### DIFF
--- a/packages/widgets-internal/components/CurrencyLogo/utils.ts
+++ b/packages/widgets-internal/components/CurrencyLogo/utils.ts
@@ -43,7 +43,7 @@ const chainName: { [key: number]: string } = {
   [ChainId.BSC]: "",
   [ChainId.ETHEREUM]: "eth",
   [ChainId.POLYGON_ZKEVM]: "polygon-zkevm",
-  [ChainId.ARBITRUM_ONE]: "arb",
+  [ChainId.ARBITRUM_ONE]: "arbitrum",
   [ChainId.ZKSYNC]: "zksync",
   [ChainId.LINEA]: "linea",
   [ChainId.BASE]: "base",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2ff6d8c</samp>

### Summary
🔄🌐🖼️

<!--
1.  🔄 - This emoji means "repeat" or "change", and it can be used to indicate that a value was changed or updated.
2.  🌐 - This emoji means "globe with meridians" or "worldwide", and it can be used to indicate that the change relates to a network or a chain ID.
3.  🖼️ - This emoji means "frame with picture" or "logo", and it can be used to indicate that the change affects the appearance or the source of a logo.
-->
Updated the logo key for Arbitrum One network in `CurrencyLogo` component. This improves the readability and accuracy of the currency logos for different chains.

> _`chainIdToLogo`_
> _Arbitrum name replaces arb_
> _Autumn of clarity_

### Walkthrough
*  Update the logo value for Arbitrum One network in the currency logo component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8475/files?diff=unified&w=0#diff-471ecc0fc1054aad916046ed33d5df5095f3ba1a328639d66f96d28f4144888bL46-R46))


