### PR TITLE
fix: Ifo numbers

### DIFF
--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -183,7 +183,10 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
   const totalLPCommittedInUSD = currencyPriceInUSD.times(totalLPCommitted)
   const totalCommitted = `~$${formatNumber(totalLPCommittedInUSD.toNumber(), 0, 0)} (${totalCommittedPercent}%)`
 
-  const sumTaxesOverflow = poolCharacteristic?.sumTaxesOverflow
+  const sumTaxesOverflow = poolCharacteristic?.totalAmountPool
+    .minus(poolCharacteristic.raisingAmountPool)
+    .times(poolCharacteristic.taxRate)
+    .times(0.01)
   const sumTaxesOverflowInUSD = currencyPriceInUSD.times(sumTaxesOverflow || ZERO)
   const pricePerTokenWithFeeToOriginalRatio = sumTaxesOverflow
     ?.plus(poolCharacteristic?.raisingAmountPool || ZERO)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The variable `sumTaxesOverflow` in `IfoCardDetails.tsx` is now calculated differently.
- The variable `totalAmountPool` is used instead of `sumTaxesOverflow` to calculate `sumTaxesOverflowInUSD` and `pricePerTokenWithFeeToOriginalRatio`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->