### PR TITLE
fix: v3 ticks issue on full range

### DIFF
--- a/packages/v3-sdk/src/utils/tickMath.ts
+++ b/packages/v3-sdk/src/utils/tickMath.ts
@@ -80,7 +80,7 @@ export abstract class TickMath {
    * @param sqrtRatioX96 the sqrt ratio as a Q64.96 for which to compute the tick
    */
   public static getTickAtSqrtRatio(sqrtRatioX96: bigint): number {
-    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 < TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
+    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 <= TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
 
     const sqrtRatioX128 = sqrtRatioX96 << 32n
 
@@ -107,7 +107,8 @@ export abstract class TickMath {
     const log_sqrt10001 = log_2 * 255738958999603826347141n
 
     const tickLow = Number((log_sqrt10001 - 3402992956809132418596140100660247210n) >> 128n)
-    const tickHigh = Number((log_sqrt10001 + 291339464771989622907027621153398088495n) >> 128n)
+    let tickHigh = Number((log_sqrt10001 + 291339464771989622907027621153398088495n) >> 128n)
+    if (tickHigh >= TickMath.MAX_TICK) tickHigh = TickMath.MAX_TICK - 1
 
     return tickLow === tickHigh ? tickLow : TickMath.getSqrtRatioAtTick(tickHigh) <= sqrtRatioX96 ? tickHigh : tickLow
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 37d1b44</samp>

### Summary
🐛🚀🔒

<!--
1.  🐛 for fixing the bugs that caused errors or overflows.
2.  🚀 for improving the performance and efficiency of the function by avoiding unnecessary calculations and comparisons.
3.  🔒 for enhancing the security and robustness of the function by preventing invalid or out-of-range inputs.
-->
Fix tick math issues in `getTickAtSqrtRatio` function. Improve error handling and prevent overflows in `tickMath.ts`.

> _`getTickAtSqrtRatio`_
> _Fixes errors and overflows_
> _Autumn of extremes_

### Walkthrough
* Fix bug and prevent overflow in `getTickAtSqrtRatio` function ([link](https://github.com/pancakeswap/pancake-frontend/pull/8587/files?diff=unified&w=0#diff-40aadb5d3a9c4d1ed8cea48254509ead98f9702caaab3f64631eb218396cfd5dL83-R83), [link](https://github.com/pancakeswap/pancake-frontend/pull/8587/files?diff=unified&w=0#diff-40aadb5d3a9c4d1ed8cea48254509ead98f9702caaab3f64631eb218396cfd5dL110-R111))


