### PR TITLE
feat: add sdcake gauge

### DIFF
--- a/packages/gauges/src/constants/config.ts
+++ b/packages/gauges/src/constants/config.ts
@@ -1871,14 +1871,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: bscTokens.usdc.address,
     feeTier: FeeAmount.LOWEST,
   },
-  // {
-  //   gid: 175,
-  //   address: '0xb4C27884308C3Bca710c220D680BAb02f6b64b51',
-  //   pairName: 'sdCAKE-CAKE',
-  //   chainId: ChainId.BSC,
-  //   type: GaugeType.StableSwap,
-  //   tokenAddresses: [bscTokens.sdcake.address, bscTokens.cake.address],
-  // },
+  {
+    gid: 175,
+    address: '0xB1D54d76E2cB9425Ec9c018538cc531440b55dbB',
+    pairName: 'CAKE-sdCAKE',
+    chainId: ChainId.BSC,
+    type: GaugeType.StableSwap,
+    tokenAddresses: [bscTokens.cake.address, bscTokens.sdcake.address],
+  },
   {
     gid: 176,
     address: '0x060d8a5a7C03882e33AcA8FC304BabE869e21Ee9',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the configuration in `config.ts` file for the stable swap gauge.

### Detailed summary:
- Updated the `address` and `pairName` for the stable swap gauge with ID 175.
- Updated the order of `tokenAddresses` in the stable swap gauge with ID 175.
- Added a new gauge with ID 175 for the `CAKE-sdCAKE` pair on the BSC chain.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->