### PR TITLE
fix: add delegate condition

### DIFF
--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -95,6 +95,11 @@ export const useCakeLockStatus = (): {
   const shouldMigrate = useMemo(() => {
     return cakePoolLockInfo?.locked && userInfo?.cakePoolType !== CakePoolType.MIGRATED && isAllowMigrate
   }, [cakePoolLockInfo?.locked, isAllowMigrate, userInfo?.cakePoolType])
+  const delegateOnly = useMemo(() => {
+    if (!userInfo) return false
+
+    return userInfo.cakePoolType === CakePoolType.DELEGATED && userInfo.amount === 0n
+  }, [userInfo])
   const now = useMemo(() => dayjs.unix(currentTimestamp), [currentTimestamp])
   const cakeLocked = useMemo(() => Boolean(userInfo && userInfo.amount > 0n), [userInfo])
   const cakeUnlockTime = useMemo(() => {
@@ -134,16 +139,13 @@ export const useCakeLockStatus = (): {
   }, [userInfo, cakePoolLocked])
 
   const status = useMemo(() => {
-    if (
-      ((!userInfo || !userInfo.amount) && !cakePoolLocked && !shouldMigrate) ||
-      userInfo?.cakePoolType === CakePoolType.DELEGATED
-    )
+    if (((!userInfo || !userInfo.amount) && !cakePoolLocked && !shouldMigrate) || delegateOnly)
       return CakeLockStatus.NotLocked
     if (cakeLockExpired) return CakeLockStatus.Expired
     if ((userInfo?.amount && userInfo.end) || cakePoolLocked) return CakeLockStatus.Locking
     if (shouldMigrate) return CakeLockStatus.Migrate
     return CakeLockStatus.NotLocked
-  }, [userInfo, shouldMigrate, cakePoolLocked, cakeLockExpired])
+  }, [userInfo, cakePoolLocked, shouldMigrate, delegateOnly, cakeLockExpired])
 
   return {
     status,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new `delegateOnly` variable to the `useVeCakeUserInfo` hook in the `CakeStaking` view.

### Detailed summary:
- Added a new `delegateOnly` variable to the `useVeCakeUserInfo` hook.
- The `delegateOnly` variable is calculated using the `userInfo` object and checks if `userInfo.cakePoolType` is `CakePoolType.DELEGATED` and `userInfo.amount` is `0n`.
- The `delegateOnly` variable is used in the `status` calculation in the `useCakeLockStatus` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->