### PR TITLE
refactor: Automatically load all experimental flags based on config

### DIFF
--- a/apps/web/src/hooks/useDataDogRUM.ts
+++ b/apps/web/src/hooks/useDataDogRUM.ts
@@ -38,6 +38,27 @@ export function useDataDogRUM() {
   }, [ready, address])
 }
 
+export type FeatureFlagEvaluation = {
+  flagName: string
+  value?: boolean | string | number
+}
+
+export function useFeatureFlagEvaluations(evaluations?: FeatureFlagEvaluation[]) {
+  const ready = useDataDogRUMReady()
+
+  useEffect(() => {
+    if (!ready || !evaluations) {
+      return
+    }
+
+    for (const { flagName, value } of evaluations) {
+      if (value !== undefined) {
+        datadogRum.addFeatureFlagEvaluation(flagName, value)
+      }
+    }
+  }, [ready, evaluations])
+}
+
 export function useFeatureFlagEvaluation(flagName: string, value?: boolean | string | number) {
   const ready = useDataDogRUMReady()
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new hook `useFeatureFlagEvaluations` and updating the existing hooks `useFeatureFlagEvaluation` and `useLoadExperimentalFeatures` to support feature flag evaluations.

### Detailed summary:
- Added a new hook `useFeatureFlagEvaluations` to evaluate feature flags.
- Updated the hook `useFeatureFlagEvaluation` to support feature flag evaluations.
- Updated the hook `useLoadExperimentalFeatures` to use the new `useFeatureFlagEvaluations` hook and evaluate multiple feature flags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->