### PR TITLE
feat: open 5%

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -31,7 +31,7 @@ export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   },
   {
     feature: EXPERIMENTAL_FEATURES.UniversalRouter,
-    percentage: 0,
+    percentage: 0.05,
     whitelist: [],
   },
 ]


### PR DESCRIPTION


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the percentage for the experimental feature `UniversalRouter` from 0 to 0.05.

### Detailed summary
- Updated the percentage for the experimental feature `UniversalRouter` from 0 to 0.05.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->