### PR TITLE
fix(style): gauge/staking white-space & overlapping

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
@@ -36,6 +36,7 @@ const weeks = [
 
 const ButtonBlocked = styled(Button)`
   flex: 1;
+  white-space: nowrap;
 `
 
 const WeekInput: React.FC<{

--- a/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
@@ -22,6 +22,7 @@ import styled from 'styled-components'
 import { useGauges } from 'views/GaugesVoting/hooks/useGauges'
 import { useGaugesTotalWeight } from 'views/GaugesVoting/hooks/useGaugesTotalWeight'
 import { GaugesList, GaugesTable } from '../GaugesTable'
+import { THeader, TRow } from '../styled'
 import { Filter, FilterValue, Gauges, OptionsModal, OptionsType } from './OptionsModal'
 
 const FilterButton = styled(Button)`
@@ -35,6 +36,12 @@ const ScrollableGaugesList = styled(GaugesList).attrs({ pagination: false })`
 
   ${({ theme }) => theme.mediaQueries.sm} {
     max-height: calc(90vh - 390px);
+  }
+`
+
+const AddGaugesTable = styled(GaugesTable)`
+  ${THeader}, ${TRow} {
+    grid-template-columns: 4fr 1.5fr 0.8fr 0.8fr;
   }
 `
 
@@ -110,7 +117,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
   }
 
   const gaugesTable = isDesktop ? (
-    <GaugesTable
+    <AddGaugesTable
       selectable
       selectRows={selectRows}
       onRowSelect={onGaugeAdd}
@@ -145,7 +152,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
       <ModalV2 isOpen={isOpen} onDismiss={onDismiss}>
         <ModalWrapper
           maxHeight="90vh"
-          minWidth="50vw"
+          minWidth={['80vw', null, null, null, null, null, '55vw']}
           height={isMobile ? '90vh' : undefined}
           style={{ overflowY: 'auto' }}
         >

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx
@@ -1,14 +1,13 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { SortArrowIcon, Text, Th } from '@pancakeswap/uikit'
+import { Flex, SortArrowIcon, Text, Th } from '@pancakeswap/uikit'
 import { useState } from 'react'
 import styled from 'styled-components'
 import { SortButton } from 'views/V3Info/components/SortButton'
 import { THeader } from '../styled'
 
-const Touchable = styled.div`
+const Touchable = styled(Flex)`
   cursor: pointer;
-  display: flex;
-  justify-content: start;
+  white-space: nowrap;
   gap: 5px;
 `
 
@@ -73,7 +72,7 @@ export const TableHeader: React.FC<{
         </Touchable>
       </Th>
       <Th>
-        <Touchable onClick={onBoostSort}>
+        <Touchable onClick={onBoostSort} justifyContent="center">
           <Text color="secondary" textTransform="uppercase" fontWeight={600}>
             {t('boost')}
           </Text>

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableRow.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableRow.tsx
@@ -111,7 +111,7 @@ const TableRowItem: React.FC<{
               {data.pairName}
             </Text>
           </FlexGap>
-          <FlexGap gap="5px" alignItems="center">
+          <FlexGap gap="5px" alignItems="center" flexWrap="wrap">
             <NetworkBadge chainId={Number(data.chainId)} />
             {data.type === GaugeType.V3 || data.type === GaugeType.V2 ? (
               <Tag outline variant="secondary">
@@ -141,16 +141,17 @@ const TableRowItem: React.FC<{
           </Flex>
         </Tooltips>
       </Flex>
-      <Flex alignItems="center" pr="25px">
+      <Flex alignItems="center">
         <Text bold fontSize={16} color={data.boostMultiplier > 100n ? '#1BC59C' : undefined}>
           {Number(data.boostMultiplier) / 100}x
         </Text>
       </Flex>
-
-      <Text bold={hitMaxCap}>
-        {hitMaxCap ? 'MAX ' : ''}
-        {maxCapPercent.toSignificant(2)}%
-      </Text>
+      <Flex alignItems="center">
+        <Text bold={hitMaxCap}>
+          {hitMaxCap ? 'MAX ' : ''}
+          {maxCapPercent.toSignificant(2)}%
+        </Text>
+      </Flex>
     </TRow>
   )
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx
@@ -46,20 +46,23 @@ export const GaugesTable: React.FC<
     setSortBy(by)
   }
 
-  const Row = ({ data: rows, index, style }): JSX.Element => {
-    const row = rows[index]
-    return (
-      <TableRow
-        style={style}
-        data={row}
-        locked={selectRows?.find((r) => r.hash === row.hash)?.locked}
-        selectable={selectable}
-        selected={selectRows?.some((r) => r.hash === row.hash)}
-        onSelect={onRowSelect}
-        totalGaugesWeight={totalGaugesWeight}
-      />
-    )
-  }
+  const Row = useCallback(
+    ({ data: rows, index, style }): JSX.Element => {
+      const row = rows[index]
+      return (
+        <TableRow
+          style={style}
+          data={row}
+          locked={selectRows?.find((r) => r.hash === row.hash)?.locked}
+          selectable={selectable}
+          selected={selectRows?.some((r) => r.hash === row.hash)}
+          onSelect={onRowSelect}
+          totalGaugesWeight={totalGaugesWeight}
+        />
+      )
+    },
+    [onRowSelect, selectRows, selectable, totalGaugesWeight],
+  )
 
   const itemKey = useCallback((index: number, row: Gauge[]) => row[index].hash, [])
   const expandHeight = useMemo(

--- a/packages/uikit/src/components/Table/Cell.tsx
+++ b/packages/uikit/src/components/Table/Cell.tsx
@@ -13,6 +13,7 @@ export const Th = styled(Td).attrs({ as: "th" })<TypographyProps>`
   color: ${({ theme }) => theme.colors.secondary};
   font-size: 12px;
   text-transform: uppercase;
+  white-space: nowrap;
 
   ${typography}
 `;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `white-space: nowrap;` to the `Cell` component in `packages/uikit/src/components/Table/Cell.tsx`.
- Added `white-space: nowrap;` to the `ButtonBlocked` component in `apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx`.
- Changed the `Touchable` component in `apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableHeader.tsx` to use `Flex` instead of `styled.div` and added `white-space: nowrap;`.
- Added `flexWrap="wrap"` to the `FlexGap` component in `apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableRow.tsx`.
- Changed the implementation of the `Row` component in `apps/web/src/views/GaugesVoting/components/Table/GaugesTable/index.tsx` to use `useCallback` and added dependencies.
- Added `THeader` and `TRow` to the `AddGaugesTable` component in `apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->