### PR TITLE
fix: Confirm modal still visible when going back

### DIFF
--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -1,11 +1,13 @@
 import DisclaimerModal, { CheckType } from 'components/DisclaimerModal'
 import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useEffect } from 'react'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useTheme } from 'styled-components'
 import { Text, Link } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { useRouter } from 'next/router'
+import { usePreviousValue } from '@pancakeswap/hooks'
 
 interface USCitizenConfirmModalProps {
   id: IdType
@@ -24,6 +26,8 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
     t,
     currentLanguage: { code },
   } = useTranslation()
+  const { pathname } = useRouter()
+  const previousPathname = usePreviousValue(pathname)
   const [, setHasAcceptedRisk] = useUserNotUsCitizenAcknowledgement(id)
   const { chainId } = useActiveChainId()
   const { isDark } = useTheme()
@@ -36,6 +40,12 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
     }
     onDismiss?.()
   }, [id, setHasAcceptedRisk, onDismiss, chainId, code, isDark])
+
+  useEffect(() => {
+    if (previousPathname && pathname !== previousPathname) {
+      onDismiss?.()
+    }
+  }, [pathname, previousPathname])
 
   return (
     <DisclaimerModal


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new useEffect hook to handle modal dismissal when the pathname changes.

### Detailed summary
- Added `useEffect` hook to dismiss modal on pathname change
- Imported `useRouter` from 'next/router'
- Imported `usePreviousValue` from '@pancakeswap/hooks'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->