### PR TITLE
fix: Disable offchain quote when exact output used

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -26,9 +26,9 @@ import useNativeCurrency from 'hooks/useNativeCurrency'
 import {
   CommonPoolsParams,
   PoolsWithState,
+  useCommonPools as useCommonPoolsWithTicks,
   useCommonPoolsLite,
   useCommonPoolsOnChain,
-  useCommonPools as useCommonPoolsWithTicks,
 } from './useCommonPools'
 import { useCurrencyUsdPrice } from './useCurrencyUsdPrice'
 import { useMulticallGasLimit } from './useMulticallGasLimit'
@@ -137,7 +137,7 @@ export function useBestAMMTrade({ type = 'quoter', ...params }: useBestAMMTradeO
   })
   const bestTradeFromOffchainQuoter = useBestAMMTradeFromOffchainQuoter({
     ...params,
-    enabled: offchainQuoterEnabled,
+    enabled: Boolean(offchainQuoterEnabled && params.tradeType !== TradeType.EXACT_OUTPUT),
     autoRevalidate: quoterAutoRevalidate,
   })
   const bestOffchainWithQuickOnChainQuote = useBetterQuote(bestTradeFromOffchainQuoter, bestTradeFromQuickOnChainQuote)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useBestAMMTrade` hook in the web app to handle trade type conditions more efficiently.

### Detailed summary
- Renamed `useCommonPools` to `useCommonPoolsWithTicks`
- Updated `enabled` condition based on `offchainQuoterEnabled` and `tradeType`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->