### PR TITLE
fix: farm card unconnected UI

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3Card.tsx
@@ -124,15 +124,16 @@ export const FarmV3Card: React.FC<React.PropsWithChildren<FarmCardProps>> = ({ f
             </Text>
           </Flex>
         )}
+
+        <Flex justifyContent="space-between">
+          <Text>{t('Earn')}:</Text>
+          <Text>{earnLabel}</Text>
+        </Flex>
         {!account && farm.boosted && (
           <Box mt="24px" mb="16px">
             <StatusView status={boostStatus} />
           </Box>
         )}
-        <Flex justifyContent="space-between">
-          <Text>{t('Earn')}:</Text>
-          <Text>{earnLabel}</Text>
-        </Flex>
         <CardActionsContainer farm={farm} lpLabel={lpLabel} account={account} />
       </FarmCardInnerContainer>
       <ExpandingWrapper>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a `Flex` component with `justifyContent="space-between"` to display the "Earn" label and its corresponding value.
- Removed the previous `Flex` component that displayed the "Earn" label and its corresponding value.
- Moved the `CardActionsContainer` component inside the `FarmCardInnerContainer` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->