### PR TITLE
fix: Remove unnecessary type from PermitBatchTransferFromData

### DIFF
--- a/packages/permit2-sdk/src/signatureTransfer.ts
+++ b/packages/permit2-sdk/src/signatureTransfer.ts
@@ -48,7 +48,7 @@ export type PermitBatchTransferFromData = {
   domain: TypedDataDomain
   types: Record<string, TypedDataParameter[]>
   values: PermitBatchTransferFrom
-  primaryType: 'PermitBatchTransferFrom' | 'PermitBatchWitnessTransferFrom'
+  primaryType: 'PermitBatchTransferFrom'
 }
 
 export type PermitBatchWitnessTransferFromData = {


### PR DESCRIPTION
Removed unnecessary 'PermitBatchWitnessTransferFrom' type from PermitBatchTransferFromData primaryType field to streamline the code.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `primaryType` in the `signatureTransfer.ts` file to only allow 'PermitBatchTransferFrom'.

### Detailed summary
- Updated `primaryType` to only allow 'PermitBatchTransferFrom'
- Removed 'PermitBatchWitnessTransferFrom' from the `primaryType` options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->