### PR TITLE
fix: Missing await

### DIFF
--- a/packages/utils/getCurrencyPrice.ts
+++ b/packages/utils/getCurrencyPrice.ts
@@ -74,7 +74,7 @@ function getRequestUrlByInfo(info?: TokenInfo | TokenInfo[]): string | undefined
 }
 
 export async function getCurrencyPrice(currency?: Currency) {
-  const prices = getCurrencyPrices(currency && [currency])
+  const prices = await getCurrencyPrices(currency && [currency])
   return (currency && prices[currency.wrapped.address]) ?? 0
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `getCurrencyPrice` function to use `await` when calling `getCurrencyPrices`. 

### Detailed summary
- Added `await` keyword to the `getCurrencyPrices` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->