### PR TITLE
fix: Remove gas cost adjustment for single hop v3 swaps

### DIFF
--- a/packages/smart-router/evm/constants/gasModel/index.ts
+++ b/packages/smart-router/evm/constants/gasModel/index.ts
@@ -23,8 +23,8 @@ import {
 export const usdGasTokensByChain = {
   [ChainId.ETHEREUM]: [ethereumTokens.usdt],
   [ChainId.GOERLI]: [goerliTestnetTokens.usdc],
-  [ChainId.BSC]: [bscTokens.busd],
-  [ChainId.BSC_TESTNET]: [bscTestnetTokens.busd],
+  [ChainId.BSC]: [bscTokens.usdt],
+  [ChainId.BSC_TESTNET]: [bscTestnetTokens.usdt],
   [ChainId.ARBITRUM_ONE]: [arbitrumTokens.usdc],
   [ChainId.ARBITRUM_GOERLI]: [arbitrumGoerliTokens.usdc],
   [ChainId.POLYGON_ZKEVM]: [polygonZkEvmTokens.usdt],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Update token addresses for `ChainId.BSC` and `ChainId.BSC_TESTNET`
- Add `v3SingleHopOnChainQuoteProvider` with `onAdjustQuoteForGas` handler
- Modify `onChainQuoteProviderFactory` to accept `onAdjustQuoteForGas` handler
- Update `processQuoteResults` to use `onAdjustQuoteForGas` handler

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->