### PR TITLE
chore(simple-staking): Disable cake pool

### DIFF
--- a/apps/web/src/views/FixedStaking/components/AmountWithUSDSub.tsx
+++ b/apps/web/src/views/FixedStaking/components/AmountWithUSDSub.tsx
@@ -23,7 +23,12 @@ export function AmountWithUSDSub({
     undefined,
     <>
       <Text fontSize={fontSize} bold mb={mb}>
-        {amount.toSignificant(5)} {amount.currency.wrapped.symbol}
+        <Balance
+          fontSize="16px"
+          value={toNumber(amount.toSignificant(6))}
+          decimals={0}
+          unit={` ${amount.currency.wrapped.symbol}`}
+        />
       </Text>
       <Balance
         unit=" USD"

--- a/apps/web/src/views/FixedStaking/components/ClaimModal.tsx
+++ b/apps/web/src/views/FixedStaking/components/ClaimModal.tsx
@@ -1,20 +1,21 @@
-import { Box, Flex, Modal, ModalV2, PreTitle, Text, Button, useModalV2, Card } from '@pancakeswap/uikit'
-import { LightCard } from 'components/Card'
 import { useTranslation } from '@pancakeswap/localization'
-import { CurrencyAmount, Percent, Currency } from '@pancakeswap/swap-sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@pancakeswap/swap-sdk-core'
+import { Box, Button, Card, Flex, Modal, ModalV2, PreTitle, Text, useModalV2 } from '@pancakeswap/uikit'
+import { LightCard } from 'components/Card'
 import { ReactNode, useMemo, useState } from 'react'
 import { formatUnixTime } from 'utils/formatTime'
 
-import { UnstakeEndedModal } from './UnstakeModal'
-import { HarvestModal } from './HarvestModal'
-import { PoolGroup, StakePositionUserInfo, StakedPosition } from '../type'
-import { useHandleWithdrawSubmission } from '../hooks/useHandleWithdrawSubmission'
+import { bscTokens } from '@pancakeswap/tokens'
 import { useCalculateProjectedReturnAmount } from '../hooks/useCalculateProjectedReturnAmount'
+import { useHandleWithdrawSubmission } from '../hooks/useHandleWithdrawSubmission'
+import useIsBoost from '../hooks/useIsBoost'
+import { useCurrentDay } from '../hooks/useStakedPools'
+import { PoolGroup, StakePositionUserInfo, StakedPosition } from '../type'
 import { AmountWithUSDSub } from './AmountWithUSDSub'
+import { HarvestModal } from './HarvestModal'
 import { ModalTitle } from './ModalTitle'
 import { StakedLimitEndOn } from './StakedLimitEndOn'
-import { useCurrentDay } from '../hooks/useStakedPools'
-import useIsBoost from '../hooks/useIsBoost'
+import { UnstakeEndedModal } from './UnstakeModal'
 
 export function ClaimModal({
   token,
@@ -180,6 +181,7 @@ export function ClaimModal({
                 </Flex>
                 {poolEnded ? null : (
                   <Button
+                    disabled={pool.token.equals(bscTokens.cake)}
                     variant="subtle"
                     width="100%"
                     onClick={() => {

--- a/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingCard.tsx
@@ -1,18 +1,19 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { CardBody, Flex, Heading, Tag, Box, Button, StarCircle } from '@pancakeswap/uikit'
+import { Box, Button, CardBody, Flex, Heading, StarCircle, Tag } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
-import CurrencyLogo from 'components/Logo/CurrencyLogo'
 import BigNumber from 'bignumber.js'
-import first from 'lodash/first'
 import { LightGreyCard } from 'components/Card'
 import Divider from 'components/Divider'
+import CurrencyLogo from 'components/Logo/CurrencyLogo'
+import first from 'lodash/first'
 import React from 'react'
 
+import { bscTokens } from '@pancakeswap/tokens'
+import { PoolGroup, StakedPosition } from '../type'
 import { FixedStakingCardBody } from './FixedStakingCardBody'
-import { StakedPositionSection } from './StakedPositionSection'
 import { FixedStakingModal } from './FixedStakingModal'
 import { InlineText } from './InlineText'
-import { StakedPosition, PoolGroup } from '../type'
+import { StakedPositionSection } from './StakedPositionSection'
 
 export function FixedStakingCard({ pool, stakedPositions }: { pool: PoolGroup; stakedPositions: StakedPosition[] }) {
   const { t } = useTranslation()
@@ -80,7 +81,11 @@ export function FixedStakingCard({ pool, stakedPositions }: { pool: PoolGroup; s
                   stakedPositions={stakedPositions}
                 >
                   {(openModal, hideStakeButton) =>
-                    hideStakeButton ? null : <Button onClick={openModal}>{t('Stake')}</Button>
+                    hideStakeButton ? null : (
+                      <Button disabled={pool.token.equals(bscTokens.cake)} onClick={openModal}>
+                        {t('Stake')}
+                      </Button>
+                    )
                   }
                 </FixedStakingModal>
               ) : null}

--- a/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingRow.tsx
@@ -1,36 +1,37 @@
+import { useTranslation } from '@pancakeswap/localization'
 import {
-  Text,
-  Flex,
   Box,
   Button,
-  ButtonMenuItem,
   ButtonMenu,
-  useMatchBreakpoints,
-  UnlockIcon,
+  ButtonMenuItem,
+  Flex,
   LockIcon,
+  Text,
+  UnlockIcon,
+  useMatchBreakpoints,
 } from '@pancakeswap/uikit'
-import { Pool, CurrencyLogo } from '@pancakeswap/widgets-internal'
-import { StyledCell } from 'views/Pools/components/PoolsTable/Cells/NameCell'
-import { useTranslation } from '@pancakeswap/localization'
-import React from 'react'
+import { CurrencyLogo, Pool } from '@pancakeswap/widgets-internal'
 import Divider from 'components/Divider'
+import React from 'react'
+import { StyledCell } from 'views/Pools/components/PoolsTable/Cells/NameCell'
 
+import { CurrencyAmount } from '@pancakeswap/swap-sdk-core'
+import { LightGreyCard } from 'components/Card'
 import {
   ActionContainer,
   InfoSection,
   StyledActionPanel,
 } from 'views/Pools/components/PoolsTable/ActionPanel/ActionPanel'
-import { LightGreyCard } from 'components/Card'
-import { CurrencyAmount } from '@pancakeswap/swap-sdk-core'
 
-import { PoolGroup, StakedPosition } from '../type'
-import { InlineText } from './InlineText'
-import { FixedStakingModal } from './FixedStakingModal'
-import { AmountWithUSDSub } from './AmountWithUSDSub'
-import { AprFooter } from './AprFooter'
-import { StakedPositionSection } from './StakedPositionSection'
+import { bscTokens } from '@pancakeswap/tokens'
 import useSelectedPeriod from '../hooks/useSelectedPeriod'
+import { PoolGroup, StakedPosition } from '../type'
+import { AmountWithUSDSub } from './AmountWithUSDSub'
 import AprCell from './AprCell'
+import { AprFooter } from './AprFooter'
+import { FixedStakingModal } from './FixedStakingModal'
+import { InlineText } from './InlineText'
+import { StakedPositionSection } from './StakedPositionSection'
 
 const FixedStakingRow = ({ pool, stakedPositions }: { pool: PoolGroup; stakedPositions: StakedPosition[] }) => {
   const { t } = useTranslation()
@@ -168,7 +169,11 @@ const FixedStakingRow = ({ pool, stakedPositions }: { pool: PoolGroup; stakedPos
                       stakingToken={pool.token}
                       stakedPositions={stakedPositions}
                     >
-                      {(openModal) => <Button onClick={openModal}>{t('Stake')}</Button>}
+                      {(openModal) => (
+                        <Button disabled={pool.token.equals(bscTokens.cake)} onClick={openModal}>
+                          {t('Stake')}
+                        </Button>
+                      )}
                     </FixedStakingModal>
                   </LightGreyCard>
                 </ActionContainer>

--- a/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
+++ b/apps/web/src/views/FixedStaking/components/StakedPositionSection.tsx
@@ -1,21 +1,22 @@
-import { Box, Button, Flex, Text, IconButton, AddIcon, MinusIcon, ChevronRightIcon } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
-import { CurrencyAmount, Percent, Currency } from '@pancakeswap/swap-sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@pancakeswap/swap-sdk-core'
+import { AddIcon, Box, Button, ChevronRightIcon, Flex, IconButton, MinusIcon, Text } from '@pancakeswap/uikit'
 import { useMemo } from 'react'
 
 import dayjs from 'dayjs'
 import { styled } from 'styled-components'
 
-import { LockedFixedTag } from './LockedFixedTag'
-import { PoolGroup, StakePositionUserInfo, StakedPosition } from '../type'
-import { ClaimModal } from './ClaimModal'
-import { UnlockedFixedTag } from './UnlockedFixedTag'
-import { FixedRestakingModal } from './RestakeFixedStakingModal'
-import { UnstakeBeforeEnededModal } from './UnstakeBeforeEndedModal'
-import { useFixedStakeAPR } from '../hooks/useFixedStakeAPR'
-import { AmountWithUSDSub } from './AmountWithUSDSub'
+import { bscTokens } from '@pancakeswap/tokens'
 import { useCalculateProjectedReturnAmount } from '../hooks/useCalculateProjectedReturnAmount'
+import { useFixedStakeAPR } from '../hooks/useFixedStakeAPR'
 import { useCurrentDay } from '../hooks/useStakedPools'
+import { PoolGroup, StakePositionUserInfo, StakedPosition } from '../type'
+import { AmountWithUSDSub } from './AmountWithUSDSub'
+import { ClaimModal } from './ClaimModal'
+import { LockedFixedTag } from './LockedFixedTag'
+import { FixedRestakingModal } from './RestakeFixedStakingModal'
+import { UnlockedFixedTag } from './UnlockedFixedTag'
+import { UnstakeBeforeEnededModal } from './UnstakeBeforeEndedModal'
 
 const FlexLeft = styled(Flex)`
   width: 100%;
@@ -233,7 +234,11 @@ export function StakedPositionSection({
             initialLockPeriod={lockPeriod}
           >
             {(openModal) => (
-              <IconButton disabled={currentDay + lockPeriod > poolEndDay} variant="secondary" onClick={openModal}>
+              <IconButton
+                disabled={pool.token.equals(bscTokens.cake) || currentDay + lockPeriod > poolEndDay}
+                variant="secondary"
+                onClick={openModal}
+              >
                 <AddIcon color="primary" width="14px" />
               </IconButton>
             )}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 08d633e</samp>

### Summary
🚫🍰🔧

<!--
1.  🚫 - This emoji represents the feature to disable CAKE staking in fixed pools, as it implies something is forbidden or blocked.
2. 🍰 - This emoji represents the CAKE token, as it is the name and logo of the token.
3. 🔧 - This emoji represents the reorganization of imports and the addition of new dependencies, as it implies something is being fixed or adjusted.
-->
Added a feature to disable CAKE staking in fixed pools. This feature affects the `ClaimModal`, `FixedStakingCard`, `FixedStakingRow`, and `StakedPositionSection` components in the `FixedStaking` view. The feature uses the `Currency` type and the `bscTokens` object to compare the pool token with the CAKE token. Also reorganized imports in the affected files.

> _Sing, O Muse, of the cunning code that changed the staking pools_
> _And how the skilled developers reorganized the imports_
> _To make the FixedStakingCard and ClaimModal components_
> _Disable the Button for the CAKE token, the sweet reward of DeFi._

### Walkthrough
*  Disable staking buttons for CAKE token in fixed pools ([link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-c547e3f232ba92d9b48daeab14a844ca60afe0b53eed2439fc9a8996dd34d0e8R184), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-587cdcd0802c7d65cfa2a5c7fa308533abbc2688dca6daaff5656529f6b6be22L83-R88), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-8ca9d02451a4cbef48a7621a5975c3891edf7aa93fd656aa1623b0c7d4c340faL171-R176), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L236-R241))
* Reorder and group imports alphabetically by source in `ClaimModal.tsx`, `FixedStakingCard.tsx`, `FixedStakingRow.tsx`, and `StakedPositionSection.tsx` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-c547e3f232ba92d9b48daeab14a844ca60afe0b53eed2439fc9a8996dd34d0e8L1-R18), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-587cdcd0802c7d65cfa2a5c7fa308533abbc2688dca6daaff5656529f6b6be22L2-R16), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-8ca9d02451a4cbef48a7621a5975c3891edf7aa93fd656aa1623b0c7d4c340faL1-R19), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-8ca9d02451a4cbef48a7621a5975c3891edf7aa93fd656aa1623b0c7d4c340faL23-R34), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L1-R3), [link](https://github.com/pancakeswap/pancake-frontend/pull/8530/files?diff=unified&w=0#diff-9a311e96b477ee4d446ee1712dfd328c3beebcef2e07f7c3113faa5259e8e9e7L9-R19))


