### PR TITLE
chore: Update opbnb subgraph

### DIFF
--- a/.changeset/orange-teachers-kiss.md
+++ b/.changeset/orange-teachers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/chains': minor
+---
+
+Add getters for subgraph endpoints by chain

--- a/apis/farms/src/bindings.d.ts
+++ b/apis/farms/src/bindings.d.ts
@@ -15,4 +15,5 @@ declare global {
   const BASE_NODE: string
   const OPBNB_NODE: string
   const OPBNB_TESTNET_NODE: string
+  const NODE_REAL_SUBGRAPH_API_KEY: string
 }

--- a/apis/farms/src/provider.ts
+++ b/apis/farms/src/provider.ts
@@ -25,6 +25,7 @@ const requireCheck = [
   BASE_NODE,
   OPBNB_NODE,
   OPBNB_TESTNET_NODE,
+  NODE_REAL_SUBGRAPH_API_KEY,
 ]
 
 const base = {

--- a/apis/farms/src/v3.ts
+++ b/apis/farms/src/v3.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign, no-await-in-loop */
-import { ChainId, V3_SUBGRAPHS } from '@pancakeswap/chains'
+import { ChainId, getV3Subgraphs } from '@pancakeswap/chains'
 import { FarmV3SupportedChainId, masterChefV3Addresses } from '@pancakeswap/farms'
 import { ERC20Token } from '@pancakeswap/sdk'
 import { CurrencyAmount } from '@pancakeswap/swap-sdk-core'
@@ -28,6 +28,10 @@ export const V3_SUBGRAPH_CLIENTS_CHAIN_IDS = [
 ] as const
 
 type SupportChainId = (typeof V3_SUBGRAPH_CLIENTS_CHAIN_IDS)[number]
+
+const V3_SUBGRAPHS = getV3Subgraphs({
+  noderealApiKey: NODE_REAL_SUBGRAPH_API_KEY,
+})
 
 export const V3_SUBGRAPH_CLIENTS = V3_SUBGRAPH_CLIENTS_CHAIN_IDS.reduce((acc, chainId) => {
   acc[chainId] = new GraphQLClient(V3_SUBGRAPHS[chainId], { fetch })

--- a/apis/farms/wrangler.toml
+++ b/apis/farms/wrangler.toml
@@ -32,4 +32,5 @@ crons = ["0 0 * * *", "*/1 * * * *"]
 # - ARBITRUM_ONE_NODE
 # - LINEA_NODE
 # - BASE_NODE
+# - NODE_REAL_SUBGRAPH_API_KEY
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these

--- a/apis/routing/src/bindings.d.ts
+++ b/apis/routing/src/bindings.d.ts
@@ -6,6 +6,7 @@ declare global {
   const GOERLI_NODE: string
   const BSC_NODE: string
   const BSC_TESTNET_NODE: string
+  const NODE_REAL_SUBGRAPH_API_KEY: string
 
   const SUBGRAPH_POOLS: R2Bucket
 }

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -1,10 +1,14 @@
-import { ChainId, V3_SUBGRAPHS } from '@pancakeswap/chains'
+import { ChainId, getV3Subgraphs } from '@pancakeswap/chains'
 import { OnChainProvider, SubgraphProvider } from '@pancakeswap/smart-router/evm'
 import { createPublicClient, http } from 'viem'
 import { bsc, bscTestnet, goerli, mainnet } from 'viem/chains'
 import { GraphQLClient } from 'graphql-request'
 
 import { SupportedChainId } from './constants'
+
+const V3_SUBGRAPHS = getV3Subgraphs({
+  noderealApiKey: NODE_REAL_SUBGRAPH_API_KEY,
+})
 
 const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE]
 requireCheck.forEach((node) => {

--- a/apis/routing/src/provider.ts
+++ b/apis/routing/src/provider.ts
@@ -6,15 +6,15 @@ import { GraphQLClient } from 'graphql-request'
 
 import { SupportedChainId } from './constants'
 
-const V3_SUBGRAPHS = getV3Subgraphs({
-  noderealApiKey: NODE_REAL_SUBGRAPH_API_KEY,
-})
-
-const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE]
+const requireCheck = [ETH_NODE, GOERLI_NODE, BSC_NODE, BSC_TESTNET_NODE, NODE_REAL_SUBGRAPH_API_KEY]
 requireCheck.forEach((node) => {
   if (!node) {
     throw new Error('Missing env var')
   }
+})
+
+const V3_SUBGRAPHS = getV3Subgraphs({
+  noderealApiKey: NODE_REAL_SUBGRAPH_API_KEY,
 })
 
 const mainnetClient = createPublicClient({

--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -27,4 +27,5 @@ crons = ["*/30 * * * *"]
 # - GOERLI_NODE
 # - BSC_NODE
 # - BSC_TESTNET_NODE
+# - NODE_REAL_SUBGRAPH_API_KEY
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -1,4 +1,4 @@
-import { ChainId, V2_SUBGRAPHS, V3_SUBGRAPHS } from '@pancakeswap/chains'
+import { ChainId, V2_SUBGRAPHS, V3_SUBGRAPHS, BLOCKS_SUBGRAPHS } from '@pancakeswap/chains'
 
 export const GRAPH_API_PROFILE = 'https://api.thegraph.com/subgraphs/name/pancakeswap/profile'
 
@@ -24,14 +24,13 @@ export const V3_BSC_INFO_CLIENT = `https://open-platform.nodereal.io/${
 }/pancakeswap-v3/graphql`
 
 export const INFO_CLIENT_ETH = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth'
-export const BLOCKS_CLIENT = 'https://api.thegraph.com/subgraphs/name/pancakeswap/blocks'
-export const BLOCKS_CLIENT_ETH = 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks'
-export const BLOCKS_CLIENT_POLYGON_ZKEVM =
-  'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest'
-export const BLOCKS_CLIENT_ZKSYNC = 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest'
-export const BLOCKS_CLIENT_LINEA = 'https://graph-query.linea.build/subgraphs/name/kybernetwork/linea-blocks'
-export const BLOCKS_CLIENT_BASE = 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest'
-export const BLOCKS_CLIENT_OPBNB = 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/blocks'
+export const BLOCKS_CLIENT = BLOCKS_SUBGRAPHS[ChainId.BSC]
+export const BLOCKS_CLIENT_ETH = BLOCKS_SUBGRAPHS[ChainId.ETHEREUM]
+export const BLOCKS_CLIENT_POLYGON_ZKEVM = BLOCKS_SUBGRAPHS[ChainId.POLYGON_ZKEVM]
+export const BLOCKS_CLIENT_ZKSYNC = BLOCKS_SUBGRAPHS[ChainId.ZKSYNC]
+export const BLOCKS_CLIENT_LINEA = BLOCKS_SUBGRAPHS[ChainId.LINEA]
+export const BLOCKS_CLIENT_BASE = BLOCKS_SUBGRAPHS[ChainId.BASE]
+export const BLOCKS_CLIENT_OPBNB = BLOCKS_SUBGRAPHS[ChainId.OPBNB]
 export const STABLESWAP_SUBGRAPH_CLIENT = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap'
 export const GRAPH_API_NFTMARKET = 'https://api.thegraph.com/subgraphs/name/pancakeswap/nft-market'
 export const GRAPH_HEALTH = 'https://api.thegraph.com/index-node/graphql'
@@ -47,16 +46,7 @@ export const CELER_API = 'https://api.celerscan.com/scan'
 
 export const INFO_CLIENT_WITH_CHAIN = V2_SUBGRAPHS
 
-export const BLOCKS_CLIENT_WITH_CHAIN = {
-  [ChainId.BSC]: BLOCKS_CLIENT,
-  [ChainId.ETHEREUM]: BLOCKS_CLIENT_ETH,
-  [ChainId.POLYGON_ZKEVM]: BLOCKS_CLIENT_POLYGON_ZKEVM,
-  [ChainId.ZKSYNC]: BLOCKS_CLIENT_ZKSYNC,
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
-  [ChainId.LINEA]: BLOCKS_CLIENT_LINEA,
-  [ChainId.BASE]: BLOCKS_CLIENT_BASE,
-  [ChainId.OPBNB]: BLOCKS_CLIENT_OPBNB,
-}
+export const BLOCKS_CLIENT_WITH_CHAIN = BLOCKS_SUBGRAPHS
 
 export const ASSET_CDN = 'https://assets.pancakeswap.finance'
 

--- a/packages/chains/src/index.test.ts
+++ b/packages/chains/src/index.test.ts
@@ -16,6 +16,9 @@ test('exports', () => {
       "V3_SUBGRAPHS",
       "V2_SUBGRAPHS",
       "BLOCKS_SUBGRAPHS",
+      "getV3Subgraphs",
+      "getV2Subgraphs",
+      "getBlocksSubgraphs",
     ]
   `)
 })

--- a/packages/chains/src/index.test.ts
+++ b/packages/chains/src/index.test.ts
@@ -15,6 +15,7 @@ test('exports', () => {
       "isTestnetChainId",
       "V3_SUBGRAPHS",
       "V2_SUBGRAPHS",
+      "BLOCKS_SUBGRAPHS",
     ]
   `)
 })

--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -1,48 +1,67 @@
 import { ChainId } from './chainId'
 
-export const V3_SUBGRAPHS = {
-  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
-  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
-  [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
-  [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
-  [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/version/latest',
-  [ChainId.POLYGON_ZKEVM_TESTNET]: null,
-  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
-  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync-testnet/version/latest',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exchange-v3-linea',
-  [ChainId.LINEA_TESTNET]:
-    'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
-  [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
-  [ChainId.OPBNB]:
-    'https://open-platform-ap.nodereal.io/19bd2b3f75c24e23bb8a0e9d4f55b271/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v3',
-  [ChainId.OPBNB_TESTNET]: null,
-  [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
-} satisfies Record<ChainId, string | null>
-
-export const V2_SUBGRAPHS = {
-  [ChainId.BSC]: 'https://proxy-worker-api.pancakeswap.com/bsc-exchange',
-  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth',
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-polygon-zkevm/version/latest',
-  [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
-  [ChainId.ZKSYNC]: ' https://api.studio.thegraph.com/query/45376/exchange-v2-zksync/version/latest',
-  [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
-  [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exhange-v2',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v2',
+type SubgraphParams = {
+  noderealApiKey?: string
 }
 
-export const BLOCKS_SUBGRAPHS = {
-  [ChainId.BSC]:
-    'https://open-platform-ap.nodereal.io/19bd2b3f75c24e23bb8a0e9d4f55b271/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/blocks',
-  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
-  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',
-  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
-  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/kybernetwork/linea-blocks',
-  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/blocks',
+const publicSubgraphParams = {
+  // Public key for nodereal subgraph endpoint
+  noderealApiKey: '19bd2b3f75c24e23bb8a0e9d4f55b271',
+}
+
+export const V3_SUBGRAPHS = getV3Subgraphs(publicSubgraphParams)
+
+export const V2_SUBGRAPHS = getV2Subgraphs(publicSubgraphParams)
+
+export const BLOCKS_SUBGRAPHS = getBlocksSubgraphs(publicSubgraphParams)
+
+export function getV3Subgraphs({ noderealApiKey }: SubgraphParams) {
+  return {
+    [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-eth',
+    [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-goerli',
+    [ChainId.BSC]: `https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-bsc`,
+    [ChainId.BSC_TESTNET]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-chapel',
+    [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-v3-arb',
+    [ChainId.ARBITRUM_GOERLI]: 'https://api.thegraph.com/subgraphs/name/chef-jojo/exhange-v3-arb-goerli',
+    [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-polygon-zkevm/version/latest',
+    [ChainId.POLYGON_ZKEVM_TESTNET]: null,
+    [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync/version/latest',
+    [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-zksync-testnet/version/latest',
+    [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exchange-v3-linea',
+    [ChainId.LINEA_TESTNET]:
+      'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
+    [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
+    [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
+    [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v3`,
+    [ChainId.OPBNB_TESTNET]: null,
+    [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
+  } satisfies Record<ChainId, string | null>
+}
+
+export function getV2Subgraphs({ noderealApiKey }: SubgraphParams) {
+  return {
+    [ChainId.BSC]: 'https://proxy-worker-api.pancakeswap.com/bsc-exchange',
+    [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth',
+    [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-polygon-zkevm/version/latest',
+    [ChainId.ZKSYNC_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-zksync-testnet/version/latest',
+    [ChainId.ZKSYNC]: ' https://api.studio.thegraph.com/query/45376/exchange-v2-zksync/version/latest',
+    [ChainId.LINEA_TESTNET]: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exhange-eth/',
+    [ChainId.ARBITRUM_ONE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-arbitrum/version/latest',
+    [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/pancakeswap/exhange-v2',
+    [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
+    [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v2`,
+  }
+}
+
+export function getBlocksSubgraphs({ noderealApiKey }: SubgraphParams) {
+  return {
+    [ChainId.BSC]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/blocks',
+    [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+    [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',
+    [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest',
+    [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
+    [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/kybernetwork/linea-blocks',
+    [ChainId.BASE]: 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest',
+    [ChainId.OPBNB]: `https://open-platform-ap.nodereal.io/${noderealApiKey}/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/blocks`,
+  }
 }

--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -16,7 +16,8 @@ export const V3_SUBGRAPHS = {
     'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/pancakeswap/exchange-v3-linea-goerli',
   [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base/version/latest',
   [ChainId.BASE_TESTNET]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-base-testnet/version/latest',
-  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v3',
+  [ChainId.OPBNB]:
+    'https://open-platform-ap.nodereal.io/19bd2b3f75c24e23bb8a0e9d4f55b271/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/exchange-v3',
   [ChainId.OPBNB_TESTNET]: null,
   [ChainId.SCROLL_SEPOLIA]: 'https://api.studio.thegraph.com/query/45376/exchange-v3-scroll-sepolia/version/latest',
 } satisfies Record<ChainId, string | null>

--- a/packages/chains/src/subgraphs.ts
+++ b/packages/chains/src/subgraphs.ts
@@ -34,3 +34,15 @@ export const V2_SUBGRAPHS = {
   [ChainId.BASE]: 'https://api.studio.thegraph.com/query/45376/exchange-v2-base/version/latest',
   [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/exchange-v2',
 }
+
+export const BLOCKS_SUBGRAPHS = {
+  [ChainId.BSC]:
+    'https://open-platform-ap.nodereal.io/19bd2b3f75c24e23bb8a0e9d4f55b271/opbnb-mainnet-graph-query/subgraphs/name/pancakeswap/blocks',
+  [ChainId.ETHEREUM]: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+  [ChainId.POLYGON_ZKEVM]: 'https://api.studio.thegraph.com/query/45376/polygon-zkevm-block/version/latest',
+  [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/45376/blocks-zksync/version/latest',
+  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
+  [ChainId.LINEA]: 'https://graph-query.linea.build/subgraphs/name/kybernetwork/linea-blocks',
+  [ChainId.BASE]: 'https://api.studio.thegraph.com/query/48211/base-blocks/version/latest',
+  [ChainId.OPBNB]: 'https://opbnb-mainnet-graph.nodereal.io/subgraphs/name/pancakeswap/blocks',
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for fetching subgraph endpoints by chain and adds a new subgraph API key for the `NODE_REAL_SUBGRAPH_API_KEY` environment variable.

### Detailed summary
- Added support for fetching subgraph endpoints by chain in `provider.ts` and `bindings.d.ts` files.
- Added a new subgraph API key (`NODE_REAL_SUBGRAPH_API_KEY`) in `provider.ts` and `bindings.d.ts` files.
- Updated the `wrangler.toml` file to include the new `NODE_REAL_SUBGRAPH_API_KEY`.
- Updated the `index.test.ts` file to include new subgraph endpoints and getter functions.
- Updated the `bindings.d.ts` file in the `routing` directory to include the new `NODE_REAL_SUBGRAPH_API_KEY`.
- Updated the `wrangler.toml` file in the `routing` directory to include the new `NODE_REAL_SUBGRAPH_API_KEY`.
- Updated the `v3.ts` file in the `farms` directory to import the `getV3Subgraphs` function and use it to fetch subgraph endpoints.
- Updated the `provider.ts` file in the `routing` directory to import the `getV3Subgraphs` function and use it to fetch subgraph endpoints.
- Updated the `endpoints.ts` file in the `apps/web/src/config/constants` directory to import the new subgraph constants.
- Updated the `subgraphs.ts` file in the `packages/chains/src` directory to use the `getV3Subgraphs` and `getV2Subgraphs` functions to fetch subgraph endpoints.

> The following files were skipped due to too many changes: `packages/chains/src/subgraphs.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->