### PR TITLE
feat: add cake-ckp syrup pool

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,16 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 366,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.ckp,
+    contractAddress: '0x87f0210c658c81e854e6022315cD68804944acaE',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.001929',
+    isFinished: false,
+    version: 3,
+  },
+  {
     sousId: 365,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.ace,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool with sousId 366 and stakingToken bscTokens.cake. 

### Detailed summary
- Added a new pool with sousId 366
- Staking token is bscTokens.cake
- Earning token is bscTokens.ckp
- Contract address is '0x87f0210c658c81e854e6022315cD68804944acaE'
- Pool category is PoolCategory.CORE
- Token per block is '0.001929'
- isFinished is set to false
- Version is 3

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->