### PR TITLE
ci: upgrade checkout action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'pancakeswap/pancake-frontend'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4

--- a/.github/workflows/testConfig.yml
+++ b/.github/workflows/testConfig.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/updateCron.yml
+++ b/.github/workflows/updateCron.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'pancakeswap/pancake-frontend'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4
@@ -67,7 +67,7 @@ jobs:
     if: github.repository == 'pancakeswap/pancake-frontend'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4
@@ -123,7 +123,7 @@ jobs:
     if: github.repository == 'pancakeswap/pancake-frontend'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2.2.4


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the code checkout action in multiple workflows from version 2 to version 3. 

### Detailed summary
- Updated the `uses` field in `.github/workflows/unitTests.yml` from `actions/checkout@v2` to `actions/checkout@v3` with `fetch-depth: 2`.
- Updated the `uses` field in `.github/workflows/testConfig.yml` from `actions/checkout@v2` to `actions/checkout@v3` with `fetch-depth: 2`.
- Updated the `uses` field in `.github/workflows/lint.yml` from `actions/checkout@v2` to `actions/checkout@v3`.
- Updated the `uses` field in `.github/workflows/format.yml` from `actions/checkout@v2` to `actions/checkout@v3`.
- Updated the `uses` field in `.github/workflows/release.yml` from `actions/checkout@v2` to `actions/checkout@v3`.
- Updated the `uses` field in `.github/workflows/updateCron.yml` from `actions/checkout@v2` to `actions/checkout@v3`.
- Updated the `uses` field in the `jobs` section of `.github/workflows/updateCron.yml` from `actions/checkout@v2` to `actions/checkout@v3`.
- Updated the `uses` field in the `jobs` section of `.github/workflows/updateCron.yml` from `actions/checkout@v2` to `actions/checkout@v3`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->