### PR TITLE
feat: add 2 bnb v2 farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -1066,6 +1066,20 @@ const farms: SerializedFarmConfig[] = [
   },
   //    * V3 by order of release (some may be out of PID order due to multiplier boost)
   {
+    pid: 180,
+    lpSymbol: 'MGP-BNB LP',
+    lpAddress: '0x2b3DBbA2D1F5158c7BA4b645B7ea187F7F1763af',
+    token: bscTokens.mgp,
+    quoteToken: bscTokens.wbnb,
+  },
+  {
+    pid: 181,
+    lpSymbol: 'PNP-BNB LP',
+    lpAddress: '0x1C5bD1B4A4Fc05cC0Fb1a0f61136512744Ca4F34',
+    token: bscTokens.pnp,
+    quoteToken: bscTokens.wbnb,
+  },
+  {
     pid: 179,
     lpSymbol: 'mDLP-DLP LP',
     lpAddress: '0xA2915ae3bc8C6C03f59496B6Dd26aa6a4335b788',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add two new liquidity pool configurations for the V3 release on BSC.

### Detailed summary
- Added a new liquidity pool with PID 180 for MGP-BNB LP
- Added a new liquidity pool with PID 181 for PNP-BNB LP

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->