### PR TITLE
test: Skip pool testnet test

### DIFF
--- a/apps/web/src/config/__tests__/pools.test.ts
+++ b/apps/web/src/config/__tests__/pools.test.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@pancakeswap/chains'
+import { ChainId, testnetChainIds } from '@pancakeswap/chains'
 import {
   SUPPORTED_CHAIN_IDS,
   SerializedPool,
@@ -13,7 +13,7 @@ import { describe, it } from 'vitest'
 describe.concurrent(
   'Config pools',
   () => {
-    for (const chainId of SUPPORTED_CHAIN_IDS) {
+    for (const chainId of SUPPORTED_CHAIN_IDS.filter((chainId_) => !testnetChainIds.includes(chainId_))) {
       const pools = getPoolsConfig(chainId) ?? []
       // Pool 0 is special (cake pool)
       // Pool 78 is a broken pool, not used, and break the tests


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to filter out testnet chain IDs from the list of supported chain IDs in the `pools.test.ts` file.
- This change ensures that the tests are not affected by the broken pool (Pool 78) and includes only the valid pools for each supported chain ID.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->