### PR TITLE
refactor: Use query in access risk

### DIFF
--- a/apps/web/src/components/SearchModal/ImportToken.tsx
+++ b/apps/web/src/components/SearchModal/ImportToken.tsx
@@ -26,9 +26,9 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useState } from 'react'
 import { useCombinedInactiveList } from 'state/lists/hooks'
 import { useAddUserToken } from 'state/user/hooks'
-import useSWRImmutable from 'swr/immutable'
 import { getBlockExploreLink, getBlockExploreName } from 'utils'
 import { chains } from 'utils/wagmi'
+import { useQuery } from '@tanstack/react-query'
 
 interface ImportProps {
   tokens: Token[]
@@ -47,10 +47,19 @@ function ImportToken({ tokens, handleCurrencySelect }: ImportProps) {
   // use for showing import source on inactive tokens
   const inactiveTokenList = useCombinedInactiveList()
 
-  const { data: hasRiskToken } = useSWRImmutable(tokens && ['has-risks', tokens], async () => {
-    const result = await Promise.all(tokens.map((token) => fetchRiskToken(token.address, token.chainId)))
-    return result.some((r) => r.riskLevel >= TOKEN_RISK.MEDIUM)
-  })
+  const { data: hasRiskToken } = useQuery(
+    ['has-risks', tokens],
+    async () => {
+      const result = await Promise.all(tokens.map((token) => fetchRiskToken(token.address, token.chainId)))
+      return result.some((r) => r.riskLevel >= TOKEN_RISK.MEDIUM)
+    },
+    {
+      enabled: Boolean(tokens),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+    },
+  )
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
     t('I have read the scanning result, understood the risk and want to proceed with token importing.'),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- The PR focuses on replacing the usage of `useSWRImmutable` with `useQuery` from `@tanstack/react-query` in two files: `ImportToken.tsx` and `index.tsx`.
- `useSWRImmutable` is removed and replaced with `useQuery` in the `ImportToken` component.
- `useSWRImmutable` is removed and replaced with `useQuery` in the `AccessRisk` component.
- The options for `useQuery` are set to disable refetching on window focus, reconnect, and mount.
- The `mutate` function is replaced with `refetch` in the `AccessRiskComponent` component.
- The `RetryRisk` component's `onClick` handler is updated to call `refetch` instead of `mutate`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->