### PR TITLE
feat(permit2-sdk): Add missing hash function and tests

### DIFF
--- a/.changeset/curly-dodos-add.md
+++ b/.changeset/curly-dodos-add.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/permit2-sdk': patch
+---
+
+Fix missing hash function and add test

--- a/packages/permit2-sdk/package.json
+++ b/packages/permit2-sdk/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest --run",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json}\"",
     "format:write": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\"",
     "prepublishOnly": "pnpm run build"

--- a/packages/permit2-sdk/src/allowanceTransfer.test.ts
+++ b/packages/permit2-sdk/src/allowanceTransfer.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import { AllowanceTransfer } from './allowanceTransfer'
+import { MaxAllowanceExpiration, MaxAllowanceTransferAmount, MaxOrderedNonce, MaxSigDeadline } from './constants'
+
+describe('AllowanceTransfer', () => {
+  describe('Max values', () => {
+    it('max values pass', () => {
+      expect(() =>
+        AllowanceTransfer.hash(
+          {
+            details: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: MaxAllowanceTransferAmount.toString(),
+              expiration: MaxAllowanceExpiration.toString(),
+              nonce: MaxOrderedNonce.toString(),
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            sigDeadline: MaxSigDeadline.toString(),
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).not.toThrow()
+    })
+
+    it('nonce out of range', () => {
+      expect(() =>
+        AllowanceTransfer.hash(
+          {
+            details: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+              expiration: '0',
+              nonce: MaxOrderedNonce + 1n,
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            sigDeadline: '0',
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('NONCE_OUT_OF_RANGE')
+    })
+
+    it('amount out of range', () => {
+      expect(() =>
+        AllowanceTransfer.hash(
+          {
+            details: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: MaxAllowanceTransferAmount + 1n,
+              expiration: '0',
+              nonce: 0,
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            sigDeadline: '0',
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('AMOUNT_OUT_OF_RANGE')
+    })
+
+    it('expiration out of range', () => {
+      expect(() =>
+        AllowanceTransfer.hash(
+          {
+            details: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+              expiration: MaxAllowanceExpiration + 1n,
+              nonce: 0,
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            sigDeadline: '0',
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('EXPIRATION_OUT_OF_RANGE')
+    })
+
+    it('sigDeadline out of range', () => {
+      expect(() =>
+        AllowanceTransfer.hash(
+          {
+            details: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+              expiration: '0',
+              nonce: 0,
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            sigDeadline: MaxSigDeadline + 1n,
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('SIG_DEADLINE_OUT_OF_RANGE')
+    })
+  })
+
+  it('non-batch', () => {
+    expect(
+      AllowanceTransfer.hash(
+        {
+          details: {
+            token: '0x0000000000000000000000000000000000000000',
+            amount: '0',
+            expiration: '0',
+            nonce: 0,
+          },
+          spender: '0x0000000000000000000000000000000000000000',
+          sigDeadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+      ),
+    ).toBe('0xd47437bffdbc4d123a2165feb6ca646b8700c038622ce304f84e9048bc744f36')
+  })
+
+  it('batch', () => {
+    expect(
+      AllowanceTransfer.hash(
+        {
+          details: [
+            {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+              expiration: '0',
+              nonce: 0,
+            },
+          ],
+          spender: '0x0000000000000000000000000000000000000000',
+          sigDeadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+      ),
+    ).toBe('0x49642ada5f77eb9458f8265eb01fed2684c2f25d50534fea3efdf2cf395deb2f')
+  })
+})

--- a/packages/permit2-sdk/src/signatureTransfer.test.ts
+++ b/packages/permit2-sdk/src/signatureTransfer.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { MaxSigDeadline, MaxSignatureTransferAmount, MaxUnorderedNonce } from './constants'
+import { SignatureTransfer } from './signatureTransfer'
+
+describe('SignatureTransfer', () => {
+  describe('Max values', () => {
+    it('max values', () => {
+      expect(() =>
+        SignatureTransfer.hash(
+          {
+            permitted: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: MaxSignatureTransferAmount.toString(),
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            nonce: MaxUnorderedNonce.toString(),
+            deadline: MaxSigDeadline.toString(),
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).not.toThrow()
+    })
+
+    it('nonce out of range', () => {
+      expect(() =>
+        SignatureTransfer.hash(
+          {
+            permitted: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            nonce: MaxUnorderedNonce + 1n,
+            deadline: '0',
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('NONCE_OUT_OF_RANGE')
+    })
+
+    it('amount out of range', () => {
+      expect(() =>
+        SignatureTransfer.hash(
+          {
+            permitted: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: MaxSignatureTransferAmount + 1n,
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            nonce: '0',
+            deadline: '0',
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('AMOUNT_OUT_OF_RANGE')
+    })
+
+    it('deadline out of range', () => {
+      expect(() =>
+        SignatureTransfer.hash(
+          {
+            permitted: {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+            },
+            spender: '0x0000000000000000000000000000000000000000',
+            nonce: '0',
+            deadline: MaxSigDeadline + 1n,
+          },
+          '0x0000000000000000000000000000000000000000',
+          1,
+        ),
+      ).toThrow('SIG_DEADLINE_OUT_OF_RANGE')
+    })
+  })
+
+  it('non-batch, no witness', () => {
+    expect(
+      SignatureTransfer.hash(
+        {
+          permitted: {
+            token: '0x0000000000000000000000000000000000000000',
+            amount: '0',
+          },
+          spender: '0x0000000000000000000000000000000000000000',
+          nonce: '0',
+          deadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+      ),
+    ).toBe('0xb9bf9813799d7f0de28d2142b0bc80ec289d4a6a5b9f41834149df4188804dc5')
+  })
+
+  it('non-batch, witness', () => {
+    expect(
+      SignatureTransfer.hash(
+        {
+          permitted: {
+            token: '0x0000000000000000000000000000000000000000',
+            amount: '0',
+          },
+          spender: '0x0000000000000000000000000000000000000000',
+          nonce: '0',
+          deadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+        {
+          witnessTypeName: 'MockWitness',
+          witnessType: { MockWitness: [{ name: 'mock', type: 'uint256' }] },
+          witness: { mock: '0x0000000000000000000000000000000000000000000000000000000000000000' },
+        },
+      ),
+    ).toBe('0x4236a4a7b3e8e65dbb4cc758ef10dc4887e2959853fb615140d0f5e0ae7be7c9')
+  })
+
+  it('batch, no witness', () => {
+    expect(
+      SignatureTransfer.hash(
+        {
+          permitted: [
+            {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+            },
+          ],
+          spender: '0x0000000000000000000000000000000000000000',
+          nonce: '0',
+          deadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+      ),
+    ).toBe('0x5ba40c5ba725fec181e4a862c717adf91682b012ad01ea99a978189106d66923')
+  })
+
+  it('batch, witness', () => {
+    expect(
+      SignatureTransfer.hash(
+        {
+          permitted: [
+            {
+              token: '0x0000000000000000000000000000000000000000',
+              amount: '0',
+            },
+          ],
+          spender: '0x0000000000000000000000000000000000000000',
+          nonce: '0',
+          deadline: '0',
+        },
+        '0x0000000000000000000000000000000000000000',
+        1,
+        {
+          witnessTypeName: 'MockWitness',
+          witnessType: { MockWitness: [{ name: 'mock', type: 'uint256' }] },
+          witness: { mock: '0x0000000000000000000000000000000000000000000000000000000000000000' },
+        },
+      ),
+    ).toBe('0xb45d605b0a4d4f16930a4f48294d94c78f34411278fd3133626cc190273e3ccf')
+  })
+})

--- a/packages/permit2-sdk/src/signatureTransfer.ts
+++ b/packages/permit2-sdk/src/signatureTransfer.ts
@@ -1,29 +1,29 @@
-import invariant from 'tiny-invariant'
 import { BigintIsh } from '@pancakeswap/sdk'
-import { Address } from 'viem'
+import invariant from 'tiny-invariant'
+import { Address, Hex, hashTypedData } from 'viem'
+import { MaxSigDeadline, MaxSignatureTransferAmount, MaxUnorderedNonce } from './constants'
 import { permit2Domain } from './domain'
-import { MaxSigDeadline, MaxUnorderedNonce, MaxSignatureTransferAmount } from './constants'
 import { TypedDataDomain, TypedDataParameter } from './utils/types'
 
-export interface Witness {
-  witness: any
+export type Witness = {
+  witness: { [key: string]: unknown }
   witnessTypeName: string
   witnessType: Record<string, TypedDataParameter[]>
 }
 
-export interface TokenPermissions {
+export type TokenPermissions = {
   token: string
   amount: BigintIsh
 }
 
-export interface PermitTransferFrom {
+export type PermitTransferFrom = {
   permitted: TokenPermissions
   spender: string
   nonce: BigintIsh
   deadline: BigintIsh
 }
 
-export interface PermitBatchTransferFrom {
+export type PermitBatchTransferFrom = {
   permitted: TokenPermissions[]
   spender: string
   nonce: BigintIsh
@@ -34,12 +34,28 @@ export type PermitTransferFromData = {
   domain: TypedDataDomain
   types: Record<string, TypedDataParameter[]>
   values: PermitTransferFrom
+  primaryType: 'PermitTransferFrom'
+}
+
+export type PermitWitnessTransferFromData = {
+  domain: TypedDataDomain
+  types: Record<string, TypedDataParameter[]>
+  values: PermitTransferFrom & { witness: { [key: string]: unknown } }
+  primaryType: 'PermitWitnessTransferFrom'
 }
 
 export type PermitBatchTransferFromData = {
   domain: TypedDataDomain
   types: Record<string, TypedDataParameter[]>
   values: PermitBatchTransferFrom
+  primaryType: 'PermitBatchTransferFrom' | 'PermitBatchWitnessTransferFrom'
+}
+
+export type PermitBatchWitnessTransferFromData = {
+  domain: TypedDataDomain
+  types: Record<string, TypedDataParameter[]>
+  values: PermitBatchTransferFrom & { witness: { [key: string]: unknown } }
+  primaryType: 'PermitBatchWitnessTransferFrom'
 }
 
 const TOKEN_PERMISSIONS = [
@@ -108,12 +124,17 @@ export abstract class SignatureTransfer {
 
   // return the data to be sent in a eth_signTypedData RPC call
   // for signing the given permit data
-  public static getPermitData(
-    permit: PermitTransferFrom | PermitBatchTransferFrom,
-    permit2Address: Address,
-    chainId: number,
-    witness?: Witness,
-  ): PermitTransferFromData | PermitBatchTransferFromData {
+  public static getPermitData<
+    TPermit extends PermitTransferFrom | PermitBatchTransferFrom,
+    TWitness extends Witness | undefined,
+    ReturnType = TPermit extends PermitTransferFrom
+      ? TWitness extends undefined
+        ? PermitTransferFromData
+        : PermitWitnessTransferFromData
+      : TWitness extends undefined
+      ? PermitBatchTransferFromData
+      : PermitBatchWitnessTransferFromData,
+  >(permit: TPermit, permit2Address: Address, chainId: number, witness?: TWitness): ReturnType {
     invariant(MaxSigDeadline >= BigInt(permit.deadline), 'SIG_DEADLINE_OUT_OF_RANGE')
     invariant(MaxUnorderedNonce >= BigInt(permit.nonce), 'NONCE_OUT_OF_RANGE')
 
@@ -122,20 +143,44 @@ export abstract class SignatureTransfer {
       validateTokenPermissions(permit.permitted)
       const types = witness ? permitTransferFromWithWitnessType(witness) : PERMIT_TRANSFER_FROM_TYPES
       const values = witness ? Object.assign(permit, { witness: witness.witness }) : permit
+      const primaryType = witness ? 'PermitWitnessTransferFrom' : 'PermitTransferFrom'
       return {
         domain,
         types,
         values,
-      }
+        primaryType,
+      } as ReturnType
     }
     permit.permitted.forEach(validateTokenPermissions)
     const types = witness ? permitBatchTransferFromWithWitnessType(witness) : PERMIT_BATCH_TRANSFER_FROM_TYPES
     const values = witness ? Object.assign(permit, { witness: witness.witness }) : permit
+    const primaryType = witness ? 'PermitBatchWitnessTransferFrom' : 'PermitBatchTransferFrom'
     return {
       domain,
       types,
       values,
-    }
+      primaryType,
+    } as ReturnType
+  }
+
+  public static hash(
+    permit: PermitTransferFrom | PermitBatchTransferFrom,
+    permit2Address: Address,
+    chainId: number,
+    witness?: Witness,
+  ): Hex {
+    const { domain, types, values, primaryType } = SignatureTransfer.getPermitData(
+      permit,
+      permit2Address,
+      chainId,
+      witness,
+    )
+    return hashTypedData({
+      domain,
+      types,
+      primaryType,
+      message: values,
+    })
   }
 }
 


### PR DESCRIPTION
Added a missing hash function and corresponding tests to the AllowanceTransfer module. This ensures that the hash function behaves correctly for various input values, including edge cases where values are at their maximum limits. The tests cover scenarios such as nonce out of range, amount out of range, expiration out of range, and sigDeadline out of range. This enhancement improves the reliability and accuracy of the AllowanceTransfer module.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a missing hash function and test for `@pancakeswap/permit2-sdk`.

### Detailed summary
- Added a hash function for permit data in `allowanceTransfer.ts`
- Updated imports and constants in `allowanceTransfer.ts` and `signatureTransfer.ts`
- Added tests for `allowanceTransfer.ts` and `signatureTransfer.ts`

> The following files were skipped due to too many changes: `packages/permit2-sdk/src/signatureTransfer.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->