### PR TITLE
feat: Remove games new tag

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -149,7 +149,6 @@ const config: (
         {
           label: t('Gaming Marketplace'),
           href: 'https://pancakeswap.games/',
-          status: { text: t('New'), color: 'success' },
           type: DropdownMenuItemType.EXTERNAL_LINK,
         },
         {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8ae8813</samp>

### Summary
🎮🗑️🔄

<!--
1.  🎮 - This emoji represents the Prediction game, which is the main subject of the change. It can also convey the idea of fun and entertainment, which are some of the goals of the game.
2.  🗑️ - This emoji represents the removal or deletion of something, which is what happened to the status property of the menu item. It can also suggest that the status label was no longer useful or relevant, and that the change was a cleanup or simplification of the code.
3.  🔄 - This emoji represents the update or refresh of something, which is what the pull request does to the menu items and icons for the Prediction game. It can also imply that the change was a minor or routine one, and that it improved the appearance or functionality of the game.
-->
Removed the status label from the Prediction game menu item in `config.ts`. This is part of a pull request that refreshes the menu design for the game.

> _`status` is gone_
> _Prediction game is old_
> _No more label, spring_

### Walkthrough
* Remove the status property from the Prediction menu item ([link](https://github.com/pancakeswap/pancake-frontend/pull/8545/files?diff=unified&w=0#diff-e0daeed87867fc4fc6b0b1a9c2d52c9bfbd175cd1822e100f43300c4046484adL152))


