### PR TITLE
feat: Add error message to transaction confirmation and fix pending confirmation in remove liquidity

### DIFF
--- a/apps/web/src/components/TransactionConfirmationModal/index.tsx
+++ b/apps/web/src/components/TransactionConfirmationModal/index.tsx
@@ -14,7 +14,7 @@ import {
   AutoColumn,
   ColumnCenter,
 } from '@pancakeswap/uikit'
-import { ConfirmationPendingContent } from '@pancakeswap/widgets-internal'
+import { ConfirmationPendingContent, TransactionErrorContent } from '@pancakeswap/widgets-internal'
 import { useTranslation } from '@pancakeswap/localization'
 import { wrappedCurrency } from 'utils/wrappedCurrency'
 import { WrappedTokenInfo } from '@pancakeswap/token-lists'
@@ -71,9 +71,9 @@ export function TransactionSubmittedContent({
               width="fit-content"
               marginTextBetweenLogo="6px"
               textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
-              tokenAddress={token.address}
+              tokenAddress={token?.address}
               tokenSymbol={currencyToAdd.symbol}
-              tokenDecimals={token.decimals}
+              tokenDecimals={token?.decimals}
               tokenLogo={token instanceof WrappedTokenInfo ? token.logoURI : undefined}
             />
           )}
@@ -90,6 +90,7 @@ interface ConfirmationModalProps {
   title: string
   customOnDismiss?: () => void
   hash: string | undefined
+  errorMessage?: string
   content: () => React.ReactNode
   attemptingTxn: boolean
   pendingText: string
@@ -98,7 +99,18 @@ interface ConfirmationModalProps {
 
 const TransactionConfirmationModal: React.FC<
   React.PropsWithChildren<InjectedModalProps & ConfirmationModalProps & ModalProps>
-> = ({ title, onDismiss, customOnDismiss, attemptingTxn, hash, pendingText, content, currencyToAdd, ...props }) => {
+> = ({
+  title,
+  onDismiss,
+  customOnDismiss,
+  attemptingTxn,
+  errorMessage,
+  hash,
+  pendingText,
+  content,
+  currencyToAdd,
+  ...props
+}) => {
   const { chainId } = useActiveChainId()
 
   const handleDismiss = useCallback(() => {
@@ -121,6 +133,8 @@ const TransactionConfirmationModal: React.FC<
           onDismiss={handleDismiss}
           currencyToAdd={currencyToAdd}
         />
+      ) : errorMessage ? (
+        <TransactionErrorContent message={errorMessage} onDismiss={handleDismiss} />
       ) : (
         content()
       )}

--- a/apps/web/src/views/AddLiquidity/components/ConfirmAddLiquidityModal.tsx
+++ b/apps/web/src/views/AddLiquidity/components/ConfirmAddLiquidityModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import { Currency, CurrencyAmount, Fraction, Percent, Token } from '@pancakeswap/sdk'
 import { InjectedModalProps, Button } from '@pancakeswap/uikit'
-import { TransactionErrorContent, ConfirmationModalContent } from '@pancakeswap/widgets-internal'
+import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 import { useTranslation } from '@pancakeswap/localization'
 import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
 import { Field } from 'state/burn/actions'
@@ -67,13 +67,6 @@ const ConfirmAddLiquidityModal: React.FC<
     percent = normalizedAmountCurrencyA / (normalizedAmountCurrencyA + amountCurrencyB)
   }
 
-  const handleDismiss = useCallback(() => {
-    if (customOnDismiss) {
-      customOnDismiss()
-    }
-    onDismiss?.()
-  }, [customOnDismiss, onDismiss])
-
   const modalHeader = useCallback(() => {
     return (
       <AddLiquidityModalHeader
@@ -105,13 +98,8 @@ const ConfirmAddLiquidityModal: React.FC<
   }, [noLiquidity, onAdd, t])
 
   const confirmationContent = useCallback(
-    () =>
-      liquidityErrorMessage ? (
-        <TransactionErrorContent onDismiss={handleDismiss} message={liquidityErrorMessage} />
-      ) : (
-        <ConfirmationModalContent topContent={modalHeader} bottomContent={modalBottom} />
-      ),
-    [liquidityErrorMessage, handleDismiss, modalHeader, modalBottom],
+    () => <ConfirmationModalContent topContent={modalHeader} bottomContent={modalBottom} />,
+    [modalHeader, modalBottom],
   )
 
   return (
@@ -122,6 +110,7 @@ const ConfirmAddLiquidityModal: React.FC<
       customOnDismiss={customOnDismiss}
       attemptingTxn={attemptingTxn}
       currencyToAdd={currencyToAdd}
+      errorMessage={liquidityErrorMessage}
       hash={hash}
       content={confirmationContent}
       pendingText={pendingText}

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -35,6 +35,7 @@ import { hexToBigInt } from 'viem'
 import { isUserRejected } from 'utils/sentry'
 import { getViemClients } from 'utils/viem'
 
+import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { useV3MintActionHandlers } from './formViews/V3FormView/form/hooks/useV3MintActionHandlers'
 import { PositionPreview } from './formViews/V3FormView/components/PositionPreview'
 import LockedDeposit from './formViews/V3FormView/components/LockedDeposit'
@@ -50,6 +51,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   const router = useRouter()
   const { sendTransactionAsync } = useSendTransaction()
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
+  const [txnErrorMessage, setTxnErrorMessage] = useState<string | undefined>()
 
   const [, , feeAmountFromUrl, tokenId] = router.query.currency || []
 
@@ -233,13 +235,13 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
           })
           setTxHash(response.hash)
         })
-        .catch((error) => {
-          console.error('Failed to send transaction', error)
-          setAttemptingTxn(false)
+        .catch((err) => {
           // we only care if the error is something _other_ than the user rejected the tx
-          if (!isUserRejected(error)) {
-            console.error(error)
+          if (!isUserRejected(err)) {
+            setTxnErrorMessage(transactionErrorToUserReadableMessage(err, t))
           }
+          setAttemptingTxn(false)
+          console.error(err)
         })
     }
   }, [
@@ -260,6 +262,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     sendTransactionAsync,
     tokenId,
     tokenIdsInMCv3Loading,
+    t,
   ])
 
   const addIsUnsupported = useIsTransactionUnsupported(currencies?.CURRENCY_A, currencies?.CURRENCY_B)
@@ -272,6 +275,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
       onFieldAInput('')
       router.push(`/liquidity/${tokenId}`)
     }
