### PR TITLE
perf: Lazy load web3inbox

### DIFF
--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -34,7 +34,7 @@ import AccessRiskTooltips from 'components/AccessRisk/AccessRiskTooltips'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useTheme from 'hooks/useTheme'
 import { useWebNotifications } from 'hooks/useWebNotifications'
-import { ReactNode, useCallback, useState } from 'react'
+import { ReactNode, lazy, useCallback, useState } from 'react'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useSubgraphHealthIndicatorManager, useUserUsernameVisibility } from 'state/user/hooks'
 import { useUserTokenRisk } from 'state/user/hooks/useUserTokenRisk'
@@ -51,6 +51,8 @@ import { styled } from 'styled-components'
 import GasSettings from './GasSettings'
 import TransactionSettings from './TransactionSettings'
 import { SettingsMode } from './types'
+
+const WebNotiToggle = lazy(() => import('./WebNotiToggle'))
 
 const BetaTag = styled.div`
   border: 2px solid ${({ theme }) => theme.colors.success};
@@ -104,7 +106,7 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
   const [audioPlay, setAudioMode] = useAudioPlay()
   const [subgraphHealth, setSubgraphHealth] = useSubgraphHealthIndicatorManager()
   const [userUsernameVisibility, setUserUsernameVisibility] = useUserUsernameVisibility()
-  const { enabled, toggle } = useWebNotifications()
+  const { enabled } = useWebNotifications()
 
   const { onChangeRecipient } = useSwapActionHandlers()
   const { chainId } = useActiveChainId()
@@ -190,8 +192,7 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
                   />
                   <BetaTag>{t('BETA')}</BetaTag>
                 </Flex>
-
-                <Toggle id="toggle-username-visibility" checked={enabled} scale="md" onChange={toggle} />
+                <WebNotiToggle enabled={enabled} />
               </Flex>
               {chainId === ChainId.BSC && (
                 <>
@@ -213,7 +214,7 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
                       />
                     </Flex>
                     <Toggle
-                      id="toggle-username-visibility"
+                      id="toggle-token-risk"
                       checked={tokenRisk}
                       scale="md"
                       onChange={() => {

--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -34,7 +34,7 @@ import AccessRiskTooltips from 'components/AccessRisk/AccessRiskTooltips'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useTheme from 'hooks/useTheme'
 import { useWebNotifications } from 'hooks/useWebNotifications'
-import { ReactNode, lazy, useCallback, useState } from 'react'
+import { ReactNode, lazy, useCallback, useState, Suspense } from 'react'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useSubgraphHealthIndicatorManager, useUserUsernameVisibility } from 'state/user/hooks'
 import { useUserTokenRisk } from 'state/user/hooks/useUserTokenRisk'
@@ -192,7 +192,9 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
                   />
                   <BetaTag>{t('BETA')}</BetaTag>
                 </Flex>
-                <WebNotiToggle enabled={enabled} />
+                <Suspense fallback={null}>
+                  <WebNotiToggle enabled={enabled} />
+                </Suspense>
               </Flex>
               {chainId === ChainId.BSC && (
                 <>

--- a/apps/web/src/components/Menu/GlobalSettings/WebNotiToggle.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/WebNotiToggle.tsx
@@ -1,0 +1,48 @@
+import { Toggle, useToast } from '@pancakeswap/uikit'
+import { useManageSubscription, useW3iAccount } from '@web3inbox/widget-react'
+import { useCallback } from 'react'
+import { useAllowNotifications } from 'state/notifications/hooks'
+import { Events } from 'views/Notifications/constants'
+import { parseErrorMessage } from 'views/Notifications/utils/errorBuilder'
+
+const useWebNotificationsToggle = () => {
+  const { account } = useW3iAccount()
+  const { unsubscribe, isSubscribed } = useManageSubscription(account)
+  const [allowNotifications, setAllowNotifications] = useAllowNotifications()
+  const toast = useToast()
+
+  const handleDiableNotifications = useCallback(async () => {
+    try {
+      if (isSubscribed) await unsubscribe()
+      setAllowNotifications(false)
+      toast.toastSuccess(Events.Unsubscribed.title, Events.Unsubscribed.message?.())
+    } catch (error) {
+      const errMessage = parseErrorMessage(Events.UnsubscribeError, error)
+      toast.toastWarning(Events.UnsubscribeError.title, errMessage)
+    }
+  }, [isSubscribed, setAllowNotifications, toast, unsubscribe])
+
+  const handleEnableNotifications = useCallback(async () => {
+    try {
+      setAllowNotifications(true)
+      toast.toastSuccess(Events.NotificationsEnabled.title, Events.NotificationsEnabled.message?.())
+    } catch (error) {
+      const errMessage = parseErrorMessage(Events.NotificationsEnabledError, error)
+      toast.toastWarning(Events.NotificationsEnabledError.title, errMessage)
+    }
+  }, [setAllowNotifications, toast])
+
+  const toggle = useCallback(
+    () => (allowNotifications ? handleDiableNotifications() : handleEnableNotifications()),
+    [allowNotifications, handleDiableNotifications, handleEnableNotifications],
+  )
+
+  return toggle
+}
+
+function WebNotiToggle({ enabled }) {
+  const toggle = useWebNotificationsToggle()
+  return <Toggle id="toggle-webnoti" checked={enabled} scale="md" onChange={toggle} />
+}
+
+export default WebNotiToggle

--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -12,7 +12,7 @@ import useTheme from 'hooks/useTheme'
 import { IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import { useWebNotifications } from 'hooks/useWebNotifications'
 import { useRouter } from 'next/router'
-import { lazy, useMemo } from 'react'
+import { lazy, useMemo, Suspense } from 'react'
 import GlobalSettings from './GlobalSettings'
 import { SettingsMode } from './GlobalSettings/types'
 import UserMenu from './UserMenu'
@@ -61,7 +61,11 @@ const Menu = (props) => {
         rightSide={
           <>
             <GlobalSettings mode={SettingsMode.GLOBAL} />
-            {enabled && <Notifications />}
+            {enabled && (
+              <Suspense fallback={null}>
+                <Notifications />
+              </Suspense>
+            )}
             <NetworkSwitcher />
             <UserMenu />
           </>

--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -12,13 +12,14 @@ import useTheme from 'hooks/useTheme'
 import { IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
 import { useWebNotifications } from 'hooks/useWebNotifications'
 import { useRouter } from 'next/router'
-import { useMemo } from 'react'
-import Notifications from 'views/Notifications'
+import { lazy, useMemo } from 'react'
 import GlobalSettings from './GlobalSettings'
 import { SettingsMode } from './GlobalSettings/types'
 import UserMenu from './UserMenu'
 import { useMenuItems } from './hooks/useMenuItems'
 import { getActiveMenuItem, getActiveSubMenuItem } from './utils'
+
+const Notifications = lazy(() => import('views/Notifications'))
 
 const LinkComponent = (linkProps) => {
   return <NextLinkFromReactRouter to={linkProps.href} {...linkProps} prefetch={false} />

--- a/apps/web/src/hooks/useWebNotifications.ts
+++ b/apps/web/src/hooks/useWebNotifications.ts
@@ -1,45 +1,11 @@
-import { useToast } from '@pancakeswap/uikit'
-import { useManageSubscription, useW3iAccount } from '@web3inbox/widget-react'
 import { EXPERIMENTAL_FEATURES } from 'config/experimentalFeatures'
 import { useExperimentalFeatureEnabled } from 'hooks/useExperimentalFeatureEnabled'
-import { useCallback } from 'react'
 import { useAllowNotifications } from 'state/notifications/hooks'
-import { Events } from 'views/Notifications/constants'
-import { parseErrorMessage } from 'views/Notifications/utils/errorBuilder'
 
 export const useWebNotifications = () => {
-  const { account } = useW3iAccount()
-  const { unsubscribe, isSubscribed } = useManageSubscription(account)
-  const [allowNotifications, setAllowNotifications] = useAllowNotifications()
-  const featurEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
-  const enabled = Boolean(allowNotifications ?? featurEnabled)
-  const toast = useToast()
+  const [allowNotifications] = useAllowNotifications()
+  const featureEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
+  const enabled = Boolean(allowNotifications ?? featureEnabled)
 
-  const handleDiableNotifications = useCallback(async () => {
-    try {
-      if (isSubscribed) await unsubscribe()
-      setAllowNotifications(false)
-      toast.toastSuccess(Events.Unsubscribed.title, Events.Unsubscribed.message?.())
-    } catch (error) {
-      const errMessage = parseErrorMessage(Events.UnsubscribeError, error)
-      toast.toastWarning(Events.UnsubscribeError.title, errMessage)
-    }
-  }, [isSubscribed, setAllowNotifications, toast, unsubscribe])
-
-  const handleEnableNotifications = useCallback(async () => {
-    try {
-      setAllowNotifications(true)
-      toast.toastSuccess(Events.NotificationsEnabled.title, Events.NotificationsEnabled.message?.())
-    } catch (error) {
-      const errMessage = parseErrorMessage(Events.NotificationsEnabledError, error)
-      toast.toastWarning(Events.NotificationsEnabledError.title, errMessage)
-    }
-  }, [setAllowNotifications, toast])
-
-  const toggle = useCallback(
-    () => (allowNotifications ? handleDiableNotifications() : handleEnableNotifications()),
-    [allowNotifications, handleDiableNotifications, handleEnableNotifications],
-  )
-
-  return { enabled, toggle }
+  return { enabled }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- The PR focuses on adding lazy loading and suspense to the `Notifications` component in the `Menu` component.
- It also adds lazy loading and suspense to the `WebNotiToggle` component in the `GlobalSettings` folder.
- The `useWebNotifications` hook has been updated to only return the `enabled` value.

Note: There are other changes in this diff, but they are not mentioned in the summary as they are negligible.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->