### PR TITLE
perf: Dont fetch token prices when apr calculator not open

### DIFF
--- a/apps/web/src/hooks/v3/usePairTokensPrice.ts
+++ b/apps/web/src/hooks/v3/usePairTokensPrice.ts
@@ -4,7 +4,12 @@ import { PriceCalculator } from '@pancakeswap/widgets-internal/roi'
 import { useMemo } from 'react'
 import { usePairPriceChartTokenData } from 'views/V3Info/hooks'
 
-export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTimeWindowEnum, chainId?: ChainId) => {
+export const usePairTokensPrice = (
+  pairAddress?: string,
+  duration?: PairDataTimeWindowEnum,
+  chainId?: ChainId,
+  enabled = true,
+) => {
   const priceTimeWindow = useMemo(() => {
     switch (duration) {
       case PairDataTimeWindowEnum.DAY:
@@ -20,7 +25,7 @@ export const usePairTokensPrice = (pairAddress?: string, duration?: PairDataTime
     }
   }, [duration])
 
-  const pairPrice = usePairPriceChartTokenData(pairAddress?.toLowerCase(), priceTimeWindow, chainId)
+  const pairPrice = usePairPriceChartTokenData(pairAddress?.toLowerCase(), priceTimeWindow, chainId, enabled)
 
   const pairPriceData: { time: Date; value: number }[] = useMemo(() => {
     return (

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -90,7 +90,7 @@ export function AprCalculator({
   const router = useRouter()
   const poolAddress = useMemo(() => (pool ? Pool.getAddress(pool.token0, pool.token1, pool.fee) : undefined), [pool])
 
-  const prices = usePairTokensPrice(poolAddress, priceSpan, baseCurrency?.chainId)
+  const prices = usePairTokensPrice(poolAddress, priceSpan, baseCurrency?.chainId, isOpen)
   const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount)
   const volume24H = usePoolAvgTradingVolume({
     address: poolAddress,

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -64,7 +64,7 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
   const roiModal = useModalV2()
 
   const [priceTimeWindow, setPriceTimeWindow] = useState(0)
-  const prices = usePairTokensPrice(lpAddress, priceTimeWindow, baseCurrency?.chainId)
+  const prices = usePairTokensPrice(lpAddress, priceTimeWindow, baseCurrency?.chainId, roiModal.isOpen)
 
   const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount)
 

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -122,6 +122,7 @@ export const usePairPriceChartTokenData = (
   address?: string,
   duration?: 'day' | 'week' | 'month' | 'year',
   targetChainId?: ChainId,
+  enabled = true,
 ): { data: PriceChartEntry[] | undefined; maxPrice?: number; minPrice?: number; averagePrice?: number } => {
   const chainName = useChainNameByQuery()
   const chainId = targetChainId || multiChainId[chainName]
@@ -148,7 +149,7 @@ export const usePairPriceChartTokenData = (
       )
     },
 
-    enabled: Boolean(chainId && !!address),
+    enabled: Boolean(enabled && chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an `enabled` parameter to the `usePairTokensPrice` hook for better control over data fetching.

### Detailed summary
- Added an `enabled` parameter to the `usePairTokensPrice` hook in `usePairTokensPrice.ts`
- Updated the usage of `usePairTokensPrice` in `FarmV3ApyButton.tsx` and `AprCalculator.tsx` to include the `enabled` parameter
- Modified the `usePairPriceChartTokenData` hook in `V3Info/hooks/index.ts` to consider the `enabled` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->