### PR TITLE
chore: list XRGB pools on BSC

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,15 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 372,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.xrgb,
+    contractAddress: '0x9d5a02246dE31cfd120aB18694309f0363906677',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.05787',
+    version: 3,
+  },
+  {
     sousId: 371,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.csix,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool with `sousId: 372` in `pools/56.ts`.

### Detailed summary
- Added a new pool with `sousId: 372`
- Staking token is `bscTokens.cake`
- Earning token is `bscTokens.xrgb`
- Contract address: `0x9d5a02246dE31cfd120aB18694309f0363906677`
- Pool category: `CORE`
- Token per block: `0.05787`
- Version: `3`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->