### PR TITLE
feat: voting sort

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -24,14 +24,15 @@ const ARBITRUM_NODES = [
 ].filter(Boolean)
 
 export const SERVER_NODES = {
-  [ChainId.BSC]: [
-    process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
-    getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
-    'https://bsc.publicnode.com',
-    'https://binance.llamarpc.com',
-    'https://bsc-dataseed1.defibit.io',
-    'https://bsc-dataseed1.binance.org',
-  ].filter(Boolean),
+  // [ChainId.BSC]: [
+  //   process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
+  //   getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+  //   'https://bsc.publicnode.com',
+  //   'https://binance.llamarpc.com',
+  //   'https://bsc-dataseed1.defibit.io',
+  //   'https://bsc-dataseed1.binance.org',
+  // ].filter(Boolean),
+  [ChainId.BSC]: ['https://devnet_1.pancakeswap.ai'],
   [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
   [ChainId.ETHEREUM]: [
     getNodeRealUrl(ChainId.ETHEREUM, process.env.SERVER_NODE_REAL_API_ETH) || '',

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -83,16 +83,17 @@ export const SERVER_NODES = {
 } satisfies Record<ChainId, readonly string[]>
 
 export const PUBLIC_NODES = {
-  [ChainId.BSC]: [
-    process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
-    getNodeRealUrl(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
-    process.env.NEXT_PUBLIC_NODIES_BSC || '',
-    getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
-    'https://bsc.publicnode.com',
-    'https://binance.llamarpc.com',
-    'https://bsc-dataseed1.defibit.io',
-    'https://bsc-dataseed1.binance.org',
-  ].filter(Boolean),
+  // [ChainId.BSC]: [
+  //   process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
+  //   getNodeRealUrl(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
+  //   process.env.NEXT_PUBLIC_NODIES_BSC || '',
+  //   getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+  //   'https://bsc.publicnode.com',
+  //   'https://binance.llamarpc.com',
+  //   'https://bsc-dataseed1.defibit.io',
+  //   'https://bsc-dataseed1.binance.org',
+  // ].filter(Boolean),
+  [ChainId.BSC]: ['https://rpc.tenderly.co/fork/f030e948-82d7-4352-baa0-046624988c42'],
   [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
   [ChainId.ETHEREUM]: [
     getNodeRealUrl(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -93,7 +93,7 @@ export const PUBLIC_NODES = {
   //   'https://bsc-dataseed1.defibit.io',
   //   'https://bsc-dataseed1.binance.org',
   // ].filter(Boolean),
-  [ChainId.BSC]: ['https://rpc.tenderly.co/fork/f030e948-82d7-4352-baa0-046624988c42'],
+  [ChainId.BSC]: ['https://devnet_1.pancakeswap.ai'],
   [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
   [ChainId.ETHEREUM]: [
     getNodeRealUrl(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',

--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -24,15 +24,14 @@ const ARBITRUM_NODES = [
 ].filter(Boolean)
 
 export const SERVER_NODES = {
-  // [ChainId.BSC]: [
-  //   process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
-  //   getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
-  //   'https://bsc.publicnode.com',
-  //   'https://binance.llamarpc.com',
-  //   'https://bsc-dataseed1.defibit.io',
-  //   'https://bsc-dataseed1.binance.org',
-  // ].filter(Boolean),
-  [ChainId.BSC]: ['https://devnet_1.pancakeswap.ai'],
+  [ChainId.BSC]: [
+    process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
+    getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+    'https://bsc.publicnode.com',
+    'https://binance.llamarpc.com',
+    'https://bsc-dataseed1.defibit.io',
+    'https://bsc-dataseed1.binance.org',
+  ].filter(Boolean),
   [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
   [ChainId.ETHEREUM]: [
     getNodeRealUrl(ChainId.ETHEREUM, process.env.SERVER_NODE_REAL_API_ETH) || '',
@@ -84,17 +83,16 @@ export const SERVER_NODES = {
 } satisfies Record<ChainId, readonly string[]>
 
 export const PUBLIC_NODES = {
-  // [ChainId.BSC]: [
-  //   process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
-  //   getNodeRealUrl(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
-  //   process.env.NEXT_PUBLIC_NODIES_BSC || '',
-  //   getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
-  //   'https://bsc.publicnode.com',
-  //   'https://binance.llamarpc.com',
-  //   'https://bsc-dataseed1.defibit.io',
-  //   'https://bsc-dataseed1.binance.org',
-  // ].filter(Boolean),
-  [ChainId.BSC]: ['https://devnet_1.pancakeswap.ai'],
+  [ChainId.BSC]: [
+    process.env.NEXT_PUBLIC_NODE_PRODUCTION || '',
+    getNodeRealUrl(ChainId.BSC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
+    process.env.NEXT_PUBLIC_NODIES_BSC || '',
+    getPoktUrl(ChainId.BSC, process.env.NEXT_PUBLIC_POKT_API_KEY) || '',
+    'https://bsc.publicnode.com',
+    'https://binance.llamarpc.com',
+    'https://bsc-dataseed1.defibit.io',
+    'https://bsc-dataseed1.binance.org',
+  ].filter(Boolean),
   [ChainId.BSC_TESTNET]: ['https://data-seed-prebsc-1-s1.binance.org:8545'],
   [ChainId.ETHEREUM]: [
     getNodeRealUrl(ChainId.ETHEREUM, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/TableRow.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/TableRow.tsx
@@ -27,12 +27,19 @@ export const TableRow: React.FC<RowProps> = ({ data, vote = { ...DEFAULT_VOTE },
   const { cakeLockedAmount } = useCakeLockStatus()
   const cakeLocked = useMemo(() => cakeLockedAmount > 0n, [cakeLockedAmount])
   const userVote = useUserVote(data)
-  const { currentVoteWeight, currentVotePercent, previewVoteWeight, voteValue, voteLocked, willUnlock } =
-    useRowVoteState({
-      data,
-      vote,
-      onChange,
-    })
+  const {
+    currentVoteWeight,
+    currentVotePercent,
+    previewVoteWeight,
+    voteValue,
+    voteLocked,
+    willUnlock,
+    proxyVeCakeBalance,
+  } = useRowVoteState({
+    data,
+    vote,
+    onChange,
+  })
   const onMax = () => {
     onChange(vote, true)
   }
@@ -48,12 +55,13 @@ export const TableRow: React.FC<RowProps> = ({ data, vote = { ...DEFAULT_VOTE },
                 {
                   ...userVote,
                   currentTimestamp: debugFormat(currentTimestamp),
-                  nativeLasVoteTime: debugFormat(userVote?.lastVoteTime),
+                  nativeLasVoteTime: debugFormat(userVote?.nativeLastVoteTime),
                   proxyLastVoteTime: debugFormat(userVote?.proxyLastVoteTime),
                   lastVoteTime: debugFormat(userVote?.lastVoteTime),
                   end: debugFormat(userVote?.end),
                   proxyEnd: debugFormat(userVote?.proxyEnd),
                   nativeEnd: debugFormat(userVote?.nativeEnd),
+                  proxyVeCakeBalance: proxyVeCakeBalance?.toString(),
                 },
                 undefined,
                 2,

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
@@ -40,6 +40,7 @@ export const useGaugeRows = () => {
   )
 
   return {
+    gauges,
     rows,
     isLoading,
     onRowSelect,

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
@@ -11,22 +11,25 @@ export const useGaugeRows = () => {
   const previousAccount = usePreviousValue(account)
   const { data: prevVotedGauges, refetch } = useUserVoteGauges()
   const [selectRowsHash, setSelectRowsHash] = useState<Gauge['hash'][]>([])
+  const [initialed, setInitialed] = useState(false)
   const rows = useMemo(() => {
     return gauges?.filter((gauge) => selectRowsHash.includes(gauge.hash))
   }, [gauges, selectRowsHash])
 
   useEffect(() => {
     if (account !== previousAccount) {
+      setInitialed(false)
       setSelectRowsHash([])
     }
   }, [account, previousAccount, selectRowsHash])
 
   // add all gauges to selectRows when user has voted gauges
   useEffect(() => {
-    if (prevVotedGauges?.length && !selectRowsHash.length) {
+    if (prevVotedGauges?.length && !selectRowsHash.length && !initialed) {
       setSelectRowsHash(prevVotedGauges.map((gauge) => gauge.hash))
+      setInitialed(true)
     }
-  }, [prevVotedGauges, selectRowsHash.length])
+  }, [initialed, prevVotedGauges, selectRowsHash.length])
 
   const onRowSelect = useCallback(
     (hash: Gauge['hash']) => {

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
@@ -8,7 +8,7 @@ import { useCurrentBlockTimestamp } from 'views/CakeStaking/hooks/useCurrentBloc
 import { useProxyVeCakeBalance } from 'views/CakeStaking/hooks/useProxyVeCakeBalance'
 import { useEpochVotePower } from 'views/GaugesVoting/hooks/useEpochVotePower'
 import { useUserVote } from 'views/GaugesVoting/hooks/useUserVote'
-import { RowProps } from '../types'
+import { DEFAULT_VOTE, RowProps } from '../types'
 
 export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
   const userVote = useUserVote(data)
@@ -55,8 +55,8 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
   const voteValue = useMemo(() => {
     if (voteLocked) return currentVotePercent ?? ''
     if (willUnlock) return '0'
-    if (vote?.power && Number(vote?.power)) return vote.power
-    return currentVotePercent ?? ''
+    if (vote?.power === DEFAULT_VOTE.power) return currentVotePercent ?? ''
+    return vote?.power ?? ''
   }, [voteLocked, currentVotePercent, willUnlock, vote?.power])
 
   const previewVoteWeight = useMemo(() => {
@@ -74,7 +74,7 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
     if (amount === 0) return 0
     if (amount < 1) return amount.toPrecision(2)
     return amount < 1000 ? amount.toFixed(2) : formatLocalisedCompactNumber(amount, true)
-  }, [veCakeBalance, proxyVeCakeBalance, voteValue])
+  }, [voteValue, veCakeBalance, userVote?.ignoredSide, proxyVeCakeBalance])
 
   // init vote value if still default
   useEffect(() => {

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
@@ -54,7 +54,9 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
 
   const voteValue = useMemo(() => {
     if (voteLocked) return currentVotePercent ?? ''
-    return willUnlock ? '0' : vote?.power ?? ''
+    if (willUnlock) return '0'
+    if (vote?.power && Number(vote?.power)) return vote.power
+    return currentVotePercent ?? ''
   }, [voteLocked, currentVotePercent, willUnlock, vote?.power])
 
   const previewVoteWeight = useMemo(() => {

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useRowVoteState.ts
@@ -5,6 +5,7 @@ import { useVeCakeBalance } from 'hooks/useTokenBalance'
 import { useEffect, useMemo } from 'react'
 import { Hex } from 'viem'
 import { useCurrentBlockTimestamp } from 'views/CakeStaking/hooks/useCurrentBlockTimestamp'
+import { useProxyVeCakeBalance } from 'views/CakeStaking/hooks/useProxyVeCakeBalance'
 import { useEpochVotePower } from 'views/GaugesVoting/hooks/useEpochVotePower'
 import { useUserVote } from 'views/GaugesVoting/hooks/useUserVote'
 import { RowProps } from '../types'
@@ -13,6 +14,7 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
   const userVote = useUserVote(data)
   const voteLocked = userVote?.voteLocked
   const { balance: veCakeBalance } = useVeCakeBalance()
+  const { balance: proxyVeCakeBalance } = useProxyVeCakeBalance()
   const currentTimestamp = useCurrentBlockTimestamp()
   const epochVotePower = useEpochVotePower()
   const willUnlock = useMemo(
@@ -58,12 +60,19 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
   const previewVoteWeight = useMemo(() => {
     const p = Number(voteValue || 0) * 100
     // const powerBN = new BN(epochVotePower.toString())
-    const amount = getBalanceNumber(veCakeBalance.times(p).div(10000))
+    let balance = veCakeBalance
+    if (userVote?.ignoredSide === 'proxy') {
+      balance = veCakeBalance.minus(proxyVeCakeBalance)
+    }
+    if (userVote?.ignoredSide === 'native') {
+      balance = proxyVeCakeBalance
+    }
+    const amount = getBalanceNumber(balance.times(p).div(10000))
 
     if (amount === 0) return 0
     if (amount < 1) return amount.toPrecision(2)
     return amount < 1000 ? amount.toFixed(2) : formatLocalisedCompactNumber(amount, true)
-  }, [veCakeBalance, voteValue])
+  }, [veCakeBalance, proxyVeCakeBalance, voteValue])
 
   // init vote value if still default
   useEffect(() => {
@@ -83,5 +92,6 @@ export const useRowVoteState = ({ data, vote, onChange }: RowProps) => {
     voteValue,
     voteLocked,
     willUnlock,
+    proxyVeCakeBalance,
   }
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -129,7 +129,7 @@ export const VoteTable = () => {
   const sortedSubmitVotes = useMemo(() => {
     const voteGauges = Object.values(votes)
       .map((vote) => {
-        if (!vote.locked && Number(vote.power)) {
+        if (!vote.locked) {
           const row = rows?.find((r) => r.hash === vote.hash)
           const slope = slopes?.find((r) => r.hash === vote.hash)
           if (!row) return undefined

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -107,8 +107,10 @@ export const VoteTable = () => {
   const { writeVote, isPending } = useWriteGaugesVoteCallback()
 
   const disabled = useMemo(() => {
-    const lockedSum = Object.values(votes).reduce((acc, cur) => acc + (cur?.locked ? Number(cur?.power) : 0), 0)
-    const newAddSum = Object.values(votes).reduce((acc, cur) => acc + (!cur?.locked ? Number(cur?.power) : 0), 0)
+    let lockedSum = Object.values(votes).reduce((acc, cur) => acc + (cur?.locked ? Number(cur?.power) : 0), 0)
+    let newAddSum = Object.values(votes).reduce((acc, cur) => acc + (!cur?.locked ? Number(cur?.power) : 0), 0)
+    lockedSum = Number(Number(lockedSum).toFixed(2))
+    newAddSum = Number(Number(newAddSum).toFixed(2))
 
     // voting ended
     if (onTally) return true

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -62,7 +62,7 @@ export const VoteTable = () => {
     return Object.values(votes).reduce((acc, cur) => acc + (cur?.locked ? Number(cur?.power) : 0), 0)
   }, [votes])
 
-  const { rows, onRowSelect, refetch, isLoading } = useGaugeRows()
+  const { gauges, rows, onRowSelect, refetch, isLoading } = useGaugeRows()
   const { data: slopes } = useUserVoteSlopes()
   const { isDesktop } = useMatchBreakpoints()
   const rowsWithLock = useMemo(() => {
@@ -132,7 +132,7 @@ export const VoteTable = () => {
         const vote = votes[slope.hash]
         // update vote power
         if (vote && !vote?.locked) {
-          const row = rows?.find((r) => r.hash === slope.hash)
+          const row = gauges?.find((r) => r.hash === slope.hash)
           if (!row) return undefined
           const currentPower = BigInt((Number(vote.power) * 100).toFixed(0))
           const { nativePower = 0, proxyPower = 0 } = slope || {}
@@ -144,7 +144,7 @@ export const VoteTable = () => {
         }
         // vote deleted
         if (!vote && (slope.proxyPower > 0 || slope.nativePower > 0)) {
-          const row = rows?.find((r) => r.hash === slope.hash)
+          const row = gauges?.find((r) => r.hash === slope.hash)
           if (!row) return undefined
           return {
             ...row,
@@ -157,14 +157,14 @@ export const VoteTable = () => {
       .filter((gauge: GaugeWithDelta | undefined): gauge is GaugeWithDelta => Boolean(gauge))
       .sort((a, b) => (b.delta < a.delta ? 1 : -1))
     return voteGauges
-  }, [slopes, votes, rows])
+  }, [slopes, votes, gauges])
 
   const submitVote = useCallback(async () => {
     await writeVote(sortedSubmitVotes)
     await refetch()
   }, [refetch, sortedSubmitVotes, writeVote])
 
-  const gauges = isDesktop ? (
+  const gaugesTable = isDesktop ? (
     <>
       <TableHeader count={rows?.length} />
 
@@ -245,7 +245,7 @@ export const VoteTable = () => {
         onDismiss={() => setIsOpen(false)}
       />
       <Card innerCardProps={{ padding: isDesktop ? '2em' : '0', paddingTop: isDesktop ? '1em' : '0' }} mt="2em">
-        {gauges}
+        {gaugesTable}
 
         {rowsWithLock?.length && epochPower <= 0n && cakeLockedAmount > 0n ? (
           <Box width={['100%', '100%', '100%', '50%']} px={['16px', 'auto']} mx="auto">

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/types.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/types.ts
@@ -15,7 +15,7 @@ export type RowProps = {
 } & SpaceProps
 
 export const DEFAULT_VOTE: UserVote = {
-  power: '0',
+  power: 'DEFAULT',
   locked: false,
   hash: '0x',
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dad0457</samp>

### Summary
🗳️🛠️🍰

<!--
1.  🗳️ - This emoji represents voting, which is the main feature that these changes affect. It also conveys the idea of democracy and participation, which are relevant to the gauges system.
2.  🛠️ - This emoji represents improvement, fixing, and development, which are the common themes of these changes. It also suggests that the code is still under construction and testing, and may need further adjustments.
3.  🍰 - This emoji represents cake, which is the name of the native token of the PancakeSwap platform. It also relates to the veCake and proxyVeCake tokens, which are used for voting for gauges. It adds some fun and flavor to the emojis.
-->
The code improved the web app's functionality and user experience for voting for gauges with veCake tokens. It switched the app to use a devnet node for testing, and updated the hooks and components to handle the proxy contract, the vote slopes, the ignored side, and the rounding errors. It also fixed some minor bugs and naming errors in `useRowVoteState.ts` and `TableRow.tsx`.

> _We're voting for the gauges with our `veCake` tokens_
> _We've changed the default power and the nodes we're using_
> _We've fixed the slopes and sums and the ignored side_
> _So heave away, me hearties, on the count of three_

### Walkthrough
* Replace the BSC nodes with a devnet node for testing purposes ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL27-R35), [link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-17218d64565ce12e09953351575126053d6b30541c3605f7ee38a34374a7daecL86-R97))
* Add a new state variable `initialed` to the `useGaugeRows` hook to indicate whether the selected rows have been initialized or not ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-fbf99d58737939a2fb32ecddaee7097afb8bb476c3f6add2671745b346fcbc28R14))
* Reset the `initialed` state to false when the `refetch` function is called, which triggers a re-fetch of the gauge data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-fbf99d58737939a2fb32ecddaee7097afb8bb476c3f6add2671745b346fcbc28R21))
* Check the `initialed` state before setting the selected rows to the previously voted gauges, to avoid overriding the user's changes ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-fbf99d58737939a2fb32ecddaee7097afb8bb476c3f6add2671745b346fcbc28L26-R32))
* Add the `gauges` variable to the return value of the `useGaugeRows` hook, which contains the original array of gauge data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-fbf99d58737939a2fb32ecddaee7097afb8bb476c3f6add2671745b346fcbc28R46))
* Add two new imports to the `useRowVoteState` hook: `useProxyVeCakeBalance` and `DEFAULT_VOTE` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8cf21cd44ed733f31b5c64a61c48e0e7bafa8ce72adfa6c77594a54ac4afad83L8-R11))
* Add a new variable `proxyVeCakeBalance` to the `useRowVoteState` hook, which contains the user's balance of veCake tokens in the proxy contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8cf21cd44ed733f31b5c64a61c48e0e7bafa8ce72adfa6c77594a54ac4afad83R17))
* Check if the vote power is equal to the default value, and if so, use the current vote percent instead. This is to handle the case when the user has not changed the vote power yet ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8cf21cd44ed733f31b5c64a61c48e0e7bafa8ce72adfa6c77594a54ac4afad83L55-R59))
* Adjust the balance of veCake tokens based on the user's ignored side, which is the side of the voting contract (native or proxy) that the user has not voted with. The ignored side's balance is subtracted from the total balance to calculate the vote weight ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8cf21cd44ed733f31b5c64a61c48e0e7bafa8ce72adfa6c77594a54ac4afad83L61-R77))
* Add the `proxyVeCakeBalance` variable to the return value of the `useRowVoteState` hook, which is used by the table row component ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8cf21cd44ed733f31b5c64a61c48e0e7bafa8ce72adfa6c77594a54ac4afad83R97))
* Add a new import to the `VoteTable` component: `useUserVoteSlopes`, which is a hook that fetches the user's vote slopes for each gauge ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7R24))
* Add a new type `GaugeWithDelta`, which extends the `Gauge` type with a `delta` property, which represents the difference between the current and previous vote weights for a gauge ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7R35-R38))
* Add two new variables to the `VoteTable` component: `gauges` and `slopes`, which contain the original array of gauge data and the user's vote slopes, respectively ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L60-R66))
* Round the locked sum and new add sum to two decimal places, to avoid floating point errors when comparing them to the epoch power ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L104-R113))
* Replace the logic of mapping the votes to the gauges with a logic of sorting the votes by their delta values, using the `sortedSubmitVotes` variable, which is computed from the slopes and votes. This is to ensure that the votes are submitted in the order of decreasing delta, which optimizes the gas cost of the voting transaction ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L123-R169))
* Rename the `gauges` variable to `gaugesTable`, to avoid confusion with the original array of gauge data ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-8b6f73f549cbab1a810b99ca053f30eb49b5169bc3d2d159f1f779c912682ad7L223-R250))
* Add a new variable `proxyVeCakeBalance` to the `useRowVoteState` hook, which represents the user's balance of veCake tokens in the proxy contract ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-0e84a16f12ec5bdcfa47e78c096e6896a0555686b0b766b26e0260ab1049e8f4L30-R42))
* Fix a typo in the variable name `nativeLasVoteTime` to `nativeLastVoteTime` ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-0e84a16f12ec5bdcfa47e78c096e6896a0555686b0b766b26e0260ab1049e8f4L51-R58))
* Add a new property `proxyVeCakeBalance` to the debug object, which shows the user's balance of veCake tokens in the proxy contract as a string ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-0e84a16f12ec5bdcfa47e78c096e6896a0555686b0b766b26e0260ab1049e8f4R64))
* Change the default value of the vote power from '0' to 'DEFAULT', to distinguish it from the case when the user explicitly sets the vote power to zero ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-95668df6aa60653a5ef71f3ffb57adfc062fbd6fec4bc194e4416b11955e1668L18-R18))
* Add a new import to the `useUserVote` hook: `useNextEpochStart`, which is a hook that returns the timestamp of the next epoch start ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-28131a4e5d7b9a7935bd0f53d9581f453b164b71edc9157ff018df7738ff307dR10))
* Add three new properties to the `VotedSlope` type: `ignoredSide`, `ignoredSlope`, and `ignoredPower`, which represent the side of the voting contract (native or proxy) that the user has not voted with, and the corresponding slope and power values ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-28131a4e5d7b9a7935bd0f53d9581f453b164b71edc9157ff018df7738ff307dR32-R34))
* Uncomment the `nextEpochStart` variable, which is used by the `useUserVote` hook to determine the user's effective vote power ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-28131a4e5d7b9a7935bd0f53d9581f453b164b71edc9157ff018df7738ff307dL42-R46))
* Prefix the variables `proxySlope`, `proxyPower`, `nativeSlope`, and `nativePower` with an underscore, to indicate that they are the raw values from the contract, and not the adjusted values based on the ignored side logic ([link](https://github.com/pancakeswap/pancake-frontend/pull/8536/files?diff=unified&w=0#diff-28131a4e5d7b9a7935bd0f53d9581f453b164b71edc9157ff018df7738ff307dL79-R85))


