### PR TITLE
refactor: Use query in nft hooks

### DIFF
--- a/apps/web/src/views/Nft/market/Home/index.tsx
+++ b/apps/web/src/views/Nft/market/Home/index.tsx
@@ -87,7 +87,7 @@ const Home = () => {
           <SearchBar />
         </StyledHeaderInner>
       </StyledPageHeader>
-      {status !== FetchStatus.Fetched ? (
+      {status !== 'success' ? (
         <PageLoader />
       ) : (
         <PageSection


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the codebase to use the `useQuery` hook from `@tanstack/react-query` instead of `useSWR` for fetching data in the NFT market feature.

### Detailed summary
- Replaced `useSWR` with `useQuery` in `useGetCollections` hook.
- Replaced `useSWR` with `useQuery` in `useGetCollection` hook.
- Replaced `useSWRImmutable` with `useQuery` in `useGetShuffledCollections` hook.
- Updated query keys and query functions accordingly.
- Added `enabled` option to control when the query should be enabled.
- Added options to disable refetching on window focus, reconnect, and mount.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->