### PR TITLE
fix: Use traditional token approval for liquidity removal

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/Migrate.tsx
+++ b/apps/web/src/views/AddLiquidityV3/Migrate.tsx
@@ -32,7 +32,7 @@ import { FeeAmount, Pool, Position, priceToClosestTick, TickMath } from '@pancak
 import { Address, useContractRead, useSignTypedData } from 'wagmi'
 import { CommitButton } from 'components/CommitButton'
 import { useDensityChartData } from 'views/AddLiquidityV3/hooks/useDensityChartData'
-import { V2_ROUTER_ADDRESS } from 'config/constants/exchange'
+// import { V2_ROUTER_ADDRESS } from 'config/constants/exchange'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
 import { useV2Pair } from 'hooks/usePairs'
 import useTotalSupply from 'hooks/useTotalSupply'
@@ -40,9 +40,13 @@ import { useIsTransactionPending, useTransactionAdder } from 'state/transactions
 import { calculateGasMargin } from 'utils'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { unwrappedToken } from 'utils/wrappedCurrency'
-import { splitSignature } from 'utils/splitSignature'
-import { encodeFunctionData, Hex, toHex } from 'viem'
-import { isUserRejected } from 'utils/sentry'
+// import { splitSignature } from 'utils/splitSignature'
+import {
+  encodeFunctionData,
+  Hex,
+  // toHex
+} from 'viem'
+// import { isUserRejected } from 'utils/sentry'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ResponsiveTwoColumns } from 'views/AddLiquidityV3'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
@@ -320,7 +324,10 @@ function V2PairMigrate({
   const isMigrationPending = useIsTransactionPending(pendingMigrationHash ?? undefined)
 
   const migrator = useV3MigratorContract()
-  const [signatureData, setSignatureData] = useState<{
+  const [
+    signatureData,
+    // setSignatureData
+  ] = useState<{
     v: number
     r: `0x${string}`
     s: `0x${string}`
@@ -334,61 +341,62 @@ function V2PairMigrate({
   const pairContractRead = usePairContract(pair?.liquidityToken?.address)
 
   const approve = useCallback(async () => {
-    // try to gather a signature for permission
-    const nonce = await pairContractRead?.read.nonces([account!])
+    return approveCallback()
+    // // try to gather a signature for permission
+    // const nonce = await pairContractRead?.read.nonces([account!])
 
-    const EIP712Domain = [
-      { name: 'name', type: 'string' },
-      { name: 'version', type: 'string' },
-      { name: 'chainId', type: 'uint256' },
-      { name: 'verifyingContract', type: 'address' },
-    ]
-    const domain = {
-      name: 'Pancake LPs',
-      version: '1',
-      chainId,
-      verifyingContract: pair.liquidityToken.address as `0x${string}`,
-    }
-    const Permit = [
-      { name: 'owner', type: 'address' },
-      { name: 'spender', type: 'address' },
-      { name: 'value', type: 'uint256' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'deadline', type: 'uint256' },
-    ]
-    const message = {
-      owner: account,
-      spender: migrator.address,
-      value: pairBalance.toString(),
-      nonce: toHex(nonce ?? 0),
-      deadline: Number(deadline),
-    }
+    // const EIP712Domain = [
+    //   { name: 'name', type: 'string' },
+    //   { name: 'version', type: 'string' },
+    //   { name: 'chainId', type: 'uint256' },
+    //   { name: 'verifyingContract', type: 'address' },
+    // ]
+    // const domain = {
+    //   name: 'Pancake LPs',
+    //   version: '1',
+    //   chainId,
+    //   verifyingContract: pair.liquidityToken.address as `0x${string}`,
+    // }
+    // const Permit = [
+    //   { name: 'owner', type: 'address' },
+    //   { name: 'spender', type: 'address' },
+    //   { name: 'value', type: 'uint256' },
+    //   { name: 'nonce', type: 'uint256' },
+    //   { name: 'deadline', type: 'uint256' },
+    // ]
+    // const message = {
+    //   owner: account,
+    //   spender: migrator.address,
+    //   value: pairBalance.toString(),
+    //   nonce: toHex(nonce ?? 0),
+    //   deadline: Number(deadline),
+    // }
 
-    signTypedDataAsync({
-      // @ts-ignore
-      domain,
-      primaryType: 'Permit',
-      types: {
-        EIP712Domain,
-        Permit,
-      },
-      message,
-    })
-      .then(splitSignature)
-      .then((signature) => {
-        setSignatureData({
-          v: signature.v,
-          r: signature.r,
-          s: signature.s,
-          deadline: Number(deadline),
-        })
-      })
-      .catch((err) => {
-        // for all errors other than 4001 (EIP-1193 user rejected request), fall back to manual approve
-        if (!isUserRejected(err)) {
-          approveCallback()
-        }
-      })
+    // signTypedDataAsync({
+    //   // @ts-ignore
+    //   domain,
+    //   primaryType: 'Permit',
+    //   types: {
+    //     EIP712Domain,
+    //     Permit,
+    //   },
+    //   message,
+    // })
+    //   .then(splitSignature)
+    //   .then((signature) => {
+    //     setSignatureData({
+    //       v: signature.v,
+    //       r: signature.r,
+    //       s: signature.s,
+    //       deadline: Number(deadline),
+    //     })
+    //   })
+    //   .catch((err) => {
+    //     // for all errors other than 4001 (EIP-1193 user rejected request), fall back to manual approve
+    //     if (!isUserRejected(err)) {
+    //       approveCallback()
+    //     }
+    //   })
   }, [
     pairContractRead,
     account,

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -32,7 +32,7 @@ import { V2_ROUTER_ADDRESS } from 'config/constants/exchange'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { useLPApr } from 'state/swap/useLPApr'
 import { formattedCurrencyAmount } from 'components/FormattedCurrencyAmount/FormattedCurrencyAmount'
-import { splitSignature } from 'utils/splitSignature'
+// import { splitSignature } from 'utils/splitSignature'
 import { Hash } from 'viem'
 
 import { MinimalPositionCard } from 'components/PositionCard'
@@ -154,61 +154,63 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
       throw new Error('missing liquidity amount')
     }
 
-    // try to gather a signature for permission
-    const nonce = await pairContractRead.read.nonces([account])
+    return approveCallback()
 
-    const EIP712Domain = [
-      { name: 'name', type: 'string' },
-      { name: 'version', type: 'string' },
-      { name: 'chainId', type: 'uint256' },
-      { name: 'verifyingContract', type: 'address' },
-    ]
-    const domain = {
-      name: 'Pancake LPs',
-      version: '1',
-      chainId,
-      verifyingContract: pair.liquidityToken.address as `0x${string}`,
-    }
-    const Permit = [
-      { name: 'owner', type: 'address' },
-      { name: 'spender', type: 'address' },
-      { name: 'value', type: 'uint256' },
-      { name: 'nonce', type: 'uint256' },
-      { name: 'deadline', type: 'uint256' },
-    ]
-    const message = {
-      owner: account,
-      spender: chainId ? V2_ROUTER_ADDRESS[chainId] : undefined,
-      value: liquidityAmount.quotient.toString(),
-      nonce,
-      deadline: Number(deadline),
-    }
+    // // try to gather a signature for permission
+    // const nonce = await pairContractRead.read.nonces([account])
 
-    signTypedDataAsync({
-      // @ts-ignore
-      domain,
-      primaryType: 'Permit',
-      types: {
-        EIP712Domain,
-        Permit,
-      },
-      message,
-    })
-      .then(splitSignature)
-      .then((signature) => {
-        setSignatureData({
-          v: signature.v,
-          r: signature.r,
-          s: signature.s,
-          deadline: Number(deadline),
-        })
-      })
-      .catch((err) => {
-        // for all errors other than 4001 (EIP-1193 user rejected request), fall back to manual approve
-        if (!isUserRejected(err)) {
-          approveCallback()
-        }
-      })
+    // const EIP712Domain = [
+    //   { name: 'name', type: 'string' },
+    //   { name: 'version', type: 'string' },
+    //   { name: 'chainId', type: 'uint256' },
+    //   { name: 'verifyingContract', type: 'address' },
+    // ]
+    // const domain = {
+    //   name: 'Pancake LPs',
+    //   version: '1',
+    //   chainId,
+    //   verifyingContract: pair.liquidityToken.address as `0x${string}`,
+    // }
+    // const Permit = [
+    //   { name: 'owner', type: 'address' },
+    //   { name: 'spender', type: 'address' },
+    //   { name: 'value', type: 'uint256' },
+    //   { name: 'nonce', type: 'uint256' },
+    //   { name: 'deadline', type: 'uint256' },
+    // ]
+    // const message = {
+    //   owner: account,
+    //   spender: chainId ? V2_ROUTER_ADDRESS[chainId] : undefined,
+    //   value: liquidityAmount.quotient.toString(),
+    //   nonce,
+    //   deadline: Number(deadline),
+    // }
+
+    // signTypedDataAsync({
+    //   // @ts-ignore
+    //   domain,
+    //   primaryType: 'Permit',
+    //   types: {
+    //     EIP712Domain,
+    //     Permit,
+    //   },
+    //   message,
+    // })
+    //   .then(splitSignature)
+    //   .then((signature) => {
+    //     setSignatureData({
+    //       v: signature.v,
+    //       r: signature.r,
+    //       s: signature.s,
+    //       deadline: Number(deadline),
+    //     })
+    //   })
+    //   .catch((err) => {
+    //     // for all errors other than 4001 (EIP-1193 user rejected request), fall back to manual approve
+    //     if (!isUserRejected(err)) {
+    //       approveCallback()
+    //     }
+    //   })
   }
 
   // wrapped onUserInput to clear signatures


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR removes the import of the `splitSignature` function in two files.
- It replaces the code that gathers a signature for permission with a call to the `approveCallback` function in both files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->