### PR TITLE
chore: adjust web3 noti feature flag to 50%

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -19,7 +19,7 @@ export type ExperimentalFeatureConfigs = FeatureRollOutConfig[]
 export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   {
     feature: EXPERIMENTAL_FEATURES.WebNotifications,
-    percentage: 1,
+    percentage: 0.5,
     whitelist: [],
   },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the percentage value for the experimental feature WebNotifications.

### Detailed summary:
- Updated the `percentage` value for the `EXPERIMENTAL_FEATURES.WebNotifications` feature from 1 to 0.5.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->