### PR TITLE
refactor: Use query in list updater

### DIFF
--- a/apps/web/src/state/lists/updater.ts
+++ b/apps/web/src/state/lists/updater.ts
@@ -7,7 +7,6 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
 import { useAllLists } from 'state/lists/hooks'
-import useSWRImmutable from 'swr/immutable'
 import { useQuery } from '@tanstack/react-query'
 import { useActiveListUrls } from './hooks'
 import { useListState, useListStateReady, initialState } from './lists'
@@ -39,14 +38,23 @@ export default function Updater(): null {
   const fetchList = useFetchListCallback(dispatch)
 
   // whenever a list is not loaded and not loading, try again to load it
-  useSWRImmutable(isReady && ['first-fetch-token-list', lists], () => {
-    Object.keys(lists).forEach((listUrl) => {
-      const list = lists[listUrl]
-      if (!list.current && !list.loadingRequestId && !list.error) {
-        fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
-      }
-    })
-  })
+  useQuery(
+    ['first-fetch-token-list', lists],
+    () => {
+      Object.keys(lists).forEach((listUrl) => {
+        const list = lists[listUrl]
+        if (!list.current && !list.loadingRequestId && !list.error) {
+          fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
+        }
+      })
+    },
+    {
+      enabled: Boolean(isReady),
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+    },
+  )
 
   useQuery(
     ['token-list'],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the `useSWRImmutable` hook with the `useQuery` hook in the `Updater` component. 

### Detailed summary
- Replaced `useSWRImmutable` with `useQuery` hook.
- Updated the fetch logic to load lists when they are not loaded and not loading.
- Added options to the `useQuery` hook for enabling/disabling refetching on window focus, reconnect, and mount.
- Added a new `useQuery` hook for fetching the `token-list`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->