### PR TITLE
fix: proxy vote expire

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useUserVote.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVote.ts
@@ -98,9 +98,12 @@ export const useUserVote = (gauge?: Gauge, useProxyPool: boolean = true) => {
         let ignoredSlope = 0n
         let ignoredPower = 0n
         let ignoredSide: 'native' | 'proxy' | undefined
+        const nativeExpired = nativeEnd > 0n && nativeEnd < nextEpochStart
+        const proxyExpired = proxyEnd > 0n && proxyEnd < nextEpochStart
+
         // when native slope will expire before current epochEnd
         // use proxy slope only
-        if (nativeEnd < nextEpochStart && proxyEnd > nextEpochStart) {
+        if (nativeExpired && !proxyExpired) {
           ignoredSlope = nativeSlope
           ignoredPower = nativePower
           ignoredSide = 'native'
@@ -109,7 +112,7 @@ export const useUserVote = (gauge?: Gauge, useProxyPool: boolean = true) => {
         }
         // when proxy slope will expire before current epochEnd
         // use native slope only
-        if (proxyEnd < nextEpochStart && nativeEnd > nextEpochStart) {
+        if (proxyExpired && !nativeExpired) {
           ignoredSlope = proxySlope
           ignoredPower = proxyPower
           ignoredSide = 'proxy'
@@ -119,7 +122,7 @@ export const useUserVote = (gauge?: Gauge, useProxyPool: boolean = true) => {
 
         // when both slopes will expire before current epochEnd
         // use max of both slopes
-        if (nativeEnd < nextEpochStart && proxyEnd < nextEpochStart) {
+        if (nativeExpired && proxyExpired) {
           const nativeWeight = _nativeSlope * (nativeEnd - BigInt(currentTimestamp))
           const proxyWeight = _proxySlope * (proxyEnd - BigInt(currentTimestamp))
           if (nativeWeight > proxyWeight) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the logic for determining the slope and power of a user's vote in the GaugesVoting feature.

### Detailed summary:
- Added a check for native slope expiration and proxy slope expiration.
- Updated the conditions for determining the ignored slope, power, and side.
- Improved the logic for using either the native slope or proxy slope based on their expiration times.
- Updated the logic for using the max of both slopes when both slopes expire before the current epoch end.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->