### PR TITLE
chore: List pnp-bnb farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 120,
+    lpAddress: '0x88240a2CA0Af5DD3b181975b9985274274CB3685',
+    token0: bscTokens.pnp,
+    token1: bscTokens.wbnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 119,
     lpAddress: '0x8A876Ca851063e0252654CA6368a5B2280f51c32',
     token0: bscTokens.cake,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new liquidity pool (LP) with PID 120
- The LP uses the tokens `bscTokens.pnp` and `bscTokens.wbnb`
- The LP address is `0x88240a2CA0Af5DD3b181975b9985274274CB3685`
- The fee amount for this LP is set to `FeeAmount.MEDIUM`
- The existing LP with PID 119 has a new LP address of `0x8A876Ca851063e0252654CA6368a5B2280f51c32`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->