### PR TITLE
perf: Support abort on worker function calls

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -19,8 +19,8 @@ import { useCurrentBlock } from 'state/block/hooks'
 import { useFeeDataWithGasPrice } from 'state/user/hooks'
 import { createViemPublicClientGetter } from 'utils/viem'
 import { publicClient } from 'utils/wagmi'
-
 import { tracker } from 'utils/datadog'
+
 import {
   CommonPoolsParams,
   PoolsWithState,
@@ -29,7 +29,7 @@ import {
 } from './useCommonPools'
 import { useCurrencyUsdPrice } from './useCurrencyUsdPrice'
 import { useMulticallGasLimit } from './useMulticallGasLimit'
-import { useWorker } from './useWorker'
+import { useGlobalWorker } from './useWorker'
 
 SmartRouter.logger.enable('error,log')
 
@@ -349,7 +349,7 @@ export const useBestAMMTradeFromQuoterApi = bestTradeHookFactory({
 
 function createUseWorkerGetBestTrade() {
   return function useWorkerGetBestTrade(): typeof SmartRouter.getBestTrade {
-    const worker = useWorker()
+    const worker = useGlobalWorker()
 
     return useCallback(
       async (
@@ -365,6 +365,7 @@ function createUseWorkerGetBestTrade() {
           quoteProvider,
           nativeCurrencyUsdPrice,
           quoteCurrencyUsdPrice,
+          signal,
         },
       ) => {
         if (!worker) {
@@ -393,6 +394,7 @@ function createUseWorkerGetBestTrade() {
           onChainQuoterGasLimit: quoterConfig?.gasLimit?.toString(),
           quoteCurrencyUsdPrice,
           nativeCurrencyUsdPrice,
+          signal,
         })
         return SmartRouter.Transformer.parseTrade(currency.chainId, result as any)
       },

--- a/apps/web/src/hooks/useWorker.ts
+++ b/apps/web/src/hooks/useWorker.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { WorkerInstance, createWorker } from 'utils/worker'
+
+export function useWorker(dedicatedWorker?: WorkerInstance) {
+  const workerRef = useRef<WorkerInstance | undefined>(dedicatedWorker)
+  const [worker, setWorker] = useState<WorkerInstance | undefined>(workerRef.current)
+
+  useEffect(() => {
+    if (workerRef.current) {
+      return () => {}
+    }
+
+    const abortController = new AbortController()
+    async function initWorkerInstance() {
+      workerRef.current = await createWorker()
+      if (abortController.signal.aborted) {
+        workerRef.current?.destroy()
+        return
+      }
+      setWorker(workerRef.current)
+    }
+    initWorkerInstance()
+
+    return () => {
+      abortController.abort()
+      workerRef.current?.destroy()
+    }
+  }, [])
+
+  return worker
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -23,6 +23,7 @@ import { SentryErrorBoundary } from 'components/ErrorBoundary'
 import { PersistGate } from 'redux-persist/integration/react'
 
 import { useDataDogRUM } from 'hooks/useDataDogRUM'
+import { useInitGlobalWorker } from 'hooks/useWorker'
 import { useLoadExperimentalFeatures } from 'hooks/useExperimentalFeatureEnabled'
 import { persistor, useStore } from 'state'
 import { usePollBlockNumber } from 'state/block/hooks'
@@ -41,6 +42,7 @@ BigNumber.config({
 })
 
 function GlobalHooks() {
+  useInitGlobalWorker()
   useDataDogRUM()
   useLoadExperimentalFeatures()
   usePollBlockNumber()

--- a/apps/web/src/quote-worker.ts
+++ b/apps/web/src/quote-worker.ts
@@ -67,7 +67,7 @@ export type WorkerEvent = WorkerGetBestTradeEvent | WorkerMultiChunkEvent
 
 // Assume the worker is single threaded
 // If there're multiple get best trade requests, should create multiple worker instances
-// let getBestTradeAbortController: AbortController | undefined
+let getBestTradeAbortController: AbortController | undefined
 
 // eslint-disable-next-line no-restricted-globals
 addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
@@ -106,8 +106,8 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       ])
       return
     }
-    // getBestTradeAbortController?.abort()
-    // getBestTradeAbortController = new AbortController()
+    getBestTradeAbortController?.abort()
+    getBestTradeAbortController = new AbortController()
 
     const {
       amount,
@@ -124,8 +124,7 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       nativeCurrencyUsdPrice,
       quoteCurrencyUsdPrice,
     } = parsed.data
-    // const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
-    const onChainProvider = createViemPublicClientGetter()
+    const onChainProvider = createViemPublicClientGetter({ transportSignal: getBestTradeAbortController.signal })
     const onChainQuoteProvider = SmartRouter.createQuoteProvider({ onChainProvider, gasLimit })
     const currencyAAmount = parseCurrencyAmount(chainId, amount)
     const currencyB = parseCurrency(chainId, currency)
@@ -147,7 +146,7 @@ addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
       quoterOptimization: false,
       quoteCurrencyUsdPrice,
       nativeCurrencyUsdPrice,
-      // signal: getBestTradeAbortController.signal,
+      signal: getBestTradeAbortController.signal,
     })
       .then((res) => {
         postMessage([

--- a/apps/web/src/state/lists/updater.ts
+++ b/apps/web/src/state/lists/updater.ts
@@ -47,6 +47,7 @@ export default function Updater(): null {
           fetchList(listUrl).catch((error) => console.debug('list added fetching error', error))
         }
       })
+      return null
     },
     {
       enabled: Boolean(isReady),

--- a/apps/web/src/state/multicall/updater.tsx
+++ b/apps/web/src/state/multicall/updater.tsx
@@ -4,7 +4,8 @@ import { useAtom } from 'jotai'
 import { useEffect, useMemo, useRef } from 'react'
 import { useCurrentBlock } from 'state/block/hooks'
 import { multicallReducerAtom, MulticallState } from 'state/multicall/reducer'
-import { worker2 } from 'utils/worker'
+import { useWorker } from 'hooks/useWorker'
+
 import { useMulticallContract } from '../../hooks/useContract'
 import {
   Call,
@@ -18,8 +19,6 @@ import { CancelledError, retry } from './retry'
 
 // chunk calls so we do not exceed the gas limit
 const CALL_CHUNK_SIZE = 500
-
-const worker = worker2
 
 /**
  * From the current all listeners state, return each call key mapped to the
@@ -93,6 +92,7 @@ export default function Updater(): null {
   const { chainId } = useActiveChainId()
   const multicallContract = useMulticallContract()
   const cancellations = useRef<{ blockNumber: number; cancellations: (() => void)[] }>()
+  const worker = useWorker()
 
   const listeningKeys: { [callKey: string]: number } = useMemo(() => {
     return activeListeningKeys(debouncedListeners, chainId)
@@ -207,7 +207,7 @@ export default function Updater(): null {
         return cancel
       }),
     }
-  }, [chainId, multicallContract, dispatch, serializedOutdatedCallKeys, currentBlock])
+  }, [worker, chainId, multicallContract, dispatch, serializedOutdatedCallKeys, currentBlock])
 
   return null
 }

--- a/apps/web/src/utils/worker.ts
+++ b/apps/web/src/utils/worker.ts
@@ -9,16 +9,20 @@ class WorkerProxy {
   // eslint-disable-next-line no-useless-constructor
   constructor(protected worker: Worker) {}
 
-  public postMessage = async <T>(message: any) => {
+  public postMessage = async <T>(message: any, eventId?: number) => {
     if (!this.worker) {
       throw new Error('Worker not initialized')
     }
 
-    const id = this.id++
+    const id = eventId ?? this.nextId
+    if (id <= this.id) {
+      throw new Error(`Failed to post Message. Duplicate message id: ${id}`)
+    }
+    this.id = id
     const promise = new Promise<T>((resolve, reject) => {
       const handler = (e: any) => {
-        const [eventId, data] = e.data
-        if (id === eventId) {
+        const [eId, data] = e.data
+        if (id === eId) {
           this.worker.removeEventListener('message', handler)
           if (data.success === false) {
             reject(data.error)
@@ -41,15 +45,39 @@ class WorkerProxy {
     })
   }
 
-  public getBestTrade = async (params: WorkerGetBestTradeEvent[1]['params']) => {
-    return this.postMessage({
-      cmd: 'getBestTrade',
-      params,
+  public getBestTrade = async (
+    params: WorkerGetBestTradeEvent[1]['params'] & {
+      signal?: AbortSignal
+    },
+  ) => {
+    const { signal, ...restParams } = params
+    const eventId = this.nextId
+    signal?.addEventListener('abort', async () => {
+      try {
+        await this.postMessage({
+          cmd: 'abort',
+          params: eventId,
+        })
+      } catch (e) {
+        console.error('[Worker GetBestTrade]: Abort Error:', e)
+      }
     })
+
+    return this.postMessage(
+      {
+        cmd: 'getBestTrade',
+        params: restParams,
+      },
+      eventId,
+    )
   }
 
   public destroy = async () => {
     return this.worker.terminate()
+  }
+
+  private get nextId() {
+    return this.id + 1
   }
 }
 

--- a/apps/web/src/utils/workerScriptLoader.ts
+++ b/apps/web/src/utils/workerScriptLoader.ts
@@ -1,0 +1,25 @@
+import { WorkerUrlExtractor as Worker } from './workerUrlExtractor'
+
+// Using alias to allow worker url to be statically analyzable by webpack
+// @see https://github.com/webpack/webpack/discussions/14648#discussioncomment-1589272
+export function createWorkerScriptLoader() {
+  const worker = new Worker(/* webpackChunkName: "quote-worker" */ new URL('../quote-worker.ts', import.meta.url))
+  let loadScriptPromise: Promise<string> | undefined
+
+  return async function loadWorkerScript() {
+    if (!loadScriptPromise) {
+      loadScriptPromise = fetch(worker.url, { cache: 'force-cache' })
+        .then((r) => r.blob())
+        .then((b) => {
+          const base = typeof window !== 'undefined' ? window.location.href : undefined
+          const addtionalWorkerSource = `
+            const originalImportScripts = self.importScripts;
+            self.importScripts = (url) => originalImportScripts.call(self, new URL(url, "${base}").toString());
+          `
+          return new Blob([addtionalWorkerSource, b], { type: 'application/javascript' })
+        })
+        .then((b) => URL.createObjectURL(b))
+    }
+    return loadScriptPromise
+  }
+}

--- a/apps/web/src/utils/workerUrlExtractor.ts
+++ b/apps/web/src/utils/workerUrlExtractor.ts
@@ -1,0 +1,7 @@
+export class WorkerUrlExtractor {
+  public url: string | URL
+
+  constructor(url: string | URL) {
+    this.url = url
+  }
+}


### PR DESCRIPTION
Reverts pancakeswap/pancake-frontend#8912

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `WorkerUrlExtractor` class to extract worker URL.
- Added `useInitGlobalWorker` and `useGlobalWorker` hooks to manage a global worker instance.
- Modified `useWorker` hook to use the global worker instance.
- Updated `Updater` component to use the global worker instance.
- Updated `worker.ts` to create and manage worker instances.
- Updated `useBestAMMTrade.ts` to use the global worker instance.

> The following files were skipped due to too many changes: `apps/web/src/hooks/useBestAMMTrade.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->