### PR TITLE
fix: cake lock amount

### DIFF
--- a/apps/web/src/views/CakeStaking/components/DataSet/NewStakingDataSet.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/NewStakingDataSet.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRow, Box, Text, TooltipText, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { getBalanceAmount, getFullDisplayBalance } from '@pancakeswap/utils/formatBalance'
+import { getDecimalAmount, getFullDisplayBalance } from '@pancakeswap/utils/formatBalance'
 import BN from 'bignumber.js'
 import { WEEK } from 'config/constants/veCake'
 import dayjs from 'dayjs'
@@ -26,13 +26,14 @@ export const NewStakingDataSet: React.FC<{
   const { t } = useTranslation()
   const { cakeLockWeeks } = useLockCakeData()
   const unlockTimestamp = useTargetUnlockTime(Number(cakeLockWeeks) * WEEK)
-  const cakeAmountBN = useMemo(() => getBalanceAmount(new BN(cakeAmount)).toString(), [cakeAmount])
+  const cakeAmountBN = useMemo(() => getDecimalAmount(new BN(cakeAmount)).toString(), [cakeAmount])
   const veCakeAmountFromNative = useVeCakeAmount(cakeAmountBN, unlockTimestamp)
   const { balance: proxyVeCakeBalance } = useProxyVeCakeBalance()
   const veCakeAmount = useMemo(
     () => proxyVeCakeBalance.plus(veCakeAmountFromNative),
     [proxyVeCakeBalance, veCakeAmountFromNative],
   )
+
   const veCake = veCakeAmount ? getFullDisplayBalance(new BN(veCakeAmount), 18, 3) : '0'
   const factor =
     veCakeAmountFromNative && veCakeAmountFromNative


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The import statement for `getBalanceAmount` has been replaced with `getDecimalAmount`
- The `cakeAmountBN` variable now uses `getDecimalAmount` instead of `getBalanceAmount` to convert `cakeAmount` to a decimal amount.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->