### PR TITLE
fix: Crash in swap when unspported chain in wallet with non native currency

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { useDebounce, usePropsChanged } from '@pancakeswap/hooks'
-import { Currency, CurrencyAmount, Native, TradeType } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/sdk'
 import {
   BATCH_MULTICALL_CONFIGS,
   PoolType,
@@ -22,6 +22,7 @@ import { tracker } from 'utils/datadog'
 import { createViemPublicClientGetter } from 'utils/viem'
 import { publicClient } from 'utils/wagmi'
 
+import useNativeCurrency from 'hooks/useNativeCurrency'
 import {
   CommonPoolsParams,
   PoolsWithState,
@@ -247,13 +248,7 @@ function bestTradeHookFactory({
     const deferQuotientRaw = useDeferredValue(amount?.quotient?.toString())
     const deferQuotient = useDebounce(deferQuotientRaw, 500)
     const { data: quoteCurrencyUsdPrice } = useCurrencyUsdPrice(currency ?? undefined)
-    const currencyNativeChain = useMemo(() => {
-      try {
-        return Native.onChain(currency?.chainId ?? ChainId.BSC)
-      } catch (e) {
-        return Native.onChain(ChainId.BSC)
-      }
-    }, [currency])
+    const currencyNativeChain = useNativeCurrency(currency?.chainId)
     const { data: nativeCurrencyUsdPrice } = useCurrencyUsdPrice(currencyNativeChain)
 
     const poolTypes = useMemo(() => {

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -247,9 +247,14 @@ function bestTradeHookFactory({
     const deferQuotientRaw = useDeferredValue(amount?.quotient?.toString())
     const deferQuotient = useDebounce(deferQuotientRaw, 500)
     const { data: quoteCurrencyUsdPrice } = useCurrencyUsdPrice(currency ?? undefined)
-    const { data: nativeCurrencyUsdPrice } = useCurrencyUsdPrice(
-      currency?.chainId ? Native.onChain(currency.chainId) : undefined,
-    )
+    const currencyNativeChain = useMemo(() => {
+      try {
+        return Native.onChain(currency?.chainId ?? ChainId.BSC)
+      } catch (e) {
+        return Native.onChain(ChainId.BSC)
+      }
+    }, [currency])
+    const { data: nativeCurrencyUsdPrice } = useCurrencyUsdPrice(currencyNativeChain)
 
     const poolTypes = useMemo(() => {
       const types: PoolType[] = []

--- a/apps/web/src/hooks/useNativeCurrency.ts
+++ b/apps/web/src/hooks/useNativeCurrency.ts
@@ -3,13 +3,13 @@ import { Native, NativeCurrency } from '@pancakeswap/sdk'
 import { useMemo } from 'react'
 import { useActiveChainId } from './useActiveChainId'
 
-export default function useNativeCurrency(): NativeCurrency {
+export default function useNativeCurrency(overrideChainId?: ChainId): NativeCurrency {
   const { chainId } = useActiveChainId()
   return useMemo(() => {
     try {
-      return Native.onChain(chainId ?? ChainId.BSC)
+      return Native.onChain(overrideChainId ?? chainId ?? ChainId.BSC)
     } catch (e) {
       return Native.onChain(ChainId.BSC)
     }
-  }, [chainId])
+  }, [overrideChainId, chainId])
 }


### PR DESCRIPTION
Issue happens if polygon selected in user's wallet and trying to access 

https://pancakeswap.finance/swap?inputCurrency=0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82&outputCurrency=0x55d398326f99059fF775485246999027B3197955


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the ability to override the chain ID in the `useNativeCurrency` hook and update the usage of the `useNativeCurrency` hook in the `useBestAMMTrade` hook.

### Detailed summary
- Added optional `overrideChainId` parameter to `useNativeCurrency` hook
- Updated `useBestAMMTrade` hook to use `useNativeCurrency` with the chain ID

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->