### PR TITLE
fix: Roi calculator range price discrepancy with add liquidity

### DIFF
--- a/packages/widgets-internal/roi/RangeSelector.tsx
+++ b/packages/widgets-internal/roi/RangeSelector.tsx
@@ -51,7 +51,7 @@ export const RangeSelector = memo(function RangeSelector({
   return (
     <FlexGap gap="16px" width="100%" mb="16px">
       <StepCounter
-        value={ticksAtLimit[isSorted ? Bound.LOWER : Bound.UPPER] ? "0" : formatPrice(leftPrice, 6) ?? ""}
+        value={ticksAtLimit[isSorted ? Bound.LOWER : Bound.UPPER] ? "0" : formatPrice(leftPrice, 5) ?? ""}
         onUserInput={onLeftRangeInput}
         width="48%"
         decrement={isSorted ? getDecrementLower : getIncrementUpper}
@@ -65,7 +65,7 @@ export const RangeSelector = memo(function RangeSelector({
         tokenB={currencyB?.symbol}
       />
       <StepCounter
-        value={ticksAtLimit[isSorted ? Bound.UPPER : Bound.LOWER] ? "∞" : formatPrice(rightPrice, 6) ?? ""}
+        value={ticksAtLimit[isSorted ? Bound.UPPER : Bound.LOWER] ? "∞" : formatPrice(rightPrice, 5) ?? ""}
         onUserInput={onRightRangeInput}
         width="48%"
         decrement={isSorted ? getDecrementUpper : getIncrementLower}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `RangeSelector` component in `packages/widgets-internal/roi/RangeSelector.tsx` to format price values with 5 decimal places instead of 6.

### Detailed summary
- Updated `formatPrice` to display values with 5 decimal places instead of 6 in `RangeSelector.tsx`
- Adjusted the decimal formatting for leftPrice and rightPrice in the component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->