### PR TITLE
feat: List Arb farm

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 38,
+    lpAddress: '0x753bA05488Cac9B3f7D59Ff7D3f13F31bB5eDf22',
+    token0: arbitrumTokens.weth,
+    token1: arbitrumTokens.wbnb,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 37,
     lpAddress: '0x714D48cb99b87F274B33A89fBb16EaD191B40b6C',
     token0: arbitrumTokens.ovn,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2565,4 +2565,15 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: polygonZkEvmTokens.usdc.address,
     feeTier: FeeAmount.LOWEST,
   },
+
+  {
+    gid: 260,
+    pairName: 'ETH-BNB',
+    address: '0x753bA05488Cac9B3f7D59Ff7D3f13F31bB5eDf22',
+    chainId: ChainId.ARBITRUM_ONE,
+    type: GaugeType.V3,
+    token0Address: arbitrumTokens.weth.address,
+    token1Address: arbitrumTokens.wbnb.address,
+    feeTier: FeeAmount.MEDIUM,
+  },
 ]

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2568,7 +2568,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
 
   {
     gid: 260,
-    pairName: 'ETH-BNB',
+    pairName: 'WETH-WBNB',
     address: '0x753bA05488Cac9B3f7D59Ff7D3f13F31bB5eDf22',
     chainId: ChainId.ARBITRUM_ONE,
     type: GaugeType.V3,

--- a/packages/tokens/src/arb.ts
+++ b/packages/tokens/src/arb.ts
@@ -207,7 +207,14 @@ export const arbitrumTokens = {
     'USD Coin (Arb1)',
     'https://www.centre.io/',
   ),
-  usdtplus: new ERC20Token(ChainId.ARBITRUM_ONE, '0xb1084db8D3C05CEbd5FA9335dF95EE4b8a0edc30', 6, 'USDT+', 'USDT+'),
+  usdtplus: new ERC20Token(
+    ChainId.ARBITRUM_ONE,
+    '0xb1084db8D3C05CEbd5FA9335dF95EE4b8a0edc30',
+    6,
+    'USDT+',
+    'USDT+',
+    'https://overnight.fi/',
+  ),
   ethplus: new ERC20Token(
     ChainId.ARBITRUM_ONE,
     '0xD4939D69B31fbE981ed6904A3aF43Ee1dc777Aab',
@@ -223,5 +230,13 @@ export const arbitrumTokens = {
     'OVN',
     'OVN',
     'https://overnight.fi/',
+  ),
+  wbnb: new ERC20Token(
+    ChainId.ARBITRUM_ONE,
+    '0xa9004A5421372E1D83fB1f85b0fc986c912f91f3',
+    18,
+    'WBNB',
+    'Wrapped BNB',
+    'https://www.bnbchain.org/en',
   ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding new farm and gauge configurations for the Arbitrum network.

### Detailed summary:
- Added a new farm configuration for pid 38 with lpAddress '0x753bA05488Cac9B3f7D59Ff7D3f13F31bB5eDf22' and feeAmount MEDIUM.
- Added a new farm configuration for pid 37 with lpAddress '0x714D48cb99b87F274B33A89fBb16EaD191B40b6C' and feeTier LOWEST.
- Added a new gauge configuration for gid 260 with pairName 'WETH-WBNB', address '0x753bA05488Cac9B3f7D59Ff7D3f13F31bB5eDf22', chainId ARBITRUM_ONE, type V3, token0Address 'arbitrumTokens.weth.address', token1Address 'arbitrumTokens.wbnb.address', and feeTier MEDIUM.
- Updated the `usdtplus` ERC20 token with a new website URL 'https://overnight.fi/'.
- Added a new ERC20 token `wbnb` with address '0xa9004A5421372E1D83fB1f85b0fc986c912f91f3', decimals 18, symbol 'WBNB', name 'Wrapped BNB', and website URL 'https://www.bnbchain.org/en'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->