### PR TITLE
fix(aptos): simulation use expireation ledger time

### DIFF
--- a/apps/aptos/hooks/useLedgerTimestamp.ts
+++ b/apps/aptos/hooks/useLedgerTimestamp.ts
@@ -1,6 +1,6 @@
-import { useCallback } from 'react'
 import { useQuery, useQueryClient } from '@pancakeswap/awgmi'
 import { fetchLedgerInfo } from '@pancakeswap/awgmi/core'
+import { useCallback } from 'react'
 import { useActiveChainId } from './useNetwork'
 
 export const useLedgerTimestamp = () => {

--- a/apps/aptos/hooks/useSimulationAndSendTransaction.ts
+++ b/apps/aptos/hooks/useSimulationAndSendTransaction.ts
@@ -21,6 +21,7 @@ export default function useSimulationAndSendTransaction() {
         results = await simulateTransactionAsync({
           payload,
           options: {
+            // only use for simulation
             expiration_timestamp_secs: Math.floor(getNow() / 1000 + 5000).toString(),
           },
         })

--- a/apps/aptos/hooks/useSimulationAndSendTransaction.ts
+++ b/apps/aptos/hooks/useSimulationAndSendTransaction.ts
@@ -1,9 +1,12 @@
 import { useSendTransaction, useSimulateTransaction } from '@pancakeswap/awgmi'
 import { useCallback } from 'react'
+import { useLedgerTimestamp } from './useLedgerTimestamp'
 
 const SAFE_FACTOR = 1.5
 
 export default function useSimulationAndSendTransaction() {
+  const getNow = useLedgerTimestamp()
+
   const { simulateTransactionAsync } = useSimulateTransaction()
 
   const { sendTransactionAsync } = useSendTransaction()
@@ -15,7 +18,12 @@ export default function useSimulationAndSendTransaction() {
       let results
 
       try {
-        results = await simulateTransactionAsync({ payload })
+        results = await simulateTransactionAsync({
+          payload,
+          options: {
+            expiration_timestamp_secs: Math.floor(getNow() / 1000 + 5000).toString(),
+          },
+        })
       } catch (error) {
         // ignore error
         if (simulateError) {
@@ -37,7 +45,7 @@ export default function useSimulationAndSendTransaction() {
         options,
       })
     },
-    [sendTransactionAsync, simulateTransactionAsync],
+    [sendTransactionAsync, simulateTransactionAsync, getNow],
   )
 
   return execute

--- a/packages/awgmi/core/src/transactions/simulateTransaction.ts
+++ b/packages/awgmi/core/src/transactions/simulateTransaction.ts
@@ -1,7 +1,7 @@
 import { HexString, TxnBuilderTypes, Types } from 'aptos'
 import { getAccount } from '../accounts/account'
 import { getClient } from '../client'
-import { WalletProviderError, SimulateTransactionError } from '../errors'
+import { SimulateTransactionError, WalletProviderError } from '../errors'
 import { getProvider } from '../providers'
 
 export type SimulateTransactionArgs = {
@@ -9,7 +9,7 @@ export type SimulateTransactionArgs = {
   networkName?: string
   throwOnError?: boolean
   payload: Types.EntryFunctionPayload
-  options?: Omit<Types.SubmitTransactionRequest, 'payload' | 'signature'>
+  options?: Partial<Omit<Types.SubmitTransactionRequest, 'payload' | 'signature'>>
   query?: {
     estimateGasUnitPrice?: boolean
     estimateMaxGasAmount?: boolean


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new hook `useLedgerTimestamp` and using it in the `useSimulationAndSendTransaction` hook. 

### Detailed summary
- Added `useLedgerTimestamp` hook in `apps/aptos/hooks/useLedgerTimestamp.ts`
- Reordered imports in `packages/awgmi/core/src/transactions/simulateTransaction.ts`
- Imported `useLedgerTimestamp` in `apps/aptos/hooks/useSimulationAndSendTransaction.ts`
- Added `getNow` function to calculate the current timestamp in `useSimulationAndSendTransaction`
- Updated `simulateTransactionAsync` call to include `expiration_timestamp_secs` option

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->