### PR TITLE
feat: Hide Arbitrum prediction

### DIFF
--- a/packages/prediction/src/chainlinkOracleContract.ts
+++ b/packages/prediction/src/chainlinkOracleContract.ts
@@ -6,23 +6,23 @@ import { ContractAddresses } from './type'
 export const chainlinkOracleBNB: Record<string, Address> = {
   [ChainId.BSC]: '0x0567F2323251f0Aab15c8dFb1967E4e8A7D42aeE',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x',
+  // [ChainId.ARBITRUM_ONE]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const chainlinkOracleCAKE: Record<string, Address> = {
   [ChainId.BSC]: '0xB6064eD41d4f67e353768aA239cA86f4F73665a1',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x',
+  // [ChainId.ARBITRUM_ONE]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const chainlinkOracleETH: Record<string, Address> = {
   [ChainId.BSC]: '0x',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612',
+  // [ChainId.ARBITRUM_ONE]: '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const chainlinkOracleWBTC: Record<string, Address> = {
   [ChainId.BSC]: '0x',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x6ce185860a4963106506C203335A2910413708e9',
+  // [ChainId.ARBITRUM_ONE]: '0x6ce185860a4963106506C203335A2910413708e9',
 } as const satisfies ContractAddresses<SupportedChainId>

--- a/packages/prediction/src/constants/supportedChains.ts
+++ b/packages/prediction/src/constants/supportedChains.ts
@@ -1,8 +1,8 @@
 import { ChainId } from '@pancakeswap/chains'
-import { arbitrum, bsc, zkSync } from 'wagmi/chains'
+import { bsc, zkSync } from 'wagmi/chains'
 
-export const SUPPORTED_CHAIN_IDS = [ChainId.BSC, ChainId.ZKSYNC, ChainId.ARBITRUM_ONE] as const
+export const SUPPORTED_CHAIN_IDS = [ChainId.BSC, ChainId.ZKSYNC] as const
 
 export type SupportedChainId = (typeof SUPPORTED_CHAIN_IDS)[number]
 
-export const targetChains = [bsc, zkSync, arbitrum]
+export const targetChains = [bsc, zkSync]

--- a/packages/prediction/src/endpoints.ts
+++ b/packages/prediction/src/endpoints.ts
@@ -5,23 +5,23 @@ import { EndPointType } from './type'
 export const GRAPH_API_PREDICTION_BNB = {
   [ChainId.BSC]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2',
   [ChainId.ZKSYNC]: '',
-  [ChainId.ARBITRUM_ONE]: '',
+  // [ChainId.ARBITRUM_ONE]: '',
 } as const satisfies EndPointType<SupportedChainId>
 
 export const GRAPH_API_PREDICTION_CAKE = {
   [ChainId.BSC]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-cake',
   [ChainId.ZKSYNC]: '',
-  [ChainId.ARBITRUM_ONE]: '',
+  // [ChainId.ARBITRUM_ONE]: '',
 } as const satisfies EndPointType<SupportedChainId>
 
 export const GRAPH_API_PREDICTION_ETH = {
   [ChainId.BSC]: '',
   [ChainId.ZKSYNC]: 'https://api.studio.thegraph.com/query/48759/prediction-v2-zksync-era/version/latest',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2-arbitrum',
+  // [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2-arbitrum',
 } as const satisfies EndPointType<SupportedChainId>
 
 export const GRAPH_API_PREDICTION_WBTC = {
   [ChainId.BSC]: '',
   [ChainId.ZKSYNC]: '',
-  [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2-arbitrum-wbtc',
+  // [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2-arbitrum-wbtc',
 } as const satisfies EndPointType<SupportedChainId>

--- a/packages/prediction/src/galetoOracleContract.ts
+++ b/packages/prediction/src/galetoOracleContract.ts
@@ -6,5 +6,5 @@ import { ContractAddresses } from './type'
 export const galetoOracleETH: Record<string, Address> = {
   [ChainId.BSC]: '0x',
   [ChainId.ZKSYNC]: '0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace',
-  [ChainId.ARBITRUM_ONE]: '0x',
+  // [ChainId.ARBITRUM_ONE]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>

--- a/packages/prediction/src/predictionContract.ts
+++ b/packages/prediction/src/predictionContract.ts
@@ -6,23 +6,23 @@ import { ContractAddresses } from './type'
 export const predictionsBNB: Record<string, Address> = {
   [ChainId.BSC]: '0x18B2A687610328590Bc8F2e5fEdDe3b582A49cdA',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x',
+  // [ChainId.ARBITRUM_ONE]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const predictionsCAKE: Record<string, Address> = {
   [ChainId.BSC]: '0x0E3A8078EDD2021dadcdE733C6b4a86E51EE8f07',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x',
+  // [ChainId.ARBITRUM_ONE]: '0x',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const predictionsETH: Record<string, Address> = {
   [ChainId.BSC]: '0x',
   [ChainId.ZKSYNC]: '0x43c7771DEB958A2e3198ED98772056ba70DaA84c',
-  [ChainId.ARBITRUM_ONE]: '0xF2F90E718a3BFaCb430c1818cB962f05A2631998',
+  // [ChainId.ARBITRUM_ONE]: '0xF2F90E718a3BFaCb430c1818cB962f05A2631998',
 } as const satisfies ContractAddresses<SupportedChainId>
 
 export const predictionsWBTC: Record<string, Address> = {
   [ChainId.BSC]: '0x',
   [ChainId.ZKSYNC]: '0x',
-  [ChainId.ARBITRUM_ONE]: '0x870CBfD72970E6ad146310Dd0EC546Db1Cbbe6F8',
+  // [ChainId.ARBITRUM_ONE]: '0x870CBfD72970E6ad146310Dd0EC546Db1Cbbe6F8',
 } as const satisfies ContractAddresses<SupportedChainId>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on removing the support for the `ARBITRUM_ONE` chain in the `prediction` package.

### Detailed summary:
- Removed the `ARBITRUM_ONE` chain from `galetoOracleContract.ts` and `chainlinkOracleContract.ts`.
- Removed the `ARBITRUM_ONE` chain from `supportedChains.ts`.
- Updated the `targetChains` array in `supportedChains.ts` to remove `ARBITRUM_ONE`.
- Removed the `ARBITRUM_ONE` chain from `predictionContract.ts`.
- Removed the `ARBITRUM_ONE` chain from `endpoints.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->