### PR TITLE
fix: Trading reward page not using clientside navigation when redirect and flashes

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -190,11 +190,6 @@ const config = {
         destination: 'https://tokens.pancakeswap.finance/images/:address',
         permanent: false,
       },
-      {
-        source: '/trading-reward',
-        destination: '/trading-reward/cake-stakers',
-        permanent: true,
-      },
     ]
   },
   webpack: (webpackConfig, { webpack, isServer }) => {

--- a/apps/web/src/pages/trading-reward/index.tsx
+++ b/apps/web/src/pages/trading-reward/index.tsx
@@ -1,0 +1,12 @@
+const TradingRewardPage = () => <></>
+
+export const getServerSideProps = () => {
+  return {
+    redirect: {
+      destination: '/trading-reward/cake-stakers',
+      permanent: true,
+    },
+  }
+}
+
+export default TradingRewardPage


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update routing logic in `next.config.mjs` and `TradingRewardPage` to redirect `/trading-reward` to `/trading-reward/cake-stakers`.

### Detailed summary
- Updated routing logic in `next.config.mjs` to redirect `/trading-reward` to `/trading-reward/cake-stakers`
- Added `getServerSideProps` in `TradingRewardPage` to handle the redirect

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->