### PR TITLE
fix: gauge pair name

### DIFF
--- a/packages/gauges/src/constants/config.ts
+++ b/packages/gauges/src/constants/config.ts
@@ -1982,7 +1982,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
   {
     gid: 185,
     address: '0xBC7766aE74f38f251683633d50Cc2C1CD14aF948',
-    pairName: 'INSP-USDT',
+    pairName: 'INSP-ETH',
     chainId: ChainId.ETHEREUM,
     type: GaugeType.V3,
     token0Address: ethereumTokens.insp.address,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the `pairName` constant in the `config.ts` file.

### Detailed summary:
- Updated the `pairName` constant from `'INSP-USDT'` to `'INSP-ETH'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->