### PR TITLE
feat: list new gauges

### DIFF
--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2576,4 +2576,31 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: arbitrumTokens.wbnb.address,
     feeTier: FeeAmount.MEDIUM,
   },
+
+  {
+    gid: 261,
+    pairName: 'mPENDLE-PENDLE',
+    address: '0x183F325b33d190597D80d1B46D865d0250fD9BF2',
+    chainId: ChainId.BSC,
+    type: GaugeType.StableSwap,
+    tokenAddresses: [bscTokens.mpendle.address, bscTokens.pendle.address],
+  },
+  {
+    gid: 262,
+    pairName: 'mDLP-DLP',
+    address: '0xA2915ae3bc8C6C03f59496B6Dd26aa6a4335b788',
+    chainId: ChainId.BSC,
+    type: GaugeType.StableSwap,
+    tokenAddresses: [bscTokens.mdlp.address, bscTokens.dlp.address],
+  },
+  {
+    gid: 263,
+    pairName: 'rBNB-BNB',
+    address: '0x5b46fC8392cDEd6A91A79d85eFabFD51C7956cA0',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.rbnb.address,
+    token1Address: bscTokens.wbnb.address,
+    feeTier: FeeAmount.LOWEST,
+  },
 ]

--- a/packages/tokens/src/bsc.ts
+++ b/packages/tokens/src/bsc.ts
@@ -2964,4 +2964,12 @@ export const bscTokens = {
     'Magpie locked DLP',
     'https://www.radiant.magpiexyz.io/stake',
   ),
+  rbnb: new ERC20Token(
+    ChainId.BSC,
+    '0xF027E525D491ef6ffCC478555FBb3CFabB3406a6',
+    18,
+    'rBNB',
+    'StaFi rBNB',
+    'https://www.stafi.io/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding new ERC20 tokens and gauge configurations for the Binance Smart Chain (BSC) network.

### Detailed summary:
- Added a new ERC20 token `rBNB` with its contract address, decimals, symbol, name, and website link.
- Added new gauge configurations for different token pairs on the BSC network, including `mPENDLE-PENDLE`, `mDLP-DLP`, and `rBNB-BNB`.
- Each gauge configuration includes a unique ID (`gid`), pair name, contract address, chain ID, gauge type, and token addresses.
- The `rBNB-BNB` gauge also includes the addresses of the two tokens involved, as well as the fee tier.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->