### PR TITLE
fix: Locked end notification not refresh when account changes

### DIFF
--- a/apps/web/src/hooks/useLockedEndNotification.tsx
+++ b/apps/web/src/hooks/useLockedEndNotification.tsx
@@ -2,12 +2,12 @@ import { useToast, Text, StyledLink } from '@pancakeswap/uikit'
 import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 
 import { useEffect } from 'react'
-import { useSWRConfig } from 'swr'
 import { useTranslation } from '@pancakeswap/localization'
 import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import { useAtom } from 'jotai'
 import { useAccount } from 'wagmi'
 import atomWithStorageWithErrorCatch from 'utils/atomWithStorageWithErrorCatch'
+import { useQueryClient } from '@tanstack/react-query'
 import { useUserCakeLockStatus } from './useUserCakeLockStatus'
 
 const lockedNotificationShowAtom = atomWithStorageWithErrorCatch('lockedNotificationShow', true, () => sessionStorage)
@@ -30,7 +30,7 @@ const LockedEndDescription: React.FC = () => {
 const useLockedEndNotification = () => {
   const { t } = useTranslation()
   const { toastInfo } = useToast()
-  const { mutate } = useSWRConfig()
+  const queryClient = useQueryClient()
   const { address: account } = useAccount()
   const isUserLockedEnd = useUserCakeLockStatus()
   const [lockedNotificationShow, setLockedNotificationShow] = useLockedNotificationShow()
@@ -39,12 +39,12 @@ const useLockedEndNotification = () => {
     if (account) {
       if (!isUndefinedOrNull(isUserLockedEnd)) {
         setLockedNotificationShow(true)
-        mutate(['userCakeLockStatus', account])
+        queryClient.invalidateQueries(['userCakeLockStatus', account])
       }
     } else {
       setLockedNotificationShow(true)
     }
-  }, [setLockedNotificationShow, account, mutate, isUserLockedEnd])
+  }, [setLockedNotificationShow, account, queryClient, isUserLockedEnd])
 
   useEffect(() => {
     if (toastInfo && isUserLockedEnd && lockedNotificationShow) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useLockedEndNotification` hook in the `useSWRConfig` import to `useQueryClient` from `@tanstack/react-query`. 

### Detailed summary
- Replaced `useSWRConfig` import with `useQueryClient` import from `@tanstack/react-query`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->