### PR TITLE
fix: Cake staking week placeholder

### DIFF
--- a/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
@@ -71,16 +71,20 @@ const WeekInput: React.FC<{
     [onInput],
   )
 
-  const appendComponent = (
-    <Box width={40} mr={12}>
-      <Image src="/images/cake-staking/lock.png" height={37} width={34} />
-    </Box>
+  const appendComponent = useMemo(
+    () => (
+      <Box width={40} mr={12}>
+        <Image src="/images/cake-staking/lock.png" height={37} width={34} />
+      </Box>
+    ),
+    [],
   )
   return (
     <>
       <BalanceInput
         width="100%"
         mb="8px"
+        placeholder="0"
         inputProps={{
           style: { textAlign: 'left', marginTop: '1px', marginBottom: '1px' },
           disabled,

--- a/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockWeeksForm.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { AutoRow, BalanceInput, BalanceInputProps, Box, Button, FlexGap, Image, Text } from '@pancakeswap/uikit'
 import { MAX_VECAKE_LOCK_WEEKS } from 'config/constants/veCake'
 import { useAtom, useAtomValue } from 'jotai'
-import { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { cakeLockWeeksAtom } from 'state/vecake/atoms'
 import styled from 'styled-components'
 import { useWriteIncreaseLockWeeksCallback } from '../hooks/useContractWrite'
@@ -39,6 +39,12 @@ const ButtonBlocked = styled(Button)`
   white-space: nowrap;
 `
 
+const LockImageElement = React.memo(() => (
+  <Box width={40} mr={12}>
+    <Image src="/images/cake-staking/lock.png" height={37} width={34} />
+  </Box>
+))
+
 const WeekInput: React.FC<{
   value: BalanceInputProps['value']
   onUserInput: BalanceInputProps['onUserInput']
@@ -71,14 +77,6 @@ const WeekInput: React.FC<{
     [onInput],
   )
 
-  const appendComponent = useMemo(
-    () => (
-      <Box width={40} mr={12}>
-        <Image src="/images/cake-staking/lock.png" height={37} width={34} />
-      </Box>
-    ),
-    [],
-  )
   return (
     <>
       <BalanceInput
@@ -92,7 +90,7 @@ const WeekInput: React.FC<{
           pattern: '^[0-9]*$',
         }}
         value={value}
-        appendComponent={appendComponent}
+        appendComponent={<LockImageElement />}
         onUserInput={onInput}
         unit={t('Weeks')}
       />


### PR DESCRIPTION
Instead of 0.0 which week staking not allowing decimal values, it should show integer

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new component `LockImageElement` to display a lock image in the `WeekInput` component in the `LockWeeksForm.tsx` file.

### Detailed summary
- Added a new `LockImageElement` component to display a lock image
- Updated the `WeekInput` component to use the `LockImageElement` component
- Replaced direct JSX element with `LockImageElement` component in `WeekInput`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->