### PR TITLE
fix(Farms): Fix updatedTime translation

### DIFF
--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3143,5 +3143,6 @@
   "Savings": "Savings",
   "Show testnet": "Show testnet",
   "Be Our Top 100 Traders and Earn a 3% Trading Fee Rebate!": "Be Our Top 100 Traders and Earn a 3% Trading Fee Rebate!",
-  "Join Now": "Join Now"
+  "Join Now": "Join Now",
+  "Updated": "Updated"
 }

--- a/packages/widgets-internal/farm/components/FarmTable/Liquidity.tsx
+++ b/packages/widgets-internal/farm/components/FarmTable/Liquidity.tsx
@@ -1,15 +1,26 @@
-import { useTranslation } from "@pancakeswap/localization";
+import { TranslateFunction, useTranslation } from "@pancakeswap/localization";
+import { HelpIcon, Skeleton, Text, TooltipRefs, useTooltip } from "@pancakeswap/uikit";
+import getTimePeriods from "@pancakeswap/utils/getTimePeriods";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { styled } from "styled-components";
-import { Skeleton, HelpIcon, Text, TooltipRefs, useTooltip } from "@pancakeswap/uikit";
 import { FarmTableLiquidityProps } from "../../types";
 
 dayjs.extend(relativeTime);
 
-const distanceToNow = (timeInMilliSeconds: number) => {
+const distanceToNow = (t: TranslateFunction, timeInMilliSeconds: number) => {
   const time = new Date(timeInMilliSeconds);
-  return time > new Date() || !Number.isFinite(timeInMilliSeconds) ? `now` : dayjs(time).toNow();
+
+  const secondsRemaining = dayjs(time).diff(dayjs(), "seconds");
+  const { days, hours, minutes, seconds } = getTimePeriods(secondsRemaining);
+
+  let toNowString = "";
+  if (days !== 0) toNowString += `${days} ${t("d")}`;
+  if (hours !== 0) toNowString += `${hours} ${t("h")}`;
+  if (minutes !== 0) toNowString += `${minutes} ${t("m")}`;
+  if (seconds !== 0) toNowString += `${seconds} ${t("s")}`;
+
+  return time > new Date() || !Number.isFinite(timeInMilliSeconds) ? t(`now`) : toNowString;
 };
 
 const ReferenceElement = styled.div`
@@ -38,10 +49,15 @@ export const StakedLiquidity: React.FunctionComponent<React.PropsWithChildren<Fa
   inactive,
 }) => {
   const { t } = useTranslation();
+
   const tooltip = useTooltip(
     <>
       <Text>{t("Total active (in-range) liquidity staked in the farm.")}</Text>
-      {updatedAt && <Text>Updated {distanceToNow(updatedAt)}</Text>}
+      {updatedAt && (
+        <Text>
+          {t("Updated")} {distanceToNow(t, updatedAt)}
+        </Text>
+      )}
     </>,
     {
       placement: "top-end",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Before:
<img width="476" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/109973128/3bef996b-dae4-4929-a736-dc60cf0255c0">

After:
<img width="370" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/109973128/ac856cfe-d1f9-4384-9f0d-9175b1e00fae">



<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on updating the translation and adding a time duration for the "Updated" text in the FarmTable component.

### Detailed summary:
- Updated the translation for the "Join Now" text in translations.json.
- Added a time duration for the "Updated" text in the FarmTable component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->