### PR TITLE
feat: add RDP farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 112,
+    lpAddress: '0xE297e1dA9a484E609D180C5B1fEfE4830df70eF1',
+    token0: bscTokens.rdp,
+    token1: bscTokens.bnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 111,
     lpAddress: '0x7D3c51D707C8C63CB9f85cEC6E9F9FF0A5fb2735',
     token0: bscTokens.vai,

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2819,4 +2819,12 @@ export const bscTokens = {
     'USDV',
     'https://usdv.money/',
   ),
+  rdp: new ERC20Token(
+    ChainId.BSC,
+    '0x27c073e8427aa493a90b8dC8b73A89e670FD77bB',
+    18,
+    'Radpie',
+    'RDP',
+    'https://www.radiant.magpiexyz.io/stake',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding a new ERC20 token called Radpie (RDP) to the Binance Smart Chain (BSC) network.

### Detailed summary:
- Added a new ERC20Token object for Radpie (RDP) with its contract address, decimals, name, symbol, and website URL.
- Added a new farm configuration for Radpie (RDP) and BNB LP with the corresponding pool ID, LP address, tokens, fee amount, etc.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->