### PR TITLE
feat: list new gauges and xai-weth farm

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -220,4 +220,11 @@ export const farmsV3 = defineFarmV3Configs([
     token1: arbitrumTokens.swETH,
     feeAmount: FeeAmount.LOWEST,
   },
+  {
+    pid: 32,
+    lpAddress: '0xf0B860d338E8B5199606322653B83A166d96E417',
+    token0: arbitrumTokens.xai,
+    token1: arbitrumTokens.weth,
+    feeAmount: FeeAmount.MEDIUM,
+  },
 ])

--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 32,
+    lpAddress: '0xf0B860d338E8B5199606322653B83A166d96E417',
+    token0: arbitrumTokens.xai,
+    token1: arbitrumTokens.weth,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 1,
     lpAddress: '0xd9e2a1a61B6E61b275cEc326465d417e52C1b95c',
     token0: arbitrumTokens.weth,
@@ -219,12 +226,5 @@ export const farmsV3 = defineFarmV3Configs([
     token0: arbitrumTokens.weth,
     token1: arbitrumTokens.swETH,
     feeAmount: FeeAmount.LOWEST,
-  },
-  {
-    pid: 32,
-    lpAddress: '0xf0B860d338E8B5199606322653B83A166d96E417',
-    token0: arbitrumTokens.xai,
-    token1: arbitrumTokens.weth,
-    feeAmount: FeeAmount.MEDIUM,
   },
 ])

--- a/packages/farms/src/types.ts
+++ b/packages/farms/src/types.ts
@@ -1,6 +1,6 @@
 import { SerializedToken, Token } from '@pancakeswap/swap-sdk-core'
-import { FeeAmount } from '@pancakeswap/v3-sdk'
 import { SerializedWrappedToken } from '@pancakeswap/token-lists'
