### PR TITLE
fix: Price when removing stable pair

### DIFF
--- a/apps/web/src/views/Swap/hooks/useEstimatedAmount.ts
+++ b/apps/web/src/views/Swap/hooks/useEstimatedAmount.ts
@@ -12,7 +12,7 @@ export function useEstimatedAmount({ estimatedCurrency, stableSwapConfig, quotie
 
       const args = isToken0 ? [1, 0, deferQuotient] : [0, 1, deferQuotient]
 
-      const estimatedAmount = await stableSwapContract.get_dy(...args)
+      const estimatedAmount = await stableSwapContract.read.get_dy(args)
 
       return CurrencyAmount.fromRawAmount(estimatedCurrency, estimatedAmount)
     },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `useEstimatedAmount` hook in the `Swap` view. 

### Detailed summary:
- Replaces a method call from `stableSwapContract.get_dy` to `stableSwapContract.read.get_dy`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->