### PR TITLE
fix(Aptos-Pools): Fix apr issue

### DIFF
--- a/packages/widgets-internal/pool/Apr.tsx
+++ b/packages/widgets-internal/pool/Apr.tsx
@@ -63,7 +63,7 @@ export function Apr<T>({
   shouldShowApr,
   account,
   autoCompoundFrequency,
-  boostedApr,
+  boostedApr = 0,
   boostedTooltipsText,
   ...props
 }: AprProps<T>) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/098f0f58-047c-4257-b240-808e8d7cd30d)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/b13187a9-329a-46e0-826f-7724cf8a21f5)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a default value for the `boostedApr` prop in the `Apr` component. 

### Detailed summary
- Added a default value of 0 for the `boostedApr` prop in the `Apr` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->