### PR TITLE
fix: Transaction updater gets stuck after receipt not found when retries

### DIFF
--- a/apps/web/src/config/constants/index.ts
+++ b/apps/web/src/config/constants/index.ts
@@ -15,6 +15,8 @@ export const INITIAL_ALLOWED_SLIPPAGE = 50
 export const DEFAULT_DEADLINE_FROM_NOW = 60 * 20
 export const L2_DEADLINE_FROM_NOW = 60 * 5
 
+export const BSC_BLOCK_TIME = 3
+
 export const FAST_INTERVAL = 10000
 export const SLOW_INTERVAL = 60000
 

--- a/apps/web/src/state/multicall/retry.ts
+++ b/apps/web/src/state/multicall/retry.ts
@@ -28,11 +28,11 @@ export class RetryableError extends Error {}
  * @param n how many times to retry
  * @param minWait min wait between retries in ms
  * @param maxWait max wait between retries in ms
- * @param trailing the function should be run after some time without running the function
+ * @param delay the function should be run after some time without running the function
  */
 export function retry<T>(
   fn: () => Promise<T>,
-  { n, minWait, maxWait, trailing }: { n: number; minWait: number; maxWait: number; trailing?: boolean },
+  { n, minWait, maxWait, delay }: { n: number; minWait: number; maxWait: number; delay?: number },
 ): { promise: Promise<T>; cancel: () => void } {
   let completed = false
   let firstRun = true
@@ -40,8 +40,8 @@ export function retry<T>(
   const promise = new Promise<T>(async (resolve, reject) => {
     rejectCancelled = reject
     while (true) {
-      if (trailing && firstRun) {
-        await waitRandom(minWait, maxWait)
+      if (delay && firstRun) {
+        await wait(delay)
         firstRun = false
       }
       let result: T

--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { usePublicClient } from 'wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { Box, Text, useToast } from '@pancakeswap/uikit'
-import { FAST_INTERVAL } from 'config/constants'
+import { BSC_BLOCK_TIME, FAST_INTERVAL } from 'config/constants'
 import useSWRImmutable from 'swr/immutable'
 import {
   BlockNotFoundError,
@@ -97,7 +97,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
           n: 10,
           minWait: 5000,
           maxWait: 10000,
-          trailing: true,
+          delay: BSC_BLOCK_TIME + 1000,
         })
       },
     )
@@ -149,15 +149,17 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
                   return { ...step, ...newObj }
                 })
 
+                const newStatus = isFinalStepComplete ? FarmTransactionStatus.SUCCESS : transaction?.nonBscFarm?.status
+
                 dispatch(
                   finalizeTransaction({
                     chainId,
                     hash: transaction.hash,
-                    receipt: { ...transaction.receipt },
+                    receipt: { ...transaction.receipt! },
                     nonBscFarm: {
-                      ...transaction.nonBscFarm,
-                      steps: newSteps,
-                      status: isFinalStepComplete ? FarmTransactionStatus.SUCCESS : transaction?.nonBscFarm?.status,
+                      ...transaction.nonBscFarm!,
+                      ...(newSteps && { steps: newSteps }),
+                      ...(newStatus && { status: newStatus }),
                     },
                   }),
                 )

--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -54,7 +54,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
       (transaction) => {
         const getTransaction = async () => {
           try {
-            const receipt: any = await provider.waitForTransactionReceipt({ hash: transaction.hash, timeout: 60_000 })
+            const receipt: any = await provider.getTransactionReceipt({ hash: transaction.hash })
 
             dispatch(
               finalizeTransaction({
@@ -97,6 +97,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
           n: 10,
           minWait: 5000,
           maxWait: 10000,
+          trailing: true,
         })
       },
     )
@@ -114,7 +115,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
   )
 
   useSWRImmutable(
-    chainId && Boolean(nonBscFarmPendingTxns?.length) && ['checkNonBscFarmTransaction', FAST_INTERVAL, chainId],
+    chainId && Boolean(nonBscFarmPendingTxns?.length) ? ['checkNonBscFarmTransaction', FAST_INTERVAL, chainId] : null,
     () => {
       nonBscFarmPendingTxns.forEach((hash) => {
         const steps = transactions[hash]?.nonBscFarm?.steps || []

--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -97,7 +97,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
           n: 10,
           minWait: 5000,
           maxWait: 10000,
-          delay: BSC_BLOCK_TIME + 1000,
+          delay: BSC_BLOCK_TIME * 1000 + 1000,
         })
       },
     )


### PR DESCRIPTION
When retrying waitForTransactionReceipt not working anymore  if it gets receipt not found exception in the first call


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the retry functionality and updating the updater component. 

### Detailed summary
- Added `delay` parameter to the `retry` function.
- Updated the `Updater` component to use `getTransactionReceipt` instead of `waitForTransactionReceipt`.
- Added a delay to the `Updater` component based on `BSC_BLOCK_TIME`.
- Updated the SWRImmutable hook in the `Updater` component to conditionally fetch data based on `nonBscFarmPendingTxns`.
- Updated the `finalizeTransaction` dispatch in the `Updater` component to handle new properties in the transaction object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->