### PR TITLE
fix(Farms): V2 farms does not display booster information on mobile

### DIFF
--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -281,8 +281,8 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                       <Apr
                         {...props.apr}
                         hideButton
-                        strikethrough={props?.details?.boosted}
-                        boosted={props?.details?.boosted}
+                        strikethrough={false}
+                        boosted={false}
                         farmCakePerSecond={multiplier.farmCakePerSecond}
                         totalMultipliers={multiplier.totalMultipliers}
                       />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/a80d44de-e3b5-4882-9293-2858cfc36eb5)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/753e6655-2b89-4dea-b078-a76b64a3e766)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `strikethrough` and `boosted` props in the `FarmTable` component's `Row` component are no longer dependent on the `details` object in the `props`.
- Both `strikethrough` and `boosted` are now set to `false` instead of relying on the `details` object.
- The `farmCakePerSecond` and `totalMultipliers` props are still passed to the `Row` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->