### PR TITLE
fix: Aptos ROI bug

### DIFF
--- a/apps/aptos/components/Farms/components/Farms.tsx
+++ b/apps/aptos/components/Farms/components/Farms.tsx
@@ -201,7 +201,13 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
         const lpRewardsApr = lpRewardsAprs?.[farm.lpAddress?.toLowerCase()] ?? 0
 
         const dualTokenRewardApr = isActive
-          ? calcPendingRewardApt(regularCakePerBlock ?? 0, aptPrice, farm?.dual?.aptIncentiveInfo ?? 0, totalLiquidity)
+          ? calcPendingRewardApt(
+              new BigNumber(farm.poolWeight ?? 0),
+              regularCakePerBlock ?? 0,
+              aptPrice,
+              farm?.dual?.aptIncentiveInfo ?? 0,
+              totalLiquidity,
+            )
           : 0
 
         return {

--- a/apps/aptos/state/farms/utils/pendingApt.ts
+++ b/apps/aptos/state/farms/utils/pendingApt.ts
@@ -1,17 +1,18 @@
-import { BIG_TEN } from '@pancakeswap/utils/bigNumber'
 import BigNumber from 'bignumber.js'
-import { FARM_DEFAULT_DECIMALS } from 'components/Farms/constants'
 import { SECONDS_IN_YEAR } from 'config'
-import { TOTAL_CAKE_RATE_PRECISION } from './pendingCake'
 
 export const calcPendingRewardApt = (
+  poolWeight: BigNumber,
   cakePerSecond: number,
   aptPrice: BigNumber,
   aptIncentiveInfo: number,
   tvlUSD: BigNumber,
 ) => {
-  const aptPerSecond = new BigNumber(cakePerSecond).times(aptIncentiveInfo).div(TOTAL_CAKE_RATE_PRECISION)
-  const aptRewardOneYearUSD = new BigNumber(aptPerSecond).times(aptPrice).times(SECONDS_IN_YEAR)
-  const aptApr = aptRewardOneYearUSD.div(tvlUSD).times(100)
-  return aptApr.div(BIG_TEN.pow(FARM_DEFAULT_DECIMALS)).toNumber()
+  const yearlyAptRewardAllocation = new BigNumber(cakePerSecond / 100000000)
+    .div(100)
+    .times(new BigNumber(poolWeight).times(100))
+  const aptPerSecond = new BigNumber(yearlyAptRewardAllocation).times(new BigNumber(aptIncentiveInfo).div(100000))
+  const aptRewardPerYear = aptPerSecond.times(SECONDS_IN_YEAR)
+  const aptAPR = aptRewardPerYear.times(aptPrice).div(tvlUSD).times(aptPrice)
+  return aptAPR.toNumber()
 }

--- a/apps/aptos/state/farms/utils/pendingApt.ts
+++ b/apps/aptos/state/farms/utils/pendingApt.ts
@@ -13,6 +13,6 @@ export const calcPendingRewardApt = (
     .times(new BigNumber(poolWeight).times(100))
   const aptPerSecond = new BigNumber(yearlyAptRewardAllocation).times(new BigNumber(aptIncentiveInfo).div(100000))
   const aptRewardPerYear = aptPerSecond.times(SECONDS_IN_YEAR)
-  const aptAPR = aptRewardPerYear.times(aptPrice).div(tvlUSD).times(aptPrice)
+  const aptAPR = aptRewardPerYear.times(aptPrice).div(tvlUSD).times(100)
   return aptAPR.toNumber()
 }

--- a/packages/uikit/src/components/RoiCalculatorModal/RoiCalculatorFooter.tsx
+++ b/packages/uikit/src/components/RoiCalculatorModal/RoiCalculatorFooter.tsx
@@ -95,10 +95,9 @@ const RoiCalculatorFooter: React.FC<React.PropsWithChildren<RoiCalculatorFooterP
     let total = new BigNumber(apr);
     // TODO: In APTOS APR is combine APR (Cake APR + Apt APR + lp APR).
     // Soon EVM (v2 Farm & pools) also will change to  combine APR.
-    if (dualTokenRewardApr !== undefined && lpRewardsApr) {
-      total = new BigNumber(apr).minus(Number(dualTokenRewardApr)).minus(lpRewardsApr ?? 0);
+    if (dualTokenRewardApr !== undefined) {
+      total = new BigNumber(apr).minus(Number(dualTokenRewardApr ?? 0)).minus(lpRewardsApr ?? 0);
     }
-
     return total.toNumber();
   }, [apr, dualTokenRewardApr, lpRewardsApr]);
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The `calcPendingRewardApt` function in `apps/aptos/state/farms/utils/pendingApt.ts` has been updated with new calculations for the APR.
- The `dualTokenRewardApr` variable in `apps/aptos/components/Farms/components/Farms.tsx` has been modified to include the new calculations.
- The `total` variable in `packages/uikit/src/components/RoiCalculatorModal/RoiCalculatorFooter.tsx` has been updated to use the modified `dualTokenRewardApr` value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->