### PR TITLE
fix: Missing translations in liquidity add/remove modals

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -198,7 +198,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
 
       setAttemptingTxn(true)
       getViemClients({ chainId })
-        .estimateGas({
+        ?.estimateGas({
           account,
           to: manager.address,
           data: calldata,
@@ -274,15 +274,30 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     }
   }, [onFieldAInput, router, txHash, tokenId])
 
-  const pendingText = useMemo(
-    () =>
-      `Supplying ${!depositADisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale) : ''} ${
-        !depositADisabled ? currencies[Field.CURRENCY_A]?.symbol : ''
-      } ${!outOfRange ? 'and' : ''} ${
-        !depositBDisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale) : ''
-      } ${!depositBDisabled ? currencies[Field.CURRENCY_B]?.symbol : ''}`,
-    [depositADisabled, depositBDisabled, currencies, parsedAmounts, outOfRange, locale],
-  )
+  const pendingText = useMemo(() => {
+    if (depositADisabled) {
+      return t('Supplying %amountA% %symbolA% %amountB% %symbolB%', {
+        amountA: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale),
+        symbolA: currencies[Field.CURRENCY_B]?.symbol,
+        amountB: '',
+        symbolB: '',
+      })
+    }
+    if (depositBDisabled) {
+      return t('Supplying %amountA% %symbolA% %amountB% %symbolB%', {
+        amountA: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale),
+        symbolA: currencies[Field.CURRENCY_A]?.symbol,
+        amountB: '',
+        symbolB: '',
+      })
+    }
+    return t('Supplying %amountA% %symbolA% and %amountB% %symbolB%', {
+      amountA: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale),
+      symbolA: currencies[Field.CURRENCY_A]?.symbol ?? '',
+      amountB: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale),
+      symbolB: currencies[Field.CURRENCY_B]?.symbol ?? '',
+    })
+  }, [depositADisabled, depositBDisabled, currencies, parsedAmounts, locale, t])
 
   const [onPresentIncreaseLiquidityModal] = useModal(
     <TransactionConfirmationModal

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -277,7 +277,7 @@ export default function V3FormView({
         account,
       }
       getViemClients({ chainId })
-        .estimateGas(txn)
+        ?.estimateGas(txn)
         .then((gas) => {
           sendTransactionAsync({
             ...txn,
@@ -352,21 +352,32 @@ export default function V3FormView({
   const showApprovalA = approvalA !== ApprovalState.APPROVED && !!parsedAmounts[Field.CURRENCY_A]
   const showApprovalB = approvalB !== ApprovalState.APPROVED && !!parsedAmounts[Field.CURRENCY_B]
 
-  const translationData = useMemo(
-    () => ({
-      amountA: !depositADisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale) : '',
-      symbolA: !depositADisabled && currencies[Field.CURRENCY_A]?.symbol ? currencies[Field.CURRENCY_A].symbol : '',
-      amountB: !depositBDisabled ? formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale) : '',
-      symbolB: !depositBDisabled && currencies[Field.CURRENCY_B]?.symbol ? currencies[Field.CURRENCY_B].symbol : '',
-    }),
-    [depositADisabled, depositBDisabled, parsedAmounts, locale, currencies],
-  )
+  const translationData = useMemo(() => {
+    if (depositADisabled) {
+      return {
+        amount: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale),
+        symbol: currencies[Field.CURRENCY_B]?.symbol ? currencies[Field.CURRENCY_B].symbol : '',
+      }
+    }
+    if (depositBDisabled) {
+      return {
+        amount: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale),
+        symbol: currencies[Field.CURRENCY_A]?.symbol ? currencies[Field.CURRENCY_A].symbol : '',
+      }
+    }
+    return {
+      amountA: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_A], 4, locale),
+      symbolA: currencies[Field.CURRENCY_A]?.symbol ? currencies[Field.CURRENCY_A].symbol : '',
+      amountB: formatCurrencyAmount(parsedAmounts[Field.CURRENCY_B], 4, locale),
+      symbolB: currencies[Field.CURRENCY_B]?.symbol ? currencies[Field.CURRENCY_B].symbol : '',
+    }
+  }, [depositADisabled, depositBDisabled, parsedAmounts, locale, currencies])
 
   const pendingText = useMemo(
     () =>
       !outOfRange
         ? t('Supplying %amountA% %symbolA% and %amountB% %symbolB%', translationData)
-        : t('Supplying %amountA% %symbolA% %amountB% %symbolB%', translationData),
+        : t('Supplying %amount% %symbol%', translationData),
     [t, outOfRange, translationData],
   )
 

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -311,6 +311,17 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
     setTxnHash('')
   }, [onPercentSelectForSlider, percentForSlider, router, txnHash])
 
+  const pendingText = useMemo(
+    () =>
+      t('Removing %amountA% %symbolA% and %amountB% %symbolB%', {
+        amountA: liquidityValue0?.toSignificant(6),
+        symbolA: liquidityValue0?.currency?.symbol,
+        amountB: liquidityValue1?.toSignificant(6),
+        symbolB: liquidityValue1?.currency?.symbol,
+      }),
+    [liquidityValue0, liquidityValue1, t],
+  )
+
   const [onPresentRemoveLiquidityModal] = useModal(
     <TransactionConfirmationModal
       title={t('Remove Liquidity')}
@@ -330,8 +341,7 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
           )}
         />
       )}
-      pendingText={`Removing ${liquidityValue0?.toSignificant(6)} ${liquidityValue0?.currency?.symbol} and
-      ${liquidityValue1?.toSignificant(6)} ${liquidityValue1?.currency?.symbol}`}
+      pendingText={pendingText}
     />,
     true,
     true,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 20390ac</samp>

### Summary
🐛🌐📝

<!--
1.  🐛 for fixing bugs and preventing errors.
2.  🌐 for improving translation and localization.
3.  📝 for improving readability and refactoring code.
-->
This pull request fixes some bugs and enhances the user interface and localization for adding and removing liquidity in the V3 pool. It affects the files `index.tsx`, `IncreaseLiquidityV3.tsx`, and `RemoveLiquidityV3.tsx` in the `AddLiquidityV3` and `RemoveLiquidity` views.

> _Sing, O Muse, of the skillful code that fixed the bugs and errors_
> _That plagued the form of liquidity, where tokens join in pairs_
> _And of the clever refactor that made the translation clear_
> _And of the new and graceful key that showed the range of prices_

### Walkthrough
*  Add optional chaining to `getViemClients` function call to prevent errors if provider is undefined ([link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL201-R201), [link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L280-R280))
*  Refactor `translationData` and `pendingText` variables to use `t` function and handle disabled deposit cases in `AddLiquidityV3` and `IncreaseLiquidityV3` views ([link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-55f1a144ef0399cae9d8672d1b068bf090c86b0cbc50caee90e5d1c87deb904bL277-R300), [link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L355-R374), [link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-93f8dec4471df1307df92d3959703cfff58885d29c64ab692855fc06bf02f764L369-R380))
*  Add and use `pendingText` variable to show translated and formatted amounts and symbols of liquidity tokens in `RemoveLiquidityV3` view ([link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-3639b5beb9d763170cb423e83fcbcd8129c820faa28a757bf95b2d841ca14261R314-R324), [link](https://github.com/pancakeswap/pancake-frontend/pull/8516/files?diff=unified&w=0#diff-3639b5beb9d763170cb423e83fcbcd8129c820faa28a757bf95b2d841ca14261L333-R344))


