### PR TITLE
fix: fix node version

### DIFF
--- a/.github/workflows/updateCron.yml
+++ b/.github/workflows/updateCron.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: 'pnpm'
-          node-version: 18
+          node-version: 18.18.2
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: 'pnpm'
-          node-version: 18
+          node-version: 18.18.2
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -131,7 +131,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: 'pnpm'
-          node-version: 18
+          node-version: 18.18.2
 
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 10182dd</samp>

### Summary
🛠️🔧🚀

<!--
1.  🛠️ - This emoji can be used to indicate a bug fix or a repair, which is what the node-version specification was intended to do.
2.  🔧 - This emoji can be used to signify a configuration or adjustment, which is also relevant for the node-version change as it affects the environment and dependencies of the project.
3.  🚀 - This emoji can be used to convey a deployment or improvement, which is the expected outcome of the node-version change as it should enable the workflow to run successfully.
-->
Specified `node-version` in `.github/workflows/updateCron.yml` to fix pnpm cache issue.

> _`node-version` set_
> _to match the pnpm cache_
> _workflow fixed - spring_

### Walkthrough
*  Specify `node-version` as `18.18.2` in the `setup-node` action to ensure compatibility with the `pnpm` version used by the project ([link](https://github.com/pancakeswap/pancake-frontend/pull/8549/files?diff=unified&w=0#diff-d3e136d6862952e13e0aecb4d8955d058fcbac2ed448194c4d6d1868679876d0L24-R24))


