### PR TITLE
fix: Invalid negative tvl

### DIFF
--- a/apps/web/src/views/V3Info/data/pool/poolData.ts
+++ b/apps/web/src/views/V3Info/data/pool/poolData.ts
@@ -181,13 +181,6 @@ export async function fetchPoolDatas(
               .minus(current?.protocolFeesUSD)
               .minus(new BigNumber(oneDay?.feesUSD).minus(oneDay?.protocolFeesUSD))
           : new BigNumber(current?.feesUSD).minus(current?.protocolFeesUSD)
-      // Hotifx: Subtract fees from TVL to correct data while subgraph is fixed.
-      /**
-       * Note: see issue desribed here https://github.com/Uniswap/v3-subgraph/issues/74
-       * During subgraph deploy switch this month we lost logic to fix this accounting.
-       * Grafted sync pending fix now.
-       * @chef-jojo: should be fixed on our version, but leaving this in for now
-       */
       const tvlToken0 = current ? parseFloat(current.totalValueLockedToken0) : 0
       const tvlToken1 = current ? parseFloat(current.totalValueLockedToken1) : 0
       let tvlUSD = current ? parseFloat(current.totalValueLockedUSD) : 0

--- a/apps/web/src/views/V3Info/data/pool/poolData.ts
+++ b/apps/web/src/views/V3Info/data/pool/poolData.ts
@@ -188,11 +188,8 @@ export async function fetchPoolDatas(
        * Grafted sync pending fix now.
        * @chef-jojo: should be fixed on our version, but leaving this in for now
        */
-      const feePercent = current ? parseFloat(current.feeTier) / 10000 / 100 : 0
-      const tvlAdjust0 = current?.volumeToken0 ? (parseFloat(current.volumeToken0) * feePercent) / 2 : 0
-      const tvlAdjust1 = current?.volumeToken1 ? (parseFloat(current.volumeToken1) * feePercent) / 2 : 0
-      const tvlToken0 = current ? parseFloat(current.totalValueLockedToken0) - tvlAdjust0 : 0
-      const tvlToken1 = current ? parseFloat(current.totalValueLockedToken1) - tvlAdjust1 : 0
+      const tvlToken0 = current ? parseFloat(current.totalValueLockedToken0) : 0
+      const tvlToken1 = current ? parseFloat(current.totalValueLockedToken1) : 0
       let tvlUSD = current ? parseFloat(current.totalValueLockedUSD) : 0
 
       const tvlUSDChange =

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -250,7 +250,11 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
                           {poolData.token0.symbol}
                         </Text>
                       </RowFixed>
-                      <Text fontSize="14px">{formatAmount(poolData.tvlToken0)}</Text>
+                      <Text fontSize="14px">
+                        {formatAmount(poolData.tvlToken0, {
+                          displayThreshold: 0.001,
+                        })}
+                      </Text>
                     </RowBetween>
                     <RowBetween>
                       <RowFixed>
@@ -259,7 +263,11 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
                           {poolData.token1.symbol}
                         </Text>
                       </RowFixed>
-                      <Text fontSize="14px">{formatAmount(poolData.tvlToken1)}</Text>
+                      <Text fontSize="14px">
+                        {formatAmount(poolData.tvlToken1, {
+                          displayThreshold: 0.001,
+                        })}
+                      </Text>
                     </RowBetween>
                   </AutoColumn>
                 </Card>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `formatAmount` function in `PoolPage.tsx` now includes a `displayThreshold` option to format the amount based on a threshold value.
- The `tvlToken0` and `tvlToken1` calculations in `poolData.ts` no longer subtract fees from the total value locked.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->