### PR TITLE
refactor: Use query in transaction updater

### DIFF
--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -202,7 +202,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
       })
     },
     {
-      enabled: Boolean(chainId && Boolean(nonBscFarmPendingTxns?.length)),
+      enabled: Boolean(chainId && nonBscFarmPendingTxns?.length),
       refetchInterval: FAST_INTERVAL,
       retryDelay: FAST_INTERVAL,
       onError: (error) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the `useSWRImmutable` hook with the `useQuery` hook from `@tanstack/react-query` in the `Updater` component. 

### Detailed summary
- Replaced `useSWRImmutable` with `useQuery` from `@tanstack/react-query`
- Updated the hook parameters and options for `useQuery`
- Set `enabled` to `Boolean(chainId && nonBscFarmPendingTxns?.length)`
- Set `refetchInterval` and `retryDelay` to `FAST_INTERVAL`
- Set `refetchOnWindowFocus`, `refetchOnReconnect`, and `refetchOnMount` to `false`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->