### PR TITLE
fix: Fix token amount input width

### DIFF
--- a/apps/web/src/components/Modal/ModalInput.tsx
+++ b/apps/web/src/components/Modal/ModalInput.tsx
@@ -31,14 +31,10 @@ const StyledTokenInput = styled('div').withConfig({
 
 const StyledInput = styled(Input)`
   box-shadow: none;
-  width: 60px;
+  width: 50%;
   margin: 0 8px;
   padding: 0 8px;
   border: none;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    width: 80px;
-  }
 
   ${({ theme }) => theme.mediaQueries.sm} {
     width: auto;

--- a/packages/uikit/src/widgets/Modal/ModalInput.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalInput.tsx
@@ -40,14 +40,10 @@ const StyledTokenInput = styled.div<InputProps>`
 
 const StyledInput = styled(Input)`
   box-shadow: none;
-  width: 60px;
+  width: 50%;
   margin: 0 8px;
   padding: 0 8px;
   border: none;
-
-  ${({ theme }) => theme.mediaQueries.xs} {
-    width: 120px;
-  }
 
   ${({ theme }) => theme.mediaQueries.sm} {
     width: auto;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/3c74bc2d-7e22-484c-b509-04eef9897975)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/8bbb7f44-9f26-439e-b5b1-29606b1c291a)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the width of the `StyledInput` component in both `ModalInput.tsx` files. 

### Detailed summary
- Updated the width of `StyledInput` from `60px` to `50%` in both `ModalInput.tsx` files.
- Removed the media query for `xs` breakpoint in both files.
- Updated the width of `StyledInput` from `80px` to `auto` in the `sm` media query in both files.
- Removed the media query for `xs` breakpoint in both files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->