### PR TITLE
fix(simple-staking): Display decimal balance

### DIFF
--- a/apps/web/src/views/FixedStaking/components/AmountWithUSDSub.tsx
+++ b/apps/web/src/views/FixedStaking/components/AmountWithUSDSub.tsx
@@ -23,12 +23,7 @@ export function AmountWithUSDSub({
     undefined,
     <>
       <Text fontSize={fontSize} bold mb={mb}>
-        <Balance
-          fontSize="16px"
-          value={toNumber(amount.toSignificant(6))}
-          decimals={0}
-          unit={` ${amount.currency.wrapped.symbol}`}
-        />
+        {amount.toSignificant(6)} {amount.currency.symbol}
       </Text>
       <Balance
         unit=" USD"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on simplifying the display of the staked amount with USD in the FixedStaking component.

### Detailed summary:
- Replaced the Balance component with a simple text display.
- Removed unnecessary props from the Balance component.
- Displayed the staked amount and currency symbol directly.
- Added the USD unit to the Balance component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->