### PR TITLE
fix: v2 token table left paren

### DIFF
--- a/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/TokensTable.tsx
@@ -1,17 +1,17 @@
-import { useState, useMemo, useCallback, useEffect, Fragment } from 'react'
-import { styled } from 'styled-components'
-import { Text, Flex, Box, Skeleton, ArrowBackIcon, ArrowForwardIcon, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { ArrowBackIcon, ArrowForwardIcon, Box, Flex, Skeleton, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import { styled } from 'styled-components'
 
-import { useMultiChainPath, useStableSwapPath, useChainNameByQuery } from 'state/info/hooks'
-import { subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
-import { TokenData } from 'state/info/types'
-import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
-import Percent from 'views/Info/components/Percent'
 import { useTranslation } from '@pancakeswap/localization'
 import orderBy from 'lodash/orderBy'
-import { formatAmount } from 'utils/formatInfoNumbers'
+import { subgraphTokenName, subgraphTokenSymbol } from 'state/info/constant'
+import { useChainNameByQuery, useMultiChainPath, useStableSwapPath } from 'state/info/hooks'
+import { TokenData } from 'state/info/types'
 import { safeGetAddress } from 'utils'
+import { formatAmount } from 'utils/formatInfoNumbers'
+import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
+import Percent from 'views/Info/components/Percent'
 import { Arrow, Break, ClickableColumnHeader, PageButtons, TableWrapper } from './shared'
 
 /**
@@ -111,7 +111,7 @@ const DataRow: React.FC<React.PropsWithChildren<{ tokenData: TokenData; index: n
             <Flex marginLeft="10px">
               <Text>{(checksummedAddress && subgraphTokenName[checksummedAddress]) || tokenData.name}</Text>
               <Text ml="8px">
-                {(checksummedAddress && subgraphTokenSymbol[checksummedAddress]) || tokenData.symbol})
+                ({(checksummedAddress && subgraphTokenSymbol[checksummedAddress]) || tokenData.symbol})
               </Text>
             </Flex>
           )}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e22ac28</samp>

### Summary
🐛📝🔣

<!--
1.  🐛 - This emoji is commonly used to indicate a bug fix, and it can convey the idea of squashing a bug or fixing an error. In this case, it can represent the UI bug that was fixed in `TokensTable.tsx`.
2.  📝 - This emoji is often used to indicate documentation, comments, or code readability improvements. It can convey the idea of writing, editing, or clarifying something. In this case, it can represent the improved code readability in `TokensTable.tsx`.
3.  🔣 - This emoji is used to indicate symbols, characters, or icons. It can convey the idea of adding, changing, or displaying something related to symbols. In this case, it can represent the missing parenthesis for token symbols that was added in `TokensTable.tsx`.
-->
Fixed a UI bug and refactored `TokensTable.tsx` component. The component now displays token symbols correctly and has cleaner code.

> _A bug in the UI was vexing_
> _So `TokensTable.tsx` needed fixing_
> _The imports were sorted_
> _A parenthesis was added_
> _And the code became more readable and less mixing_

### Walkthrough
*  Add missing opening parenthesis for token symbol in tokens table ([link](https://github.com/pancakeswap/pancake-frontend/pull/8518/files?diff=unified&w=0#diff-59df06b26c18631c47f904e6c3cdf91c6a50e1571fe469a57d603bd320289064L114-R114))
* Reorder imports alphabetically by package and name in `TokensTable.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8518/files?diff=unified&w=0#diff-59df06b26c18631c47f904e6c3cdf91c6a50e1571fe469a57d603bd320289064L1-R14))


