### PR TITLE
fix: Multiple worker script requests

### DIFF
--- a/apps/web/src/quote-worker.ts
+++ b/apps/web/src/quote-worker.ts
@@ -67,7 +67,7 @@ export type WorkerEvent = WorkerGetBestTradeEvent | WorkerMultiChunkEvent
 
 // Assume the worker is single threaded
 // If there're multiple get best trade requests, should create multiple worker instances
-let getBestTradeAbortController: AbortController | undefined
+// let getBestTradeAbortController: AbortController | undefined
 
 // eslint-disable-next-line no-restricted-globals
 addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
@@ -106,8 +106,8 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       ])
       return
     }
-    getBestTradeAbortController?.abort()
-    getBestTradeAbortController = new AbortController()
+    // getBestTradeAbortController?.abort()
+    // getBestTradeAbortController = new AbortController()
 
     const {
       amount,
@@ -124,7 +124,8 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       nativeCurrencyUsdPrice,
       quoteCurrencyUsdPrice,
     } = parsed.data
-    const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
+    // const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
+    const onChainProvider = createViemPublicClientGetter()
     const onChainQuoteProvider = SmartRouter.createQuoteProvider({ onChainProvider, gasLimit })
     const currencyAAmount = parseCurrencyAmount(chainId, amount)
     const currencyB = parseCurrency(chainId, currency)
@@ -146,7 +147,7 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       quoterOptimization: false,
       quoteCurrencyUsdPrice,
       nativeCurrencyUsdPrice,
-      signal: getBestTradeAbortController.signal,
+      // signal: getBestTradeAbortController.signal,
     })
       .then((res) => {
         postMessage([

--- a/apps/web/src/state/multicall/updater.tsx
+++ b/apps/web/src/state/multicall/updater.tsx
@@ -4,7 +4,7 @@ import { useAtom } from 'jotai'
 import { useEffect, useMemo, useRef } from 'react'
 import { useCurrentBlock } from 'state/block/hooks'
 import { multicallReducerAtom, MulticallState } from 'state/multicall/reducer'
-import { createWorker } from 'utils/worker'
+import { worker2 } from 'utils/worker'
 import { useMulticallContract } from '../../hooks/useContract'
 import {
   Call,
@@ -19,7 +19,7 @@ import { CancelledError, retry } from './retry'
 // chunk calls so we do not exceed the gas limit
 const CALL_CHUNK_SIZE = 500
 
-const worker = createWorker()
+const worker = worker2
 
 /**
  * From the current all listeners state, return each call key mapped to the

--- a/apps/web/src/utils/worker.ts
+++ b/apps/web/src/utils/worker.ts
@@ -51,6 +51,10 @@ class WorkerProxy {
   }
 }
 
+export const worker = createWorker()
+
+export const worker2 = createWorker()
+
 export function createWorker() {
   return typeof window !== 'undefined' && typeof Worker !== 'undefined'
     ? new WorkerProxy(new Worker(/* webpackChunkName: "quote-worker" */ new URL('../quote-worker.ts', import.meta.url)))


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR adds two new exports `worker` and `worker2` in the `worker.ts` file.
- The `createWorker` function in `worker.ts` now returns a new instance of `WorkerProxy` using the `quote-worker.ts` file.
- The import of `createWorker` in `updater.tsx` is replaced with the import of `worker2`.
- Several changes are made in the `quote-worker.ts` file, including commenting out the `getBestTradeAbortController` variable and related code, and commenting out the `onChainProvider` variable and related code.
- The imports of `createWorker`, `worker`, and `worker2` in `useBestAMMTrade.ts` are updated.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->