### PR TITLE
feat: add gauge

### DIFF
--- a/packages/gauges/src/constants/config.ts
+++ b/packages/gauges/src/constants/config.ts
@@ -2149,6 +2149,24 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: zksyncTokens.usdc.address,
     feeTier: FeeAmount.LOWEST,
   },
+  {
+    gid: 203,
+    pairName: 'RDP-BNB',
+    address: '0xE297e1dA9a484E609D180C5B1fEfE4830df70eF1',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.rdp.address,
+    token1Address: bscTokens.wbnb.address,
+    feeTier: FeeAmount.MEDIUM,
+  },
+  {
+    gid: 204,
+    pairName: 'sdCAKE-CAKE',
+    address: '0xB1D54d76E2cB9425Ec9c018538cc531440b55dbB',
+    chainId: ChainId.BSC,
+    type: GaugeType.StableSwap,
+    tokenAddresses: [bscTokens.sdcake.address, bscTokens.cake.address],
+  },
 ]
 
 export const GAUGES_CONFIG = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding two new gauges to the GAUGES_CONFIG constant in the config.ts file.

### Detailed summary
- Added a new gauge with gid 203 for the pair RDP-BNB.
- Added a new gauge with gid 204 for the pair sdCAKE-CAKE.
- Updated the feeTier for the gauge with gid 203 to FeeAmount.MEDIUM.
- Added tokenAddresses property to the gauge with gid 204, specifying the token addresses for bscTokens.sdcake and bscTokens.cake.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->