### PR TITLE
fix: Sg indicator not working when initial access

### DIFF
--- a/apps/web/src/hooks/useSubgraphHealth.ts
+++ b/apps/web/src/hooks/useSubgraphHealth.ts
@@ -58,7 +58,9 @@ const useSubgraphHealth = (subgraphName?: string) => {
             ),
             currentBlockNumber
               ? Promise.resolve(currentBlockNumber)
-              : Number(publicClient({ chainId: ChainId.BSC }).getBlockNumber()),
+              : publicClient({ chainId: ChainId.BSC })
+                  .getBlockNumber()
+                  .then((blockNumber) => Number(blockNumber)),
           ])
 
           const isHealthy = indexingStatusForCurrentVersion?.health === 'healthy'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the `useSubgraphHealth` hook in the `web` app by correctly handling the retrieval of the current block number asynchronously.

### Detailed summary
- Refactored to retrieve current block number asynchronously
- Converted block number to a number type for consistency
- Checked if the subgraph health status is 'healthy'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->