### PR TITLE
chore: clean ts errors

### DIFF
--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -1,49 +1,49 @@
+import { PositionDetails } from '@pancakeswap/farms'
+import { useTranslation } from '@pancakeswap/localization'
+import { isStableSwapSupported } from '@pancakeswap/smart-router/evm'
 import {
   AddIcon,
   Button,
-  CardBody,
-  CardFooter,
-  Text,
-  Dots,
-  Flex,
-  Tag,
   ButtonMenu,
   ButtonMenuItem,
+  CardBody,
+  CardFooter,
   Checkbox,
-  IconButton,
+  Dots,
+  Flex,
   HistoryIcon,
-  useModal,
+  IconButton,
   Link,
+  Tag,
+  Text,
+  useModal,
 } from '@pancakeswap/uikit'
-import { PositionDetails } from '@pancakeswap/farms'
+import { Liquidity } from '@pancakeswap/widgets-internal'
+import { AppBody, AppHeader } from 'components/App'
+import TransactionsModal from 'components/App/Transactions/TransactionsModal'
+import { RangeTag } from 'components/RangeTag'
+import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import { V3_MIGRATION_SUPPORTED_CHAINS } from 'config/constants/supportChains'
-import { isStableSwapSupported } from '@pancakeswap/smart-router/evm'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import useV2PairsByAccount from 'hooks/useV2Pairs'
+import { useV3Positions } from 'hooks/v3/useV3Positions'
+import { useAtom } from 'jotai'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
+import React, { ReactNode, useMemo, useState } from 'react'
 import { styled } from 'styled-components'
-import { AppBody, AppHeader } from 'components/App'
-import { useV3Positions } from 'hooks/v3/useV3Positions'
+import atomWithStorageWithErrorCatch from 'utils/atomWithStorageWithErrorCatch'
 import { CHAIN_IDS } from 'utils/wagmi'
+import { LiquidityCardRow } from 'views/AddLiquidity/components/LiquidityCardRow'
+import { StablePairCard } from 'views/AddLiquidityV3/components/StablePairCard'
+import { V2PairCard } from 'views/AddLiquidityV3/components/V2PairCard'
 import PositionListItem from 'views/AddLiquidityV3/formViews/V3FormView/components/PoolListItem'
 import Page from 'views/Page'
-import { useTranslation } from '@pancakeswap/localization'
-import { RangeTag } from 'components/RangeTag'
-import useV2PairsByAccount from 'hooks/useV2Pairs'
 import useStableConfig, {
   LPStablePair,
   StableConfigContext,
   useLPTokensWithBalanceByAccount,
 } from 'views/Swap/hooks/useStableConfig'