+import { FeeAmount } from '@pancakeswap/v3-sdk'
 import BigNumber from 'bignumber.js'
 import { Address } from 'viem'
 

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2165,8 +2165,8 @@ export const CONFIG_PROD: GaugeConfig[] = [
     address: '0x4A080D9488cE2C8258185d78852275D6d3c2820c',
     chainId: ChainId.POLYGON_ZKEVM,
     type: GaugeType.V3,
-    token0Address: polygonZkEvmTokens.weth.address,
-    token1Address: polygonZkEvmTokens.usdt.address,
+    token0Address: polygonZkEvmTokens.usdt.address,
+    token1Address: polygonZkEvmTokens.weth.address,
     feeTier: FeeAmount.LOW,
   },
   {

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2195,8 +2195,8 @@ export const CONFIG_PROD: GaugeConfig[] = [
     address: '0x39aCc7cf02af19A1eB0e3628bA0F5C48f44beBF3',
     chainId: ChainId.POLYGON_ZKEVM,
     type: GaugeType.V3,
-    token0Address: polygonZkEvmTokens.grai.address,
-    token1Address: polygonZkEvmTokens.usdc.address,
+    token0Address: polygonZkEvmTokens.usdc.address,
+    token1Address: polygonZkEvmTokens.grai.address,
     feeTier: FeeAmount.LOW,
   },
   {

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2161,12 +2161,12 @@ export const CONFIG_PROD: GaugeConfig[] = [
   },
   {
     gid: 216,
-    pairName: 'WETH-USDC',
+    pairName: 'WETH-USDT',
     address: '0x4A080D9488cE2C8258185d78852275D6d3c2820c',
     chainId: ChainId.POLYGON_ZKEVM,
     type: GaugeType.V3,
     token0Address: polygonZkEvmTokens.weth.address,
-    token1Address: polygonZkEvmTokens.usdc.address,
+    token1Address: polygonZkEvmTokens.usdt.address,
     feeTier: FeeAmount.LOW,
   },
   {

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2175,8 +2175,8 @@ export const CONFIG_PROD: GaugeConfig[] = [
     address: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
     chainId: ChainId.POLYGON_ZKEVM,
     type: GaugeType.V3,
-    token0Address: polygonZkEvmTokens.usdc.address,
-    token1Address: polygonZkEvmTokens.usdt.address,
+    token0Address: polygonZkEvmTokens.usdt.address,
+    token1Address: polygonZkEvmTokens.usdc.address,
     feeTier: FeeAmount.LOWEST,
   },
   {

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2175,7 +2175,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     address: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
     chainId: ChainId.POLYGON_ZKEVM,
     type: GaugeType.V3,
-    token0Address: polygonZkEvmTokens.usdt.address,
+    token0Address: polygonZkEvmTokens.usdc.address,
     token1Address: polygonZkEvmTokens.usdt.address,
     feeTier: FeeAmount.LOWEST,
   },

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
-import { arbitrumTokens, bscTokens, ethereumTokens, zksyncTokens } from '@pancakeswap/tokens'
+import { arbitrumTokens, bscTokens, ethereumTokens, polygonZkEvmTokens, zksyncTokens } from '@pancakeswap/tokens'
 import { FeeAmount } from '@pancakeswap/v3-sdk'
 import { GaugeConfig, GaugeType } from '../../types'
 
@@ -2148,5 +2148,65 @@ export const CONFIG_PROD: GaugeConfig[] = [
     chainId: ChainId.BSC,
     type: GaugeType.StableSwap,
     tokenAddresses: [bscTokens.mcake.address, bscTokens.cake.address],
+  },
+  {
+    gid: 215,
+    pairName: 'WETH-USDC',
+    address: '0xD43b9dCbB61e6ccFbCFef9f21e1BB5064F1CB33f',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.weth.address,
+    token1Address: polygonZkEvmTokens.usdc.address,
+    feeTier: FeeAmount.LOW,
+  },
+  {
+    gid: 216,
+    pairName: 'WETH-USDC',
+    address: '0x4A080D9488cE2C8258185d78852275D6d3c2820c',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.weth.address,
+    token1Address: polygonZkEvmTokens.usdc.address,
+    feeTier: FeeAmount.LOW,
+  },
+  {
+    gid: 217,
+    pairName: 'USDT-USDC',
+    address: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.usdt.address,
+    token1Address: polygonZkEvmTokens.usdt.address,
+    feeTier: FeeAmount.LOWEST,
+  },
+  {
+    gid: 218,
+    pairName: 'WETH-MATIC',
+    address: '0xaE30fcdEE41dC9eC265e841D8185d055B87d1B7a',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.weth.address,
+    token1Address: polygonZkEvmTokens.matic.address,
+    feeTier: FeeAmount.MEDIUM,
+  },
+  {
+    gid: 219,
+    pairName: 'GRAI-USDC',
+    address: '0x39aCc7cf02af19A1eB0e3628bA0F5C48f44beBF3',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.grai.address,
+    token1Address: polygonZkEvmTokens.usdc.address,
+    feeTier: FeeAmount.LOW,
+  },
+  {
+    gid: 220,
+    pairName: 'WETH-BTC',
+    address: '0xf1e501f74Ed9dc619be53Fddb698c94AbF9D56B6',
+    chainId: ChainId.POLYGON_ZKEVM,
+    type: GaugeType.V3,
+    token0Address: polygonZkEvmTokens.weth.address,
+    token1Address: polygonZkEvmTokens.wbtc.address,
+    feeTier: FeeAmount.LOW,
   },
 ]

--- a/packages/tokens/src/42161.ts
+++ b/packages/tokens/src/42161.ts
@@ -175,4 +175,12 @@ export const arbitrumTokens = {
     'swETH',
     'https://www.swellnetwork.io/',
   ),
+  xai: new ERC20Token(
+    ChainId.ARBITRUM_ONE,
+    '0x4Cb9a7AE498CEDcBb5EAe9f25736aE7d428C9D66',
+    18,
+    'XAI',
+    'Xai',
+    'https://xai.games/',
+  ),
 }

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2884,4 +2884,12 @@ export const bscTokens = {
     'mCake Token',
     'https://www.pancake.magpiexyz.io/stake',
   ),
+  insp: new ERC20Token(
+    ChainId.BSC,
+    '0x8D279274789CceC8af94a430A5996eAaCE9609A9',
+    18,
+    'INSP',
+    'Inspect Token',
+    'https://www.inspect.xyz/',
+  ),
 }

--- a/packages/tokens/src/56.ts
+++ b/packages/tokens/src/56.ts
@@ -2889,7 +2889,7 @@ export const bscTokens = {
     '0x8D279274789CceC8af94a430A5996eAaCE9609A9',
     18,
     'INSP',
-    'Inspect Token',
+    'INSPECT',
     'https://www.inspect.xyz/',
   ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding new ERC20 tokens and gauge configurations for various chains, including Arbitrum and Polygon ZkEVM.

### Detailed summary:
- Added a new ERC20 token `XAI` with its contract address and details.
- Added a new ERC20 token `INSP` with its contract address and details.
- Updated the import statement for `SerializedWrappedToken` in `types.ts`.
- Added new gauge configurations for various token pairs on Arbitrum and Polygon ZkEVM chains.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->