### PR TITLE
fix(typecheck): src/views/TradingCompetition

### DIFF
--- a/apps/web/src/hooks/useUsernameWithVisibility.ts
+++ b/apps/web/src/hooks/useUsernameWithVisibility.ts
@@ -1,6 +1,6 @@
 import { useUserUsernameVisibility } from 'state/user/hooks'
 
-const useGetUsernameWithVisibility = (username: string) => {
+const useGetUsernameWithVisibility = (username?: string) => {
   const [userUsernameVisibility, setUserUsernameVisibility] = useUserUsernameVisibility()
 
   return {

--- a/apps/web/src/views/TradingCompetition/components/RegisterModal/ReactivateProfile.tsx
+++ b/apps/web/src/views/TradingCompetition/components/RegisterModal/ReactivateProfile.tsx
@@ -1,8 +1,8 @@
-import { Heading, Button, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { Button, Heading, Text } from '@pancakeswap/uikit'
+import { useRouter } from 'next/router'
 import { CompetitionProps } from 'views/TradingCompetition/types'
 import { useAccount } from 'wagmi'
-import { useRouter } from 'next/router'
 
 const ReactivateProfile: React.FC<React.PropsWithChildren<CompetitionProps>> = ({ onDismiss }) => {
   const { address: account } = useAccount()
@@ -10,8 +10,8 @@ const ReactivateProfile: React.FC<React.PropsWithChildren<CompetitionProps>> = (
   const router = useRouter()
 
   const handleClick = () => {
-    router.push(`/profile/${account.toLowerCase()}`)
-    onDismiss()
+    router.push(`/profile/${account?.toLowerCase()}`)
+    onDismiss?.()
   }
 
   return (

--- a/apps/web/src/views/TradingCompetition/components/YourScore/AchievementPoints.tsx
+++ b/apps/web/src/views/TradingCompetition/components/YourScore/AchievementPoints.tsx
@@ -1,11 +1,11 @@
-import { Text, Flex, Image } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { Flex, Image, Text } from '@pancakeswap/uikit'
 
 interface AchievementPointsProps {
-  achievement: {
+  achievement?: {
     image?: string
   }
-  userPointReward: number | string
+  userPointReward?: number | string
 }
 
 const AchievementPoints: React.FC<React.PropsWithChildren<AchievementPointsProps>> = ({

--- a/apps/web/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
+++ b/apps/web/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx
@@ -1,26 +1,26 @@
-import { ReactNode } from 'react'
+import { useTranslation } from '@pancakeswap/localization'
 import {
-  Text,
-  Heading,
+  BlockIcon,
+  Button,
   Flex,
-  Skeleton,
+  Heading,
   MedalBronzeIcon,
   MedalGoldIcon,
   MedalPurpleIcon,
   MedalSilverIcon,
   MedalTealIcon,
-  BlockIcon,
-  Button,
+  Skeleton,
+  Text,
   useModal,
 } from '@pancakeswap/uikit'
-import { styled } from 'styled-components'
-import { useTranslation } from '@pancakeswap/localization'
-import { REGISTRATION, LIVE } from 'config/constants/trading-competition/phases'
+import { LIVE, REGISTRATION } from 'config/constants/trading-competition/phases'
 import useGetUsernameWithVisibility from 'hooks/useUsernameWithVisibility'
-import { YourScoreProps } from '../../types'
-import UserRankBox from './UserRankBox'
-import NextRankBox from './NextRankBox'
+import { ReactNode } from 'react'
+import { styled } from 'styled-components'
 import { localiseTradingVolume } from '../../helpers'
+import { YourScoreProps } from '../../types'
+import NextRankBox from './NextRankBox'
+import UserRankBox from './UserRankBox'
 
 const TeamRankTextWrapper = styled(Flex)`
   align-items: center;
@@ -56,11 +56,11 @@ const CardUserInfo: React.FC<React.PropsWithChildren<CardUserInfoProps>> = ({
 }) => {
   const { t } = useTranslation()
   const [onPresentShareModal] = useModal(shareModal, false)
-  const { global, team, volume, next_rank: nextRank } = userLeaderboardInformation
+  const { global, team, volume, next_rank: nextRank } = userLeaderboardInformation ?? {}
   const { usernameWithVisibility } = useGetUsernameWithVisibility(profile?.username)
   const shouldShowUserRanks = account && hasRegistered
 
-  const getMedal = (currentRank_: string | number) => {
+  const getMedal = (currentRank_?: string | number) => {
     const currentRank = Number(currentRank_)
     if (currentRank === 1) {
       return {
@@ -98,7 +98,7 @@ const CardUserInfo: React.FC<React.PropsWithChildren<CardUserInfoProps>> = ({
     }
   }
 
-  const getNextTier = (currentRank_: string | number) => {
+  const getNextTier = (currentRank_?: string | number) => {
     const currentRank = Number(currentRank_)
     if (currentRank === 1) {
       return {
@@ -171,14 +171,14 @@ const CardUserInfo: React.FC<React.PropsWithChildren<CardUserInfoProps>> = ({
       </Text>
       {shouldShowUserRanks && (
         <>
-          {profile?.nft && volume > 0 && (
+          {profile?.nft && volume && volume > 0 && (
             <Button mt="12px" variant="secondary" scale="sm" onClick={onPresentShareModal}>
               {t('Share Score')}
             </Button>
           )}
           <RanksWrapper>
             <Flex width="100%" flexDirection={['column', null, null, 'row']} mr={['8px', null, null, 0]}>
-              {volume > 0 && (
+              {volume && volume > 0 && (
                 <UserRankBox
                   flex="1"
                   title={t('Rank in team').toUpperCase()}
@@ -233,9 +233,9 @@ const CardUserInfo: React.FC<React.PropsWithChildren<CardUserInfoProps>> = ({
                 <NextRankBox
                   flex="2"
                   title={`${t('Next tier').toUpperCase()}: ${nextTier?.color}`}
-                  footer={t('to become #%rank% in team', { rank: nextTier?.rank })}
+                  footer={t('to become #%rank% in team', { rank: nextTier?.rank ?? undefined })}
                   currentMedal={medal?.current}
-                  nextMedal={medal?.next}
+                  nextMedal={medal?.next ?? undefined}
                 >
                   <Heading scale="lg">+${userLeaderboardInformation && localiseTradingVolume(nextRank)}</Heading>
                 </NextRankBox>

--- a/apps/web/src/views/TradingCompetition/components/YourScore/UserPrizeGridDollar.tsx
+++ b/apps/web/src/views/TradingCompetition/components/YourScore/UserPrizeGridDollar.tsx
@@ -1,7 +1,7 @@
-import { Text, Skeleton } from '@pancakeswap/uikit'
+import { Skeleton, Text } from '@pancakeswap/uikit'
 
 interface UserPrizeGridDollarProps {
-  dollarValueOfTokensReward: number
+  dollarValueOfTokensReward: number | null
 }
 
 const UserPrizeGridDollar: React.FC<React.PropsWithChildren<UserPrizeGridDollarProps>> = ({

--- a/apps/web/src/views/TradingCompetition/easter/components/PrizesInfo/PrizesGrid/EasterPrizesGrid.tsx
+++ b/apps/web/src/views/TradingCompetition/easter/components/PrizesInfo/PrizesGrid/EasterPrizesGrid.tsx
@@ -1,24 +1,24 @@
-import { useState } from 'react'
-import { Tiers, Rank, easterPrizes } from 'config/constants/trading-competition/prizes'
+import { useTranslation } from '@pancakeswap/localization'
 import {
   BlockIcon,
   Box,
   CheckmarkCircleIcon,
+  CrownIcon,
   Flex,
   MedalBronzeIcon,
   MedalGoldIcon,
   MedalPurpleIcon,
   MedalSilverIcon,
   MedalTealIcon,
-  CrownIcon,
   Tab,
   TabMenu,
-  Text,
   TeamPlayerIcon,
+  Text,
   TrophyGoldIcon,
 } from '@pancakeswap/uikit'
-import { useTranslation } from '@pancakeswap/localization'
-import { Td, BoldTd, StyledPrizeTable } from '../../../../components/StyledPrizeTable'
+import { Rank, Tiers, easterPrizes } from 'config/constants/trading-competition/prizes'
+import { useState } from 'react'
+import { BoldTd, StyledPrizeTable, Td } from '../../../../components/StyledPrizeTable'
 
 const COLOR_GOLD = '#FFBF33'
 const COLOR_SILVER = '#C1C1C1'
@@ -118,8 +118,8 @@ const EasterPrizesGrid = () => {
                   </BoldTd>
                   <Td>
                     <Flex alignItems="center" flexWrap="wrap" justifyContent="center" width="100%">
-                      {champion > 0 && <CrownIcon mr={[0, '4px']} />}
-                      {teamPlayer > 0 && <TeamPlayerIcon mr={[0, '4px']} />}
+                      {champion && champion > 0 && <CrownIcon mr={[0, '4px']} />}
+                      {teamPlayer && teamPlayer > 0 && <TeamPlayerIcon mr={[0, '4px']} />}
                       <TrophyGoldIcon mr={[0, '4px']} />
                       <Text fontSize="12px" color="textSubtle">
                         {`+${getTotalAchievementPoints(row.achievements).toLocaleString(undefined, {

--- a/apps/web/src/views/TradingCompetition/easter/components/YourScore/EasterUserPrizeGrid.tsx
+++ b/apps/web/src/views/TradingCompetition/easter/components/YourScore/EasterUserPrizeGrid.tsx
@@ -1,18 +1,18 @@
-import React from 'react'
-import { styled } from 'styled-components'
+import { useTranslation } from '@pancakeswap/localization'
 import {
   BlockIcon,
   CheckmarkCircleIcon,
-  Flex,
   CrownIcon,
-  Text,
-  TeamPlayerIcon,
-  TrophyGoldIcon,
+  Flex,
   Skeleton,
+  TeamPlayerIcon,
+  Text,
+  TrophyGoldIcon,
 } from '@pancakeswap/uikit'
-import { useTranslation } from '@pancakeswap/localization'
-import { useCompetitionCakeRewards, getEasterRewardGroupAchievements } from '../../../helpers'
-import { BoldTd, Td, StyledPrizeTable } from '../../../components/StyledPrizeTable'
+import React from 'react'
+import { styled } from 'styled-components'
+import { BoldTd, StyledPrizeTable, Td } from '../../../components/StyledPrizeTable'
+import { getEasterRewardGroupAchievements, useCompetitionCakeRewards } from '../../../helpers'
 
 const StyledThead = styled.thead`
   border-bottom: 2px solid ${({ theme }) => theme.colors.cardBorder};
@@ -51,8 +51,8 @@ const EasterUserPrizeGrid: React.FC<React.PropsWithChildren<{ userTradingInforma
           </BoldTd>
           <Td>
             <Flex alignItems="center" flexWrap="wrap" justifyContent="center" width="100%">
-              {champion > 0 && <CrownIcon mr={[0, '4px']} />}
-              {teamPlayer > 0 && <TeamPlayerIcon mr={[0, '4px']} />}
+              {champion && champion > 0 && <CrownIcon mr={[0, '4px']} />}
+              {teamPlayer && teamPlayer > 0 && <TeamPlayerIcon mr={[0, '4px']} />}
               <TrophyGoldIcon mr={[0, '4px']} />
               <Text fontSize="12px" color="textSubtle" textTransform="lowercase">
                 + {userPointReward} {t('Points')}

--- a/apps/web/src/views/TradingCompetition/helpers.ts
+++ b/apps/web/src/views/TradingCompetition/helpers.ts
@@ -1,13 +1,13 @@
-import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
-import { easterPrizes, PrizesConfig } from 'config/constants/trading-competition/prizes'
-import BigNumber from 'bignumber.js'
-import { useStablecoinPrice } from 'hooks/useStablecoinPrice'
 import { bscTokens } from '@pancakeswap/tokens'
-import { multiplyPriceByAmount } from 'utils/prices'
+import { getBalanceNumber } from '@pancakeswap/utils/formatBalance'
+import BigNumber from 'bignumber.js'
+import { easterPrizes, PrizesConfig } from 'config/constants/trading-competition/prizes'
 import { useCakePrice } from 'hooks/useCakePrice'
+import { useStablecoinPrice } from 'hooks/useStablecoinPrice'
+import { multiplyPriceByAmount } from 'utils/prices'
 
-export const localiseTradingVolume = (value: number, decimals = 0) => {
-  return value.toLocaleString('en-US', { maximumFractionDigits: decimals })
+export const localiseTradingVolume = (value?: number, decimals = 0) => {
+  return value?.toLocaleString('en-US', { maximumFractionDigits: decimals })
 }
 
 export const useCompetitionCakeRewards = (userCakeReward: string | number) => {
@@ -65,12 +65,12 @@ export const useMoboxCompetitionRewards = ({
   userCakeRewards,
   userMoboxRewards,
 }: {
-  userCakeRewards: string | number
-  userMoboxRewards: string | number
+  userCakeRewards?: string | number
+  userMoboxRewards?: string | number
 }) => {
   const moboxPriceBUSD = useStablecoinPrice(bscTokens.mbox)
-  const cakeAsBigNumber = new BigNumber(userCakeRewards as string)
-  const moboxAsBigNumber = new BigNumber(userMoboxRewards as string)
+  const cakeAsBigNumber = userCakeRewards ? new BigNumber(userCakeRewards) : new BigNumber(0)
+  const moboxAsBigNumber = userMoboxRewards ? new BigNumber(userMoboxRewards) : new BigNumber(0)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
   const moboxBalance = getBalanceNumber(moboxAsBigNumber)
   const cakePriceBusd = useCakePrice()
@@ -91,12 +91,12 @@ export const useModCompetitionRewards = ({
   userCakeRewards,
   userDarRewards,
 }: {
-  userCakeRewards: string | number
-  userDarRewards: string | number
+  userCakeRewards?: string | number
+  userDarRewards?: string | number
 }) => {
   const darPriceBUSD = useStablecoinPrice(bscTokens.dar)
-  const cakeAsBigNumber = new BigNumber(userCakeRewards as string)
-  const darAsBigNumber = new BigNumber(userDarRewards as string)
+  const cakeAsBigNumber = userCakeRewards ? new BigNumber(userCakeRewards) : new BigNumber(0)
+  const darAsBigNumber = userDarRewards ? new BigNumber(userDarRewards) : new BigNumber(0)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
   const darBalance = getBalanceNumber(darAsBigNumber, bscTokens.dar.decimals)
   const cakePriceBusd = useCakePrice()
@@ -126,7 +126,11 @@ export const getEasterRewardGroupAchievements = (userRewardGroup: string, teamRa
 }
 
 // given we have userPointReward and userRewardGroup, we can find the specific reward because no Rank has same two values.
-export const getRewardGroupAchievements = (prizes: PrizesConfig, userRewardGroup: string, userPointReward: string) => {
+export const getRewardGroupAchievements = (
+  prizes: PrizesConfig,
+  userRewardGroup?: string,
+  userPointReward?: string,
+) => {
   const prize = Object.values(prizes)
     .flat()
     .find((rank) => rank.achievements.points === Number(userPointReward) && rank.group === userRewardGroup)

--- a/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxUserPrizeGrid.tsx
+++ b/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxUserPrizeGrid.tsx
@@ -1,13 +1,13 @@
-import { BlockIcon, CheckmarkCircleIcon, Flex, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { BlockIcon, CheckmarkCircleIcon, Flex, Text } from '@pancakeswap/uikit'
 
 import { styled } from 'styled-components'
+import { mboxPrizes } from '../../../../../config/constants/trading-competition/prizes'
+import { BoldTd, StyledPrizeTable, Td } from '../../../components/StyledPrizeTable'
+import AchievementPoints from '../../../components/YourScore/AchievementPoints'
+import UserPrizeGridDollar from '../../../components/YourScore/UserPrizeGridDollar'
 import { getRewardGroupAchievements, useMoboxCompetitionRewards } from '../../../helpers'
 import { UserTradingInformation } from '../../../types'
-import { BoldTd, StyledPrizeTable, Td } from '../../../components/StyledPrizeTable'
-import { mboxPrizes } from '../../../../../config/constants/trading-competition/prizes'
-import UserPrizeGridDollar from '../../../components/YourScore/UserPrizeGridDollar'
-import AchievementPoints from '../../../components/YourScore/AchievementPoints'
 
 const StyledThead = styled.thead`
   border-bottom: 2px solid ${({ theme }) => theme.colors.cardBorder};
@@ -18,7 +18,7 @@ const MoboxUserPrizeGrid: React.FC<React.PropsWithChildren<{ userTradingInformat
 }) => {
   const { t } = useTranslation()
   const { userRewardGroup, userCakeRewards, userMoboxRewards, userPointReward, canClaimMysteryBox, canClaimNFT } =
-    userTradingInformation
+    userTradingInformation ?? {}
   const { cakeReward, moboxReward, dollarValueOfTokensReward } = useMoboxCompetitionRewards({
     userCakeRewards,
     userMoboxRewards,

--- a/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxYourScore.tsx
+++ b/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxYourScore.tsx
@@ -1,15 +1,15 @@
-import { Skeleton, Heading, Text } from '@pancakeswap/uikit'
-import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
-import ScoreHeader from '../../../components/YourScore/ScoreHeader'
+import { Heading, Skeleton, Text } from '@pancakeswap/uikit'
+import { styled } from 'styled-components'
+import { LIVE } from '../../../../../config/constants/trading-competition/phases'
 import RibbonWithImage from '../../../components/RibbonWithImage'
-import { YourScoreProps } from '../../../types'
+import ScoreCard from '../../../components/YourScore/ScoreCard'
+import ScoreHeader from '../../../components/YourScore/ScoreHeader'
+import UserRankBox from '../../../components/YourScore/UserRankBox'
+import CakersShare from '../../../pngs/mobox-cakers-share.png'
 import FlippersShare from '../../../pngs/mobox-flippers-share.png'
 import StormShare from '../../../pngs/mobox-storm-share.png'
-import CakersShare from '../../../pngs/mobox-cakers-share.png'
-import ScoreCard from '../../../components/YourScore/ScoreCard'
-import UserRankBox from '../../../components/YourScore/UserRankBox'
-import { LIVE } from '../../../../../config/constants/trading-competition/phases'
+import { YourScoreProps } from '../../../types'
 import MoboxUserPrizeGrid from './MoboxUserPrizeGrid'
 
 const Wrapper = styled.div`
@@ -55,7 +55,7 @@ const MoboxYourScore: React.FC<React.PropsWithChildren<YourScoreProps>> = ({
             title={t('Your MBOX volume rank').toUpperCase()}
             footer={t('Based on your MBOX/BNB and MBOX/BUSD trading')}
             // Add responsive mr if competition is LIVE
-            mr={currentPhase.state === LIVE ? [0, null, null, '8px'] : 0}
+            mr={currentPhase?.state === LIVE ? [0, null, null, '8px'] : 0}
           >
             {!userLeaderboardInformation ? (
               <Skeleton height="26px" width="110px" />

--- a/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModUserPrizeGrid.tsx
+++ b/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModUserPrizeGrid.tsx
@@ -1,13 +1,13 @@
-import { BlockIcon, CheckmarkCircleIcon, Flex, Text } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
+import { BlockIcon, CheckmarkCircleIcon, Flex, Text } from '@pancakeswap/uikit'
 
 import { styled } from 'styled-components'
+import { modPrizes } from '../../../../../config/constants/trading-competition/prizes'
+import { BoldTd, StyledPrizeTable, Td } from '../../../components/StyledPrizeTable'
+import AchievementPoints from '../../../components/YourScore/AchievementPoints'
+import UserPrizeGridDollar from '../../../components/YourScore/UserPrizeGridDollar'
 import { getRewardGroupAchievements, useModCompetitionRewards } from '../../../helpers'
 import { UserTradingInformation } from '../../../types'
-import { BoldTd, StyledPrizeTable, Td } from '../../../components/StyledPrizeTable'
-import { modPrizes } from '../../../../../config/constants/trading-competition/prizes'
-import UserPrizeGridDollar from '../../../components/YourScore/UserPrizeGridDollar'
-import AchievementPoints from '../../../components/YourScore/AchievementPoints'
 import { useCanClaimSpecialNFT } from '../../../useCanClaimSpecialNFT'
 
 const StyledThead = styled.thead`
@@ -18,7 +18,8 @@ const ModUserPrizeGrid: React.FC<React.PropsWithChildren<{ userTradingInformatio
   userTradingInformation,
 }) => {
   const { t } = useTranslation()
-  const { userRewardGroup, userCakeRewards, userDarRewards, userPointReward, canClaimNFT } = userTradingInformation
+  const { userRewardGroup, userCakeRewards, userDarRewards, userPointReward, canClaimNFT } =
+    userTradingInformation ?? {}
   const canClaimSpecialNFT = useCanClaimSpecialNFT()
   const { cakeReward, darReward, dollarValueOfTokensReward } = useModCompetitionRewards({
     userCakeRewards,

--- a/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModYourScore.tsx
+++ b/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModYourScore.tsx
@@ -1,15 +1,15 @@
-import { Skeleton, Heading, Text } from '@pancakeswap/uikit'
-import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
-import ScoreHeader from '../../../components/YourScore/ScoreHeader'
+import { Heading, Skeleton, Text } from '@pancakeswap/uikit'
+import { styled } from 'styled-components'
+import { LIVE } from '../../../../../config/constants/trading-competition/phases'
 import RibbonWithImage from '../../../components/RibbonWithImage'
-import { UserLeaderboardSharedInformation, CompetitionProps } from '../../../types'
+import ScoreCard from '../../../components/YourScore/ScoreCard'
+import ScoreHeader from '../../../components/YourScore/ScoreHeader'
+import UserRankBox from '../../../components/YourScore/UserRankBox'
+import CakersShare from '../../../pngs/MoD-cakers-share.png'
 import FlippersShare from '../../../pngs/MoD-flippers-share.png'
 import StormShare from '../../../pngs/MoD-storm-share.png'
-import CakersShare from '../../../pngs/MoD-cakers-share.png'
-import ScoreCard from '../../../components/YourScore/ScoreCard'
-import UserRankBox from '../../../components/YourScore/UserRankBox'
-import { LIVE } from '../../../../../config/constants/trading-competition/phases'
+import { CompetitionProps, UserLeaderboardSharedInformation } from '../../../types'
 import ModUserPrizeGrid from './ModUserPrizeGrid'
 
 const Wrapper = styled.div`
@@ -63,7 +63,7 @@ const ModYourScore: React.FC<React.PropsWithChildren<MoDYourScoreProps>> = ({
             title={t('Your DAR volume rank').toUpperCase()}
             footer={t('Based on your DAR/BNB trading')}
             // Add responsive mr if competition is LIVE
-            mr={currentPhase.state === LIVE ? [0, null, null, '8px'] : 0}
+            mr={currentPhase?.state === LIVE ? [0, null, null, '8px'] : 0}
           >
             {!userLeaderboardInformation ? (
               <Skeleton height="26px" width="110px" />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates several components and hooks in the `TradingCompetition` section of the web app. Changes include making certain props optional, importing UI components, and handling null values.

### Detailed summary
- Updated `useGetUsernameWithVisibility` hook to accept an optional `username`
- Modified props to accept `null` values in various components
- Imported UI components like `Skeleton`, `Text`, `Button`, `Heading`, and `Flex`
- Updated routing logic in `ReactivateProfile` component
- Imported translation and state management functions
- Refactored components to handle null values and optional props

> The following files were skipped due to too many changes: `apps/web/src/views/TradingCompetition/mod/components/YourScore/ModYourScore.tsx`, `apps/web/src/views/TradingCompetition/helpers.ts`, `apps/web/src/views/TradingCompetition/components/YourScore/CardUserInfo.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->