### PR TITLE
fix: Migrate manual approval address

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/Migrate.tsx
+++ b/apps/web/src/views/AddLiquidityV3/Migrate.tsx
@@ -361,7 +361,7 @@ function V2PairMigrate({
   } | null>(null)
   const { approvalState, approveCallback } = useApproveCallback(
     CurrencyAmount.fromRawAmount(pair.liquidityToken, pairBalance.toString()),
-    chainId ? V2_ROUTER_ADDRESS[chainId] : undefined,
+    migrator.address,
   )
 
   const pairContractRead = usePairContract(pair?.liquidityToken?.address)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to add the `migrator.address` parameter to the `useApproveCallback` hook in the `Migrate.tsx` file.
- Additionally, the `usePairContract` hook is used to retrieve the pair contract for the liquidity token.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->