### PR TITLE
fix: resolve notification not loading bug

### DIFF
--- a/apps/web/src/views/Notifications/components/NotificationDropdown/NotificationMenu.tsx
+++ b/apps/web/src/views/Notifications/components/NotificationDropdown/NotificationMenu.tsx
@@ -34,13 +34,11 @@ const NotificationMenu: React.FC<
   UserMenuProps & {
     isMenuOpen: boolean
     setIsMenuOpen: Dispatch<SetStateAction<boolean>>
-    isRegistered: boolean
-    handleRegistration: () => Promise<void>
     viewIndex: PAGE_VIEW
     subscriptionId: string | undefined
     account: string | undefined
   }
-> = ({ children, isMenuOpen, setIsMenuOpen, isRegistered, handleRegistration, viewIndex, subscriptionId, account }) => {
+> = ({ children, isMenuOpen, setIsMenuOpen, viewIndex, subscriptionId, account }) => {
   const hasUnread = useHasUnreadNotifications(subscriptionId)
   const dispatch = useAppDispatch()
   const { messages: notifications } = useMessages(account)
@@ -57,20 +55,12 @@ const NotificationMenu: React.FC<
   }, [dispatch, notifications, subscriptionId])
 
   const toggleMenu = useCallback(() => {
-    if (isRegistered) handleRegistration()
     if (!isMenuOpen) {
       requestNotificationPermission()
       markAllNotificationsAsRead()
     }
     setIsMenuOpen(!isMenuOpen)
-  }, [
-    setIsMenuOpen,
-    isMenuOpen,
-    isRegistered,
-    handleRegistration,
-    markAllNotificationsAsRead,
-    requestNotificationPermission,
-  ])
+  }, [setIsMenuOpen, isMenuOpen, markAllNotificationsAsRead, requestNotificationPermission])
 
   useEffect(() => {
     const checkIfClickedOutside = (e: MouseEvent) => {

--- a/apps/web/src/views/Notifications/index.tsx
+++ b/apps/web/src/views/Notifications/index.tsx
@@ -32,8 +32,6 @@ const Notifications = () => {
   })
 
   const isReady = Boolean(isSubscribed && account && isW3iInitialized)
-  const isRegistered = Boolean(!identityKey && isSubscribed)
-
   const onDismiss = useCallback(() => setIsMenuOpen(false), [setIsMenuOpen])
   const toggleOnboardView = useCallback(() => setViewIndex(PAGE_VIEW.OnboardView), [setViewIndex])
 

--- a/apps/web/src/views/Notifications/index.tsx
+++ b/apps/web/src/views/Notifications/index.tsx
@@ -67,10 +67,11 @@ const Notifications = () => {
     if (!address || !isReady) setViewIndex(PAGE_VIEW.OnboardView)
     if (address) setAccount(`eip155:1:${address}`)
     if (isReady) {
+      handleRegistration()
       setViewIndex(PAGE_VIEW.NotificationView)
       setIsSubscribing(false)
     }
-  }, [address, isReady, setAccount, setIsSubscribing])
+  }, [address, isReady, setAccount, setIsSubscribing, handleRegistration])
 
   useEffect(() => {
     if (!subscription?.topic) return () => null
@@ -86,8 +87,6 @@ const Notifications = () => {
     <NotificationMenu
       isMenuOpen={isMenuOpen}
       setIsMenuOpen={setIsMenuOpen}
-      isRegistered={isRegistered}
-      handleRegistration={handleRegistration}
       viewIndex={viewIndex}
       subscriptionId={subscription?.topic}
       account={account}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to remove the `isRegistered` prop from the `NotificationMenu` component and handle the registration separately.

### Detailed summary:
- Removed the `isRegistered` prop from the `NotificationMenu` component.
- Moved the `handleRegistration` function call to the `Notifications` component.
- Updated the dependencies of the `useEffect` hook in the `Notifications` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->