### PR TITLE
chore: Remove v3 sg indicator from swap

### DIFF
--- a/apps/web/src/pages/swap.tsx
+++ b/apps/web/src/pages/swap.tsx
@@ -1,7 +1,5 @@
 import { CHAIN_IDS } from 'utils/wagmi'
 
-import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
-
 import { SwapFeaturesProvider } from 'views/Swap/SwapFeaturesContext'
 import Swap from '../views/Swap'
 
@@ -9,7 +7,6 @@ const SwapPage = () => {
   return (
     <SwapFeaturesProvider>
       <Swap />
-      <V3SubgraphHealthIndicator />
     </SwapFeaturesProvider>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `V3SubgraphHealthIndicator` component from the `SwapPage` in `swap.tsx`.

### Detailed summary
- Removed `V3SubgraphHealthIndicator` component from `SwapPage` in `swap.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->