### PR TITLE
feat: List dmail farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -48,6 +48,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 142,
+    lpAddress: '0x4167f229a0323F480518b61CB35eD4d6a0C5EA27',
+    token0: bscTokens.usdt,
+    token1: bscTokens.dmail,
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 141,
     lpAddress: '0x9F5a0AD81Fe7fD5dFb84EE7A0CFb83967359BD90',
     token0: bscTokens.usdt,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -2732,4 +2732,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: bscTokens.sol.address,
     feeTier: FeeAmount.MEDIUM,
   },
+  {
+    gid: 273,
+    pairName: 'USDT-DMAIL',
+    address: '0x4167f229a0323F480518b61CB35eD4d6a0C5EA27',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.usdt.address,
+    token1Address: bscTokens.dmail.address,
+    feeTier: FeeAmount.HIGH,
+  },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -2996,4 +2996,12 @@ export const bscTokens = {
     'SOLANA',
     'https://solana.com/',
   ),
+  dmail: new ERC20Token(
+    ChainId.BSC,
+    '0xcC6f1e1B87cfCbe9221808d2d85C501aab0B5192',
+    18,
+    'DMAIL',
+    'Dmail Network',
+    'https://dmail.ai/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new ERC20 token called DMAIL to the BSC network. It also adds a new farm and gauge for the USDT-DMAIL pair on BSC.

### Detailed summary
- Added a new ERC20 token `DMAIL` with address `0xcC6f1e1B87cfCbe9221808d2d85C501aab0B5192` on BSC.
- Added a new farm with PID 142 and LP address `0x4167f229a0323F480518b61CB35eD4d6a0C5EA27` for the USDT-DMAIL pair on BSC.
- Added a new gauge with GID 273, pair name `USDT-DMAIL`, and address `0x4167f229a0323F480518b61CB35eD4d6a0C5EA27` on BSC.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->