### PR TITLE
fix: now translation #9044

### DIFF
--- a/packages/widgets-internal/farm/components/FarmTable/Liquidity.tsx
+++ b/packages/widgets-internal/farm/components/FarmTable/Liquidity.tsx
@@ -20,7 +20,7 @@ const distanceToNow = (t: TranslateFunction, timeInMilliSeconds: number) => {
   if (minutes !== 0) toNowString += `${minutes} ${t("m")}`;
   if (seconds !== 0) toNowString += `${seconds} ${t("s")}`;
 
-  return time > new Date() || !Number.isFinite(timeInMilliSeconds) ? t(`now`) : toNowString;
+  return time > new Date() || !Number.isFinite(timeInMilliSeconds) ? t("Now") : toNowString;
 };
 
 const ReferenceElement = styled.div`


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The PR updates the translation key from `now` to `Now` in the `Liquidity.tsx` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->