### PR TITLE
fix: replace public client

### DIFF
--- a/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
+++ b/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
@@ -1,24 +1,24 @@
 import { ChainId } from '@gelatonetwork/limit-orders-lib'
+import { BSC_BLOCK_TIME } from 'config'
 import { CHAINS } from 'config/chains'
+import { AVERAGE_CHAIN_BLOCK_TIMES } from 'config/constants/averageChainBlockTimes'
+import { useCallback } from 'react'
+import { RetryableError, retry } from 'state/multicall/retry'
 import {
-  TransactionReceipt,
+  BlockNotFoundError,
   GetTransactionReceiptParameters,
-  createPublicClient,
-  http,
   PublicClient,
   TransactionNotFoundError,
+  TransactionReceipt,
   TransactionReceiptNotFoundError,
-  BlockNotFoundError,
   WaitForTransactionReceiptTimeoutError,
+  createPublicClient,
+  http,
 } from 'viem'
-import { useCallback } from 'react'
-import { retry, RetryableError } from 'state/multicall/retry'
 import { usePublicClient } from 'wagmi'
-import { AVERAGE_CHAIN_BLOCK_TIMES } from 'config/constants/averageChainBlockTimes'
-import { BSC_BLOCK_TIME } from 'config'
 import { useActiveChainId } from './useActiveChainId'
 
-const viemClientsPublicNodes = CHAINS.reduce((prev, cur) => {
+export const viemClientsPublicNodes = CHAINS.reduce((prev, cur) => {
   return {
     ...prev,
     [cur.id]: createPublicClient({

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -14,11 +14,11 @@ import { basisPointsToPercent } from 'utils/exchange'
 import { logSwap, logTx } from 'utils/log'
 import { isUserRejected } from 'utils/sentry'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
-import { viemClients } from 'utils/viem'
 import { Address, Hex, TransactionExecutionError, hexToBigInt } from 'viem'
 import { useSendTransaction } from 'wagmi'
 import { SendTransactionResult } from 'wagmi/actions'
 
+import { viemClientsPublicNodes } from 'hooks/usePublicNodeWaitForTransaction'
 import { logger } from 'utils/datadog'
 import { isZero } from '../utils/isZero'
 
@@ -58,7 +58,7 @@ export default function useSendSwapTransaction(
   const { t } = useTranslation()
   const addTransaction = useTransactionAdder()
   const { sendTransactionAsync } = useSendTransaction()
-  const publicClient = viemClients[chainId as ChainId]
+  const publicClient = viemClientsPublicNodes[chainId as ChainId]
   const [allowedSlippage] = useUserSlippage() || [INITIAL_ALLOWED_SLIPPAGE]
   const { recipient } = useSwapState()
   const recipientAddress = recipient === null ? account : recipient


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `useSendSwapTransaction` hook to use the `viemClientsPublicNodes` object instead of `viemClients` for fetching public client data.

### Detailed summary
- Replaced `viemClients` with `viemClientsPublicNodes` in `useSendSwapTransaction` hook.
- Updated import statements in `useSendSwapTransaction` and `usePublicNodeWaitForTransaction` hooks.
- Removed unused imports in `usePublicNodeWaitForTransaction` hook.
- Exported `viemClientsPublicNodes` object from `usePublicNodeWaitForTransaction` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->