### PR TITLE
perf: Only request for worker script once

### DIFF
--- a/apps/web/src/hooks/useWorker.ts
+++ b/apps/web/src/hooks/useWorker.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { WorkerInstance, createWorker } from 'utils/worker'
+
+export function useWorker(dedicatedWorker?: WorkerInstance) {
+  const workerRef = useRef<WorkerInstance | undefined>(dedicatedWorker)
+  const [worker, setWorker] = useState<WorkerInstance | undefined>(workerRef.current)
+
+  useEffect(() => {
+    if (workerRef.current) {
+      return () => {}
+    }
+
+    const abortController = new AbortController()
+    async function initWorkerInstance() {
+      workerRef.current = await createWorker()
+      if (abortController.signal.aborted) {
+        workerRef.current?.destroy()
+        return
+      }
+      setWorker(workerRef.current)
+    }
+    initWorkerInstance()
+
+    return () => {
+      abortController.abort()
+      workerRef.current?.destroy()
+    }
+  }, [])
+
+  return worker
+}

--- a/apps/web/src/quote-worker.ts
+++ b/apps/web/src/quote-worker.ts
@@ -67,7 +67,7 @@ export type WorkerEvent = WorkerGetBestTradeEvent | WorkerMultiChunkEvent
 
 // Assume the worker is single threaded
 // If there're multiple get best trade requests, should create multiple worker instances
-// let getBestTradeAbortController: AbortController | undefined
+let getBestTradeAbortController: AbortController | undefined
 
 // eslint-disable-next-line no-restricted-globals
 addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
@@ -106,8 +106,8 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       ])
       return
     }
-    // getBestTradeAbortController?.abort()
-    // getBestTradeAbortController = new AbortController()
+    getBestTradeAbortController?.abort()
+    getBestTradeAbortController = new AbortController()
 
     const {
       amount,
@@ -124,8 +124,7 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       nativeCurrencyUsdPrice,
       quoteCurrencyUsdPrice,
     } = parsed.data
-    // const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
-    const onChainProvider = createViemPublicClientGetter()
+    const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
     const onChainQuoteProvider = SmartRouter.createQuoteProvider({ onChainProvider, gasLimit })
     const currencyAAmount = parseCurrencyAmount(chainId, amount)
     const currencyB = parseCurrency(chainId, currency)
@@ -147,7 +146,7 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       quoterOptimization: false,
       quoteCurrencyUsdPrice,
       nativeCurrencyUsdPrice,
