### PR TITLE
fix: Use thegraph for bsc price info

### DIFF
--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -7,7 +7,7 @@ import { useChainNameByQuery } from 'state/info/hooks'
 import { Block } from 'state/info/types'
 import { getChainName } from 'state/info/utils'
 import { getDeltaTimestamps } from 'utils/getDeltaTimestamps'
-import { v3InfoClients } from 'utils/graphql'
+import { v3Clients, v3InfoClients } from 'utils/graphql'
 import { useBlockFromTimeStampQuery } from 'views/Info/hooks/useBlocksFromTimestamps'
 
 import { useQuery } from '@tanstack/react-query'
@@ -143,7 +143,7 @@ export const usePairPriceChartTokenData = (
         address,
         DURATION_INTERVAL[duration ?? 'day'],
         startTimestamp,
-        v3InfoClients[targetChainId ?? chainId],
+        v3Clients[targetChainId ?? chainId],
         multiChainName[targetChainId ?? chainId],
         SUBGRAPH_START_BLOCK[chainId],
       )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the GraphQL client import and usage in `V3Info` view hooks.

### Detailed summary
- Updated import of `v3InfoClients` to include `v3Clients`
- Updated usage of `v3InfoClients` to use `v3Clients` in `usePairPriceChartTokenData` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->