### PR TITLE
fetch pools prices in parallel rather than sequential

### DIFF
--- a/apps/web/src/state/pools/index.ts
+++ b/apps/web/src/state/pools/index.ts
@@ -200,7 +200,7 @@ export const fetchPoolsPublicDataAsync = (chainId: number) => async (dispatch, g
 
     const liveData: any[] = []
 
-    for (const pool of poolsConfig) {
+    await Promise.all(poolsConfig.map(async pool => {
       const timeLimit = timeLimitsSousIdMap[pool.sousId]
       const totalStaking = totalStakingsSousIdMap[pool.sousId]
       const isPoolEndBlockExceeded =
@@ -250,7 +250,7 @@ export const fetchPoolsPublicDataAsync = (chainId: number) => async (dispatch, g
         apr,
         isFinished: isPoolFinished,
       })
-    }
+    }))
 
     dispatch(setPoolsPublicData(liveData || []))
   } catch (error) {


### PR DESCRIPTION
Making pool page initial load faster by loading all pool prices in parallel rather than sequential. Especially when the Llama pricing API is used this massively reduces pools load time for users with high latency connections like common on mobile.
There was a race condition in the past where .map with the async callback was not correctly awaited, but this was fixed by introducing a sequential for loop rather than awaiting it correctly.