### PR TITLE
chore(PriceChart): Modify precision to 5 when amount < 1

### DIFF
--- a/apps/web/src/views/Swap/components/Chart/BasicChart.tsx
+++ b/apps/web/src/views/Swap/components/Chart/BasicChart.tsx
@@ -98,7 +98,7 @@ const BasicChart = ({
             outputSymbol={outputCurrency?.symbol}
           >
             <Text color={isChangePositive ? 'success' : 'failure'} fontSize="20px" ml="4px" bold>
-              {`${isChangePositive ? '+' : ''}${changeValue.toFixed(3)} (${changePercentage}%)`}
+              {`${isChangePositive ? '+' : ''}${changeValue.toFixed(5)} (${changePercentage}%)`}
             </Text>
           </PairPriceDisplay>
           <Text small color="secondary">

--- a/packages/utils/formatInfoNumbers.ts
+++ b/packages/utils/formatInfoNumbers.ts
@@ -53,7 +53,7 @@ export const formatAmount = (
 
   let precision = 2
   if (tokenPrecision) {
-    precision = amount < 1 || tokenPrecision === 'enhanced' ? 3 : 2
+    precision = amount < 1 || tokenPrecision === 'enhanced' ? 5 : 2
   }
 
   const amountWithPrecision = parseFloat(amount?.toFixed(precision))


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Before:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/152efa57-b6b3-4dd2-802c-c9dbe7fa59c0)

After:
![image](https://github.com/pancakeswap/pancake-frontend/assets/109973128/8ff9de92-1ce3-4de6-9279-f23fd98389a1)


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Increased precision for `amount` when `tokenPrecision` is 'enhanced' or `amount` is less than 1 in `packages/utils/formatInfoNumbers.ts`
- Increased precision for `changeValue` in `apps/web/src/views/Swap/components/Chart/BasicChart.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->