### PR TITLE
📝 Pancakeswap Smart Router - Update the command to add compatible version of the library

### DIFF
--- a/packages/smart-router/README.md
+++ b/packages/smart-router/README.md
@@ -17,7 +17,7 @@ For working code example, please refer to [smart-router-example](https://github.
 0. Install other dependencies
 
 ```bash
-$ pnpm add viem graphql-request @pancakeswap/sdk @pancakeswap/tokens
+$ pnpm add viem@^1.19.11 graphql-request @pancakeswap/sdk @pancakeswap/tokens
 ```
 
 1. Prepare on-chain rpc provider and subgraph providers

--- a/packages/smart-router/README.md
+++ b/packages/smart-router/README.md
@@ -25,7 +25,7 @@ $ pnpm add viem@^1.19.11 graphql-request @pancakeswap/sdk @pancakeswap/tokens
 ```typescript
 import { createPublicClient, http } from 'viem'
 import { GraphQLClient } from 'graphql-request'
-import { SmartRouter } from '@pancakeswap/smart-router/evm'
+import { SmartRouter } from '@pancakeswap/smart-router'
 
 const publicClient = createPublicClient({
   chain: mainnet,


### PR DESCRIPTION
This pull request only updates the command to add compatible version of the library `viem`.

As [issue](https://github.com/pancakeswap/pancake-frontend/issues/9107) opened. 
The guide in this `Readme.md` is incompatible with the latest versions of the `viem` library. This update aims to mitigate this paleative issue while the library is incompatible with newer versions of `viem`, for example in version `2.7.11`

If you find this pull request helpful or want to buy me a cup of coffee, feel free to send any amount of crypto to my wallet address: `0xB0fc1C69447984B5B712EE63f4DE8F16D6aa65F4`. Remember, every Satoshi counts! :smile::sparkles::rocket:

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the version of `viem` to `1.19.11` and remove the unnecessary `/evm` suffix from the import path of `SmartRouter`.

### Detailed summary
- Updated `viem` version to `1.19.11`
- Removed `/evm` suffix from `SmartRouter` import path

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->