### PR TITLE
fix: position manager amountInUsd NaN display issue

### DIFF
--- a/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
+++ b/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
@@ -1,12 +1,12 @@
-import { memo, useMemo } from 'react'
-import { Button, Text, RowBetween, Row, Flex, MinusIcon, AddIcon } from '@pancakeswap/uikit'
-import { CurrencyLogo } from '@pancakeswap/widgets-internal'
-import type { AtomBoxProps } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
-import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { Currency, CurrencyAmount, Price } from '@pancakeswap/sdk'
+import type { AtomBoxProps } from '@pancakeswap/uikit'
+import { AddIcon, Button, Flex, MinusIcon, Row, RowBetween, Text } from '@pancakeswap/uikit'
+import { formatAmount } from '@pancakeswap/utils/formatFractions'
+import { CurrencyLogo } from '@pancakeswap/widgets-internal'
+import { memo, useMemo } from 'react'
 import { styled } from 'styled-components'
-import { useTotalAssetInUsd, useTotalAssetInSingleDepositTokenAmount } from '../hooks'
+import { useTotalAssetInSingleDepositTokenAmount, useTotalAssetInUsd } from '../hooks'
 
 const Title = styled(Text).attrs({
   bold: true,
@@ -113,7 +113,7 @@ export const CurrencyAmountDisplay = memo(function CurrencyAmountDisplay({
   const amountDisplay = useMemo(() => formatAmount(amount) || '0', [amount])
 
   const amountInUsd = useMemo(() => {
-    return Number(formatAmount(amount)) * (priceUSD ?? 0)
+    return Number(formatAmount(amount)) * (priceUSD ?? 0) || 0
   }, [amount, priceUSD])
 
   return (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Reordered imports in `StakedAssets.tsx` file.
- Added `memo` and `useMemo` from React.
- Added `useTotalAssetInSingleDepositTokenAmount` and `useTotalAssetInUsd` hooks from `../hooks`.
- Added fallback value of 0 for `amountInUsd` calculation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->