### PR TITLE
feat: new cgpt syrup pool

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -19,7 +19,7 @@ export const livePools: SerializedPool[] = [
     earningToken: bscTokens.cgpt,
     contractAddress: '0x55c8BcEc0df2A61B6eF24815B3462293A27366a2',
     poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '0.03800',
+    tokenPerBlock: '0.038',
     version: 3,
   },
   {

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,15 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 368,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.cgpt,
+    contractAddress: '0x55c8BcEc0df2A61B6eF24815B3462293A27366a2',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.03800',
+    version: 3,
+  },
+  {
     sousId: 367,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.irl,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool with ID 368 and stakingToken bscTokens.cake. 

### Detailed summary
- Added a new pool with ID 368 and stakingToken bscTokens.cake.
- Added earningToken bscTokens.cgpt.
- Set contractAddress to '0x55c8BcEc0df2A61B6eF24815B3462293A27366a2'.
- Set poolCategory to PoolCategory.CORE.
- Set tokenPerBlock to '0.038'.
- Set version to 3.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->