+    setTxnErrorMessage(undefined)
   }, [onFieldAInput, router, txHash, tokenId])
 
   const pendingText = useMemo(() => {
@@ -305,6 +309,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
       title="Increase Liquidity"
       customOnDismiss={handleDismissConfirmation}
       attemptingTxn={attemptingTxn}
+      errorMessage={txnErrorMessage}
       hash={txHash}
       content={() => (
         <ConfirmationModalContent

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -57,6 +57,7 @@ import { getViemClients } from 'utils/viem'
 import { calculateGasMargin } from 'utils'
 
 import { useDensityChartData } from 'views/AddLiquidityV3/hooks/useDensityChartData'
+import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import RangeSelector from './components/RangeSelector'
 import { PositionPreview } from './components/PositionPreview'
 import RateToggle from './components/RateToggle'
@@ -120,6 +121,7 @@ export default function V3FormView({
   const { data: signer } = useWalletClient()
   const { sendTransactionAsync } = useSendTransaction()
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirm
+  const [txnErrorMessage, setTxnErrorMessage] = useState<string | undefined>()
 
   const {
     t,
@@ -305,11 +307,11 @@ export default function V3FormView({
             })
             .catch((error) => {
               console.error('Failed to send transaction', error)
-              setAttemptingTxn(false)
               // we only care if the error is something _other_ than the user rejected the tx
               if (!isUserRejected(error)) {
-                console.error(error)
+                setTxnErrorMessage(transactionErrorToUserReadableMessage(error, t))
               }
+              setAttemptingTxn(false)
             })
         })
     }
@@ -329,6 +331,7 @@ export default function V3FormView({
     quoteCurrency,
     sendTransactionAsync,
     signer,
+    t,
   ])
 
   const handleDismissConfirmation = useCallback(() => {
@@ -391,6 +394,7 @@ export default function V3FormView({
       customOnDismiss={handleDismissConfirmation}
       attemptingTxn={attemptingTxn}
       hash={txHash}
+      errorMessage={txnErrorMessage}
       content={() => (
         <ConfirmationModalContent
           topContent={() =>

--- a/apps/web/src/views/Swap/components/ConfirmRemoveLiquidityModal.tsx
+++ b/apps/web/src/views/Swap/components/ConfirmRemoveLiquidityModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import { Currency, CurrencyAmount, Pair, Percent, Token } from '@pancakeswap/sdk'
 import { AddIcon, Button, InjectedModalProps, Text, AutoColumn } from '@pancakeswap/uikit'
-import { ConfirmationModalContent, TransactionErrorContent } from '@pancakeswap/widgets-internal'
+import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 
 import { useTranslation } from '@pancakeswap/localization'
 import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
@@ -138,15 +138,8 @@ const ConfirmRemoveLiquidityModal: React.FC<
   }, [currencyA, currencyB, parsedAmounts, approval, onRemove, pair, tokenA, tokenB, t, signatureData])
 
   const confirmationContent = useCallback(
-    () =>
-      liquidityErrorMessage ? (
-        <>
-          <TransactionErrorContent onDismiss={onDismiss} message={liquidityErrorMessage} />
-        </>
-      ) : (
-        <ConfirmationModalContent topContent={modalHeader} bottomContent={modalBottom} />
-      ),
-    [liquidityErrorMessage, onDismiss, modalHeader, modalBottom],
+    () => <ConfirmationModalContent topContent={modalHeader} bottomContent={modalBottom} />,
+    [modalHeader, modalBottom],
   )
 
   return (
@@ -156,6 +149,7 @@ const ConfirmRemoveLiquidityModal: React.FC<
       customOnDismiss={customOnDismiss}
       attemptingTxn={attemptingTxn}
       hash={hash}
+      errorMessage={liquidityErrorMessage}
       content={confirmationContent}
       pendingText={pendingText}
     />


### PR DESCRIPTION
Remove liqudity is in pending confirmation after submitting the transaction which instead transaction submitted message should be shown.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the Swap and Add Liquidity features. 

### Detailed summary
- Removed unused import `TransactionErrorContent` from `ConfirmRemoveLiquidityModal.tsx`
- Added import `transactionErrorToUserReadableMessage` to `index.tsx`, `V3FormView/index.tsx`, `ConfirmAddLiquidityModal.tsx`, `TransactionConfirmationModal/index.tsx`, `PoolPage.tsx`, and `IncreaseLiquidityV3.tsx`
- Added `errorMessage` prop to `ConfirmRemoveLiquidityModal.tsx`, `ConfirmAddLiquidityModal.tsx`, `TransactionConfirmationModal/index.tsx`, `PoolPage.tsx`, and `IncreaseLiquidityV3.tsx`
- Updated error handling logic in `V3FormView/index.tsx`, `PoolPage.tsx`, and `IncreaseLiquidityV3.tsx`

> The following files were skipped due to too many changes: `apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->