### PR TITLE
feat: add 3 bsc v3 farm & update merkl notice

### DIFF
--- a/.changeset/blue-oranges-tan.md
+++ b/.changeset/blue-oranges-tan.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/widgets-internal': patch
+---
+
+feat: add farm&merkl notice option

--- a/apps/web/src/views/Farms/components/FarmCard/CardHeading.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/CardHeading.tsx
@@ -1,7 +1,7 @@
 import { Token } from '@pancakeswap/sdk'
-import { AutoRow, Flex, Heading, Skeleton, Tag, useTooltip, FarmMultiplierInfo, Box } from '@pancakeswap/uikit'
-import { FarmWidget } from '@pancakeswap/widgets-internal'
+import { AutoRow, Box, FarmMultiplierInfo, Flex, Heading, Skeleton, Tag, useTooltip } from '@pancakeswap/uikit'
 import { FeeAmount } from '@pancakeswap/v3-sdk'
+import { FarmWidget } from '@pancakeswap/widgets-internal'
 import { TokenPairImage } from 'components/TokenImage'
 import { styled } from 'styled-components'
 
@@ -22,6 +22,7 @@ type ExpandableSectionProps = {
   farmCakePerSecond?: string
   totalMultipliers?: string
   merklLink?: string
+  hasBothFarmAndMerkl?: boolean
 }
 
 const Wrapper = styled(Flex)`
@@ -46,6 +47,7 @@ const CardHeading: React.FC<React.PropsWithChildren<ExpandableSectionProps>> = (
   farmCakePerSecond,
   totalMultipliers,
   merklLink,
+  hasBothFarmAndMerkl,
 }) => {
   const isReady = multiplier !== undefined
 
@@ -71,7 +73,12 @@ const CardHeading: React.FC<React.PropsWithChildren<ExpandableSectionProps>> = (
             {lpLabel?.split(' ')?.[0] ?? ''}
             {merklLink ? (
               <Box mr="-4px" ml="4px">
-                <MerklNotice.WithTooltip placement="top" tooltipOffset={[0, 10]} merklLink={merklLink} />
+                <MerklNotice.WithTooltip
+                  placement="top"
+                  tooltipOffset={[0, 10]}
+                  merklLink={merklLink}
+                  hasFarm={hasBothFarmAndMerkl}
+                />
               </Box>
             ) : null}
           </Heading>

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Card, ExpandableSectionButton, Flex, Text, TooltipText, useModalV2, useTooltip, Box } from '@pancakeswap/uikit'
+import { Box, Card, ExpandableSectionButton, Flex, Text, TooltipText, useModalV2, useTooltip } from '@pancakeswap/uikit'
 import { FarmWidget } from '@pancakeswap/widgets-internal'
 import BigNumber from 'bignumber.js'
 import { CHAIN_QUERY_NAME } from 'config/chains'
@@ -8,16 +8,17 @@ import { useCallback, useMemo, useState } from 'react'
 import { multiChainPaths } from 'state/info/constant'
 import { styled } from 'styled-components'
 import { getBlockExploreLink } from 'utils'
+import { getMerklLink } from 'utils/getMerklLink'
 import { unwrappedToken } from 'utils/wrappedCurrency'
+import { isAddressEqual } from 'viem'
 import { AddLiquidityV3Modal } from 'views/AddLiquidityV3/Modal'
 import { V3Farm } from 'views/Farms/FarmsV3'
 import { useFarmV3Multiplier } from 'views/Farms/hooks/v3/useFarmV3Multiplier'
-import { getMerklLink } from 'utils/getMerklLink'
+import { StatusView } from '../../YieldBooster/components/bCakeV3/StatusView'
+import { BoostStatus, useBoostStatus } from '../../YieldBooster/hooks/bCakeV3/useBoostStatus'
 import CardHeading from '../CardHeading'
 import CardActionsContainer from './CardActionsContainer'
 import { FarmV3ApyButton } from './FarmV3ApyButton'
-import { StatusView } from '../../YieldBooster/components/bCakeV3/StatusView'
-import { useBoostStatus, BoostStatus } from '../../YieldBooster/hooks/bCakeV3/useBoostStatus'
 
 const { DetailsSection } = FarmWidget.FarmCard
 
@@ -69,6 +70,11 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({ f
   const infoUrl = useMemo(() => {
     return chainId ? `/info/v3${multiChainPaths[chainId]}/pairs/${lpAddress}?chain=${CHAIN_QUERY_NAME[chainId]}` : ''
   }, [chainId, lpAddress])
+  const hasBothFarmAndMerkl = useMemo(
+    // for now, only rETH-ETH require both farm and merkl, so we hardcode it here
+    () => Boolean(merklLink) && isAddressEqual(farm.lpAddress, '0x2201d2400d30BFD8172104B4ad046d019CA4E7bd'),
+    [farm.lpAddress, merklLink],
+  )
 
   const toggleExpandableSection = useCallback(() => {
     setShowExpandableSection((prev) => !prev)
@@ -93,6 +99,7 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({ f
         <CardHeading
           lpLabel={lpLabel}
           merklLink={merklLink}
+          hasBothFarmAndMerkl={hasBothFarmAndMerkl}
           multiplier={farm.multiplier}
           token={farm.token}
           quoteToken={farm.quoteToken}

--- a/apps/web/src/views/Farms/components/FarmTable/Farm.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Farm.tsx
@@ -12,6 +12,7 @@ export const FarmCell: React.FunctionComponent<React.PropsWithChildren<FarmWidge
   isReady,
   isStaking,
   merklLink,
+  hasBothFarmAndMerkl,
 }) => {
   return (
     <Flex alignItems="center">
@@ -23,6 +24,7 @@ export const FarmCell: React.FunctionComponent<React.PropsWithChildren<FarmWidge
         isReady={isReady}
         isStaking={isStaking}
         merklLink={merklLink}
+        hasBothFarmAndMerkl={hasBothFarmAndMerkl}
       >
         <TokenPairImage width={40} height={40} variant="inverted" primaryToken={token} secondaryToken={quoteToken} />
       </FarmTokenInfo>

--- a/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -225,6 +225,8 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({ farms, cake
           isStaking: farm.stakedPositions?.length > 0,
           isCommunity: farm.isCommunity,
           merklLink,
+          // @notice: this is a hack to make the merkl notice work for rETH-ETH
+          hasBothFarmAndMerkl: Boolean(merklLink) && farm.lpAddress === '0x2201d2400d30BFD8172104B4ad046d019CA4E7bd',
         },
         type: 'v3',
         details: farm,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -1,9 +1,9 @@
 import { bscTokens } from '@pancakeswap/tokens'
 import { FeeAmount, Pool } from '@pancakeswap/v3-sdk'
 import { getAddress } from 'viem'
-import { CAKE_BNB_LP_MAINNET } from './common'
-import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 import { FarmConfigV3, SerializedFarmConfig } from '..'
+import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
+import { CAKE_BNB_LP_MAINNET } from './common'
 
 const v3TopFixedLps: FarmConfigV3[] = [
   {
@@ -47,6 +47,27 @@ export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
   // new lps should follow after the top fixed lps
   // latest first
+  {
+    pid: 102,
+    lpAddress: '0x1A1703Bf5f1Da9DB0f62d17e8c54e84Fd732D695',
+    token0: bscTokens.bonk,
+    token1: bscTokens.bnb,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 101,
+    lpAddress: '0x2f74ad2c64be7DC07C9f51E9d338EcB7C1ee0B18',
+    token0: bscTokens.usdt,
+    token1: bscTokens.bonk,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 100,
+    lpAddress: '0xB5D01A6e99FdcDB6DB8D0A342C35036Adeb8FB48',
+    token0: bscTokens.kuji,
+    token1: bscTokens.bnb,
+    feeAmount: FeeAmount.HIGH,
+  },
   {
     pid: 99,
     lpAddress: '0x4BBA1018b967e59220b22Ca03f68821A3276c9a6',

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3095,5 +3095,8 @@
   "Seconds": "Seconds",
   "PancakeSwap Meetup": "PancakeSwap Meetup",
   "Spain": "Spain",
-  "Automated Liquidity Optimization": "Automated Liquidity Optimization"
+  "Automated Liquidity Optimization": "Automated Liquidity Optimization",
+  "Incentives can be earned on either Merkl or Farm but NOT both": "Incentives can be earned on either Merkl or Farm but NOT both",
+  "To earn Farm rewards, continue seeding liquidity on PancakeSwap and stake your LP token in the Farm.": "To earn Farm rewards, continue seeding liquidity on PancakeSwap and stake your LP token in the Farm.",
+  "To earn Merkl rewards, continue seeding liquidity on PancakeSwap but DO NOT stake your LP token in the Farm. Claim your rewards directly on ": "To earn Merkl rewards, continue seeding liquidity on PancakeSwap but DO NOT stake your LP token in the Farm. Claim your rewards directly on "
 }

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2771,4 +2771,20 @@ export const bscTokens = {
     'Stake DAO CAKE',
     'https://lockers.stakedao.org/',
   ),
+  kuji: new ERC20Token(
+    ChainId.BSC,
+    '0x073690e6CE25bE816E68F32dCA3e11067c9FB5Cc',
+    6,
+    'KUJI',
+    'Kujira native asset',
+    'https://kujira.network/',
+  ),
+  bonk: new ERC20Token(
+    ChainId.BSC,
+    '0xA697e272a73744b343528C3Bc4702F2565b2F422',
+    5,
+    'Bonk',
+    'Bonk',
+    'https://bonkcoin.com',
+  ),
 }

--- a/packages/widgets-internal/farm/components/FarmTable/FarmTokenInfo.tsx
+++ b/packages/widgets-internal/farm/components/FarmTable/FarmTokenInfo.tsx
@@ -29,6 +29,7 @@ const Farm: React.FunctionComponent<React.PropsWithChildren<FarmTableFarmTokenIn
   isReady,
   isStaking,
   merklLink,
+  hasBothFarmAndMerkl,
   children,
 }) => {
   const { t } = useTranslation();
@@ -63,7 +64,7 @@ const Farm: React.FunctionComponent<React.PropsWithChildren<FarmTableFarmTokenIn
         {handleRenderFarming}
         <Row gap="sm">
           <Text bold>{label}</Text>
-          {merklLink ? <MerklNotice.WithTooltip merklLink={merklLink} /> : null}
+          {merklLink ? <MerklNotice.WithTooltip hasFarm={hasBothFarmAndMerkl} merklLink={merklLink} /> : null}
         </Row>
       </div>
     </Container>

--- a/packages/widgets-internal/farm/components/MerklNotice/index.tsx
+++ b/packages/widgets-internal/farm/components/MerklNotice/index.tsx
@@ -11,10 +11,39 @@ const InlineLink = styled(LinkExternal)`
 type MerklNoticeContentProps = {
   linkColor?: string;
   merklLink: string;
+  hasFarm?: boolean;
 };
 
