### PR TITLE
fix: vote table tbody

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -153,7 +153,7 @@ export const VoteTable = () => {
 
       {!isLoading ? (
         rows?.length ? (
-          <tbody>
+          <div>
             <Scrollable expanded={expanded}>
               {rows.map((row) => (
                 <TableRow
@@ -165,7 +165,7 @@ export const VoteTable = () => {
               ))}
             </Scrollable>
             {rows?.length > 3 ? <ExpandRow text={t('Show all')} onCollapse={() => setExpanded(!expanded)} /> : null}
-          </tbody>
+          </div>
         ) : (
           <EmptyTable />
         )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2fcc764</samp>

### Summary
🛠️🖼️🖱️

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the changes involved fixing a problem or improving something.
2. 🖼️ - This emoji represents a picture or a frame, and can be used to indicate that the changes involved rendering or displaying something visually.
3. 🖱️ - This emoji represents a mouse or a scroll, and can be used to indicate that the changes involved a scrollable component or a user interaction.
-->
Fixed a bug in the Gauges Voting view that caused the vote table to display incorrectly. Changed the HTML structure of the table to use `<div>` elements instead of `<tbody>` elements.

> _`<Scrollable>` is the portal to hell_
> _Where the tables of doom are rendered_
> _We break the rules of the HTML_
> _We use `<div>`s to transcend the order_

### Walkthrough
*  Replace `<tbody>` element with `<div>` element in `VoteTable` component to fix rendering issue with `<Scrollable>` component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8528/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L156-R156), [link](https://github.com/pancakeswap/pancake-frontend/pull/8528/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L168-R168))


