### PR TITLE
feat: add sdcake farm & gauge

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 119,
+    lpAddress: '0x8A876Ca851063e0252654CA6368a5B2280f51c32',
+    token0: bscTokens.cake,
+    token1: bscTokens.sdcake,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 118,
     lpAddress: '0x57dBE41582591e8a420cc80FB669F953d137a571',
     token0: bscTokens.mubi,

--- a/packages/gauges/src/constants/config.ts
+++ b/packages/gauges/src/constants/config.ts
@@ -2237,6 +2237,16 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: zksyncTokens.usdt.address,
     feeTier: FeeAmount.LOW,
   },
+  {
+    gid: 212,
+    pairName: 'sdCAKE-CAKE',
+    address: '0x8A876Ca851063e0252654CA6368a5B2280f51c32',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.sdcake.address,
+    token1Address: bscTokens.cake.address,
+    feeTier: FeeAmount.MEDIUM,
+  },
 ]
 
 export const GAUGES_CONFIG = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new liquidity pool (LP) with PID 119 and LP address '0x8A876Ca851063e0252654CA6368a5B2280f51c32' for the BSC network.
- The new LP consists of the tokens 'cake' and 'sdcake' from the BSC token list.
- The fee amount for the new LP is set to 'MEDIUM'.
- Added a new gauge with GID 212 and pair name 'sdCAKE-CAKE' for the BSC network.
- The new gauge uses the LP address '0x8A876Ca851063e0252654CA6368a5B2280f51c32' and is of type 'GaugeType.V3'.
- The tokens 'sdcake' and 'cake' are used in the new gauge, with their respective addresses from the BSC token list.
- The fee tier for the new gauge is set to 'MEDIUM'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->