### PR TITLE
chore: Make token warning links external

### DIFF
--- a/apps/web/src/views/Swap/components/SwapWarningModal/56/LUSDWarning.tsx
+++ b/apps/web/src/views/Swap/components/SwapWarningModal/56/LUSDWarning.tsx
@@ -12,14 +12,14 @@ const LUSDWarning = () => {
           'Please exercise due caution when trading or providing liquidity for the lUSD token. The protocol was recently affected by an ',
         )}
         <Link
-          m="0 4px"
+          external
           style={{ display: 'inline' }}
           href="https://twitter.com/LinearFinance/status/1704818417880936535"
         >
           {t('exploit.')}
         </Link>
         {t('For more information, please refer to Linear Finance’s')}
-        <Link ml="4px" style={{ display: 'inline' }} href="https://twitter.com/LinearFinance">
+        <Link external ml="4px" style={{ display: 'inline' }} href="https://twitter.com/LinearFinance">
           {t('Twitter')}
         </Link>
       </Text>

--- a/apps/web/src/views/Swap/components/SwapWarningModal/56/METISWarning.tsx
+++ b/apps/web/src/views/Swap/components/SwapWarningModal/56/METISWarning.tsx
@@ -11,11 +11,16 @@ const METISWarning = () => {
         {t(
           'Please exercise due caution when trading / providing liquidity for the METIS token. The protocol was recently affected by the',
         )}
-        <Link m="0 4px" style={{ display: 'inline' }} href="https://twitter.com/MetisDAO/status/1676431481621676032">
+        <Link
+          external
+          m="0 4px"
+          style={{ display: 'inline' }}
+          href="https://twitter.com/MetisDAO/status/1676431481621676032"
+        >
           {t('PolyNetwork Exploit.')}
         </Link>
         {t('For more information, please refer to MetisDAO’s')}
-        <Link ml="4px" style={{ display: 'inline' }} href="https://twitter.com/MetisDAO">
+        <Link external ml="4px" style={{ display: 'inline' }} href="https://twitter.com/MetisDAO">
           {t('Twitter')}
         </Link>
       </Text>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the warning modals in the Swap feature to include external links to relevant Twitter posts for more information on recent exploits.

### Detailed summary
- Added `external` prop to Link components for Twitter links in LUSDWarning.tsx and METISWarning.tsx
- Updated href URLs for Twitter links in LUSDWarning.tsx and METISWarning.tsx

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->