### PR TITLE
feat: List new farms

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 37,
+    lpAddress: '0x714D48cb99b87F274B33A89fBb16EaD191B40b6C',
+    token0: arbitrumTokens.ovn,
+    token1: arbitrumTokens.usdplus,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 36,
     lpAddress: '0xdAA80a051E22A7f7b0cfC33Aa29572fbDE65183E',
     token0: arbitrumTokens.weth,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,20 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 135,
+    lpAddress: '0x93bA6af467c7B46B44D5C0BB300270c732510C9C',
+    token0: bscTokens.manta,
+    token1: bscTokens.wbnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
+    pid: 134,
+    lpAddress: '0xb624FE83Dfc393aAB921EbBc2Bf38Fdd238F2380',
+    token0: bscTokens.ovn,
+    token1: bscTokens.usdt,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 133,
     lpAddress: '0x9dD70024FF211bA754c089CDee47BdeDc17C4CBe',
     token0: bscTokens.usdt,

--- a/packages/farms/constants/eth.ts
+++ b/packages/farms/constants/eth.ts
@@ -48,7 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
     feeAmount: FeeAmount.MEDIUM,
   },
   // Keep those farms on top
-
+  {
+    pid: 55,
+    lpAddress: '0x3733493eC5D2C181Dcd7C54ed100641c0f07BB0e',
+    token0: ethereumTokens.pxETH,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.LOWEST,
+  },
   {
     pid: 54,
     lpAddress: '0xBc1a2e1B745497D214B99F359369d304D0aCf935',

--- a/packages/farms/constants/polygonZkEVM.ts
+++ b/packages/farms/constants/polygonZkEVM.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 7,
+    lpAddress: '0x849c0ae884bFDc14DDdeB7Cae95494f368414855',
+    token0: polygonZkEvmTokens.usdce,
+    token1: polygonZkEvmTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 1,
     lpAddress: '0xD43b9dCbB61e6ccFbCFef9f21e1BB5064F1CB33f',
     token0: polygonZkEvmTokens.weth,

--- a/packages/farms/constants/zkSync.ts
+++ b/packages/farms/constants/zkSync.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 14,
+    lpAddress: '0x16B3Bbd346eB864eD28B99cf89dDe59aD31A034F',
+    token0: zksyncTokens.usdc,
+    token1: zksyncTokens.wstETH,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 13,
     lpAddress: '0x5631fE6d29E3CB717517DA05A9970e499DEF5e31',
     token0: zksyncTokens.weth,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding new farms to different networks. 

### Detailed summary
- Added a new farm with pid 55 on Ethereum network with lpAddress '0x3733493eC5D2C181Dcd7C54ed100641c0f07BB0e' and tokens pxETH and WETH.
- Added a new farm with pid 14 on zkSync network with lpAddress '0x16B3Bbd346eB864eD28B99cf89dDe59aD31A034F' and tokens USDC and wstETH.
- Added a new farm with pid 37 on Arbitrum network with lpAddress '0x714D48cb99b87F274B33A89fBb16EaD191B40b6C' and tokens OVN and USDplus.
- Added a new farm with pid 7 on PolygonZkEVM network with lpAddress '0x849c0ae884bFDc14DDdeB7Cae95494f368414855' and tokens USDCe and USDC.
- Added two new farms with pids 135 and 134 on BSC network with lpAddresses '0x93bA6af467c7B46B44D5C0BB300270c732510C9C' and '0xb624FE83Dfc393aAB921EbBc2Bf38Fdd238F2380' respectively, and tokens MANTA and wBNB, and OVN and USDT respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->