### PR TITLE
chore: fix veCake migrated card display logic

### DIFF
--- a/apps/web/src/views/CakeStaking/components/SyrupPool/VeCakeMigrateCard.tsx
+++ b/apps/web/src/views/CakeStaking/components/SyrupPool/VeCakeMigrateCard.tsx
@@ -12,7 +12,7 @@ export const VeCakeMigrateCard: React.FC<{ isTableView?: boolean; lockEndTime?: 
     const { t } = useTranslation()
     const isMigratedToVeCake = useIsMigratedToVeCake()
     const isUserAllowMigrate = useCheckIsUserAllowMigrate(lockEndTime)
-    if (!isUserAllowMigrate) return null
+    if (!isUserAllowMigrate && !isMigratedToVeCake) return null
     return (
       <ShineStyledBox
         p="10px"

--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -205,7 +205,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
     (account &&
       vaultPosition === VaultPosition.None &&
       (vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault)) ||
-    isUserDelegated
+    ((vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault) && isUserDelegated)
   ) {
     if (isMobile) {
       return vaultKey === VaultKey.CakeVault || vaultKey === VaultKey.CakeFlexibleSideVault ? (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on allowing users to migrate to VeCake in the SyrupPool component and updating the condition for stake actions in the PoolsTable component.

### Detailed summary:
- In `VeCakeMigrateCard.tsx`:
  - Added a condition to check if the user is migrated to VeCake before rendering the component.
- In `Stake.tsx`:
  - Updated the condition for stake actions to include delegated users only for CakeVault and CakeFlexibleSideVault.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->