### PR TITLE
chore: Ignore migrated position and CAKE pool position when user delegated

### DIFF
--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -41,7 +41,6 @@ export enum VaultKey {
   CakeVault = 'cakeVault',
   CakeFlexibleSideVault = 'cakeFlexibleSideVault',
   IfoPool = 'ifoPool',
-  None = 'none',
 }
 
 export type SerializedPool = SerializedPoolWithInfo & {

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -1,17 +1,17 @@
-import { parseEther } from 'viem'
 import { SerializedFarmsState } from '@pancakeswap/farms'
-import { Token } from '@pancakeswap/sdk'
 import { SerializedPoolWithInfo } from '@pancakeswap/pools'
-import { Address } from 'wagmi'
+import { Token } from '@pancakeswap/sdk'
 import BigNumber from 'bignumber.js'
 import {
   CampaignType,
-  TFetchStatus,
   LotteryStatus,
   LotteryTicket,
+  TFetchStatus,
   Team,
   TranslatableText,
 } from 'config/constants/types'
+import { parseEther } from 'viem'
+import { Address } from 'wagmi'
 import { NftToken } from './nftMarket/types'
 
 export enum GAS_PRICE {
@@ -41,6 +41,7 @@ export enum VaultKey {
   CakeVault = 'cakeVault',
   CakeFlexibleSideVault = 'cakeFlexibleSideVault',
   IfoPool = 'ifoPool',
+  None = 'none',
 }
 
 export type SerializedPool = SerializedPoolWithInfo & {

--- a/apps/web/src/views/CakeStaking/hooks/useIsUserDelegated.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useIsUserDelegated.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
+import { CakePoolType } from '../types'
 import { useVeCakeUserInfo } from './useVeCakeUserInfo'
 
 export const useIsUserDelegated = (): boolean => {
   const { data: userInfo } = useVeCakeUserInfo()
   const isUserDelegated = useMemo(() => {
-    return userInfo?.cakePoolType === 2
+    return userInfo?.cakePoolType === CakePoolType.DELEGATED
   }, [userInfo])
   return isUserDelegated
 }

--- a/apps/web/src/views/CakeStaking/hooks/useIsUserDelegated.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useIsUserDelegated.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react'
+import { useVeCakeUserInfo } from './useVeCakeUserInfo'
+
+export const useIsUserDelegated = (): boolean => {
+  const { data: userInfo } = useVeCakeUserInfo()
+  const isUserDelegated = useMemo(() => {
+    return userInfo?.cakePoolType === 2
+  }, [userInfo])
+  return isUserDelegated
+}

--- a/apps/web/src/views/CakeStaking/types.ts
+++ b/apps/web/src/views/CakeStaking/types.ts
@@ -4,3 +4,9 @@ export enum CakeLockStatus {
   Expired = 'Expired',
   Migrate = 'Migrate',
 }
+
+export enum CakePoolType {
+  NOT_MIGRATED = 0,
+  MIGRATED = 1,
+  DELEGATED = 2,
+}

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
@@ -21,6 +21,7 @@ import BigNumber from 'bignumber.js'
 import { LightGreyCard } from 'components/Card'
 import { useCakePrice } from 'hooks/useCakePrice'
 import { useVaultPoolByKey } from 'state/pools/hooks'
+import { VaultKey } from 'state/types'
 import { getVaultPosition, VaultPosition } from 'utils/cakePool'
 import NotEnoughTokensModal from '../../Modals/NotEnoughTokensModal'
 import VaultStakeModal from '../VaultStakeModal'
@@ -28,7 +29,7 @@ import VaultStakeModal from '../VaultStakeModal'
 interface HasStakeActionProps {
   pool: Pool.DeserializedPool<Token>
   stakingTokenBalance: BigNumber
-  performanceFee: number
+  performanceFee?: number
 }
 
 const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> = ({
@@ -36,10 +37,10 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
   stakingTokenBalance,
   performanceFee,
 }) => {
-  const { userData } = useVaultPoolByKey(pool.vaultKey)
-  const {
-    balance: { cakeAsBigNumber, cakeAsNumberBalance },
-  } = userData
+  const { userData } = useVaultPoolByKey(pool.vaultKey ?? VaultKey.None)
+
+  const cakeAsBigNumber = userData?.balance?.cakeAsBigNumber
+  const cakeAsNumberBalance = userData?.balance?.cakeAsNumberBalance
   const isMigratedToVeCake = useIsMigratedToVeCake()
 
   const lockPosition = getVaultPosition(userData)
@@ -48,7 +49,7 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
   const { t } = useTranslation()
   const cakePriceBusd = useCakePrice()
   const stakedDollarValue = cakePriceBusd.gt(0)
-    ? getBalanceNumber(cakeAsBigNumber.multipliedBy(cakePriceBusd), stakingToken.decimals)
+    ? getBalanceNumber(cakeAsBigNumber?.multipliedBy(cakePriceBusd), stakingToken.decimals)
     : 0
 
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
@@ -56,7 +57,7 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
     <VaultStakeModal stakingMax={stakingTokenBalance} performanceFee={performanceFee} pool={pool} />,
   )
   const [onPresentUnstake] = useModal(
-    <VaultStakeModal stakingMax={cakeAsBigNumber} pool={pool} isRemovingStake />,
+    <VaultStakeModal stakingMax={cakeAsBigNumber ?? new BigNumber(0)} pool={pool} isRemovingStake />,
     true,
     true,
     `withdraw-vault-${pool.sousId}-${pool.vaultKey}`,
@@ -65,7 +66,7 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
     <LightGreyCard>
       <Flex mb="16px" justifyContent="space-between" alignItems="center">
         <Flex flexDirection="column">
-          <Balance fontSize="20px" bold value={cakeAsNumberBalance} decimals={5} />
+          <Balance fontSize="20px" bold value={cakeAsNumberBalance ?? 0} decimals={5} />
           <Text as={Flex} fontSize="12px" color="textSubtle" flexWrap="wrap">
             {cakePriceBusd.gt(0) ? (
               <Balance

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
@@ -37,7 +37,7 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
   stakingTokenBalance,
   performanceFee,
 }) => {
-  const { userData } = useVaultPoolByKey(pool.vaultKey ?? VaultKey.None)
+  const { userData } = useVaultPoolByKey(pool.vaultKey ?? VaultKey.CakeVaultV1)
 
   const cakeAsBigNumber = userData?.balance?.cakeAsBigNumber
   const cakeAsNumberBalance = userData?.balance?.cakeAsNumberBalance

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx
@@ -1,20 +1,20 @@
 import { Flex, Skeleton, useModal } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
 
+import { Token } from '@pancakeswap/sdk'
 import BigNumber from 'bignumber.js'
 import { VaultKey } from 'state/types'
-import { Token } from '@pancakeswap/sdk'
+import LockedStakeModal from '../../LockedPool/Modals/LockedStakeModal'
 import NotEnoughTokensModal from '../../Modals/NotEnoughTokensModal'
 import { VaultStakeButtonGroup } from '../../Vault/VaultStakeButtonGroup'
 import VaultStakeModal from '../VaultStakeModal'
-import LockedStakeModal from '../../LockedPool/Modals/LockedStakeModal'
 import HasSharesActions from './HasSharesActions'
 
 interface VaultStakeActionsProps {
   pool: Pool.DeserializedPool<Token>
   stakingTokenBalance: BigNumber
-  accountHasSharesStaked: boolean
-  performanceFee: number
+  accountHasSharesStaked?: boolean
+  performanceFee?: number
 }
 
 const VaultStakeActions: React.FC<React.PropsWithChildren<VaultStakeActionsProps>> = ({
@@ -43,7 +43,7 @@ const VaultStakeActions: React.FC<React.PropsWithChildren<VaultStakeActionsProps
     ) : (
       <VaultStakeButtonGroup
         onFlexibleClick={stakingTokenBalance.gt(0) ? onPresentStake : onPresentTokenRequired}
-        onLockedClick={pool.vaultKey === VaultKey.CakeVault ? openPresentLockedStakeModal : null}
+        onLockedClick={pool.vaultKey === VaultKey.CakeVault ? openPresentLockedStakeModal : () => {}}
       />
     )
   }

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
@@ -1,16 +1,17 @@
 import BigNumber from 'bignumber.js'
 
-import { styled } from 'styled-components'
-import { Flex, Text, Box } from '@pancakeswap/uikit'
+import { Box, Flex, Text } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
+import { styled } from 'styled-components'
 
 import { useTranslation } from '@pancakeswap/localization'
-import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { Token } from '@pancakeswap/sdk'
+import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 
+import { VaultKey } from 'state/types'
+import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 import VaultApprovalAction from './VaultApprovalAction'
 import VaultStakeActions from './VaultStakeActions'
-import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 
 const InlineText = styled(Text)`
   display: inline;
@@ -19,16 +20,16 @@ const InlineText = styled(Text)`
 const CakeVaultCardActions: React.FC<
   React.PropsWithChildren<{
     pool: Pool.DeserializedPool<Token>
-    accountHasSharesStaked: boolean
+    accountHasSharesStaked?: boolean
     isLoading: boolean
-    performanceFee: number
+    performanceFee?: number
   }>
 > = ({ pool, accountHasSharesStaked, isLoading, performanceFee }) => {
   const { stakingToken, userData } = pool
   const { t } = useTranslation()
   const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO
 
-  const { isVaultApproved, setLastUpdated } = useCheckVaultApprovalStatus(pool.vaultKey)
+  const { isVaultApproved, setLastUpdated } = useCheckVaultApprovalStatus(pool.vaultKey ?? VaultKey.None)
 
   return (
     <Flex flexDirection="column">
@@ -52,7 +53,11 @@ const CakeVaultCardActions: React.FC<
           </InlineText>
         </Box>
         {!isVaultApproved && !accountHasSharesStaked ? (
-          <VaultApprovalAction vaultKey={pool.vaultKey} isLoading={isLoading} setLastUpdated={setLastUpdated} />
+          <VaultApprovalAction
+            vaultKey={pool.vaultKey ?? VaultKey.None}
+            isLoading={isLoading}
+            setLastUpdated={setLastUpdated}
+          />
         ) : (
           <VaultStakeActions
             pool={pool}

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx
@@ -29,7 +29,7 @@ const CakeVaultCardActions: React.FC<
   const { t } = useTranslation()
   const stakingTokenBalance = userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO
 
-  const { isVaultApproved, setLastUpdated } = useCheckVaultApprovalStatus(pool.vaultKey ?? VaultKey.None)
+  const { isVaultApproved, setLastUpdated } = useCheckVaultApprovalStatus(pool.vaultKey ?? VaultKey.CakeVaultV1)
 
   return (
     <Flex flexDirection="column">
@@ -54,7 +54,7 @@ const CakeVaultCardActions: React.FC<
         </Box>
         {!isVaultApproved && !accountHasSharesStaked ? (
           <VaultApprovalAction
-            vaultKey={pool.vaultKey ?? VaultKey.None}
+            vaultKey={pool.vaultKey ?? VaultKey.CakeVaultV1}
             isLoading={isLoading}
             setLastUpdated={setLastUpdated}
           />

--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -37,10 +37,10 @@ interface CakeVaultDetailProps {
   account?: string
   pool: Pool.DeserializedPool<Token>
   vaultPool: DeserializedCakeVault
-  accountHasSharesStaked: boolean
+  accountHasSharesStaked?: boolean
   defaultFooterExpanded?: boolean
   showICake?: boolean
-  performanceFeeAsDecimal: number
+  performanceFeeAsDecimal?: number
 }
 
 export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailProps>> = ({
@@ -105,7 +105,7 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
                 <Box>
                   {account && (
                     <Box mb="8px">
-                      <UnstakingFeeCountdownRow vaultKey={pool.vaultKey} />
+                      <UnstakingFeeCountdownRow vaultKey={pool.vaultKey ?? VaultKey.None} />
                     </Box>
                   )}
                   {/* <RecentCakeProfitRow pool={pool} /> */}
@@ -145,10 +145,9 @@ const CakeVaultCard: React.FC<React.PropsWithChildren<CakeVaultProps>> = ({
   const vaultPool = useVaultPoolByKey(pool?.vaultKey || VaultKey.CakeVault)
   const totalStaked = pool?.totalStaked
 
-  const {
-    userData: { userShares, isLoading: isVaultUserDataLoading },
-    fees: { performanceFeeAsDecimal },
-  } = vaultPool
+  const userShares = vaultPool?.userData?.userShares
+  const isVaultUserDataLoading = vaultPool?.userData?.isLoading
+  const performanceFeeAsDecimal = vaultPool?.fees?.performanceFeeAsDecimal
 
   const accountHasSharesStaked = userShares && userShares.gt(0)
   const isLoading = !pool?.userData || isVaultUserDataLoading
@@ -163,10 +162,10 @@ const CakeVaultCard: React.FC<React.PropsWithChildren<CakeVaultProps>> = ({
         {!showSkeleton || (totalStaked && totalStaked.gte(0)) ? (
           <>
             <Pool.PoolCardHeaderTitle
-              title={vaultPoolConfig[pool.vaultKey].name}
-              subTitle={vaultPoolConfig[pool.vaultKey].description}
+              title={vaultPoolConfig?.[pool.vaultKey ?? '']?.name ?? ''}
+              subTitle={vaultPoolConfig?.[pool.vaultKey ?? ''].description ?? ''}
             />
-            <TokenPairImage {...vaultPoolConfig[pool.vaultKey].tokenImage} width={64} height={64} />
+            <TokenPairImage {...vaultPoolConfig?.[pool.vaultKey ?? ''].tokenImage} width={64} height={64} />
           </>
         ) : (
           <Flex width="100%" justifyContent="space-between">

--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -105,7 +105,7 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
                 <Box>
                   {account && (
                     <Box mb="8px">
-                      <UnstakingFeeCountdownRow vaultKey={pool.vaultKey ?? VaultKey.None} />
+                      <UnstakingFeeCountdownRow vaultKey={pool.vaultKey ?? VaultKey.CakeVaultV1} />
                     </Box>
                   )}
                   {/* <RecentCakeProfitRow pool={pool} /> */}

--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -66,8 +66,6 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
   const isLocked = (vaultPool as DeserializedLockedCakeVault)?.userData?.locked
   const isUserDelegated = useIsUserDelegated()
 
-  console.log(isUserDelegated, 'isUserDelegated')
-
   if (!pool) {
     return null
   }
@@ -77,10 +75,10 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
       <StyledCardBody isLoading={isLoading}>
         {vaultPosition >= VaultPosition.LockedEnd && <VeCakeUpdateCard isLockEndOrAfterLock />}
 
-        {account && pool.vaultKey === VaultKey.CakeVault && (
+        {account && pool.vaultKey === VaultKey.CakeVault && !isUserDelegated && (
           <VaultPositionTagWithLabel userData={(vaultPool as DeserializedLockedCakeVault)?.userData} />
         )}
-        {account && pool.vaultKey === VaultKey.CakeVault && isLocked ? (
+        {account && pool.vaultKey === VaultKey.CakeVault && isLocked && !isUserDelegated ? (
           <>
             <LockedStakingApy
               userData={(vaultPool as DeserializedLockedCakeVault).userData}
@@ -102,7 +100,7 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
               <VeCakeCard />
             )}
             {/* {<StakingApy pool={pool} />} */}
-            {vaultPosition !== VaultPosition.None && (
+            {vaultPosition !== VaultPosition.None && !isUserDelegated && (
               <FlexGap mt="16px" gap="24px" flexDirection={accountHasSharesStaked ? 'column-reverse' : 'column'}>
                 <Box>
                   {account && (

--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -13,6 +13,7 @@ import useVCake from 'views/Pools/hooks/useVCake'
 import { useAccount } from 'wagmi'
 
 import { VeCakeCard, VeCakeUpdateCard } from 'views/CakeStaking/components/SyrupPool'
+import { useIsUserDelegated } from 'views/CakeStaking/hooks/useIsUserDelegated'
 import LockedStakingApy from '../LockedPool/LockedStakingApy'
 import CardFooter from '../PoolCard/CardFooter'
 import { VaultPositionTagWithLabel } from '../Vault/VaultPositionTag'
@@ -63,6 +64,9 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
 
   const vaultPosition = getVaultPosition(vaultPool.userData)
   const isLocked = (vaultPool as DeserializedLockedCakeVault)?.userData?.locked
+  const isUserDelegated = useIsUserDelegated()
+
+  console.log(isUserDelegated, 'isUserDelegated')
 
   if (!pool) {
     return null
@@ -92,7 +96,7 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
           </>
         ) : (
           <>
-            {account && vaultPosition === VaultPosition.Flexible ? (
+            {account && vaultPosition === VaultPosition.Flexible && !isUserDelegated ? (
               <VeCakeUpdateCard isFlexibleStake />
             ) : (
               <VeCakeCard />

--- a/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/index.tsx
@@ -125,7 +125,7 @@ export const CakeVaultDetail: React.FC<React.PropsWithChildren<CakeVaultDetailPr
           </>
         )}
       </StyledCardBody>
-      {account && (
+      {account && !isUserDelegated && (
         <CardFooter isLocked={isLocked} defaultExpanded={defaultFooterExpanded} pool={pool} account={account} />
       )}
     </>

--- a/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
+++ b/apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx
@@ -1,15 +1,15 @@
-import { useState, useMemo, useEffect } from 'react'
-import { Modal, Box } from '@pancakeswap/uikit'
-import useTheme from 'hooks/useTheme'
-import { VaultKey } from 'state/types'
-import { getBalanceNumber, getDecimalAmount } from '@pancakeswap/utils/formatBalance'
 import { useTranslation } from '@pancakeswap/localization'
+import { Box, Modal } from '@pancakeswap/uikit'
+import { getBalanceNumber, getDecimalAmount } from '@pancakeswap/utils/formatBalance'
 import BigNumber from 'bignumber.js'
-import { GenericModalProps } from '../types'
+import useTheme from 'hooks/useTheme'
+import { useEffect, useMemo, useState } from 'react'
+import { VaultKey } from 'state/types'
+import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 import BalanceField from '../Common/BalanceField'
 import LockedBodyModal from '../Common/LockedModalBody'
+import { GenericModalProps } from '../types'
 import RoiCalculatorModalProvider from './RoiCalculatorModalProvider'
-import { useCheckVaultApprovalStatus } from '../../../hooks/useApprove'
 
 const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = ({
   onDismiss,
@@ -33,7 +33,7 @@ const LockedStakeModal: React.FC<React.PropsWithChildren<GenericModalProps>> = (
   const usdValueStaked = useMemo(
     () =>
       getBalanceNumber(
-        getDecimalAmount(new BigNumber(lockedAmount), stakingToken.decimals).multipliedBy(stakingTokenPrice),
+        getDecimalAmount(new BigNumber(lockedAmount), stakingToken.decimals).multipliedBy(stakingTokenPrice ?? 0),
         stakingToken.decimals,
       ),
     [lockedAmount, stakingTokenPrice, stakingToken.decimals],

--- a/apps/web/src/views/Pools/components/LockedPool/types/index.ts
+++ b/apps/web/src/views/Pools/components/LockedPool/types/index.ts
@@ -13,7 +13,7 @@ export interface GenericModalProps {
   stakingToken: Token
   currentBalance: BigNumber
   stakingTokenBalance: BigNumber
-  stakingTokenPrice: number
+  stakingTokenPrice?: number
   customLockAmount?: string
   customLockWeekInSeconds?: number
 }
@@ -87,7 +87,7 @@ export interface ModalValidator {
 export interface LockedModalBodyPropsType {
   onDismiss?: VoidFn
   stakingToken: Token
-  stakingTokenPrice: number
+  stakingTokenPrice?: number
   currentBalance?: BigNumber
   lockedAmount: BigNumber
   editAmountOnly?: React.ReactElement

--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -30,6 +30,7 @@ import {
   VeCakeUpdateCard,
   VeCakeUpdateCardTableView,
 } from 'views/CakeStaking/components/SyrupPool'
+import { useIsUserDelegated } from 'views/CakeStaking/hooks/useIsUserDelegated'
 import WithdrawAllButton from '../../LockedPool/Buttons/WithdrawAllButton'
 import LockDurationRow from '../../LockedPool/Common/LockDurationRow'
 import YieldBoostRow from '../../LockedPool/Common/YieldBoostRow'
@@ -158,6 +159,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
     [pool.vaultKey],
   )
   const isMigratedToVeCake = useIsMigratedToVeCake()
+  const isUserDelegated = useIsUserDelegated()
 
   return (
     <StyledActionPanel expanded={expanded}>
@@ -199,7 +201,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
       </InfoSection>
       <ActionContainer>
         <Box width="100%">
-          {pool.vaultKey === VaultKey.CakeVault && (
+          {pool.vaultKey === VaultKey.CakeVault && !isUserDelegated && (
             <VaultPositionTagWithLabel
               userData={vaultData.userData as DeserializedLockedVaultUser}
               width={['auto', null, 'fit-content']}
@@ -209,7 +211,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
           <ActionContainer isAutoVault={!!pool.vaultKey} hasBalance={poolStakingTokenBalance.gt(0)}>
             {pool.vaultKey ? (
               <>
-                {account && vaultPosition !== VaultPosition.None ? (
+                {account && vaultPosition !== VaultPosition.None && !isUserDelegated ? (
                   <AutoHarvest pool={pool} />
                 ) : (
                   <VeCakeCardTableView />
@@ -221,7 +223,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
             <Stake pool={pool} />
           </ActionContainer>
         </Box>
-        {isCakePool && account && vaultPosition !== VaultPosition.None && (
+        {!isUserDelegated && isCakePool && account && vaultPosition !== VaultPosition.None && (
           <Flex width="100%">
             <Message
               variant="warning"

--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -35,6 +35,7 @@ import useUserDataInVaultPresenter from 'views/Pools/components/LockedPool/hooks
 import { useProfileRequirement } from 'views/Pools/hooks/useProfileRequirement'
 
 import { VeCakeButton } from 'views/CakeStaking/components/SyrupPool/VeCakeButton'
+import { useIsUserDelegated } from 'views/CakeStaking/hooks/useIsUserDelegated'
 import { useApprovePool, useCheckVaultApprovalStatus, useVaultApprove } from '../../../hooks/useApprove'
 import VaultStakeModal from '../../CakeVaultCard/VaultStakeModal'
 import BurningCountDown from '../../LockedPool/Common/BurningCountDown'
@@ -151,6 +152,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
       stakingTokenBalance={stakingTokenBalance}
     />,
   )
+  const isUserDelegated = useIsUserDelegated()
 
   const { notMeetRequired, notMeetThreshold } = useProfileRequirement(profileRequirement)
 
@@ -202,7 +204,8 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
     !account ||
     (account &&
       vaultPosition === VaultPosition.None &&
-      (vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault))
+      (vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault)) ||
+    isUserDelegated
   ) {
     if (isMobile) {
       return vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault ? (

--- a/apps/web/src/views/Pools/components/PoolsTable/PoolRow.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/PoolRow.tsx
@@ -8,6 +8,7 @@ import { VeCakeBenefitCard } from 'views/CakeStaking/components/SyrupPool/VeCake
 
 import { Token } from '@pancakeswap/swap-sdk-core'
 import styled from 'styled-components'
+import { useIsUserDelegated } from 'views/CakeStaking/hooks/useIsUserDelegated'
 import ActionPanel from './ActionPanel/ActionPanel'
 import AprCell from './Cells/AprCell'
 import AutoAprCell from './Cells/AutoAprCell'
@@ -35,6 +36,7 @@ export const VaultPoolRow: React.FC<
   const isXLargerScreen = isXl || isXxl
   const pool = useDeserializedPoolByVaultKey(vaultKey) as Pool.DeserializedPoolLockedVault<Token>
   const { totalCakeInVault } = useVaultPoolByKey(vaultKey)
+  const isUserDelegated = useIsUserDelegated()
 
   const { stakingToken, totalStaked } = pool
 
@@ -45,7 +47,7 @@ export const VaultPoolRow: React.FC<
   return (
     <Pool.ExpandRow initialActivity={initialActivity} panel={<ActionPanel account={account} pool={pool} expanded />}>
       <NameCell pool={pool} />
-      {!account ? (
+      {!account || isUserDelegated ? (
         <MigrateCell>
           {isMobile ? (
             <Text fontSize={14} lineHeight="14px">
@@ -56,7 +58,7 @@ export const VaultPoolRow: React.FC<
           )}
         </MigrateCell>
       ) : null}
-      {account && (
+      {account && !isUserDelegated && (
         <>
           {isXLargerScreen && <AutoEarningsCell pool={pool} account={account} />}
           {isXLargerScreen ? <StakedCell pool={pool} account={account} /> : null}


### PR DESCRIPTION
…egated

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

copilot:all

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- Added `CakePoolType` enum with values `NOT_MIGRATED`, `MIGRATED`, and `DELEGATED` in `apps/web/src/views/CakeStaking/types.ts`
- Created `useIsUserDelegated` hook in `apps/web/src/views/CakeStaking/hooks/useIsUserDelegated.ts`
- Added `useIsUserDelegated` hook in `apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx`, `apps/web/src/views/Pools/components/VaultPoolRow.tsx`, `apps/web/src/views/Pools/components/PoolRow.tsx`, `apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/VaultStakeActions.tsx`, `apps/web/src/views/Pools/components/LockedPool/Modals/LockedStakeModal.tsx`, and `apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/index.tsx` files

> The following files were skipped due to too many changes: `apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx`, `apps/web/src/views/Pools/components/CakeVaultCard/index.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->