### PR TITLE
fix(GaugesVoting): Fix sort button

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
@@ -61,21 +61,21 @@ export const TableHeader: React.FC<{
         </Text>
       </Th>
       <Th>
-        <Touchable>
+        <Touchable onClick={onVoteSort}>
           <Text color="secondary" textTransform="uppercase" fontWeight={600}>
             {t('votes')}
           </Text>
-          <SortButton scale="sm" variant="subtle" onClick={onVoteSort} className={getSortClassName(voteSort)}>
+          <SortButton scale="sm" variant="subtle" className={getSortClassName(voteSort)}>
             <SortArrowIcon />
           </SortButton>
         </Touchable>
       </Th>
       <Th>
-        <Touchable>
+        <Touchable onClick={onBoostSort}>
           <Text color="secondary" textTransform="uppercase" fontWeight={600}>
             {t('boost')}
           </Text>
-          <SortButton scale="sm" variant="subtle" onClick={onBoostSort} className={getSortClassName(boostSort)}>
+          <SortButton scale="sm" variant="subtle" className={getSortClassName(boostSort)}>
             <SortArrowIcon />
           </SortButton>
         </Touchable>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at adb0393</samp>

### Summary
🖱️🔀📊

<!--
1.  🖱️ - This emoji represents a computer mouse, which is the device that users would typically use to click on the table header cells. It also suggests the idea of interactivity and sorting by clicking.
2.  🔀 - This emoji represents the shuffle or randomize icon, which is often used to indicate sorting or changing the order of items. It also suggests the idea of switching between ascending and descending order by clicking again.
3.  📊 - This emoji represents a bar chart, which is a common way of visualizing data in tables. It also suggests the idea of comparing and analyzing the vote and boost values across different rows.
-->
Improved the sorting functionality of the gauges voting table by making the whole header cells clickable. Modified the `Touchable` component in `TableHeader.tsx` to achieve this.

> _`Touchable` changed_
> _Table header cells sortable_
> _Winter of clicking_

### Walkthrough
*  Make the vote and boost table header cells sortable by clicking anywhere on them ([link](https://github.com/pancakeswap/pancake-frontend/pull/8504/files?diff=unified&w=0#diff-1e19294b710179d62409777fc1c830d24ad1429ea32b6d06a0b169215b305232L64-R68), [link](https://github.com/pancakeswap/pancake-frontend/pull/8504/files?diff=unified&w=0#diff-1e19294b710179d62409777fc1c830d24ad1429ea32b6d06a0b169215b305232L74-R78))


