### PR TITLE
chore: list bsc and arb farm

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 41,
+    lpAddress: '0x35D85D531BE7159cB6f92E8B9CeaF04eC28c6ad9',
+    token0: arbitrumTokens.usdv,
+    token1: arbitrumTokens.usdplus,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 40,
     lpAddress: '0x8a06339Abd7499Af755DF585738ebf43D5D62B94',
     token0: arbitrumTokens.usdtplus,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 138,
+    lpAddress: '0x55458175c5F5D34B9bD01c81F172780ED4271b23',
+    token0: bscTokens.aitech,
+    token1: bscTokens.usdt,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 137,
     lpAddress: '0x172fcD41E0913e95784454622d1c3724f546f849',
     token0: bscTokens.usdt,

--- a/packages/tokens/src/constants/arb.ts
+++ b/packages/tokens/src/constants/arb.ts
@@ -239,4 +239,12 @@ export const arbitrumTokens = {
     'Wrapped BNB',
     'https://www.bnbchain.org/en',
   ),
+  usdv: new ERC20Token(
+    ChainId.ARBITRUM_ONE,
+    '0x323665443CEf804A3b5206103304BD4872EA4253',
+    6,
+    'USDV',
+    'USDV',
+    'https://usdv.money/',
+  ),
 }

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -2972,4 +2972,12 @@ export const bscTokens = {
     'StaFi rBNB',
     'https://www.stafi.io/',
   ),
+  aitech: new ERC20Token(
+    ChainId.BSC,
+    '0x2D060Ef4d6BF7f9e5edDe373Ab735513c0e4F944',
+    18,
+    'AITECH',
+    'AITECH',
+    'https://www.aitech.vision/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding new ERC20 tokens and updating farm configurations.

### Detailed summary:
- Added a new ERC20 token `AITECH` for ChainId.BSC with address `0x2D060Ef4d6BF7f9e5edDe373Ab735513c0e4F944`.
- Updated the farm configuration for ChainId.ARBITRUM_ONE by adding a new farm with pid 41, lpAddress `0x35D85D531BE7159cB6f92E8B9CeaF04eC28c6ad9`, token0 `USDV`, token1 `USDPLUS`, and feeAmount `LOWEST`.
- Updated the farm configuration for ChainId.BSC by adding a new farm with pid 138, lpAddress `0x55458175c5F5D34B9bD01c81F172780ED4271b23`, token0 `AITECH`, token1 `USDT`, and feeAmount `MEDIUM`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->