### PR TITLE
fix: vecake banner responsive

### DIFF
--- a/apps/web/src/views/Home/components/Banners/VeCakeBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/VeCakeBanner.tsx
@@ -237,10 +237,10 @@ const VeCakeBanner = () => {
             <Image src={vecakeMobileBunny} alt="vecakeMobileBunny" width={161} height={177.7} placeholder="blur" />
           )}
           <BgWrapper>
-            {isDesktop ? (
-              <Image src={vecakeBg} alt="vecakeBg" width={1126} height={192} placeholder="blur" />
-            ) : (
+            {isMobile ? (
               <Image src={vecakeMobileBg} alt="vecakeBg" placeholder="blur" />
+            ) : (
+              <Image src={vecakeBg} alt="vecakeBg" width={1126} height={192} placeholder="blur" />
             )}
           </BgWrapper>
         </RightWrapper>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d2ba997</samp>

### Summary
🐛📱🎨

<!--
1.  🐛 Bug fix: The change fixes a bug in the logic that caused the wrong image to be rendered for different screen sizes.
2.  📱 Responsive design: The change enhances the responsive design of the vecake banner component by using appropriate images for mobile and desktop devices.
3.  🎨 Layout improvement: The change improves the layout of the vecake banner component by avoiding stretching or cropping the background image.
-->
Fix vecake banner image logic for mobile and desktop views. This change enhances the UI of the `VeCakeBanner` component in `apps/web/src/views/Home/components/Banners/VeCakeBanner.tsx`.

> _`isMobile` fixed_
> _vecake banner now adapts_
> _to autumnal screens_

### Walkthrough
* Fix the logic for rendering the vecake background image based on the device size ([link](https://github.com/pancakeswap/pancake-frontend/pull/8481/files?diff=unified&w=0#diff-119dc8e6a5a5415ae331ea64b75200e50386078b9a20b577762590f1d8ef6ffdL240-R243))


