### PR TITLE
fix: allow symbol contain space

### DIFF
--- a/packages/token-lists/schema/pancakeswap.json
+++ b/packages/token-lists/schema/pancakeswap.json
@@ -203,7 +203,7 @@
         "symbol": {
           "type": "string",
           "description": "The symbol for the token; must be alphanumeric",
-          "pattern": "^[a-zA-Z0-9+\\-%/$.]+$",
+          "pattern": "^[a-zA-Z0-9+\\-%/$.\\s]+$",
           "minLength": 1,
           "maxLength": 20,
           "examples": ["USDC"]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the validation pattern for the symbol field in the pancakeswap.json schema.

### Detailed summary:
- The pattern for the symbol field in the pancakeswap.json schema is updated.
- The new pattern allows alphanumeric characters, plus signs, hyphens, percentage signs, forward slashes, periods, and whitespace.
- The minimum length for the symbol is still 1.
- The maximum length for the symbol is still 20.
- An example value for the symbol field is provided as "USDC".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->