### PR TITLE
feat: fix gauge order and list aptos farm

### DIFF
--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -14,6 +14,14 @@ const farms: SerializedFarmConfig[] = [
     quoteToken: mainnetTokens.cake,
   },
   {
+    pid: 22,
+    lpSymbol: 'APT-stAPT',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt, 0x1::aptos_coin::AptosCoin>',
+    token: mainnetTokens.apt,
+    quoteToken: mainnetTokens.stAPT,
+  },
+  {
     pid: 1,
     lpSymbol: 'CAKE-APT LP',
     lpAddress:

--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -14,14 +14,6 @@ const farms: SerializedFarmConfig[] = [
     quoteToken: mainnetTokens.cake,
   },
   {
-    pid: 22,
-    lpSymbol: 'APT-stAPT',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt, 0x1::aptos_coin::AptosCoin>',
-    token: mainnetTokens.apt,
-    quoteToken: mainnetTokens.stAPT,
-  },
-  {
     pid: 1,
     lpSymbol: 'CAKE-APT LP',
     lpAddress:
@@ -46,6 +38,14 @@ const farms: SerializedFarmConfig[] = [
     quoteToken: mainnetTokens.cake,
   },
   // * By order of release
+  {
+    pid: 22,
+    lpSymbol: 'APT-stAPT',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt, 0x1::aptos_coin::AptosCoin>',
+    token: mainnetTokens.apt,
+    quoteToken: mainnetTokens.stAPT,
+  },
   {
     pid: 21,
     lpSymbol: 'GUI-APT LP',

--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -43,8 +43,8 @@ const farms: SerializedFarmConfig[] = [
     lpSymbol: 'APT-stAPT',
     lpAddress:
       '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt, 0x1::aptos_coin::AptosCoin>',
-    token: mainnetTokens.apt,
-    quoteToken: mainnetTokens.stAPT,
+    token: mainnetTokens.stAPT,
+    quoteToken: mainnetTokens.apt,
   },
   {
     pid: 21,

--- a/apps/aptos/config/constants/tokens/1.ts
+++ b/apps/aptos/config/constants/tokens/1.ts
@@ -146,4 +146,12 @@ export const mainnetTokens = {
     'GUI',
     'GUI INU',
   ),
+  stAPT: new Coin(
+    ChainId.MAINNET,
+    '0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt',
+    8,
+    'stAPT',
+    'staked Aptos Coin',
+    'https://stake.amnis.finance/',
+  ),
 }

--- a/apps/aptos/config/constants/tokens/1.ts
+++ b/apps/aptos/config/constants/tokens/1.ts
@@ -151,7 +151,7 @@ export const mainnetTokens = {
     '0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt',
     8,
     'stAPT',
-    'staked Aptos Coin',
+    'Staked Aptos Coin',
     'https://stake.amnis.finance/',
   ),
 }

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2187,16 +2187,16 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: polygonZkEvmTokens.wbtc.address,
     feeTier: FeeAmount.LOW,
   },
-  // {
-  //   gid: 221,
-  //   pairName: 'ETH-swETH',
-  //   address: '0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14',
-  //   chainId: ChainId.ETHEREUM,
-  //   type: GaugeType.V3,
-  //   token0Address: ethereumTokens.weth.address,
-  //   token1Address: ethereumTokens.swETH.address,
-  //   feeTier: FeeAmount.LOW,
-  // },
+  {
+    gid: 221,
+    pairName: 'swETH-ETH',
+    address: '0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14',
+    chainId: ChainId.ETHEREUM,
+    type: GaugeType.V3,
+    token0Address: ethereumTokens.swETH.address,
+    token1Address: ethereumTokens.weth.address,
+    feeTier: FeeAmount.LOW,
+  },
   {
     gid: 222,
     pairName: 'HAY-USDT',
@@ -2377,16 +2377,6 @@ export const CONFIG_PROD: GaugeConfig[] = [
   },
   {
     gid: 241,
-    pairName: 'MGP-WETH',
-    address: '0x4E910E367C2DbF42cdB8D6b041033793fe480803',
-    chainId: ChainId.ARBITRUM_ONE,
-    type: GaugeType.V2,
-    token0Address: arbitrumTokens.weth.address,
-    token1Address: arbitrumTokens.mgp.address,
-    feeTier: FeeAmount.MEDIUM,
-  },
-  {
-    gid: 242,
     pairName: 'RDP-BNB',
     address: '0xc9B415b8331e1Fb0d2f3442Ac8413E279304090f',
     chainId: ChainId.BSC,
@@ -2396,7 +2386,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.MEDIUM,
   },
   {
-    gid: 243,
+    gid: 242,
     pairName: 'PNP-BNB',
     address: '0x1C5bD1B4A4Fc05cC0Fb1a0f61136512744Ca4F34',
     chainId: ChainId.BSC,
@@ -2406,7 +2396,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.MEDIUM,
   },
   {
-    gid: 244,
+    gid: 243,
     pairName: 'CKP-mCAKE',
     address: '0xdb92AD18eD18752a194b9D831413B09976B34AE1',
     chainId: ChainId.BSC,
@@ -2416,7 +2406,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.MEDIUM,
   },
   {
-    gid: 245,
+    gid: 244,
     pairName: 'HUAHUA-USDT',
     address: '0xE08078C1daACef415b2653e7256A70002F41Eeb6',
     chainId: ChainId.BSC,
@@ -2426,17 +2416,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.HIGH,
   },
   {
-    gid: 246,
-    pairName: 'swETH-ETH',
-    address: '0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14',
-    chainId: ChainId.ETHEREUM,
-    type: GaugeType.V3,
-    token0Address: ethereumTokens.swETH.address,
-    token1Address: ethereumTokens.weth.address,
-    feeTier: FeeAmount.LOW,
-  },
-  {
-    gid: 247,
+    gid: 245,
     pairName: 'ETH-USDC',
     address: '0xd5539D0360438a66661148c633A9F0965E482845',
     chainId: ChainId.LINEA,
@@ -2446,7 +2426,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOW,
   },
   {
-    gid: 248,
+    gid: 246,
     pairName: 'USDT-USDC',
     address: '0x6a72F4F191720c411Cd1fF6A5EA8DeDEC3A64771',
     chainId: ChainId.LINEA,
@@ -2456,7 +2436,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOWEST,
   },
   {
-    gid: 249,
+    gid: 247,
     pairName: 'BTC-ETH',
     address: '0xbD3bc396C9393e63bBc935786Dd120B17F58Df4c',
     chainId: ChainId.LINEA,
@@ -2466,7 +2446,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOW,
   },
   {
-    gid: 250,
+    gid: 248,
     pairName: 'USDC-DAI',
     address: '0xA48E0630B7b9dCb250112143C9D0fe47d26CB1e4',
     chainId: ChainId.LINEA,
@@ -2476,7 +2456,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOWEST,
   },
   {
-    gid: 251,
+    gid: 249,
     pairName: 'USDC-axlUSDC',
     address: '0x85164B6d8a74bA481AB6D02D2C4e779ECCBAF982',
     chainId: ChainId.LINEA,
@@ -2486,7 +2466,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOWEST,
   },
   {
-    gid: 252,
+    gid: 250,
     pairName: 'wstETH-ETH',
     address: '0x3f63a467C54c96538bD36A7DF1b9E7C4719DcaC9',
     chainId: ChainId.LINEA,
@@ -2496,7 +2476,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOWEST,
   },
   {
-    gid: 253,
+    gid: 251,
     pairName: 'AI-BNB',
     address: '0x85Bf2332c9033624B5d6f2607D8f07f22Bc86345',
     chainId: ChainId.BSC,
@@ -2506,7 +2486,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.HIGH,
   },
   {
-    gid: 254,
+    gid: 252,
     pairName: 'wROSE-USDT',
     address: '0x9dD70024FF211bA754c089CDee47BdeDc17C4CBe',
     chainId: ChainId.BSC,
@@ -2516,7 +2496,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     feeTier: FeeAmount.LOW,
   },
   {
-    gid: 255,
+    gid: 253,
     pairName: 'wstETH-ETH',
     address: '0x5631fE6d29E3CB717517DA05A9970e499DEF5e31',
     chainId: ChainId.ZKSYNC,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a new staked Aptos coin (`stAPT`) and a new farm (`APT-stAPT`) to the existing configuration. It also updates the configuration for some existing gauges.

### Detailed summary:
- Added a new staked Aptos coin (`stAPT`) with the following details:
  - Chain ID: MAINNET
  - Address: 0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt
  - Decimals: 8
  - Symbol: stAPT
  - Name: Staked Aptos Coin
  - Website: https://stake.amnis.finance/

- Added a new farm (`APT-stAPT`) with the following details:
  - Pool ID: 22
  - LP Symbol: APT-stAPT
  - LP Address: 0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x111ae3e5bc816a5e63c2da97d0aa3886519e0cd5e4b046659fa35796bd11542a::stapt_token::StakedApt, 0x1::aptos_coin::AptosCoin>
  - Token: stAPT
  - Quote Token: APT

- Updated the configuration for some existing gauges. Notable changes include:
  - Updated the pair name for gauge with GID 221 from 'ETH-swETH' to 'swETH-ETH'
  - Updated the token addresses for gauge with GID 221 to use swETH as token0 and WETH as token1
  - Updated the GID for gauge with pair name 'PNP-BNB' from 243 to 242
  - Updated the GID for gauge with pair name 'CKP-mCAKE' from 244 to 243
  - Updated the GID for gauge with pair name 'HUAHUA-USDT' from 245 to 244
  - Updated the GID for gauge with pair name 'swETH-ETH' from 246 to 245
  - Updated the GID for gauge with pair name 'ETH-USDC' from 247 to 246
  - Updated the GID for gauge with pair name 'USDT-USDC' from 248 to 247
  - Updated the GID for gauge with pair name 'BTC-ETH' from 249 to 248
  - Updated the GID for gauge with pair name 'USDC-DAI' from 250 to 249
  - Updated the GID for gauge with pair name 'USDC-axlUSDC' from 251 to 250
  - Updated the GID for gauge with pair name 'wstETH-ETH' from 252 to 251
  - Updated the GID for gauge with pair name 'AI-BNB' from 253 to 252
  - Updated the GID for gauge with pair name 'wROSE-USDT' from 254 to 253
  - Updated the GID for gauge with pair name 'wstETH-ETH' from 255 to 251

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->