### PR TITLE
chore: fix userDelegated pool table view

### DIFF
--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/ActionPanel.tsx
@@ -223,7 +223,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
             ) : (
               <Harvest {...pool} />
             )}
-            {!isUserDelegated && <Stake pool={pool} />}
+            <Stake pool={pool} />
           </ActionContainer>
         </Box>
         {isCakePool && account && vaultPosition !== VaultPosition.None && (
@@ -237,7 +237,7 @@ const ActionPanel: React.FC<React.PropsWithChildren<ActionPanelProps>> = ({ acco
                   style={{ gap: isMobile ? 15 : 24, flexDirection: isMobile ? 'column' : 'row' }}
                 >
                   {isUserDelegated && <VeCakeDelegatedCard isTableView />}
-                  {vaultPosition === VaultPosition.Locked && (
+                  {vaultPosition === VaultPosition.Locked && !isUserDelegated && (
                     <VeCakeMigrateCard
                       isTableView
                       lockEndTime={(vaultData?.userData as DeserializedLockedVaultUser)?.lockEndTime}

--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -214,7 +214,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
         <ConnectWalletButton width="100%" />
       )
     }
-
+    if (vaultKey === VaultKey.CakeVault && isUserDelegated) return null
     return (
       <ActionContainer>
         <ActionTitles>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making a change in the `ActionPanel` component of the `PoolsTable` in the `Stake.tsx` file. It modifies the rendering condition for the `Stake` component based on the `vaultKey` and `isUserDelegated` values.

### Detailed summary:
- If `vaultKey` is `CakeVault` and `isUserDelegated` is true, the `Stake` component is not rendered.
- The rendering condition for the `Stake` component is modified to always render it, regardless of the `isUserDelegated` value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->