### PR TITLE
feat(Blog): Hide language

### DIFF
--- a/apps/blog/hooks/useLanguage.ts
+++ b/apps/blog/hooks/useLanguage.ts
@@ -6,6 +6,10 @@ interface ResponseLanguageType {
   name: string
 }
 
+// We can't hide the language in Strapi only can delete it.
+// 日本語, Georgian, Français, Deutsch
+const HIDE_LANGUAGE_CODE = ['ja', 'ka', 'fr', 'de']
+
 const useLanguage = () => {
   const { t } = useTranslation()
   const defaultLanguage = { label: t('All'), value: 'all' }
@@ -16,10 +20,12 @@ const useLanguage = () => {
       try {
         const response = await fetch(`/api/locales`)
         const result: ResponseLanguageType[] = await response.json()
-        const languages = result.map((i) => ({
-          label: i.name,
-          value: i.code,
-        }))
+        const languages = result
+          .filter((i) => !HIDE_LANGUAGE_CODE.includes(i.code))
+          .map((i) => ({
+            label: i.name,
+            value: i.code,
+          }))
         return [defaultLanguage, ...languages].sort((a) => (a.value === 'en' ? -1 : 1))
       } catch (error) {
         console.error('Get all language error: ', error)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "preinstall": "npx only-allow pnpm",
     "dev": "turbo run dev --filter=web... --concurrency=26",
     "dev:aptos": "pnpm turbo run dev --filter=aptos-web... --concurrency=20",
-    "dev:blog": "pnpm turbo run dev --filter=blog... --concurrency=11",
+    "dev:blog": "pnpm turbo run dev --filter=blog... --concurrency=12",
     "dev:bridge": "pnpm turbo run dev --filter=bridge... --concurrency=16",
     "dev:games": "pnpm turbo run dev --filter=games... --concurrency=20",
     "storybook": "turbo run start --filter=uikit...",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the `dev:blog` script in the `package.json` file and making changes to the `useLanguage` hook in the `apps/blog/hooks/useLanguage.ts` file.

### Detailed summary:
- Updated the `dev:blog` script in `package.json` to use a concurrency value of 12 instead of 11.
- Added a constant `HIDE_LANGUAGE_CODE` array in `useLanguage.ts` to hide certain language codes.
- Filtered out languages with codes present in `HIDE_LANGUAGE_CODE` array in the `languages` array.
- Updated the mapping logic in the `languages` array to include only non-hidden languages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->