### PR TITLE
refactor: Use query in active ifo with blocks hook

### DIFF
--- a/apps/web/src/hooks/useActiveIfoWithBlocks.ts
+++ b/apps/web/src/hooks/useActiveIfoWithBlocks.ts
@@ -1,17 +1,17 @@
-import useSWRImmutable from 'swr/immutable'
 import { ChainId } from '@pancakeswap/chains'
 import { Ifo } from '@pancakeswap/ifos'
 
 import { publicClient } from 'utils/wagmi'
 
+import { useQuery } from '@tanstack/react-query'
 import { ifoV3ABI } from '../config/abi/ifoV3'
 import { useActiveIfoConfig } from './useIfoConfig'
 
 export const useActiveIfoWithBlocks = (): (Ifo & { startBlock: number; endBlock: number }) | null => {
   const { activeIfo } = useActiveIfoConfig()
 
-  const { data: currentIfoBlocks = { startBlock: 0, endBlock: 0 } } = useSWRImmutable(
-    activeIfo ? ['ifo', 'currentIfo'] : null,
+  const { data: currentIfoBlocks = { startBlock: 0, endBlock: 0 } } = useQuery(
+    ['ifo', 'currentIfo'],
     async () => {
       if (!activeIfo?.address) {
         return {
@@ -40,6 +40,12 @@ export const useActiveIfoWithBlocks = (): (Ifo & { startBlock: number; endBlock:
         startBlock: startBlockResponse.status === 'success' ? Number(startBlockResponse.result) : 0,
         endBlock: endBlockResponse.status === 'success' ? Number(endBlockResponse.result) : 0,
       }
+    },
+    {
+      enabled: Boolean(activeIfo),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
     },
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on replacing the usage of `useSWRImmutable` with `useQuery` in the `useActiveIfoWithBlocks` hook.

### Detailed summary:
- Replaced `useSWRImmutable` with `useQuery`.
- Added options to `useQuery` for enabling/disabling refetch behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->