### PR TITLE
perf: Prioritize single swap quotes

### DIFF
--- a/.changeset/sixty-knives-refuse.md
+++ b/.changeset/sixty-knives-refuse.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': minor
+---
+
+Add retry options to onchain quoter

--- a/packages/smart-router/evm/constants/exchange.ts
+++ b/packages/smart-router/evm/constants/exchange.ts
@@ -157,6 +157,11 @@ export const ADDITIONAL_BASES: {
     // rETH - ETH
     [ethereumTokens.weth.address]: [ethereumTokens.rETH],
   },
+  [ChainId.BASE]: {
+    // axlusdc - USDbC
+    [baseTokens.axlusdc.address]: [baseTokens.usdbc],
+    [baseTokens.usdbc.address]: [baseTokens.axlusdc],
+  },
 }
 
 /**

--- a/packages/smart-router/evm/v3-router/providers/onChainQuoteProvider.ts
+++ b/packages/smart-router/evm/v3-router/providers/onChainQuoteProvider.ts
@@ -4,7 +4,15 @@ import { Abi, Address } from 'viem'
 import retry, { Options as RetryOptions } from 'async-retry'
 // import uniq from 'lodash/uniq.js'
 
-import { GasModel, OnChainProvider, QuoteProvider, QuoterOptions, RouteWithoutQuote, RouteWithQuote } from '../types'
+import {
+  GasModel,
+  OnChainProvider,
+  QuoteProvider,
+  QuoteRetryOptions,
+  QuoterOptions,
+  RouteWithoutQuote,
+  RouteWithQuote,
+} from '../types'
 import { mixedRouteQuoterV1ABI } from '../../abis/IMixedRouteQuoterV1'
 import { quoterV2ABI } from '../../abis/IQuoterV2'
 import { encodeMixedRouteToPath, getQuoteCurrency, isStablePool, isV2Pool, isV3Pool } from '../utils'
@@ -31,7 +39,7 @@ const SUCCESS_RATE_CONFIG = {
   [ChainId.LINEA_TESTNET]: 0.1,
   [ChainId.OPBNB]: 0.1,
   [ChainId.OPBNB_TESTNET]: 0.1,
-  [ChainId.BASE]: 0.05,
+  [ChainId.BASE]: 0.1,
   [ChainId.BASE_TESTNET]: 0.1,
   [ChainId.SCROLL_SEPOLIA]: 0.1,
 } as const satisfies Record<ChainId, number>
@@ -83,18 +91,18 @@ export class ProviderGasError extends Error {
   public name = 'ProviderGasError'
 }
 
-export type QuoteRetryOptions = RetryOptions
-
 interface GetQuotesConfig {
   gasLimitPerCall: number
 }
 
-const retryControllerFactory = () => {
+const retryControllerFactory = ({ retries }: QuoteRetryOptions) => {
   const errors: Error[] = []
+  let remainingRetries = retries || 0
   return {
-    shouldRetry: (error: Error) => errors.every((err) => err.name !== error.name),
+    shouldRetry: (error: Error) => remainingRetries > 0 && errors.every((err) => err.name !== error.name),
     onRetry: (error: Error) => {
       errors.push(error)
+      remainingRetries -= 1
     },
     getErrorsOnPreviousRetries: () => errors,
   }
@@ -113,7 +121,7 @@ function onChainQuoteProviderFactory({ getQuoteFunctionName, getQuoterAddress, a
 
       return async function getRoutesWithQuote(
         routes: RouteWithoutQuote[],
-        { blockNumber: blockNumberFromConfig, gasModel }: QuoterOptions,
+        { blockNumber: blockNumberFromConfig, gasModel, retry: retryOptions }: QuoterOptions,
       ): Promise<RouteWithQuote[]> {
         if (!routes.length) {
           return []
@@ -139,7 +147,13 @@ function onChainQuoteProviderFactory({ getQuoteFunctionName, getQuoterAddress, a
         const multicall2Provider = new PancakeMulticallProvider(chainId, chainProvider, defaultGasLimitPerCall)
         const inputs = routes.map<CallInputs>((route) => getCallInputs(route, isExactIn))
 
-        const { shouldRetry, onRetry } = retryControllerFactory()
+        const retryOptionsWithDefault = {
+          retries: DEFAULT_BATCH_RETRIES,
+          minTimeout: 25,
+          maxTimeout: 250,
+          ...retryOptions,
+        }
+        const { shouldRetry, onRetry } = retryControllerFactory(retryOptionsWithDefault)
 
         async function getQuotes({ gasLimitPerCall }: GetQuotesConfig) {
           try {
@@ -192,42 +206,35 @@ function onChainQuoteProviderFactory({ getQuoteFunctionName, getQuoterAddress, a
           }
         }
 
-        const quoteResult = await retry(
-          async (bail) => {
-            try {
-              const quotes = await getQuotes({
-                gasLimitPerCall: defaultGasLimitPerCall,
-              })
-              return quotes
-            } catch (e: unknown) {
-              const error = e instanceof Error ? e : new Error(`Unexpected error type ${e}`)
-              if (!shouldRetry(error)) {
-                // bail is actually rejecting the promise on retry function
-                return bail(error)
-              }
-              if (error instanceof SuccessRateError) {
-                onRetry(error)
-                const { successRateFailureOverrides } = multicallConfigs
-                return getQuotes({
-                  gasLimitPerCall: successRateFailureOverrides.gasLimitPerCall,
-                })
-              }
-              if (error instanceof ProviderGasError) {
-                onRetry(error)
-                const { gasErrorFailureOverride } = multicallConfigs
-                return getQuotes({
-                  gasLimitPerCall: gasErrorFailureOverride.gasLimitPerCall,
-                })
-              }
-              throw error
+        const quoteResult = await retry(async (bail) => {
+          try {
+            const quotes = await getQuotes({
+              gasLimitPerCall: defaultGasLimitPerCall,
+            })
+            return quotes
+          } catch (e: unknown) {
+            const error = e instanceof Error ? e : new Error(`Unexpected error type ${e}`)
+            if (!shouldRetry(error)) {
+              // bail is actually rejecting the promise on retry function
+              return bail(error)
             }
-          },
-          {
-            retries: DEFAULT_BATCH_RETRIES,
-            minTimeout: 25,
-            maxTimeout: 250,
-          },
-        )
+            if (error instanceof SuccessRateError) {
+              onRetry(error)
+              const { successRateFailureOverrides } = multicallConfigs
+              return getQuotes({
+                gasLimitPerCall: successRateFailureOverrides.gasLimitPerCall,
+              })
+            }
+            if (error instanceof ProviderGasError) {
+              onRetry(error)
+              const { gasErrorFailureOverride } = multicallConfigs
+              return getQuotes({
+                gasLimitPerCall: gasErrorFailureOverride.gasLimitPerCall,
+              })
+            }
+            throw error
+          }
+        }, retryOptionsWithDefault)
 
         if (!quoteResult) {
           throw new Error(`Unexpected empty quote result ${quoteResult}`)

--- a/packages/smart-router/evm/v3-router/providers/onChainQuoteProvider.ts
+++ b/packages/smart-router/evm/v3-router/providers/onChainQuoteProvider.ts
@@ -1,7 +1,7 @@
 import { BigintIsh, Currency, CurrencyAmount } from '@pancakeswap/sdk'
 import { ChainId } from '@pancakeswap/chains'
 import { Abi, Address } from 'viem'
-import retry, { Options as RetryOptions } from 'async-retry'
+import retry from 'async-retry'
 // import uniq from 'lodash/uniq.js'
 
 import {

--- a/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
+++ b/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
@@ -59,7 +59,7 @@ export function createQuoteProvider(config: QuoterConfig): QuoteProvider<QuoterC
         getOffChainQuotes(routesCanQuoteOffChain, { blockNumber, gasModel }),
         getMixedRouteQuotes(mixedRoutesHaveV3Pool, { blockNumber, gasModel, retry: { retries: 0 } }),
         getV3Quotes(v3SingleHopRoutes, { blockNumber, gasModel }),
-        getV3Quotes(v3MultihopRoutes, { blockNumber, gasModel, retry: { retries: 0 } }),
+        getV3Quotes(v3MultihopRoutes, { blockNumber, gasModel, retry: { retries: 1 } }),
       ])
       if (results.every((result) => result.status === 'rejected')) {
         throw new Error(results.map((result) => (result as PromiseRejectedResult).reason).join(','))

--- a/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
+++ b/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
@@ -30,7 +30,8 @@ export function createQuoteProvider(config: QuoterConfig): QuoteProvider<QuoterC
       routes: RouteWithoutQuote[],
       { blockNumber, gasModel }: QuoterOptions,
     ): Promise<RouteWithQuote[]> {
-      const v3Routes: RouteWithoutQuote[] = []
+      const v3SingleHopRoutes: RouteWithoutQuote[] = []
+      const v3MultihopRoutes: RouteWithoutQuote[] = []
       const mixedRoutesHaveV3Pool: RouteWithoutQuote[] = []
       const routesCanQuoteOffChain: RouteWithoutQuote[] = []
       for (const route of routes) {
@@ -39,7 +40,11 @@ export function createQuoteProvider(config: QuoterConfig): QuoteProvider<QuoterC
           continue
         }
         if (route.type === RouteType.V3) {
-          v3Routes.push(route)
+          if (route.pools.length === 1) {
+            v3SingleHopRoutes.push(route)
+            continue
+          }
+          v3MultihopRoutes.push(route)
           continue
         }
         const { pools } = route
@@ -52,8 +57,9 @@ export function createQuoteProvider(config: QuoterConfig): QuoteProvider<QuoterC
 
       const results = await Promise.allSettled([
         getOffChainQuotes(routesCanQuoteOffChain, { blockNumber, gasModel }),
-        getMixedRouteQuotes(mixedRoutesHaveV3Pool, { blockNumber, gasModel }),
-        getV3Quotes(v3Routes, { blockNumber, gasModel }),
+        getMixedRouteQuotes(mixedRoutesHaveV3Pool, { blockNumber, gasModel, retry: { retries: 0 } }),
+        getV3Quotes(v3SingleHopRoutes, { blockNumber, gasModel }),
+        getV3Quotes(v3MultihopRoutes, { blockNumber, gasModel, retry: { retries: 0 } }),
       ])
       if (results.every((result) => result.status === 'rejected')) {
         throw new Error(results.map((result) => (result as PromiseRejectedResult).reason).join(','))

--- a/packages/smart-router/evm/v3-router/types/providers.ts
+++ b/packages/smart-router/evm/v3-router/types/providers.ts
@@ -2,6 +2,7 @@ import { Currency, BigintIsh } from '@pancakeswap/sdk'
 import { ChainId } from '@pancakeswap/chains'
 import { PublicClient } from 'viem'
 import type { GraphQLClient } from 'graphql-request'
+import type { Options as RetryOptions } from 'async-retry'
 
 import { Pool, PoolType } from './pool'
 import { RouteWithoutQuote, RouteWithQuote } from './route'
@@ -22,9 +23,12 @@ export interface PoolProvider {
   getCandidatePools: (params: GetPoolParams) => Promise<Pool[]>
 }
 
+export type QuoteRetryOptions = RetryOptions
+
 export interface QuoterOptions {
   blockNumber?: BigintIsh
   gasModel: GasModel
+  retry?: QuoteRetryOptions
 }
 
 export type QuoterConfig = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 389e05c</samp>

### Summary
🛠️🚀📝

<!--
1.  🛠️ - This emoji represents the addition of a new feature or functionality, such as the ability to customize the retry behavior of the on-chain quote provider.
2.  🚀 - This emoji represents the improvement or enhancement of an existing feature or functionality, such as the support for multi-hop V3 routes and the quote provider selection.
3.  📝 - This emoji represents the documentation or typing of the code, such as the enhancement of the `QuoterOptions` interface and the import of the `RetryOptions` type.
-->
This pull request improves the functionality and reliability of the V3 router by adding support for multi-hop routes, customizing the retry behavior of the on-chain quote provider, and using a consistent success rate threshold. It modifies the `onChainQuoteProvider.ts`, `quoteProviders.ts`, and `providers.ts` files in the `packages/smart-router/evm/v3-router` directory.

> _We are the masters of the route_
> _We customize the retry_
> _We face the chains with no doubt_
> _We get the best quote or die_

### Walkthrough
*  Add and use `QuoteRetryOptions` type and `retry` property to customize the retry behavior of the on-chain quote provider ([link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L7-R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L34-R42), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L86-R105), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L116-R124), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L142-R156), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-9ee18cb7fa7b08aada0e9a3c92dede9202fb872ba10bd8f230843faef707f463L195-R237), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-af970447e91def4d88a80070b0ac3acc54fe8635121580383bd18b2cdffbc2fdR5), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-af970447e91def4d88a80070b0ac3acc54fe8635121580383bd18b2cdffbc2fdL25-R31))
*  Separate single-hop and multi-hop V3 routes and use different quote providers for each case in the `createQuoteProvider` function of `quoteProviders.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-4048276923cd03ee6d8a16e5d98b690dce94d9fff751d6c112f14b3a7c98c3bdL33-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-4048276923cd03ee6d8a16e5d98b690dce94d9fff751d6c112f14b3a7c98c3bdL42-R47), [link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-4048276923cd03ee6d8a16e5d98b690dce94d9fff751d6c112f14b3a7c98c3bdL55-R62))
*  Disable the retry behavior for the mixed route and V3 quote providers in the `createQuoteProvider` function of `quoteProviders.ts` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8480/files?diff=unified&w=0#diff-4048276923cd03ee6d8a16e5d98b690dce94d9fff751d6c112f14b3a7c98c3bdL55-R62))


