### PR TITLE
feat: add gauges and farms

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,27 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 115,
+    lpAddress: '0x961C19a53e5EA0e43B8F9020553F94623Ce475B6',
+    token0: bscTokens.mubi,
+    token1: bscTokens.wbnb,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 114,
+    lpAddress: '0x442EFB99C2727c6000727C3cf672e3d77C9cDEaD',
+    token0: bscTokens.wbnb,
+    token1: bscTokens.ordi,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
+    pid: 113,
+    lpAddress: '0xcF0bA206D688Fc9AE8A268F8b9077F4307600895',
+    token0: bscTokens.sats,
+    token1: bscTokens.wbnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 112,
     lpAddress: '0xE297e1dA9a484E609D180C5B1fEfE4830df70eF1',
     token0: bscTokens.rdp,

--- a/packages/gauges/src/constants/config.ts
+++ b/packages/gauges/src/constants/config.ts
@@ -2167,6 +2167,36 @@ export const CONFIG_PROD: GaugeConfig[] = [
     type: GaugeType.StableSwap,
     tokenAddresses: [bscTokens.sdcake.address, bscTokens.cake.address],
   },
+  {
+    gid: 205,
+    pairName: 'sats-BNB',
+    address: '0xcF0bA206D688Fc9AE8A268F8b9077F4307600895',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.sats.address,
+    token1Address: bscTokens.wbnb.address,
+    feeTier: FeeAmount.MEDIUM,
+  },
+  {
+    gid: 206,
+    pairName: 'ordi-BNB',
+    address: '0x442EFB99C2727c6000727C3cf672e3d77C9cDEaD',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.ordi.address,
+    token1Address: bscTokens.wbnb.address,
+    feeTier: FeeAmount.HIGH,
+  },
+  {
+    gid: 207,
+    pairName: 'MUBI-BNB',
+    address: '0x961C19a53e5EA0e43B8F9020553F94623Ce475B6',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.mubi.address,
+    token1Address: bscTokens.wbnb.address,
+    feeTier: FeeAmount.HIGH,
+  },
 ]
 
 export const GAUGES_CONFIG = {

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2827,4 +2827,21 @@ export const bscTokens = {
     'Radpie',
     'https://www.radiant.magpiexyz.io/stake',
   ),
+  sats: new ERC20Token(
+    ChainId.BSC,
+    '0x143D7A700a533B4baF6D693449b278A8A2F5927d',
+    18,
+    'sats',
+    'sats',
+    'https://satscoin.vip/',
+  ),
+  ordi: new ERC20Token(ChainId.BSC, '0xe2aE1a99bBd2eFab0a5C38f2146B7aCE61aBC5cE', 18, 'ordi', 'ordi', ''),
+  mubi: new ERC20Token(
+    ChainId.BSC,
+    '0x38e382F74dfb84608F3C1F10187f6bEf5951DE93',
+    18,
+    'MUBI',
+    'MUBI',
+    'https://multibit.exchange/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding new ERC20 tokens and configuring gauges for these tokens in the BSC network.

### Detailed summary:
- Added new ERC20 tokens: sats, ordi, and MUBI.
- Configured gauges for the new tokens: sats-BNB, ordi-BNB, and MUBI-BNB.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->