### PR TITLE
chore: Update swap error log cause

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -15,7 +15,7 @@ import { logSwap, logTx } from 'utils/log'
 import { isUserRejected } from 'utils/sentry'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { viemClients } from 'utils/viem'
-import { Address, Hex, hexToBigInt } from 'viem'
+import { Address, Hex, TransactionExecutionError, hexToBigInt } from 'viem'
 import { useSendTransaction } from 'wagmi'
 import { SendTransactionResult } from 'wagmi/actions'
 
@@ -213,15 +213,15 @@ export default function useSendSwapTransaction(
               throw new TransactionRejectedError(t('Transaction rejected'))
             } else {
               // otherwise, the error was unexpected and we need to convey that
-              logger.error(
+              logger.warn(
                 'Swap failed',
                 {
                   chainId,
                   input: trade.inputAmount.currency,
                   output: trade.outputAmount.currency,
                   address: call.address,
-                  calldata: call.calldata,
                   value: call.value,
+                  cause: error instanceof TransactionExecutionError ? error.cause : undefined,
                 },
                 error,
               )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on updating the `useSendSwapTransaction` hook in the `V3Swap` view. The notable changes include:

- Importing `TransactionExecutionError` from `viem`
- Logging a warning message instead of an error when the swap fails
- Adding the `cause` property to the log message if the error is an instance of `TransactionExecutionError`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->