### PR TITLE
perf: Use account hook instead of web3

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockCake/NotLocking.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCake/NotLocking.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, Button, ColumnCenter, Grid, Heading, useMatchBreakpoints } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useMemo } from 'react'
 import { useLockCakeData } from 'state/vecake/hooks'
 import { useWriteApproveAndLockCallback } from 'views/CakeStaking/hooks/useContractWrite'
+import { useAccount } from 'wagmi'
 import { NewStakingDataSet } from '../DataSet'
 import { LockCakeForm } from '../LockCakeForm'
 import { LockWeeksForm } from '../LockWeeksForm'
@@ -21,7 +21,7 @@ export const NotLocking = () => {
 }
 
 export const NotLockingCard = () => {
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const { t } = useTranslation()
   const { cakeLockAmount, cakeLockWeeks } = useLockCakeData()
   const { isDesktop } = useMatchBreakpoints()

--- a/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
+++ b/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
@@ -2,7 +2,7 @@ import { useOfficialsAndUserAddedTokens } from 'hooks/Tokens'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useFixedStakingContract, useVaultPoolContract } from 'hooks/useContract'
 import { getAddress } from 'viem'
-import { useContractRead } from 'wagmi'
+import { useAccount, useContractRead } from 'wagmi'
 import toNumber from 'lodash/toNumber'
 import { useMemo } from 'react'
 import { useSingleContractMultipleData } from 'state/multicall/hooks'
@@ -11,13 +11,14 @@ import { VaultKey } from '@pancakeswap/pools'
 import { VaultPosition, getVaultPosition } from 'utils/cakePool'
 import { getBalanceAmount } from '@pancakeswap/utils/formatBalance'
 
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { FixedStakingPool, StakedPosition } from '../type'
 import { DISABLED_POOLS } from '../constant'
 
 export function useCurrentDay(): number {
   const fixedStakingContract = useFixedStakingContract()
 
-  const { chainId } = useActiveWeb3React()
+  const { chainId } = useActiveChainId()
 
   const { data } = useContractRead({
     abi: fixedStakingContract.abi,
@@ -75,7 +76,7 @@ export function useIfUserLocked() {
 }
 export function useStakedPositionsByUser(poolIndexes: number[]): StakedPosition[] {
   const fixedStakingContract = useFixedStakingContract()
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const tokens = useOfficialsAndUserAddedTokens()
 
   const results = useSingleContractMultipleData({
@@ -138,7 +139,7 @@ export function useStakedPositionsByUser(poolIndexes: number[]): StakedPosition[
 export function useStakedPools(): FixedStakingPool[] {
   const fixedStakingContract = useFixedStakingContract()
   const tokens = useOfficialsAndUserAddedTokens()
-  const { chainId } = useActiveWeb3React()
+  const { chainId } = useActiveChainId()
 
   const { data: poolLength } = useContractRead({
     abi: fixedStakingContract.abi,

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -14,7 +14,6 @@ import {
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { Hex } from 'viem'
@@ -24,6 +23,7 @@ import { useEpochOnTally } from 'views/GaugesVoting/hooks/useEpochTime'
 import { useEpochVotePower } from 'views/GaugesVoting/hooks/useEpochVotePower'
 import { useUserVoteSlopes } from 'views/GaugesVoting/hooks/useUserVoteGauges'
 import { useWriteGaugesVoteCallback } from 'views/GaugesVoting/hooks/useWriteGaugesVoteCallback'
+import { useAccount } from 'wagmi'
 import { RemainingVotePower } from '../../RemainingVotePower'
 import { AddGaugeModal } from '../AddGauge/AddGaugeModal'
 import { EmptyTable } from './EmptyTable'
@@ -46,7 +46,7 @@ const Scrollable = styled.div.withConfig({ shouldForwardProp: (prop) => !['expan
 `
 
 export const VoteTable = () => {
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const { t } = useTranslation()
   // const { cakeUnlockTime, cakeLockedAmount } = useCakeLockStatus()
   const { cakeLockedAmount } = useCakeLockStatus()

--- a/apps/web/src/views/PositionManagers/hooks/useAdapterInfo.ts
+++ b/apps/web/src/views/PositionManagers/hooks/useAdapterInfo.ts
@@ -4,9 +4,8 @@ import { usePositionManagerWrapperContract, useContract } from 'hooks/useContrac
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { publicClient } from 'utils/wagmi'
 import { Address } from 'viem'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { Percent } from '@pancakeswap/sdk'
-import { erc20ABI } from 'wagmi'
+import { erc20ABI, useAccount } from 'wagmi'
 
 export async function getAdapterTokensAmounts({ address, chainId }): Promise<{
   token0Amounts: bigint
@@ -107,7 +106,7 @@ export const useAdapterTokensAmounts = (adapterAddress: Address) => {
 }
 
 export const useUserAmounts = (wrapperAddress: Address) => {
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const contract = usePositionManagerWrapperContract(wrapperAddress)
   const { data, refetch } = useQuery({
     queryKey: ['useUserAmounts', wrapperAddress, account],
@@ -186,7 +185,7 @@ export const usePositionInfo = (wrapperAddress: Address, adapterAddress: Address
 }
 
 export const useUserPendingRewardAmounts = (wrapperAddress: Address) => {
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const contract = usePositionManagerWrapperContract(wrapperAddress)
   const { data, refetch } = useQuery({
     queryKey: ['useUserPendingRewardAmounts', account, wrapperAddress],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the usage of `useActiveWeb3React` with `useAccount` from the `wagmi` library. 

### Detailed summary
- Replaced `useActiveWeb3React` with `useAccount` in `NotLocking.tsx`, `useAdapterInfo.ts`, `VoteTable/index.tsx`, and `useStakedPools.ts`
- Updated imports and function calls accordingly

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->