### PR TITLE
chore(PositionManager): Adjust stakedOnly placement

### DIFF
--- a/apps/web/src/views/PositionManagers/containers/Controls.tsx
+++ b/apps/web/src/views/PositionManagers/containers/Controls.tsx
@@ -17,8 +17,8 @@ export function Controls() {
     <ControlsContainer>
       <ControlGroup>
         {/* <ViewSwitch /> */}
-        <StakeOnlyToggle />
         <LiveSwitch />
+        <StakeOnlyToggle />
       </ControlGroup>
       <ControlGroup justifyContent="flex-end">
         <SortFilter />
@@ -27,12 +27,12 @@ export function Controls() {
     </ControlsContainer>
   ) : (
     <ControlsContainer justifyContent="flex-start" flexDirection="column">
+      <ControlGroup justifyContent="flex-start">
+        <LiveSwitch />
+      </ControlGroup>
       <ControlGroup>
         {/* <ViewSwitch /> */}
         <StakeOnlyToggle />
-      </ControlGroup>
-      <ControlGroup justifyContent="flex-start">
-        <LiveSwitch />
       </ControlGroup>
       <ControlGroup>
         <SortFilter />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

The placement of StakedOnly should be consistent with other features.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to the Controls component in the PositionManagers view.

### Detailed summary:
- Moved the `<LiveSwitch />` component inside the `<ControlGroup justifyContent="flex-start">` component.
- Reordered the components within the `<ControlsContainer justifyContent="flex-start" flexDirection="column">` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->