### PR TITLE
fix: xs device

### DIFF
--- a/apps/web/src/views/Home/components/Banners/VeCakeBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/VeCakeBanner.tsx
@@ -57,15 +57,19 @@ const RightWrapper = styled.div`
 
   > span:nth-child(2) {
     position: absolute !important;
-    right: 10px;
+    right: 1%;
     z-index: 2;
     bottom: 42px;
 
     ${({ theme }) => theme.mediaQueries.sm} {
-      right: 10%;
+      right: 6%;
       bottom: 2px;
     }
 
+    ${({ theme }) => theme.mediaQueries.md} {
+      right: 10%;
+      bottom: 2px;
+    }
     ${({ theme }) => theme.mediaQueries.lg} {
       right: 12%;
       bottom: 2px;
@@ -105,7 +109,7 @@ const Header = styled.div`
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   margin-bottom: 6px;
-  width: 80%;
+  width: 100%;
 
   &::after {
     letter-spacing: 0.01em;
@@ -121,6 +125,10 @@ const Header = styled.div`
     top: 0;
     z-index: -1;
     padding-right: 100px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    width: 80%;
   }
 
   ${({ theme }) => theme.mediaQueries.lg} {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4fc3045</samp>

### Summary
📱📐🎨

<!--
1.  📱 This emoji represents the responsiveness of the banner components on different screen sizes, as it is a common symbol for mobile devices and different screen orientations.
2.  📐 This emoji represents the alignment of the banner components, as it is a tool for measuring and adjusting angles and distances.
3.  🎨 This emoji represents the aesthetic improvement of the banner design, as it is a symbol for creativity and color.
-->
Improve responsiveness and alignment of `VeCakeBanner` component. Adjust margin and width of text elements based on screen size.

> _Oh, we're the banner crew and we know what to do_
> _We make the `Header` fit on any screen_
> _We adjust the `RightWrapper` margin with a clue_
> _And we pull together with a media query_

### Walkthrough
*  Adjust the position of the text span in the `RightWrapper` component to make it more responsive and aligned with the cake slice image ([link](https://github.com/pancakeswap/pancake-frontend/pull/8548/files?diff=unified&w=0#diff-119dc8e6a5a5415ae331ea64b75200e50386078b9a20b577762590f1d8ef6ffdL60-R72))
*  Increase the width of the `Header` component on the default screen size to make it more visible and centered ([link](https://github.com/pancakeswap/pancake-frontend/pull/8548/files?diff=unified&w=0#diff-119dc8e6a5a5415ae331ea64b75200e50386078b9a20b577762590f1d8ef6ffdL108-R112))
*  Add a media query for the small screen size and set the header width to 80% to prevent overflowing or wrapping ([link](https://github.com/pancakeswap/pancake-frontend/pull/8548/files?diff=unified&w=0#diff-119dc8e6a5a5415ae331ea64b75200e50386078b9a20b577762590f1d8ef6ffdR130-R133))
*  Add a media query for the medium screen size and set the right margin of the text span in the `RightWrapper` component to 10% ([link](https://github.com/pancakeswap/pancake-frontend/pull/8548/files?diff=unified&w=0#diff-119dc8e6a5a5415ae331ea64b75200e50386078b9a20b577762590f1d8ef6ffdL60-R72))


