### PR TITLE
fix: reverse lp address

### DIFF
--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -42,7 +42,7 @@ const farms: SerializedFarmConfig[] = [
     pid: 21,
     lpSymbol: 'GUI-APT LP',
     lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0xe4ccb6d39136469f376242c31b34d10515c8eaaa38092f804db8e08a8f53c5b2::assets_v1::EchoCoin002, 0x1::aptos_coin::AptosCoin>',
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xe4ccb6d39136469f376242c31b34d10515c8eaaa38092f804db8e08a8f53c5b2::assets_v1::EchoCoin002>',
     token: mainnetTokens.gui,
     quoteToken: mainnetTokens.apt,
   },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the LP token address in the APTOS app configuration.

### Detailed summary:
- Updated the LP token address in the APTOS app configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->