### PR TITLE
fix: Use same currency display components when removing liquidity

### DIFF
--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -445,7 +445,9 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
                   </Text>
                 </Flex>
                 <Flex>
-                  <Text small>{formatCurrencyAmount(liquidityValue0, 4, locale)}</Text>
+                  <Text small>
+                    <FormattedCurrencyAmount currencyAmount={liquidityValue0} />
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="flex-end" mb="8px">
@@ -463,7 +465,9 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
                   </Text>
                 </Flex>
                 <Flex>
-                  <Text small>{formatCurrencyAmount(liquidityValue1, 4, locale)}</Text>
+                  <Text small>
+                    <FormattedCurrencyAmount currencyAmount={liquidityValue1} />
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="flex-end" mb="8px">
@@ -482,7 +486,9 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
                   </Text>
                 </Flex>
                 <Flex>
-                  <Text small>{formatCurrencyAmount(feeValue0, 4, locale)}</Text>
+                  <Text small>
+                    <FormattedCurrencyAmount currencyAmount={feeValue0} />
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="flex-end" mb="8px">
@@ -500,7 +506,9 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
                   </Text>
                 </Flex>
                 <Flex>
-                  <Text small>{formatCurrencyAmount(feeValue1, 4, locale)}</Text>
+                  <Text small>
+                    <FormattedCurrencyAmount currencyAmount={feeValue1} />
+                  </Text>
                 </Flex>
               </Flex>
               <Flex justifyContent="flex-end" mb="8px">

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -46,7 +46,7 @@ import { hexToBigInt } from 'viem'
 
 import { RangeTag } from 'components/RangeTag'
 import Divider from 'components/Divider'
-import { formatCurrencyAmount, formatRawAmount } from 'utils/formatCurrencyAmount'
+import { formatRawAmount } from 'utils/formatCurrencyAmount'
 import { basisPointsToPercent } from 'utils/exchange'
 import { getViemClients } from 'utils/viem'
 import { calculateGasMargin } from 'utils'
@@ -80,10 +80,7 @@ export default function RemoveLiquidityV3() {
 }
 
 function Remove({ tokenId }: { tokenId?: bigint }) {
-  const {
-    t,
-    currentLanguage: { locale },
-  } = useTranslation()
+  const { t } = useTranslation()
 
   // flag for receiving WNATIVE
   const [receiveWNATIVE, setReceiveWNATIVE] = useState(false)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the currency amount formatting in the `RemoveLiquidityV3` component.

### Detailed summary
- Removed `formatCurrencyAmount` function imports
- Replaced direct usage of `formatCurrencyAmount` with `<FormattedCurrencyAmount>` component for `liquidityValue0`, `liquidityValue1`, `feeValue0`, and `feeValue1` in the component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->