### PR TITLE
feat(Position Managers): List AIOZ-WBNB

### DIFF
--- a/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
+++ b/apps/web/src/views/PositionManagers/components/YieldInfo.tsx
@@ -40,7 +40,7 @@ export const YieldInfo = memo(function YieldInfo({
   const { t } = useTranslation()
 
   const earning = useMemo(
-    () => (withCakeReward && apr.isInCakeRewardDateRange ? ['CAKE', t('Fees')].join(' + ') : t('Fees')),
+    () => (withCakeReward && apr.isInCakeRewardDateRange ? t('CAKE + Fees') : t('Fees')),
     [withCakeReward, t, apr.isInCakeRewardDateRange],
   )
 

--- a/packages/position-managers/src/constants/vaults/bsc.ts
+++ b/packages/position-managers/src/constants/vaults/bsc.ts
@@ -5,6 +5,25 @@ import { MANAGER } from '../managers'
 
 export const vaults: VaultConfig[] = [
   {
+    id: 14,
+    idByManager: 8,
+    name: 'BRIL',
+    address: '0xf299115CdA681475DabFF3883939F91F5Cc40352',
+    adapterAddress: '0x38bcc39F1fcb218F17c1C88651891F73681d11C1',
+    currencyA: bscTokens.aioz,
+    currencyB: bscTokens.wbnb,
+    earningToken: bscTokens.cake,
+    feeTier: FeeAmount.MEDIUM,
+    strategy: Strategy.YIELD_IQ,
+    manager: MANAGER.BRIL,
+    isSingleDepositToken: true,
+    allowDepositToken0: true,
+    allowDepositToken1: false,
+    managerInfoUrl: 'https://www.bril.finance/',
+    strategyInfoUrl: 'https://docs.bril.finance/yield-iq/overview',
+    learnMoreAboutUrl: 'https://docs.bril.finance/bril-finance/introduction',
+  },
+  {
     id: 12,
     idByManager: 1,
     name: 'DEFIEDGE',


### PR DESCRIPTION
wrapper: `0xf299115CdA681475DabFF3883939F91F5Cc40352`

adapter: `0x38bcc39F1fcb218F17c1C88651891F73681d11C1`



<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the YieldInfo component in the PositionManagers view and adding a new vault configuration for BRIL in the bsc.ts file.

### Detailed summary
- Updated the earning calculation in YieldInfo.tsx to include 'CAKE + Fees' instead of just 'CAKE' or 'Fees'.
- Added a new vault configuration for BRIL in bsc.ts with specific details such as ID, name, addresses, currencies, earning token, fee tier, strategy, manager, deposit token options, and URLs for manager and strategy information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->