-export const MerklNoticeContent: React.FC<MerklNoticeContentProps> = ({ linkColor = "primary", merklLink }) => {
+export const MerklNoticeContent: React.FC<MerklNoticeContentProps> = ({
+  linkColor = "primary",
+  merklLink,
+  hasFarm,
+}) => {
   const { t } = useTranslation();
+
+  if (hasFarm) {
+    return (
+      <>
+        <Box>
+          <Text display="inline" color="currentColor">
+            {t("Incentives can be earned on either Merkl or Farm but NOT both")}
+            <br />
+            <br />
+            <p>
+              {t(
+                "To earn Merkl rewards, continue seeding liquidity on PancakeSwap but DO NOT stake your LP token in the Farm. Claim your rewards directly on "
+              )}
+              <InlineLink color={linkColor} external display="inline" href={merklLink}>
+                {t("Merkl")}
+              </InlineLink>
+            </p>
+            <br />
+            {t("To earn Farm rewards, continue seeding liquidity on PancakeSwap and stake your LP token in the Farm.")}
+          </Text>
+        </Box>
+      </>
+    );
+  }
   return (
     <>
       <Box>
@@ -41,6 +70,7 @@ type MerklNoticeProps = {
   placement?: Placement;
   tooltipOffset?: [number, number];
   merklLink: string;
+  hasFarm?: boolean;
 };
 
 const MerklNotice: React.FC<MerklNoticeProps> = ({
@@ -48,12 +78,16 @@ const MerklNotice: React.FC<MerklNoticeProps> = ({
   placement = "top-start",
   tooltipOffset = [-20, 10],
   merklLink,
+  hasFarm,
 }) => {
-  const { tooltip, tooltipVisible, targetRef } = useTooltip(<MerklNoticeContent merklLink={merklLink} />, {
-    placement,
-    tooltipOffset,
-    trigger: isMobile ? "focus" : "hover",
-  });
+  const { tooltip, tooltipVisible, targetRef } = useTooltip(
+    <MerklNoticeContent merklLink={merklLink} hasFarm={hasFarm} />,
+    {
+      placement,
+      tooltipOffset,
+      trigger: isMobile ? "focus" : "hover",
+    }
+  );
   return (
     <>
       <TooltipText ref={targetRef} display="inline">

--- a/packages/widgets-internal/farm/types.ts
+++ b/packages/widgets-internal/farm/types.ts
@@ -1,6 +1,6 @@
-import { ReactNode } from "react";
-import BigNumber from "bignumber.js";
 import { Token } from "@pancakeswap/sdk";
+import BigNumber from "bignumber.js";
+import { ReactNode } from "react";
 
 export interface FarmTableEarnedProps {
   earnings: number;
@@ -34,6 +34,7 @@ export interface FarmTableFarmTokenInfoProps {
   children?: ReactNode;
   isCommunity?: boolean;
   merklLink?: string;
+  hasBothFarmAndMerkl?: boolean;
 }
 
 export type ColumnsDefTypes = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b5728b7</samp>

### Summary
🌾🏆🛠️

<!--
1.  🌾 - This emoji represents the concept of farming, which is the main feature of the `FarmTable` component and the `FarmCard` component. It also relates to the new property `hasBothFarmAndMerkl` that was added to the `farm` object to handle the special case of farms with both reward options.
2. 🏆 - This emoji represents the concept of rewards, which is the main benefit of providing liquidity to the farms. It also relates to the new feature that shows both merkl and farm rewards for some farms, and the new prop `hasFarm` that was added to the `MerklNotice` component to show different tooltip messages.
3. 🛠️ - This emoji represents the concept of improvement, which is the goal of the changes that improve the import order, add utility functions, and handle special cases. It also relates to the new tokens that were added to the `bscTokens` object and the new farms that were added for v3 liquidity pools with fixed fees.
-->
This pull request adds support for farms with both merkl and farm rewards, which are a new feature of v3 liquidity pools with fixed fees. It modifies several components and types in the `FarmCard`, `FarmTable`, and `FarmTokenInfo` modules, and adds new props and variables to handle the dual reward options. It also adds new farms and tokens to the `bsc.ts` and `56.ts` files, and sorts some imports for readability.

> _Sing, O Muse, of the valiant deeds of the code warriors_
> _Who toiled and sweated to enhance the farms of DeFi_
> _Adding new tokens and pools with fixed fees and rewards_
> _And handling the rare case of the double-gifted `rETH-ETH`._

### Walkthrough
*  Add three new farms and two new tokens to the constants and tokens files ([link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-9e450d0474e6b664d46d9fefef8b01d8c419db2fcf3f6f4f9488691f10b3279dR51-R71), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-71ff5223fbd0d4df9a3c1d29ff72168019f58785ec79d2fae29f002d095f3bf4R2774-R2789))
*  Add a new prop `hasBothFarmAndMerkl` to the `Farm`, `FarmTokenInfo`, and `CardHeading` components to handle the special case of the rETH-ETH farm that has both a merkl and a farm reward option ([link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bR25), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bR50), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdR73-R77), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdR102), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-125d2abf5d0e8a2834f8a59fcccca127a7165c2a2b793bb61706874c1c38a815R15), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-125d2abf5d0e8a2834f8a59fcccca127a7165c2a2b793bb61706874c1c38a815R27), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-745ddf268270aff7533d4283013f9072c3e4538dc75d863c7e9f321018ded662R228-R229), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-1bf6a2ce429692e0645a0ce6dc27684297b5e5d0bab589ababe2f5f476830262R32))
*  Pass the new prop `hasFarm` to the `MerklNotice` and `MerklWarning` components to customize the tooltip and warning content based on whether the farm has a farm reward option or not ([link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bL74-R81), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L179-R186), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L279-R287), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-1bf6a2ce429692e0645a0ce6dc27684297b5e5d0bab589ababe2f5f476830262L66-R67), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-f4ec63297299d4fb00e44783f068762542b0f74eb955ada9caf20febd689e764L14-R46), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-f4ec63297299d4fb00e44783f068762542b0f74eb955ada9caf20febd689e764R73), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-f4ec63297299d4fb00e44783f068762542b0f74eb955ada9caf20febd689e764L51-R90))
*  Add a new import `isAddressEqual` from `viem` to compare addresses in the `FarmV3Card` and `ActionPanel` components ([link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdL11-R21), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L19-R23))
*  Sort the imports alphabetically in several files ([link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-6f6483f176b9edb2af9f59ce5d5143a0ac1cdf6c7c2659a15a48bec0dc40bc0bL2-R4), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-0926d6da81132aa1cd49885997401cae5462da8d578d1cad4a5421df08bef0bdL2-R2), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-009c8666f9c509a072e7acd279f14537ec47283bb4347cd5302f185a27cb9532L4-R12), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-9e450d0474e6b664d46d9fefef8b01d8c419db2fcf3f6f4f9488691f10b3279dL4-R6), [link](https://github.com/pancakeswap/pancake-frontend/pull/8574/files?diff=unified&w=0#diff-d0cb7668b4d506320295735b7f9bb71d866a9ffcff55572d04b93fe58fb113daL1-R3))


