### PR TITLE
fix: serve wev3 notis to all users

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -21,7 +21,7 @@ export type ExperimentalFeatureConfigs = FeatureRollOutConfig[]
 export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   {
     feature: EXPERIMENTAL_FEATURES.WebNotifications,
-    percentage: 0.5,
+    percentage: 1.0,
     whitelist: [],
   },
   {

--- a/apps/web/src/hooks/useWebNotifications.ts
+++ b/apps/web/src/hooks/useWebNotifications.ts
@@ -1,13 +1,11 @@
+import { EXPERIMENTAL_FEATURES } from 'config/experimentalFeatures'
+import { useExperimentalFeatureEnabled } from 'hooks/useExperimentalFeatureEnabled'
 import { useAllowNotifications } from 'state/notifications/hooks'
 
 export const useWebNotifications = () => {
   const [allowNotifications] = useAllowNotifications()
-
-  // uncomment if need to add web3 notis back to feature flag
-  // const featureEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
-  // const enabled = Boolean(allowNotifications ?? featureEnabled)
-
-  const enabled = Boolean(allowNotifications)
+  const featureEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
+  const enabled = Boolean(allowNotifications ?? featureEnabled)
 
   return { enabled }
 }

--- a/apps/web/src/hooks/useWebNotifications.ts
+++ b/apps/web/src/hooks/useWebNotifications.ts
@@ -1,11 +1,13 @@
-import { EXPERIMENTAL_FEATURES } from 'config/experimentalFeatures'
-import { useExperimentalFeatureEnabled } from 'hooks/useExperimentalFeatureEnabled'
 import { useAllowNotifications } from 'state/notifications/hooks'
 
 export const useWebNotifications = () => {
   const [allowNotifications] = useAllowNotifications()
-  const featureEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
-  const enabled = Boolean(allowNotifications ?? featureEnabled)
+
+  // uncomment if need to add web3 notis back to feature flag
+  // const featureEnabled = useExperimentalFeatureEnabled(EXPERIMENTAL_FEATURES.WebNotifications)
+  // const enabled = Boolean(allowNotifications ?? featureEnabled)
+
+  const enabled = Boolean(allowNotifications)
 
   return { enabled }
 }

--- a/apps/web/src/state/notifications/reducer.ts
+++ b/apps/web/src/state/notifications/reducer.ts
@@ -23,7 +23,7 @@ export interface NotificationState {
 
 export const initialState: NotificationState = {
   notifications: {},
-  allowNotifications: undefined,
+  allowNotifications: true,
 }
 
 export default createReducer(initialState, (builder) =>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to increase the percentage for the WebNotifications experimental feature to 1.0 and set allowNotifications to true in the notifications reducer.

### Detailed summary
- Increased percentage for `EXPERIMENTAL_FEATURES.WebNotifications` to 1.0
- Set `allowNotifications` to true in notifications reducer

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->