-      // signal: getBestTradeAbortController.signal,
+      signal: getBestTradeAbortController.signal,
     })
       .then((res) => {
         postMessage([

--- a/apps/web/src/state/lists/updater.ts
+++ b/apps/web/src/state/lists/updater.ts
@@ -47,6 +47,7 @@ export default function Updater(): null {
           fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
         }
       })
+      return null
     },
     {
       enabled: Boolean(isReady),

--- a/apps/web/src/state/multicall/updater.tsx
+++ b/apps/web/src/state/multicall/updater.tsx
@@ -4,7 +4,8 @@ import { useAtom } from 'jotai'
 import { useEffect, useMemo, useRef } from 'react'
 import { useCurrentBlock } from 'state/block/hooks'
 import { multicallReducerAtom, MulticallState } from 'state/multicall/reducer'
-import { worker2 } from 'utils/worker'
+import { useWorker } from 'hooks/useWorker'
+
 import { useMulticallContract } from '../../hooks/useContract'
 import {
   Call,
@@ -18,8 +19,6 @@ import { CancelledError, retry } from './retry'
 
 // chunk calls so we do not exceed the gas limit
 const CALL_CHUNK_SIZE = 500
-
-const worker = worker2
 
 /**
  * From the current all listeners state, return each call key mapped to the
@@ -93,6 +92,7 @@ export default function Updater(): null {
   const { chainId } = useActiveChainId()
   const multicallContract = useMulticallContract()
   const cancellations = useRef<{ blockNumber: number; cancellations: (() => void)[] }>()
+  const worker = useWorker()
 
   const listeningKeys: { [callKey: string]: number } = useMemo(() => {
     return activeListeningKeys(debouncedListeners, chainId)
@@ -207,7 +207,7 @@ export default function Updater(): null {
         return cancel
       }),
     }
-  }, [chainId, multicallContract, dispatch, serializedOutdatedCallKeys, currentBlock])
+  }, [worker, chainId, multicallContract, dispatch, serializedOutdatedCallKeys, currentBlock])
 
   return null
 }

--- a/apps/web/src/utils/workerScriptLoader.ts
+++ b/apps/web/src/utils/workerScriptLoader.ts
@@ -1,0 +1,17 @@
+import { WorkerUrlExtractor as Worker } from './workerUrlExtractor'
+
+// Using alias to allow worker url to be statically analyzable by webpack
+// @see https://github.com/webpack/webpack/discussions/14648#discussioncomment-1589272
+export function createWorkerScriptLoader() {
+  const worker = new Worker(/* webpackChunkName: "quote-worker" */ new URL('../quote-worker.ts', import.meta.url))
+  let loadScriptPromise: Promise<string> | undefined
+
+  return async function loadWorkerScript() {
+    if (!loadScriptPromise) {
+      loadScriptPromise = fetch(worker.url, { cache: 'force-cache' })
+        .then((r) => r.blob())
+        .then((b) => URL.createObjectURL(b))
+    }
+    return loadScriptPromise
+  }
+}

--- a/apps/web/src/utils/workerScriptLoader.ts
+++ b/apps/web/src/utils/workerScriptLoader.ts
@@ -16,8 +16,7 @@ export function createWorkerScriptLoader() {
             const originalImportScripts = self.importScripts;
             self.importScripts = (url) => originalImportScripts.call(self, new URL(url, "${base}").toString());
           `
-          const blob = new Blob([addtionalWorkerSource], { type: 'application/javascript' })
-          return new Blob([blob, b], { type: 'application/javascript' })
+          return new Blob([addtionalWorkerSource, b], { type: 'application/javascript' })
         })
         .then((b) => URL.createObjectURL(b))
     }

--- a/apps/web/src/utils/workerScriptLoader.ts
+++ b/apps/web/src/utils/workerScriptLoader.ts
@@ -10,6 +10,15 @@ export function createWorkerScriptLoader() {
     if (!loadScriptPromise) {
       loadScriptPromise = fetch(worker.url, { cache: 'force-cache' })
         .then((r) => r.blob())
+        .then((b) => {
+          const base = typeof window !== 'undefined' ? window.location.href : undefined
+          const addtionalWorkerSource = `
+            const originalImportScripts = self.importScripts;
+            self.importScripts = (url) => originalImportScripts.call(self, new URL(url, "${base}").toString());
+          `
+          const blob = new Blob([addtionalWorkerSource], { type: 'application/javascript' })
+          return new Blob([blob, b], { type: 'application/javascript' })
+        })
         .then((b) => URL.createObjectURL(b))
     }
     return loadScriptPromise

--- a/apps/web/src/utils/workerUrlExtractor.ts
+++ b/apps/web/src/utils/workerUrlExtractor.ts
@@ -1,0 +1,7 @@
+export class WorkerUrlExtractor {
+  public url: string | URL
+
+  constructor(url: string | URL) {
+    this.url = url
+  }
+}


### PR DESCRIPTION
Reverts pancakeswap/pancake-frontend#8909

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `WorkerUrlExtractor` class in `apps/web/src/utils/workerUrlExtractor.ts`
- Added `useWorker` hook in `apps/web/src/hooks/useWorker.ts`
- Added `createWorkerScriptLoader` function in `apps/web/src/utils/workerScriptLoader.ts`
- Updated `apps/web/src/state/multicall/updater.tsx` to use `useWorker` hook
- Updated `apps/web/src/utils/worker.ts` to use `createWorkerScriptLoader` function
- Updated `apps/web/src/quote-worker.ts` to use `getBestTradeAbortController` variable
- Updated `apps/web/src/hooks/useBestAMMTrade.ts` to use `useWorker` hook for worker initialization

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->