### PR TITLE
feat: List GTAI farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 139,
+    lpAddress: '0x55458175c5F5D34B9bD01c81F172780ED4271b23',
+    token0: bscTokens.gtai,
+    token1: bscTokens.usdt,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 138,
     lpAddress: '0x55458175c5F5D34B9bD01c81F172780ED4271b23',
     token0: bscTokens.aitech,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -49,7 +49,7 @@ export const farmsV3 = defineFarmV3Configs([
   // latest first
   {
     pid: 139,
-    lpAddress: '0x55458175c5F5D34B9bD01c81F172780ED4271b23',
+    lpAddress: '0xb24cd29e32FaCDDf9e73831d5cD1FFcd1e535423',
     token0: bscTokens.gtai,
     token1: bscTokens.usdt,
     feeAmount: FeeAmount.MEDIUM,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
This PR adds two new liquidity pools for the BSC network. 

- A new liquidity pool with PID 139 is added with the LP address `0xb24cd29e32FaCDDf9e73831d5cD1FFcd1e535423`, consisting of the tokens `bscTokens.gtai` and `bscTokens.usdt`, with a medium fee amount.

- Another new liquidity pool with PID 138 is added with the LP address `0x55458175c5F5D34B9bD01c81F172780ED4271b23`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->