### PR TITLE
fix(PositionMgr): Fix ALPACA StrategyInfo url

### DIFF
--- a/packages/position-managers/src/constants/vaults/bsc.ts
+++ b/packages/position-managers/src/constants/vaults/bsc.ts
@@ -83,7 +83,8 @@ export const vaults: VaultConfig[] = [
     allowDepositToken0: false,
     allowDepositToken1: true,
     managerInfoUrl: 'https://www.alpacafinance.org/',
-    strategyInfoUrl: 'https://docs.alpacafinance.org/leveraged-yield-farming/strategies',
+    strategyInfoUrl:
+      'https://docs.alpacafinance.org/automated-vault/introduction-to-automated-vaults/savings-vault-strategy',
     learnMoreAboutUrl: 'https://docs.alpacafinance.org/leveraged-yield-farming/strategies/pancakeswap-farms',
     priceFromV3FarmPid: 5,
     minDepositUSD: 50,
@@ -105,7 +106,8 @@ export const vaults: VaultConfig[] = [
     allowDepositToken0: false,
     allowDepositToken1: true,
     managerInfoUrl: 'https://www.alpacafinance.org/',
-    strategyInfoUrl: 'https://docs.alpacafinance.org/leveraged-yield-farming/strategies',
+    strategyInfoUrl:
+      'https://docs.alpacafinance.org/automated-vault/introduction-to-automated-vaults/savings-vault-strategy',
     learnMoreAboutUrl: 'https://docs.alpacafinance.org/leveraged-yield-farming/strategies/pancakeswap-farms',
     priceFromV3FarmPid: 8,
     minDepositUSD: 50,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `strategyInfoUrl` for BSC vaults in the Alpaca Finance position managers.

### Detailed summary
- Updated `strategyInfoUrl` for BSC vaults to a new link related to automated vaults and savings vault strategy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->