### PR TITLE
feat: Update perp only eth support v1 link

### DIFF
--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -14,6 +14,10 @@ const mapPerpChain = (chainId: ChainId): string => {
       return 'ethereum'
     case ChainId.ARBITRUM_ONE:
       return 'arbitrum'
+    case ChainId.OPBNB:
+      return 'opbnb'
+    case ChainId.BASE:
+      return 'base'
     default:
       return 'bsc'
   }

--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -19,7 +19,7 @@ const mapPerpChain = (chainId: ChainId): string => {
   }
 }
 
-const supportV2Chains: ChainId[] = [ChainId.BSC, ChainId.ARBITRUM_ONE]
+const supportV1Chains: ChainId[] = [ChainId.ETHEREUM]
 
 export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualUrlProps) => {
   if (!chainId || !languageCode) {
@@ -27,7 +27,7 @@ export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualU
   }
 
   const perpChain = mapPerpChain(chainId)
-  const version = supportV2Chains.includes(chainId) ? 'v2/' : ''
+  const version = supportV1Chains.includes(chainId) ? '' : 'v2/'
   return `https://perp.pancakeswap.finance/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(
     isDark,
   )}&chain=${perpChain}`


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding support for the OPBNB and BASE chains in the `getPerpetualUrl` function.

### Detailed summary:
- Added support for the OPBNB chain in the `getPerpetualUrl` function.
- Added support for the BASE chain in the `getPerpetualUrl` function.
- Updated the `supportV1Chains` array to include ChainId.ETHEREUM instead of ChainId.BSC.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->