### PR TITLE
fix: invert token

### DIFF
--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -43,8 +43,8 @@ const farms: SerializedFarmConfig[] = [
     lpSymbol: 'GUI-APT LP',
     lpAddress:
       '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xe4ccb6d39136469f376242c31b34d10515c8eaaa38092f804db8e08a8f53c5b2::assets_v1::EchoCoin002>',
-    token: mainnetTokens.gui,
-    quoteToken: mainnetTokens.apt,
+    token: mainnetTokens.apt,
+    quoteToken: mainnetTokens.gui,
   },
   {
     pid: 20,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- In `apps/aptos/config/constants/farms/1.ts`, the `lpAddress` property is updated.
- The `token` and `quoteToken` properties are swapped in the object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->