### PR TITLE
perf: Remove pottery status fetch for menu

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItemsStatus.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItemsStatus.ts
@@ -1,8 +1,6 @@
 import { useUserCakeLockStatus } from 'hooks/useUserCakeLockStatus'
 import { useMemo } from 'react'
-import { PotteryDepositStatus } from 'state/types'
 import { useCompetitionStatus } from './useCompetitionStatus'
-import { usePotteryStatus } from './usePotteryStatus'
 import { useVotingStatus } from './useVotingStatus'
 import { useTradingRewardStatus } from './useTradingRewardStatus'
 import { useIfoStatus } from './useIfoStatus'
@@ -10,7 +8,6 @@ import { useIfoStatus } from './useIfoStatus'
 export const useMenuItemsStatus = (): Record<string, string> => {
   const ifoStatus = useIfoStatus()
   const competitionStatus = useCompetitionStatus()
-  const potteryStatus = usePotteryStatus()
   const votingStatus = useVotingStatus()
   const isUserLocked = useUserCakeLockStatus()
   const tradingRewardStatus = useTradingRewardStatus()
@@ -19,9 +16,6 @@ export const useMenuItemsStatus = (): Record<string, string> => {
     return {
       '/competition': competitionStatus || '',
       '/ifo': ifoStatus || '',
-      ...(potteryStatus === PotteryDepositStatus.BEFORE_LOCK && {
-        '/pottery': 'pot_open',
-      }),
       ...(votingStatus && {
         '/voting': votingStatus,
       }),
@@ -32,5 +26,5 @@ export const useMenuItemsStatus = (): Record<string, string> => {
         '/trading-reward': tradingRewardStatus,
       }),
     }
-  }, [competitionStatus, ifoStatus, potteryStatus, votingStatus, isUserLocked, tradingRewardStatus])
+  }, [competitionStatus, ifoStatus, votingStatus, isUserLocked, tradingRewardStatus])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Removed import of `PotteryDepositStatus` from `state/types`
- Removed import of `usePotteryStatus` from `./usePotteryStatus`
- Removed `potteryStatus` variable and its usage in the return object of `useMenuItemsStatus` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->