### PR TITLE
fix: Lottery ticket match display

### DIFF
--- a/apps/web/src/views/Lottery/components/TicketNumber.tsx
+++ b/apps/web/src/views/Lottery/components/TicketNumber.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Flex, Text } from '@pancakeswap/uikit'
+import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import { LotteryTicket } from 'config/constants/types'
 import _uniqueId from 'lodash/uniqueId'
 import { styled } from 'styled-components'
@@ -34,7 +35,7 @@ const TicketNumber: React.FC<React.PropsWithChildren<TicketNumberProps>> = ({ lo
   const { t } = useTranslation()
   const reversedNumber = parseRetrievedNumber(number)
   const numberAsArray = reversedNumber.split('')
-  const numberMatches = rewardBracket ? rewardBracket + 1 : null
+  const numberMatches = !isUndefinedOrNull(rewardBracket) && rewardBracket! >= 0 ? rewardBracket! + 1 : null
 
   return (
     <Flex flexDirection="column" mb="12px">
@@ -42,14 +43,14 @@ const TicketNumber: React.FC<React.PropsWithChildren<TicketNumberProps>> = ({ lo
         <Text fontSize="12px" color="textSubtle">
           #{localId || id}
         </Text>
-        {rewardBracket && rewardBracket >= 0 && (
+        {numberMatches ? (
           <Text fontSize="12px">
             {t('Matched first')} {numberMatches}
           </Text>
-        )}
+        ) : null}
       </Flex>
       <StyledNumberWrapper>
-        {rewardBracket && rewardBracket >= 0 && <RewardHighlighter numberMatches={numberMatches!} />}
+        {numberMatches ? <RewardHighlighter numberMatches={numberMatches} /> : null}
         {numberAsArray.map((digit) => (
           <Text key={`${localId || id}-${digit}-${_uniqueId()}`} fontSize="16px">
             {digit}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the logic in `TicketNumber.tsx` to use the `isUndefinedOrNull` function and improve the handling of `rewardBracket`.

### Detailed summary
- Updated logic to check for undefined or null `rewardBracket`
- Improved conditional rendering based on `numberMatches` variable

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->