### PR TITLE
chore: add position manager startTime filter

### DIFF
--- a/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
@@ -176,8 +176,19 @@ export const ThirdPartyVaultCard = memo(function PCSVaultCard({
       earned: earningUsdValue,
       totalStaked: totalStakedInUsd,
       isUserStaked: totalAssetsInUsd > 0,
+      startTime: info.startTimestamp,
+      endTime: info.endTimestamp,
     })
-  }, [earningUsdValue, totalStakedInUsd, id, totalAssetsInUsd, apr, updatePositionMangerDetailsData])
+  }, [
+    earningUsdValue,
+    totalStakedInUsd,
+    id,
+    totalAssetsInUsd,
+    apr,
+    updatePositionMangerDetailsData,
+    info.startTimestamp,
+    info.endTimestamp,
+  ])
   return (
     <DuoTokenVaultCard
       id={id}

--- a/apps/web/src/views/PositionManagers/containers/VaultCards.tsx
+++ b/apps/web/src/views/PositionManagers/containers/VaultCards.tsx
@@ -21,6 +21,7 @@ export const VaultCards = memo(function VaultCards() {
   const { status } = usePositionManagerStatus()
   const [sortBy] = useSortBy()
   const [stakeOnly] = useStakeOnly()
+
   const { data: positionMangerDetailsData, updateData: updatePositionMangerDetailsData } =
     usePositionManagerDetailsData()
   const aprTimeWindows = useMemo(() => {
@@ -35,6 +36,12 @@ export const VaultCards = memo(function VaultCards() {
   const aprDataList = useFetchApr(aprTimeWindows)
   const { farmsWithPositions: farmsV3 } = useFarmsV3WithPositionsAndBooster()
   const cards = configs
+    .filter((d) => {
+      if ((positionMangerDetailsData?.[d.id]?.startTime ?? 0) <= Date.now() / 1000) {
+        return true
+      }
+      return false
+    })
     .filter((d) => {
       if (stakeOnly) {
         return positionMangerDetailsData?.[d.id]?.isUserStaked

--- a/apps/web/src/views/PositionManagers/hooks/usePositionManagerDetailsData.ts
+++ b/apps/web/src/views/PositionManagers/hooks/usePositionManagerDetailsData.ts
@@ -1,10 +1,12 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 export interface PositionManagerDetailsData {
   apr: number
   earned: number
   totalStaked: number
   isUserStaked: boolean
+  startTime: number
+  endTime: number
 }
 
 export const usePositionManagerDetailsData = () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `startTime` and `endTime` properties to the `PositionManagerDetailsData` interface.
- Imported `useCallback` and `useState` from `react` in `usePositionManagerDetailsData.ts`.
- Updated dependencies in the `usePositionManagerDetailsData` hook.
- Added `info.startTimestamp` and `info.endTimestamp` to the dependencies array in the `usePositionManagerDetailsData` hook.
- Updated the filter condition in `VaultCards.tsx` to check if the `startTime` is less than or equal to the current time.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->