-import React, { ReactNode, useMemo, useState } from 'react'
-import { V2PairCard } from 'views/AddLiquidityV3/components/V2PairCard'
-import { StablePairCard } from 'views/AddLiquidityV3/components/StablePairCard'
-import TransactionsModal from 'components/App/Transactions/TransactionsModal'
-import { LiquidityCardRow } from 'views/AddLiquidity/components/LiquidityCardRow'
-import atomWithStorageWithErrorCatch from 'utils/atomWithStorageWithErrorCatch'
-import { useAtom } from 'jotai'
-import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
-import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import { Liquidity } from '@pancakeswap/widgets-internal'
 
 const Body = styled(CardBody)`
   background-color: ${({ theme }) => theme.colors.dropdownDeep};

--- a/apps/web/src/state/info/types.ts
+++ b/apps/web/src/state/info/types.ts
@@ -33,10 +33,10 @@ export type Transaction = {
   hash: string
   timestamp: string
   sender: string
-  token0Symbol: string
-  token1Symbol: string
-  token0Address: string
-  token1Address: string
+  token0Symbol?: string
+  token1Symbol?: string
+  token0Address?: string
+  token1Address?: string
   amountUSD: number
   amountToken0: number
   amountToken1: number

--- a/apps/web/src/state/lists/hooks.ts
+++ b/apps/web/src/state/lists/hooks.ts
@@ -18,6 +18,7 @@ import mapValues from 'lodash/mapValues'
 import _pickBy from 'lodash/pickBy'
 import uniqBy from 'lodash/uniqBy'
 import { useMemo } from 'react'
+import { notEmpty } from 'utils/notEmpty'
 import DEFAULT_TOKEN_LIST from '../../config/constants/tokenLists/pancake-default.tokenlist.json'
 import ONRAMP_TOKEN_LIST from '../../config/constants/tokenLists/pancake-supported-onramp-currency-list.json'
 import UNSUPPORTED_TOKEN_LIST from '../../config/constants/tokenLists/pancake-unsupported.tokenlist.json'
@@ -111,7 +112,7 @@ export const combinedTokenMapFromOfficialsUrlsAtom = atom((get) => {
 export const tokenListFromOfficialsUrlsAtom = atom((get) => {
   const lists: ListsState['byUrl'] = get(selectorByUrlsAtom)
 
-  const mergedTokenLists: TokenInfo[] = OFFICIAL_LISTS.reduce((acc, url) => {
+  const mergedTokenLists: TokenInfo[] = OFFICIAL_LISTS.reduce<TokenInfo[]>((acc, url) => {
     if (lists?.[url]?.current?.tokens) {
       acc.push(...(lists?.[url]?.current?.tokens || []))
     }
@@ -166,7 +167,7 @@ export function listToTokenMap(list: TokenList, key?: string): TokenAddressMap {
       }
       return null
     })
-    .filter(Boolean)
+    .filter(notEmpty)
 
   const groupedTokenMap: { [chainId: string]: WrappedTokenInfo[] } = groupBy(tokenMap, 'chainId')
 
@@ -202,7 +203,10 @@ export function useAllLists(): {
 
   const urls = useAtomValue(selectorByUrlsAtom)
 
-  return useMemo(() => _pickBy(urls, (_, url) => MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)), [chainId, urls])
+  return useMemo(
+    () => _pickBy(urls, (_, url) => chainId && MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)),
+    [chainId, urls],
+  )
 }
 
 function combineMaps(map1: TokenAddressMap, map2: TokenAddressMap): TokenAddressMap {
@@ -218,7 +222,7 @@ export function useActiveListUrls(): string[] | undefined {
   const { chainId } = useActiveChainId()
   const urls = useAtomValue(activeListUrlsAtom)
 
-  return useMemo(() => urls.filter((url) => MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)), [urls, chainId])
+  return useMemo(() => urls.filter((url) => chainId && MULTI_CHAIN_LIST_URLS[chainId]?.includes(url)), [urls, chainId])
 }
 
 export function useInactiveListUrls() {

--- a/apps/web/src/state/lottery/fetchUnclaimedUserRewards.ts
+++ b/apps/web/src/state/lottery/fetchUnclaimedUserRewards.ts
@@ -1,14 +1,15 @@
-import BigNumber from 'bignumber.js'
-import { LotteryStatus, LotteryTicket, LotteryTicketClaimData } from 'config/constants/types'
-import { LotteryUserGraphEntity, LotteryRoundGraphEntity } from 'state/types'
-import { publicClient } from 'utils/wagmi'
 import { ChainId } from '@pancakeswap/chains'
+import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
+import BigNumber from 'bignumber.js'
 import { lotteryV2ABI } from 'config/abi/lotteryV2'
 import { NUM_ROUNDS_TO_CHECK_FOR_REWARDS } from 'config/constants/lottery'
+import { LotteryStatus, LotteryTicket, LotteryTicketClaimData } from 'config/constants/types'
+import { LotteryRoundGraphEntity, LotteryUserGraphEntity } from 'state/types'
 import { getLotteryV2Address } from 'utils/addressHelpers'
-import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { fetchUserTicketsForMultipleRounds } from './getUserTicketsData'
+import { notEmpty } from 'utils/notEmpty'
+import { publicClient } from 'utils/wagmi'
 import { MAX_LOTTERIES_REQUEST_SIZE } from './getLotteriesData'
+import { fetchUserTicketsForMultipleRounds } from './getUserTicketsData'
 
 interface RoundDataAndUserTickets {
   roundId: string
@@ -27,18 +28,18 @@ const fetchCakeRewardsForTickets = async (
       abi: lotteryV2ABI,
       functionName: 'viewRewardsForTicketId',
       address: lotteryAddress,
-      args: [BigInt(roundId), BigInt(id), rewardBracket],
+      args: [BigInt(roundId || 0), BigInt(id), rewardBracket],
     } as const
   })
 
   try {
     const client = publicClient({ chainId: ChainId.BSC })
-    const cakeRewards = await client.multicall({
+    const cakeRewards = (await client.multicall({
       contracts: calls,
       allowFailure: false,
-    })
+    })) as bigint[]
 
-    const cakeTotal = cakeRewards.reduce((accum: BigNumber, cakeReward: bigint) => {
+    const cakeTotal = cakeRewards.reduce<BigNumber>((accum: BigNumber, cakeReward: bigint) => {
       return accum.plus(new BigNumber(cakeReward.toString()))
     }, BIG_ZERO)
 
@@ -48,7 +49,7 @@ const fetchCakeRewardsForTickets = async (
     return { ticketsWithUnclaimedRewards, cakeTotal }
   } catch (error) {
     console.error(error)
-    return { ticketsWithUnclaimedRewards: null, cakeTotal: null }
+    return { ticketsWithUnclaimedRewards: [], cakeTotal: BIG_ZERO }
   }
 }
 
@@ -57,7 +58,7 @@ const getRewardBracketByNumber = (ticketNumber: string, finalNumber: string): nu
   // i.e. '1123456' should be evaluated as '6543211'
   const ticketNumAsArray = ticketNumber.split('').reverse()
   const winningNumsAsArray = finalNumber.split('').reverse()
-  const matchingNumbers = []
+  const matchingNumbers: string[] = []
 
   // The number at index 6 in all tickets is 1 and will always match, so finish at index 5
   for (let index = 0; index < winningNumsAsArray.length - 1; index++) {
@@ -74,7 +75,7 @@ const getRewardBracketByNumber = (ticketNumber: string, finalNumber: string): nu
 
 export const getWinningTickets = async (
   roundDataAndUserTickets: RoundDataAndUserTickets,
-): Promise<LotteryTicketClaimData> => {
+): Promise<LotteryTicketClaimData | null> => {
   const { roundId, userTickets, finalNumber } = roundDataAndUserTickets
 
   const ticketsWithRewardBrackets = userTickets.map((ticket) => {
@@ -103,7 +104,7 @@ export const getWinningTickets = async (
   }
 
   if (allWinningTickets.length > 0) {
-    return { ticketsWithUnclaimedRewards: null, allWinningTickets, cakeTotal: null, roundId }
+    return { ticketsWithUnclaimedRewards: [], allWinningTickets, cakeTotal: BIG_ZERO, roundId }
   }
 
   return null
@@ -111,7 +112,7 @@ export const getWinningTickets = async (
 
 const getWinningNumbersForRound = (targetRoundId: string, lotteriesData: LotteryRoundGraphEntity[]) => {
   const targetRound = lotteriesData.find((pastLottery) => pastLottery.id === targetRoundId)
-  return targetRound?.finalNumber
+  return targetRound?.finalNumber || ''
 }
 
 const fetchUnclaimedUserRewards = async (
@@ -171,9 +172,9 @@ const fetchUnclaimedUserRewards = async (
     )
 
     // Filter to only rounds with unclaimed tickets
-    const roundsWithUnclaimedWinningTickets = roundsWithWinningTickets.filter(
-      (winningTicketData) => winningTicketData.ticketsWithUnclaimedRewards,
-    )
+    const roundsWithUnclaimedWinningTickets = roundsWithWinningTickets
+      .filter((winningTicketData) => winningTicketData?.ticketsWithUnclaimedRewards)
+      .filter(notEmpty)
 
     return roundsWithUnclaimedWinningTickets
   }

--- a/apps/web/src/state/lottery/getLotteriesData.ts
+++ b/apps/web/src/state/lottery/getLotteriesData.ts
@@ -1,7 +1,7 @@
-import { request, gql } from 'graphql-request'
 import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
-import { LotteryRoundGraphEntity, LotteryResponse } from 'state/types'
-import { getRoundIdsArray, fetchMultipleLotteries } from './helpers'
+import { gql, request } from 'graphql-request'
+import { LotteryResponse, LotteryRoundGraphEntity } from 'state/types'
+import { fetchMultipleLotteries, getRoundIdsArray } from './helpers'
 
 export const MAX_LOTTERIES_REQUEST_SIZE = 100
 
@@ -38,10 +38,10 @@ const applyNodeDataToLotteriesGraphResponse = (
       startTime: nodeRoundData.startTime,
       status: nodeRoundData.status,
       id: nodeRoundData.lotteryId,
-      ticketPrice: graphRoundData?.ticketPrice,
-      totalTickets: graphRoundData?.totalTickets,
-      totalUsers: graphRoundData?.totalUsers,
-      winningTickets: graphRoundData?.winningTickets,
+      ticketPrice: graphRoundData?.ticketPrice || '',
+      totalTickets: graphRoundData?.totalTickets || '',
+      totalUsers: graphRoundData?.totalUsers || '',
+      winningTickets: graphRoundData?.winningTickets || '',
     }
   })
 

--- a/apps/web/src/state/lottery/getUserTicketsData.ts
+++ b/apps/web/src/state/lottery/getUserTicketsData.ts
@@ -2,7 +2,7 @@ import { lotteryV2ABI } from 'config/abi/lotteryV2'
 import { TICKET_LIMIT_PER_REQUEST } from 'config/constants/lottery'
 import { LotteryTicket } from 'config/constants/types'
 import { getLotteryV2Contract } from 'utils/contractHelpers'
-import { ContractFunctionResult, Address } from 'viem'
+import { Address, ContractFunctionResult } from 'viem'
 
 const lotteryContract = getLotteryV2Contract()
 
@@ -28,7 +28,7 @@ export const viewUserInfoForLotteryId = async (
   lotteryId: string,
   cursor: number,
   perRequestLimit: number,
-): Promise<LotteryTicket[]> => {
+): Promise<LotteryTicket[] | null> => {
   try {
     const data = await lotteryContract.read.viewUserInfoForLotteryId([
       account as Address,
@@ -46,14 +46,17 @@ export const viewUserInfoForLotteryId = async (
 export const fetchUserTicketsForOneRound = async (account: string, lotteryId: string): Promise<LotteryTicket[]> => {
   let cursor = 0
   let numReturned = TICKET_LIMIT_PER_REQUEST
-  const ticketData = []
+  const ticketData: LotteryTicket[] = []
 
   while (numReturned === TICKET_LIMIT_PER_REQUEST) {
     // eslint-disable-next-line no-await-in-loop
     const response = await viewUserInfoForLotteryId(account, lotteryId, cursor, TICKET_LIMIT_PER_REQUEST)
+
     cursor += TICKET_LIMIT_PER_REQUEST
-    numReturned = response.length
-    ticketData.push(...response)
+    if (response) {
+      numReturned = response.length
+      ticketData.push(...response)
+    }
   }
 
   return ticketData

--- a/apps/web/src/state/lottery/helpers.ts
+++ b/apps/web/src/state/lottery/helpers.ts
@@ -132,13 +132,13 @@ export const fetchCurrentLotteryIdAndMaxBuy = async () => {
     })
 
     return {
-      currentLotteryId: currentLotteryId ? currentLotteryId.toString() : null,
-      maxNumberTicketsPerBuyOrClaim: maxNumberTicketsPerBuyOrClaim ? maxNumberTicketsPerBuyOrClaim.toString() : null,
+      currentLotteryId: currentLotteryId ? currentLotteryId.toString() : '',
+      maxNumberTicketsPerBuyOrClaim: maxNumberTicketsPerBuyOrClaim ? maxNumberTicketsPerBuyOrClaim.toString() : '',
     }
   } catch (error) {
     return {
-      currentLotteryId: null,
-      maxNumberTicketsPerBuyOrClaim: null,
+      currentLotteryId: '',
+      maxNumberTicketsPerBuyOrClaim: '',
     }
   }
 }

--- a/apps/web/src/state/lottery/index.ts
+++ b/apps/web/src/state/lottery/index.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-param-reassign */
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { LotteryTicket, LotteryStatus } from 'config/constants/types'
-import { LotteryState, LotteryRoundGraphEntity, LotteryUserGraphEntity, LotteryResponse } from 'state/types'
-import { fetchLottery, fetchCurrentLotteryIdAndMaxBuy } from './helpers'
+import { LotteryStatus, LotteryTicket } from 'config/constants/types'
+import { LotteryResponse, LotteryRoundGraphEntity, LotteryState, LotteryUserGraphEntity } from 'state/types'
+import { resetUserState } from '../global/actions'
 import getLotteriesData from './getLotteriesData'
 import getUserLotteryData, { getGraphLotteryUser } from './getUserLotteryData'
-import { resetUserState } from '../global/actions'
+import { fetchCurrentLotteryIdAndMaxBuy, fetchLottery } from './helpers'
 
 interface PublicLotteryData {
   currentLotteryId: string
@@ -13,12 +13,12 @@ interface PublicLotteryData {
 }
 
 const initialState: LotteryState = {
-  currentLotteryId: null,
+  currentLotteryId: '',
   isTransitioning: false,
-  maxNumberTicketsPerBuyOrClaim: null,
+  maxNumberTicketsPerBuyOrClaim: '',
   currentRound: {
     isLoading: true,
-    lotteryId: null,
+    lotteryId: '',
     status: LotteryStatus.PENDING,
     startTime: '',
     endTime: '',
@@ -27,7 +27,7 @@ const initialState: LotteryState = {
     treasuryFee: '',
     firstTicketId: '',
     amountCollectedInCake: '',
-    finalNumber: null,
+    finalNumber: 0,
     cakePerBracket: [],
     countWinnersPerBracket: [],
     rewardsBreakdown: [],
@@ -36,7 +36,7 @@ const initialState: LotteryState = {
       tickets: [],
     },
   },
-  lotteriesData: null,
+  lotteriesData: [],
   userLotteryData: { account: '', totalCake: '', totalTickets: '', rounds: [] },
 }
 
@@ -107,6 +107,7 @@ export const LotterySlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(resetUserState, (state) => {
       state.userLotteryData = { ...initialState.userLotteryData }
+
       state.currentRound = { ...state.currentRound, userTickets: { ...initialState.currentRound.userTickets } }
     })
     builder.addCase(fetchCurrentLottery.fulfilled, (state, action: PayloadAction<LotteryResponse>) => {

--- a/apps/web/src/state/mint/hooks.ts
+++ b/apps/web/src/state/mint/hooks.ts
@@ -1,10 +1,10 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency, CurrencyAmount, Pair, Percent, Price, Token } from '@pancakeswap/sdk'
+import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 import { BIG_INT_ZERO } from 'config/constants/exchange'
 import { PairState, useV2Pair } from 'hooks/usePairs'
 import useTotalSupply from 'hooks/useTotalSupply'
 import { useCallback, useMemo } from 'react'
-import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 import { useAddLiquidityV2FormDispatch, useAddLiquidityV2FormState } from 'state/mint/reducer'
 import { useAccount } from 'wagmi'
 import { useCurrencyBalances } from '../wallet/hooks'
@@ -79,6 +79,7 @@ export function useDerivedMintInfo(
     () =>
       Boolean(
         pairState === PairState.EXISTS &&
+          pair &&
           totalSupply &&
           totalSupply.quotient === BIG_INT_ZERO &&
           ((pair.reserve0.quotient > BIG_INT_ZERO && pair.reserve1.quotient === BIG_INT_ZERO) ||

--- a/apps/web/src/state/multicall/retry.test.ts
+++ b/apps/web/src/state/multicall/retry.test.ts
@@ -1,5 +1,5 @@
-import { vi, describe, it } from 'vitest'
-import { retry, RetryableError } from './retry'
+import { describe, it, vi } from 'vitest'
+import { RetryableError, retry } from './retry'
 
 describe.concurrent('retry', () => {
   beforeEach(() => {
@@ -58,7 +58,7 @@ describe.concurrent('retry', () => {
   }
 
   it('waits random amount of time between min and max', async () => {
-    const promises = []
+    const promises: Promise<void>[] = []
     for (let i = 0; i < 10; i++) {
       promises.push(
         checkTime(

--- a/apps/web/src/state/pools/helpers.ts
+++ b/apps/web/src/state/pools/helpers.ts
@@ -1,17 +1,17 @@
-import BigNumber from 'bignumber.js'
-import {
-  SerializedPool,
-  SerializedCakeVault,
-  DeserializedCakeVault,
-  SerializedLockedCakeVault,
-  VaultKey,
-} from 'state/types'
+import { DeserializedPool } from '@pancakeswap/pools'
+import { Token } from '@pancakeswap/sdk'
 import { deserializeToken } from '@pancakeswap/token-lists'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
-import { DeserializedPool } from '@pancakeswap/pools'
+import BigNumber from 'bignumber.js'
+import {
+  DeserializedCakeVault,
+  SerializedCakeVault,
+  SerializedLockedCakeVault,
+  SerializedPool,
+  VaultKey,
+} from 'state/types'
 import { safeGetAddress } from 'utils'
 import { convertSharesToCake } from 'views/Pools/helpers'
-import { Token } from '@pancakeswap/sdk'
 
 type UserData =
   | DeserializedPool<Token>['userData']
@@ -62,9 +62,9 @@ export const transformPool = (pool: SerializedPool): DeserializedPool<Token> => 
     stakingToken: deserializeToken(stakingToken),
     earningToken: deserializeToken(earningToken),
     userData: transformUserData(userData),
-    totalStaked: new BigNumber(totalStaked),
-    stakingLimit: new BigNumber(stakingLimit),
-    stakingLimitEndTimestamp: numberSecondsForUserLimit + startTimestamp,
+    totalStaked: new BigNumber(totalStaked || '0'),
+    stakingLimit: new BigNumber(stakingLimit || '0'),
+    stakingLimitEndTimestamp: (numberSecondsForUserLimit || 0) + (startTimestamp || 0),
   }
 }
 
@@ -103,8 +103,8 @@ export const transformVault = (vaultKey: VaultKey, vault: SerializedCakeVault): 
       },
     } = vault as SerializedLockedCakeVault
 
-    const totalCakeInVault = new BigNumber(totalCakeInVaultAsString)
-    const totalLockedAmount = new BigNumber(totalLockedAmountAsString)
+    const totalCakeInVault = new BigNumber(totalCakeInVaultAsString || '0')
+    const totalLockedAmount = new BigNumber(totalLockedAmountAsString || '0')
     const lockedAmount = new BigNumber(lockedAmountAsString)
     const userBoostedShare = new BigNumber(userBoostedShareAsString)
     const currentOverdueFee = currentOverdueFeeAsString ? new BigNumber(currentOverdueFeeAsString) : BIG_ZERO

--- a/apps/web/src/state/pools/hooks.ts
+++ b/apps/web/src/state/pools/hooks.ts
@@ -1,44 +1,44 @@
+import { ChainId } from '@pancakeswap/chains'
+import { getFarmConfig } from '@pancakeswap/farms/constants'
+import { getSourceChain, isIfoSupported } from '@pancakeswap/ifos'
+import { getLivePoolsConfig } from '@pancakeswap/pools'
+import { Token } from '@pancakeswap/sdk'
+import { Pool } from '@pancakeswap/widgets-internal'
+import { FAST_INTERVAL } from 'config/constants'
+import { useFastRefreshEffect, useSlowRefreshEffect } from 'hooks/useRefreshEffect'
 import { useEffect, useMemo } from 'react'
-import { useAccount } from 'wagmi'
 import { batch, useSelector } from 'react-redux'
 import { useAppDispatch } from 'state'
-import { useFastRefreshEffect, useSlowRefreshEffect } from 'hooks/useRefreshEffect'
-import { FAST_INTERVAL } from 'config/constants'
-import { getFarmConfig } from '@pancakeswap/farms/constants'
-import { Pool } from '@pancakeswap/widgets-internal'
-import { Token } from '@pancakeswap/sdk'
-import { ChainId } from '@pancakeswap/chains'
-import { getLivePoolsConfig } from '@pancakeswap/pools'
-import { isIfoSupported, getSourceChain } from '@pancakeswap/ifos'
+import { useAccount } from 'wagmi'
 
-import { useActiveChainId } from 'hooks/useActiveChainId'
-import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useQuery } from '@tanstack/react-query'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import {
-  fetchPoolsPublicDataAsync,
-  fetchPoolsUserDataAsync,
-  fetchCakeVaultPublicData,
-  fetchCakeVaultUserData,
-  fetchCakeVaultFees,
-  fetchPoolsStakingLimitsAsync,
-  fetchUserIfoCreditDataAsync,
-  fetchIfoPublicDataAsync,
+  fetchCakeFlexibleSideVaultFees,
   fetchCakeFlexibleSideVaultPublicData,
   fetchCakeFlexibleSideVaultUserData,
-  fetchCakeFlexibleSideVaultFees,
-  fetchCakePoolUserDataAsync,
   fetchCakePoolPublicDataAsync,
+  fetchCakePoolUserDataAsync,
+  fetchCakeVaultFees,
+  fetchCakeVaultPublicData,
+  fetchCakeVaultUserData,
+  fetchIfoPublicDataAsync,
+  fetchPoolsPublicDataAsync,
+  fetchPoolsStakingLimitsAsync,
+  fetchPoolsUserDataAsync,
+  fetchUserIfoCreditDataAsync,
   setInitialPoolConfig,
 } from '.'
-import { VaultKey } from '../types'
 import { fetchFarmsPublicDataAsync } from '../farms'
+import { VaultKey } from '../types'
 import {
+  ifoCeilingSelector,
+  ifoCreditSelector,
   makePoolWithUserDataLoadingSelector,
   makeVaultPoolByKey,
-  poolsWithVaultSelector,
-  ifoCreditSelector,
-  ifoCeilingSelector,
   makeVaultPoolWithKeySelector,
+  poolsWithVaultSelector,
 } from './selectors'
 
 // Only fetch farms for live pools
@@ -86,7 +86,7 @@ export const useFetchPublicPoolsData = () => {
   }, [dispatch, chainId])
 }
 
-export const usePool = (sousId: number): { pool: Pool.DeserializedPool<Token>; userDataLoaded: boolean } => {
+export const usePool = (sousId: number): { pool?: Pool.DeserializedPool<Token>; userDataLoaded: boolean } => {
   const poolWithUserDataLoadingSelector = useMemo(() => makePoolWithUserDataLoadingSelector(sousId), [sousId])
   return useSelector(poolWithUserDataLoadingSelector)
 }

--- a/apps/web/src/state/pools/selectors.ts
+++ b/apps/web/src/state/pools/selectors.ts
@@ -1,10 +1,10 @@
-import BigNumber from 'bignumber.js'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { createSelector } from '@reduxjs/toolkit'
+import BigNumber from 'bignumber.js'
+import { VaultPosition, getVaultPosition } from '../../utils/cakePool'
 import { State, VaultKey } from '../types'
 import { transformPool, transformVault } from './helpers'
 import { initialPoolVaultState } from './index'
-import { getVaultPosition, VaultPosition } from '../../utils/cakePool'
 
 const selectPoolsData = (state: State) => state.pools.data
 const selectPoolData = (sousId) => (state: State) => state.pools.data.find((p) => p.sousId === sousId)
@@ -13,9 +13,9 @@ const selectVault = (key: VaultKey) => (state: State) => key ? state.pools[key] 
 const selectIfo = (state: State) => state.pools.ifo
 const selectIfoUserCredit = (state: State) => state.pools.ifo.credit ?? BIG_ZERO
 
-export const makePoolWithUserDataLoadingSelector = (sousId) =>
+export const makePoolWithUserDataLoadingSelector = (sousId: number) =>
   createSelector([selectPoolData(sousId), selectUserDataLoaded], (pool, userDataLoaded) => {
-    return { pool: transformPool(pool), userDataLoaded }
+    return { pool: pool ? transformPool(pool) : undefined, userDataLoaded }
   })
 
 export const poolsWithUserDataLoadingSelector = createSelector(
@@ -46,7 +46,8 @@ export const poolsWithVaultSelector = createSelector(
     }
 
     const lockedVaultPosition = getVaultPosition(deserializedLockedCakeVault.userData)
-    const hasFlexibleSideSharesStaked = deserializedFlexibleSideCakeVault.userData.userShares.gt(0)
+    const hasFlexibleSideSharesStaked =
+      deserializedFlexibleSideCakeVault?.userData && deserializedFlexibleSideCakeVault.userData.userShares.gt(0)
 
     const cakeAutoFlexibleSideVault =
       cakePool && (lockedVaultPosition > VaultPosition.Flexible || hasFlexibleSideSharesStaked)

--- a/apps/web/src/state/profile/hooks.ts
+++ b/apps/web/src/state/profile/hooks.ts
@@ -18,7 +18,7 @@ export const useProfileForAddress = (
   isLoading: boolean
   isFetching: boolean
   isValidating: boolean
-  refresh: () => Promise<QueryObserverResult<GetProfileResponse>>
+  refresh: () => Promise<QueryObserverResult<GetProfileResponse | null>>
 } => {
   const { data, status, refetch, isFetching } = useQuery({
     queryKey: [address, 'profile'],
@@ -65,7 +65,7 @@ export const useProfile = (): {
   hasActiveProfile: boolean
   isInitialized: boolean
   isLoading: boolean
-  refresh: () => Promise<QueryObserverResult<GetProfileResponse | undefined>>
+  refresh: () => Promise<QueryObserverResult<GetProfileResponse | undefined | null>>
 } => {
   const { address: account } = useAccount()
   const { data, status, refetch } = useQuery({

--- a/apps/web/src/state/swap/hooks.test.ts
+++ b/apps/web/src/state/swap/hooks.test.ts
@@ -1,13 +1,14 @@
 /* eslint-disable no-var */
 /* eslint-disable vars-on-top */
-import { useEffect } from 'react'
+import { Currency } from '@pancakeswap/swap-sdk-core'
 import { renderHook } from '@testing-library/react-hooks'
+import { useCurrency } from 'hooks/Tokens'
 import { useAtom } from 'jotai'
 import { parse } from 'querystring'
-import { Mock, vi } from 'vitest'
+import { useEffect } from 'react'
 import { swapReducerAtom } from 'state/swap/reducer'
-import { useCurrency } from 'hooks/Tokens'
 import { createReduxWrapper } from 'testUtils'
+import { Mock, vi } from 'vitest'
 import { Field, replaceSwapState } from './actions'
 import { queryParametersToSwapState, useDerivedSwapInfo, useSwapState } from './hooks'
 
@@ -136,7 +137,13 @@ describe('#useDerivedSwapInfo', () => {
         } = useSwapState()
         const inputCurrency = useCurrency(inputCurrencyId)
         const outputCurrency = useCurrency(outputCurrencyId)
-        return useDerivedSwapInfo(independentField, typedValue, inputCurrency, outputCurrency, recipient)
+        return useDerivedSwapInfo(
+          independentField,
+          typedValue,
+          inputCurrency as Currency,
+          outputCurrency as Currency,
+          recipient || '',
+        )
       },
       { wrapper: createReduxWrapper() },
     )
@@ -161,7 +168,7 @@ describe('#useDerivedSwapInfo', () => {
               typedValue: '0.11',
               inputCurrencyId: 'BNB',
               outputCurrencyId: 'BNB',
-              recipient: undefined,
+              recipient: '',
             }),
           )
         }, [dispatch])
@@ -174,7 +181,13 @@ describe('#useDerivedSwapInfo', () => {
         } = useSwapState()
         const inputCurrency = useCurrency(inputCurrencyId)
         const outputCurrency = useCurrency(outputCurrencyId)
-        return useDerivedSwapInfo(independentField, typedValue, inputCurrency, outputCurrency, recipient)
+        return useDerivedSwapInfo(
+          independentField,
+          typedValue,
+          inputCurrency as Currency,
+          outputCurrency as Currency,
+          recipient || '',
+        )
       },
       {
         wrapper: createReduxWrapper(),
@@ -210,7 +223,13 @@ describe('#useDerivedSwapInfo', () => {
         } = useSwapState()
         const inputCurrency = useCurrency(inputCurrencyId)
         const outputCurrency = useCurrency(outputCurrencyId)
-        const swapInfo = useDerivedSwapInfo(independentField, typedValue, inputCurrency, outputCurrency, recipient)
+        const swapInfo = useDerivedSwapInfo(
+          independentField,
+          typedValue,
+          inputCurrency as Currency,
+          outputCurrency as Currency,
+          recipient || '',
+        )
         return {
           swapInfo,
         }

--- a/apps/web/src/state/swap/useStableSwapPairs.ts
+++ b/apps/web/src/state/swap/useStableSwapPairs.ts
@@ -5,5 +5,5 @@ import { useMemo } from 'react'
 export function useStableSwapPairs() {
   const { chainId } = useActiveChainId()
 
-  return useMemo(() => LegacyRouter.stableSwapPairsByChainId[chainId] || [], [chainId])
+  return useMemo(() => (chainId && LegacyRouter.stableSwapPairsByChainId[chainId]) || [], [chainId])
 }

--- a/apps/web/src/state/teams/helpers.ts
+++ b/apps/web/src/state/teams/helpers.ts
@@ -1,15 +1,15 @@
-import merge from 'lodash/merge'
-import teamsList from 'config/constants/teams'
-import { getProfileContract } from 'utils/contractHelpers'
-import { Team } from 'config/constants/types'
-import { TeamsById } from 'state/types'
-import { pancakeProfileABI } from 'config/abi/pancakeProfile'
-import { getPancakeProfileAddress } from 'utils/addressHelpers'
-import fromPairs from 'lodash/fromPairs'
-import { publicClient } from 'utils/wagmi'
 import { ChainId } from '@pancakeswap/chains'
+import { pancakeProfileABI } from 'config/abi/pancakeProfile'
+import teamsList from 'config/constants/teams'
+import { Team } from 'config/constants/types'
+import fromPairs from 'lodash/fromPairs'
+import merge from 'lodash/merge'
+import { TeamsById } from 'state/types'
+import { getPancakeProfileAddress } from 'utils/addressHelpers'
+import { getProfileContract } from 'utils/contractHelpers'
+import { publicClient } from 'utils/wagmi'
 
-export const getTeam = async (teamId: number): Promise<Team> => {
+export const getTeam = async (teamId: number): Promise<Team | null> => {
   try {
     const profileContract = getProfileContract()
     const {
@@ -34,7 +34,7 @@ export const getTeam = async (teamId: number): Promise<Team> => {
 /**
  * Gets on-chain data and merges it with the existing static list of teams
  */
-export const getTeams = async (): Promise<TeamsById> => {
+export const getTeams = async (): Promise<TeamsById | null> => {
   try {
     const profileContract = getProfileContract()
     const teamsById = fromPairs(teamsList.map((team) => [team.id, team]))

--- a/apps/web/src/state/transactions/actions.ts
+++ b/apps/web/src/state/transactions/actions.ts
@@ -76,7 +76,7 @@ export const addTransaction = createAction<{
   approval?: { tokenAddress: string; spender: string }
   claim?: { recipient: string }
   summary?: string
-  translatableSummary?: { text: string; data?: Record<string, string | number | undefined> }
+  translatableSummary?: { text: string; data?: Record<string, string | number> }
   type?: TransactionType
   order?: Order
   nonBscFarm?: NonBscFarmTransactionType

--- a/apps/web/src/state/transactions/reducer.ts
+++ b/apps/web/src/state/transactions/reducer.ts
@@ -1,20 +1,20 @@
 /* eslint-disable no-param-reassign */
-import { createReducer } from '@reduxjs/toolkit'
 import { Order } from '@gelatonetwork/limit-orders-lib'
+import { createReducer } from '@reduxjs/toolkit'
 import { confirmOrderCancellation, confirmOrderSubmission, saveOrder } from 'utils/localStorageOrders'
 import { Hash } from 'viem'
+import { resetUserState } from '../global/actions'
 import {
-  addTransaction,
-  checkedTransaction,
-  clearAllTransactions,
-  finalizeTransaction,
+  FarmTransactionStatus,
+  NonBscFarmTransactionType,
   SerializableTransactionReceipt,
   TransactionType,
+  addTransaction,
+  checkedTransaction,
   clearAllChainTransactions,
-  NonBscFarmTransactionType,
-  FarmTransactionStatus,
+  clearAllTransactions,
+  finalizeTransaction,
 } from './actions'
-import { resetUserState } from '../global/actions'
 
 const now = () => Date.now()
 
@@ -101,14 +101,14 @@ export default createReducer(initialState, (builder) =>
       } else if (tx.type === 'limit-order-cancellation') {
         confirmOrderCancellation(chainId, receipt.from, hash, receipt.status !== 0)
       } else if (tx.type === 'non-bsc-farm') {
-        if (tx.nonBscFarm.steps[0].status === FarmTransactionStatus.PENDING) {
+        if (tx.nonBscFarm && tx.nonBscFarm.steps[0].status === FarmTransactionStatus.PENDING) {
           if (receipt.status === FarmTransactionStatus.FAIL) {
             tx.nonBscFarm = { ...tx.nonBscFarm, status: receipt.status }
           }
 
           tx.nonBscFarm.steps[0] = {
             ...tx.nonBscFarm.steps[0],
-            status: receipt.status,
+            status: receipt.status || FarmTransactionStatus.PENDING,
           }
         } else {
           tx.nonBscFarm = nonBscFarm

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -481,7 +481,7 @@ export interface UserRound {
 
 // Pottery
 export interface PotteryState {
-  lastVaultAddress: Address
+  lastVaultAddress: Address | null
   publicData: SerializedPotteryPublicData
   userData: SerializedPotteryUserData
   finishedRoundInfo: PotteryRoundInfo

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -132,15 +132,15 @@ export interface DeserializedLockedCakeVault extends Omit<DeserializedCakeVault,
 
 export interface SerializedLockedCakeVault extends Omit<SerializedCakeVault, 'userData'> {
   totalLockedAmount?: SerializedBigNumber
-  userData?: SerializedLockedVaultUser
+  userData: SerializedLockedVaultUser
 }
 
 export interface SerializedCakeVault {
   totalShares?: SerializedBigNumber
   pricePerFullShare?: SerializedBigNumber
   totalCakeInVault?: SerializedBigNumber
-  fees?: SerializedVaultFees
-  userData?: SerializedVaultUser
+  fees: SerializedVaultFees
+  userData: SerializedVaultUser
 }
 
 // Ifo
@@ -448,7 +448,7 @@ export interface LotteryState {
   isTransitioning: boolean
   currentRound: LotteryResponse & { userTickets?: LotteryRoundUserTickets }
   lotteriesData?: LotteryRoundGraphEntity[]
-  userLotteryData?: LotteryUserGraphEntity
+  userLotteryData: LotteryUserGraphEntity
 }
 
 export interface LotteryRoundGraphEntity {

--- a/apps/web/src/views/Swap/hooks/useStableConfig.ts
+++ b/apps/web/src/views/Swap/hooks/useStableConfig.ts
@@ -87,7 +87,7 @@ export const StableConfigContext = createContext<{
   stableSwapInfoContract: UseStableSwapInfoContract
   stableSwapContract: ReturnType<typeof useStableSwapContract>
   stableSwapLPContract: ReturnType<typeof useStableSwapLPContract>
-  stableSwapConfig: StableSwapConfig
+  stableSwapConfig?: StableSwapConfig
 } | null>(null)
 
 export default function useStableConfig({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving data handling and error handling in various parts of the codebase.

### Detailed summary
- Added null check for `chainId` before accessing `LegacyRouter.stableSwapPairsByChainId`
- Made `stableSwapConfig` optional in `useStableConfig`
- Updated types in `types.ts` to make certain fields optional
- Updated `translatableSummary` type in `actions.ts` to exclude `undefined`
- Refactored `retry.test.ts` to use `vitest` imports
- Updated return type of `refresh` function in `profile/hooks.ts`
- Added `tryParseAmount` import in `mint/hooks.ts`
- Refactored imports in `getLotteriesData.ts` and updated field default values
- Updated types in `types.ts` to make certain fields required
- Updated `userData` and `fees` fields in `types.ts` to be required
- Updated `lastVaultAddress` field in `getLotteriesData.ts` to be nullable
- Updated return type of `viewUserInfoForLotteryId` in `getUserTicketsData.ts`
- Refactored imports and updated return type in `teams/helpers.ts`
- Updated `resetUserState` import in `reducer.ts`
- Improved error handling and data handling in various parts of the codebase

> The following files were skipped due to too many changes: `apps/web/src/state/pools/helpers.ts`, `apps/web/src/state/lists/hooks.ts`, `apps/web/src/state/lottery/index.ts`, `apps/web/src/state/swap/hooks.test.ts`, `apps/web/src/state/profile/helpers.ts`, `apps/web/src/state/lottery/helpers.ts`, `apps/web/src/state/pools/hooks.ts`, `apps/web/src/pages/liquidity/index.tsx`, `apps/web/src/state/lottery/getUserLotteryData.ts`, `apps/web/src/state/pottery/index.ts`, `apps/web/src/state/lottery/fetchUnclaimedUserRewards.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->