### PR TITLE
chore: Update stableswap fee rate

### DIFF
--- a/packages/smart-router/evm/constants/stableSwap/56.ts
+++ b/packages/smart-router/evm/constants/stableSwap/56.ts
@@ -100,7 +100,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.mcake,
     stableSwapAddress: '0xc54d35a8Cfd9f6dAe50945Df27A91C9911A03ab1',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.001,
+    stableLpFee: 0.005,
     stableLpFeeRateOfTotalFee: 0.5,
   },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the stableLpFee value in the smart-router package's 56.ts file. 

### Detailed summary
- Updated stableLpFee from 0.001 to 0.005.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->