### PR TITLE
chore(PositionManager): only show data startTime > current time

### DIFF
--- a/apps/web/src/views/PositionManagers/containers/VaultCards.tsx
+++ b/apps/web/src/views/PositionManagers/containers/VaultCards.tsx
@@ -6,6 +6,7 @@ import { CardLayout } from '../components'
 import {
   PositionManagerStatus,
   useFetchApr,
+  usePositionInfo,
   usePositionManagerDetailsData,
   usePositionManagerStatus,
   useSearch,
@@ -46,6 +47,15 @@ export const VaultCards = memo(function VaultCards() {
         return `${d.currencyA.symbol}-${d.currencyB.symbol}${d.name}`.toLowerCase().includes(search.toLowerCase())
       }
       return true
+    })
+    .filter((d) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const info = usePositionInfo(d.address, d.adapterAddress ?? '0x')
+      if (info.startTimestamp <= Date.now() / 1000) {
+        return true
+      }
+
+      return false
     })
     .filter(() => {
       if (status === PositionManagerStatus.FINISHED) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `usePositionInfo` hook to fetch position information
- Filtered out positions that have not started yet

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->