### PR TITLE
fix: Supported chains not visible when no account connected

### DIFF
--- a/apps/web/src/components/NetworkModal/UnsupportedNetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/UnsupportedNetworkModal.tsx
@@ -7,16 +7,16 @@ import useAuth from 'hooks/useAuth'
 import { useMenuItems } from 'components/Menu/hooks/useMenuItems'
 import { useRouter } from 'next/router'
 import { getActiveMenuItem, getActiveSubMenuItem } from 'components/Menu/utils'
-import { useAccount, useNetwork } from 'wagmi'
+import { useAccount } from 'wagmi'
 import { useMemo } from 'react'
 import { ChainId } from '@pancakeswap/chains'
+import { viemClients } from 'utils/viem'
 import Dots from '../Loader/Dots'
 
 // Where chain is not supported or page not supported
 export function UnsupportedNetworkModal({ pageSupportedChains }: { pageSupportedChains: number[] }) {
   const { switchNetworkAsync, isLoading, canSwitch } = useSwitchNetwork()
   const switchNetworkLocal = useSwitchNetworkLocal()
-  const { chains } = useNetwork()
   const chainId = useLocalNetworkChain() || ChainId.BSC
   const { isConnected } = useAccount()
   const { logout } = useAuth()
@@ -32,8 +32,11 @@ export function UnsupportedNetworkModal({ pageSupportedChains }: { pageSupported
   }, [menuItems, pathname])
 
   const supportedMainnetChains = useMemo(
-    () => chains.filter((chain) => !chain.testnet && pageSupportedChains?.includes(chain.id)),
-    [chains, pageSupportedChains],
+    () =>
+      Object.values(viemClients)
+        .map((client) => client.chain)
+        .filter((chain) => chain && !chain.testnet && pageSupportedChains?.includes(chain.id)),
+    [pageSupportedChains],
   )
 
   return (
@@ -41,7 +44,7 @@ export function UnsupportedNetworkModal({ pageSupportedChains }: { pageSupported
       <Grid style={{ gap: '16px' }} maxWidth="336px">
         <Text>
           {t('Currently %feature% only supported in', { feature: typeof title === 'string' ? title : 'this page' })}{' '}
-          {supportedMainnetChains?.map((c) => c.name).join(', ')}
+          {supportedMainnetChains?.map((c) => c?.name).join(', ')}
         </Text>
         <div style={{ textAlign: 'center' }}>
           <Image
@@ -59,7 +62,7 @@ export function UnsupportedNetworkModal({ pageSupportedChains }: { pageSupported
           <Button
             isLoading={isLoading}
             onClick={() => {
-              if (supportedMainnetChains.map((c) => c.id).includes(chainId)) {
+              if (supportedMainnetChains.map((c) => c?.id).includes(chainId)) {
                 switchNetworkAsync(chainId)
               } else {
                 switchNetworkAsync(ChainId.BSC)

--- a/apps/web/src/components/NetworkModal/UnsupportedNetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/UnsupportedNetworkModal.tsx
@@ -69,7 +69,13 @@ export function UnsupportedNetworkModal({ pageSupportedChains }: { pageSupported
               }
             }}
           >
-            {isLoading ? <Dots>{t('Switch network in wallet')}</Dots> : t('Switch network in wallet')}
+            {isLoading ? (
+              <Dots>{isConnected ? t('Switch network in wallet') : t('Switch network')}</Dots>
+            ) : isConnected ? (
+              t('Switch network in wallet')
+            ) : (
+              t('Switch network')
+            )}
           </Button>
         ) : (
           <Message variant="danger">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- The PR focuses on updating the `NetworkModal` component to use `viemClients` instead of `useNetwork` from the `wagmi` library.
- It also updates the `UnsupportedNetworkModal` component to use `viemClients` instead of `useNetwork` from the `wagmi` library.
- These changes are made to improve the functionality and performance of the components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->