### PR TITLE
fix: Remove v3 liquidity info not shown when has 0 percent

### DIFF
--- a/apps/web/src/hooks/v3/useDerivedV3BurnInfo.ts
+++ b/apps/web/src/hooks/v3/useDerivedV3BurnInfo.ts
@@ -6,6 +6,7 @@ import { useToken } from 'hooks/Tokens'
 import { ReactNode, useMemo } from 'react'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 import { useAccount } from 'wagmi'
+import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import { usePool } from './usePools'
 import { useV3PositionFees } from './useV3PositionFees'
 
@@ -47,7 +48,7 @@ export function useDerivedV3BurnInfo(
     [pool, position],
   )
 
-  const liquidityPercentage = percent ? new Percent(percent, 100) : undefined
+  const liquidityPercentage = !isUndefinedOrNull(percent) ? new Percent(percent!, 100) : undefined
 
   const discountedAmount0 = positionSDK
     ? liquidityPercentage?.multiply(positionSDK.amount0.quotient).quotient


### PR DESCRIPTION
<img width="451" alt="Screenshot 2024-02-21 at 11 55 17" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/a16d641e-998b-49af-8861-d9ba2a0fcd26">
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `useDerivedV3BurnInfo` hook by checking if `percent` is not undefined or null before creating a `Percent` object.

### Detailed summary
- Added check for `percent` not being undefined or null before creating `Percent` object.
- Imported `isUndefinedOrNull` function from `@pancakeswap/utils/isUndefinedOrNull`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->