### PR TITLE
fix: Harvest card pending tx indicator not working

### DIFF
--- a/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -50,7 +50,7 @@ interface HarvestCardProps extends TextProps {
 const HarvestCard: React.FC<React.PropsWithChildren<HarvestCardProps>> = ({ onHarvestStart, onHarvestEnd }) => {
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
+  const { fetchWithCatchTxError, loading: v2PendingTx } = useCatchTxError()
   const { farmsWithStakedBalance, earningsSum: farmEarningsSum } = useFarmsWithBalance()
 
   const cakePriceBusd = useCakePrice()
@@ -65,7 +65,9 @@ const HarvestCard: React.FC<React.PropsWithChildren<HarvestCardProps>> = ({ onHa
 
   const earningsText = getEarningsText(numFarmsToCollect, hasCakePoolToCollect, earningsBusd, t)
   const [preText, toCollectText] = earningsText.split(earningsBusd.toString())
-  const { onHarvestAll } = useFarmsV3BatchHarvest()
+  const { onHarvestAll, harvesting: v3PendingTx } = useFarmsV3BatchHarvest()
+
+  const pendingTx = v2PendingTx || v3PendingTx
 
   const harvestAllFarms = useCallback(async () => {
     onHarvestStart?.()


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Renamed `pendingTx` variable to `v2PendingTx` for clarity.
- Added `v3PendingTx` variable to track pending transactions for V3 farms.
- Combined `v2PendingTx` and `v3PendingTx` variables to `pendingTx`.
- Updated `onHarvestAll` function to include V3 farms harvesting logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->