### PR TITLE
test: Add globals types for apps

### DIFF
--- a/apps/aptos/tsconfig.json
+++ b/apps/aptos/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2020",
     "noImplicitAny": false,
     "baseUrl": ".",
+    "types": ["vitest/globals"],
     "paths": {
       "@pancakeswap/awgmi": ["../../packages/awgmi/src"],
       "@pancakeswap/awgmi/core": ["../../packages/awgmi/core/src"],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,6 +7,7 @@
     "noFallthroughCasesInSwitch": true,
     "downlevelIteration": true,
     "target": "ES2020",
+    "types": ["vitest/globals"],
     "paths": {
       "*": ["./src/*"],
       "@pancakeswap/uikit": ["../../packages/uikit/src/index.ts"],

--- a/packages/prediction/vitest.config.ts
+++ b/packages/prediction/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    globals: true,
     passWithNoTests: true,
   },
 })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on adding the `vitest/globals` type to the `tsconfig.json` files in the `web` and `aptos` apps. 

Notable changes:
- Added `types: ["vitest/globals"]` to `apps/web/tsconfig.json`
- Added `types: ["vitest/globals"]` to `apps/aptos/tsconfig.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->