### PR TITLE
fix: Transaction updater duplicate receipts

### DIFF
--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -79,8 +79,6 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
               t('Transaction receipt'),
               <ToastDescriptionWithTx txHash={receipt.transactionHash} txChainId={chainId} />,
             )
-
-            merge(fetchedTransactions.current, { [transaction.hash]: transactions[transaction.hash] })
           } catch (error) {
             console.error(error)
             if (error instanceof TransactionNotFoundError) {
@@ -92,8 +90,9 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
             } else if (error instanceof WaitForTransactionReceiptTimeoutError) {
               throw new RetryableError(`Timeout reached when fetching transaction receipt: ${transaction.hash}`)
             }
+          } finally {
+            merge(fetchedTransactions.current, { [transaction.hash]: transactions[transaction.hash] })
           }
-          merge(fetchedTransactions.current, { [transaction.hash]: transactions[transaction.hash] })
         }
         retry(getTransaction, {
           n: 10,


### PR DESCRIPTION
When multiple transaction happens in short period, it will try to fetch already fetching (retrying) transactions again since it doesnt have the receipt yet. Therefore duplicate receipts shown as toast

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->
