### PR TITLE
fix: SG Indicator initally shows delayed in chains other than bsc with wrong text and block

### DIFF
--- a/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
@@ -16,7 +16,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 export function subgraphHealthIndicatorFactory({ getSubgraphName }: FactoryParams) {
-  return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraphName'>) {
+  return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraphName' | 'chainId'>) {
     const { chainId } = useActiveChainId()
     const subgraphName = useMemo(() => chainId && getSubgraphName(chainId), [chainId])
 
@@ -27,7 +27,7 @@ export function subgraphHealthIndicatorFactory({ getSubgraphName }: FactoryParam
     const portalRoot = getPortalRoot()
 
     return portalRoot
-      ? createPortal(<SubgraphHealthIndicator subgraphName={subgraphName} {...props} />, portalRoot)
+      ? createPortal(<SubgraphHealthIndicator chainId={chainId} subgraphName={subgraphName} {...props} />, portalRoot)
       : null
   }
 }

--- a/apps/web/src/hooks/useSubgraphHealth.ts
+++ b/apps/web/src/hooks/useSubgraphHealth.ts
@@ -24,7 +24,7 @@ export type SubgraphHealthState = {
 const NOT_OK_BLOCK_DIFFERENCE = 200 // ~15 minutes delay
 const WARNING_BLOCK_DIFFERENCE = 50 // ~2.5 minute delay
 
-const useSubgraphHealth = (subgraphName?: string) => {
+const useSubgraphHealth = (chainId?: ChainId, subgraphName?: string) => {
   const [sgHealth, setSgHealth] = useState<SubgraphHealthState>({
     status: SubgraphStatus.UNKNOWN,
     currentBlock: 0,
@@ -58,8 +58,8 @@ const useSubgraphHealth = (subgraphName?: string) => {
             ),
             currentBlockNumber
               ? Promise.resolve(currentBlockNumber)
-              : publicClient({ chainId: ChainId.BSC })
-                  .getBlockNumber()
+              : publicClient({ chainId })
+                  ?.getBlockNumber()
                   .then((blockNumber) => Number(blockNumber)),
           ])
 
@@ -99,7 +99,7 @@ const useSubgraphHealth = (subgraphName?: string) => {
         getSubgraphHealth()
       }
     },
-    [subgraphName],
+    [subgraphName, chainId],
   )
 
   return sgHealth

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1447,7 +1447,7 @@
   "Slight delay": "Slight delay",
   "Delayed": "Delayed",
   "Fast": "Fast",
-  "Subgraph is currently experiencing delays due to BSC issues. Performance may suffer until subgraph is restored.": "Subgraph is currently experiencing delays due to BSC issues. Performance may suffer until subgraph is restored.",
+  "Subgraph is currently experiencing delays due to %chainName% issues. Performance may suffer until subgraph is restored.": "Subgraph is currently experiencing delays due to %chainName% issues. Performance may suffer until subgraph is restored.",
   "Subgraph is currently experiencing delays due to BSC issues. Rank and volume data may be inaccurate until subgraph is restored.": "Subgraph is currently experiencing delays due to BSC issues. Rank and volume data may be inaccurate until subgraph is restored.",
   "No issues with the subgraph.": "No issues with the subgraph.",
   "Turn on subgraph health indicator all the time. Default is to show the indicator only when the network is delayed": "Turn on subgraph health indicator all the time. Default is to show the indicator only when the network is delayed",


### PR DESCRIPTION

<img width="356" alt="Screenshot 2024-03-14 at 12 39 09" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/c15d7cd4-08dd-4e82-9917-f86ddb84f4ea">

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance subgraph health monitoring by adding support for different blockchain chains.

### Detailed summary
- `useSubgraphHealth` now accepts `chainId` parameter
- `SubgraphHealthIndicator` now supports `chainId`
- Updated translations to include dynamic chain name
- Added support for multiple blockchain chains in various components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->