### PR TITLE
fix: Modal v1 overlay cant trigger custom on dismiss

### DIFF
--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -116,7 +116,7 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     return { isOpen, nodeId, modalNode, setModalNode, onPresent: handlePresent, onDismiss: handleDismiss };
   }, [isOpen, nodeId, modalNode, setModalNode, handlePresent, handleDismiss]);
 
-  const handleAnimationStart = useCallback(() => animationHandler(animationRef.current), [animationRef]);
+  const handleAnimationStart = useCallback(() => animationHandler(animationRef.current), []);
 
   const portal = useMemo(() => getPortalRoot(), []);
 

--- a/packages/uikit/src/widgets/Modal/ModalContext.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useCallback, useMemo, useRef, useState } from "re
 import { isMobile } from "react-device-detect";
 import { createPortal } from "react-dom";
 import { styled } from "styled-components";
+import get from "lodash/get";
 import { mountAnimation, unmountAnimation } from "../../components/BottomDrawer/styles";
 import { Overlay } from "../../components/Overlay";
 import { useIsomorphicEffect } from "../../hooks";
@@ -105,13 +106,17 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   const handleOverlayDismiss = useCallback(() => {
     if (closeOnOverlayClick) {
+      const customOnDismiss = get(modalNode, "props.customOnDismiss") as any;
+      customOnDismiss?.();
       handleDismiss();
     }
-  }, [closeOnOverlayClick, handleDismiss]);
+  }, [closeOnOverlayClick, handleDismiss, modalNode]);
 
   const providerValue = useMemo(() => {
     return { isOpen, nodeId, modalNode, setModalNode, onPresent: handlePresent, onDismiss: handleDismiss };
   }, [isOpen, nodeId, modalNode, setModalNode, handlePresent, handleDismiss]);
+
+  const handleAnimationStart = useCallback(() => animationHandler(animationRef.current), [animationRef]);
 
   const portal = useMemo(() => getPortalRoot(), []);
 
@@ -129,7 +134,7 @@ const ModalProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
                 >
                   <StyledModalWrapper
                     ref={animationRef}
-                    onAnimationStart={() => animationHandler(animationRef.current)}
+                    onAnimationStart={handleAnimationStart}
                     {...animationMap}
                     variants={animationVariants}
                     transition={{ duration: 0.3 }}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new feature to the ModalContext component. 

### Detailed summary
- Added a new import for the `get` function from lodash library.
- Added a new callback function `handleAnimationStart` to handle animation start events.
- Updated the `onAnimationStart` prop of the `StyledModalWrapper` component to use the `handleAnimationStart` callback function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->