### PR TITLE
feat: Show testnet on settings

### DIFF
--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -34,9 +34,10 @@ import AccessRiskTooltips from 'components/AccessRisk/AccessRiskTooltips'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useTheme from 'hooks/useTheme'
 import { useWebNotifications } from 'hooks/useWebNotifications'
-import { ReactNode, lazy, useCallback, useState, Suspense } from 'react'
+import { ReactNode, Suspense, lazy, useCallback, useState } from 'react'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useSubgraphHealthIndicatorManager, useUserUsernameVisibility } from 'state/user/hooks'
+import { useUserShowTestnet } from 'state/user/hooks/useUserShowTestnet'
 import { useUserTokenRisk } from 'state/user/hooks/useUserTokenRisk'
 import { useMMLinkedPoolByDefault } from 'state/user/mmLinkedPool'
 import {
@@ -106,6 +107,7 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
   const [audioPlay, setAudioMode] = useAudioPlay()
   const [subgraphHealth, setSubgraphHealth] = useSubgraphHealthIndicatorManager()
   const [userUsernameVisibility, setUserUsernameVisibility] = useUserUsernameVisibility()
+  const [showTestnet, setShowTestnet] = useUserShowTestnet()
   const { enabled } = useWebNotifications()
 
   const { onChangeRecipient } = useSwapActionHandlers()
@@ -195,6 +197,19 @@ const SettingsModal: React.FC<React.PropsWithChildren<InjectedModalProps>> = ({ 
                 <Suspense fallback={null}>
                   <WebNotiToggle enabled={enabled} />
                 </Suspense>
+              </Flex>
+              <Flex justifyContent="space-between" alignItems="center" mb="24px">
+                <Flex alignItems="center">
+                  <Text>{t('Show testnet')}</Text>
+                </Flex>
+                <Toggle
+                  id="toggle-show-testnet"
+                  checked={showTestnet}
+                  scale="md"
+                  onChange={() => {
+                    setShowTestnet((s) => !s)
+                  }}
+                />
               </Flex>
               {chainId === ChainId.BSC && (
                 <>

--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -23,10 +23,10 @@ import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
+import { useUserShowTestnet } from 'state/user/hooks/useUserShowTestnet'
 import { chainNameConverter } from 'utils/chainNameConverter'
 import { chains } from 'utils/wagmi'
 import { useNetwork } from 'wagmi'
-
 import { ChainLogo } from './Logo/ChainLogo'
 
 const AptosChain = {
@@ -36,6 +36,7 @@ const AptosChain = {
 
 const NetworkSelect = ({ switchNetwork, chainId }) => {
   const { t } = useTranslation()
+  const [showTestnet] = useUserShowTestnet()
 
   return (
     <>
@@ -47,7 +48,7 @@ const NetworkSelect = ({ switchNetwork, chainId }) => {
         .filter((chain) => {
           if (chain.id === chainId) return true
           if ('testnet' in chain && chain.testnet) {
-            return process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production'
+            return showTestnet
           }
           return true
         })

--- a/apps/web/src/state/user/hooks/useUserShowTestnet.ts
+++ b/apps/web/src/state/user/hooks/useUserShowTestnet.ts
@@ -1,0 +1,10 @@
+import { useAtom } from 'jotai'
+import atomWithStorageWithErrorCatch from 'utils/atomWithStorageWithErrorCatch'
+
+const USER_SHOW_TESTNET = 'pcs:user-show-testnet'
+
+const userShowTestnetAtom = atomWithStorageWithErrorCatch<boolean>(USER_SHOW_TESTNET, false)
+
+export function useUserShowTestnet() {
+  return useAtom(userShowTestnetAtom)
+}

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3141,6 +3141,7 @@
   "Your deposit value in USD": "Your deposit value in USD",
   "Min deposit USD": "Min deposit USD",
   "Savings": "Savings",
+  "Show testnet": "Show testnet",
   "Be Our Top 100 Traders and Earn a 3% Trading Fee Rebate!": "Be Our Top 100 Traders and Earn a 3% Trading Fee Rebate!",
   "Join Now": "Join Now"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a "Show testnet" toggle button in the settings modal. It also introduces a new hook `useUserShowTestnet` to manage the state of the toggle button.

### Detailed summary
- Added "Show testnet" toggle button in the settings modal.
- Introduced `useUserShowTestnet` hook to manage the state of the toggle button.
- Updated `NetworkSelect` component to use the `showTestnet` state from the hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->