### PR TITLE
fix: max tick check on v3 sdk

### DIFF
--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -1,28 +1,28 @@
+import { useTranslation } from '@pancakeswap/localization'
 import { Currency, CurrencyAmount, Price, Token } from '@pancakeswap/swap-sdk-core'
 import {
-  encodeSqrtRatioX96,
   FeeAmount,
-  nearestUsableTick,
   Pool,
   Position,
-  priceToClosestTick,
   TICK_SPACINGS,
   TickMath,
+  encodeSqrtRatioX96,
+  nearestUsableTick,
+  priceToClosestTick,
 } from '@pancakeswap/v3-sdk'
+import { BIG_INT_ZERO } from 'config/constants/exchange'
+import { Bound } from 'config/constants/types'
 import { ReactNode, useMemo } from 'react'
 import { Field } from 'state/mint/actions'
-import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
-import { BIG_INT_ZERO } from 'config/constants/exchange'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { useTranslation } from '@pancakeswap/localization'
-import { Bound } from 'config/constants/types'
+import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
 import { MintState } from 'views/AddLiquidityV3/formViews/V3FormView/form/reducer'
 
 import { useAccount } from 'wagmi'
-import { tryParseTick } from './utils'
-import { usePool } from './usePools'
-import { getTickToPrice } from './utils/getTickToPrice'
 import { PoolState } from './types'
+import { usePool } from './usePools'
+import { tryParseTick } from './utils'
+import { getTickToPrice } from './utils/getTickToPrice'
 
 export default function useV3DerivedInfo(
   currencyA?: Currency,
@@ -143,6 +143,7 @@ export default function useV3DerivedInfo(
   const mockPool = useMemo(() => {
     if (!pool && tokenA && tokenB && feeAmount && price && !invalidPrice) {
       const currentTick = priceToClosestTick(price)
+      console.log('currentTick', currentTick)
       const currentSqrt = TickMath.getSqrtRatioAtTick(currentTick)
       return new Pool(tokenA, tokenB, feeAmount, currentSqrt, 0n, currentTick, [])
     }
@@ -176,6 +177,8 @@ export default function useV3DerivedInfo(
           : (invertPrice && typeof rightRangeTypedValue === 'boolean') ||
             (!invertPrice && typeof leftRangeTypedValue === 'boolean')
           ? tickSpaceLimits[Bound.LOWER]
+            ? tickSpaceLimits[Bound.LOWER] + 1
+            : tickSpaceLimits[Bound.LOWER]
           : invertPrice
           ? tryParseTick(feeAmount, rightRangeTypedValue)
           : tryParseTick(feeAmount, leftRangeTypedValue),
@@ -185,6 +188,8 @@ export default function useV3DerivedInfo(
           : (!invertPrice && typeof rightRangeTypedValue === 'boolean') ||
             (invertPrice && typeof leftRangeTypedValue === 'boolean')
           ? tickSpaceLimits[Bound.UPPER]
+            ? tickSpaceLimits[Bound.UPPER] - 1
+            : tickSpaceLimits[Bound.UPPER]
           : invertPrice
           ? tryParseTick(feeAmount, leftRangeTypedValue)
           : tryParseTick(feeAmount, rightRangeTypedValue),

--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -176,7 +176,7 @@ export default function useV3DerivedInfo(
           : (invertPrice && typeof rightRangeTypedValue === 'boolean') ||
             (!invertPrice && typeof leftRangeTypedValue === 'boolean')
           ? tickSpaceLimits[Bound.LOWER]
-            ? tickSpaceLimits[Bound.LOWER] + 1
+            ? tickSpaceLimits[Bound.LOWER]
             : tickSpaceLimits[Bound.LOWER]
           : invertPrice
           ? tryParseTick(feeAmount, rightRangeTypedValue)
@@ -187,7 +187,9 @@ export default function useV3DerivedInfo(
           : (!invertPrice && typeof rightRangeTypedValue === 'boolean') ||
             (invertPrice && typeof leftRangeTypedValue === 'boolean')
           ? tickSpaceLimits[Bound.UPPER]
-            ? tickSpaceLimits[Bound.UPPER] - 1
+            ? tickSpaceLimits[Bound.UPPER] === TickMath.MAX_TICK // if fee tier = 100 then TickMath.MAX_TICK will cause overflow, so minus 1 here
+              ? TickMath.MAX_TICK - 1
+              : tickSpaceLimits[Bound.UPPER]
             : tickSpaceLimits[Bound.UPPER]
           : invertPrice
           ? tryParseTick(feeAmount, leftRangeTypedValue)

--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -143,7 +143,6 @@ export default function useV3DerivedInfo(
   const mockPool = useMemo(() => {
     if (!pool && tokenA && tokenB && feeAmount && price && !invalidPrice) {
       const currentTick = priceToClosestTick(price)
-      console.log('currentTick', currentTick)
       const currentSqrt = TickMath.getSqrtRatioAtTick(currentTick)
       return new Pool(tokenA, tokenB, feeAmount, currentSqrt, 0n, currentTick, [])
     }

--- a/packages/v3-sdk/src/utils/tickMath.ts
+++ b/packages/v3-sdk/src/utils/tickMath.ts
@@ -80,7 +80,7 @@ export abstract class TickMath {
    * @param sqrtRatioX96 the sqrt ratio as a Q64.96 for which to compute the tick
    */
   public static getTickAtSqrtRatio(sqrtRatioX96: bigint): number {
-    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 <= TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
+    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 < TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
 
     const sqrtRatioX128 = sqrtRatioX96 << 32n
 

--- a/packages/v3-sdk/src/utils/tickMath.ts
+++ b/packages/v3-sdk/src/utils/tickMath.ts
@@ -80,7 +80,7 @@ export abstract class TickMath {
    * @param sqrtRatioX96 the sqrt ratio as a Q64.96 for which to compute the tick
    */
   public static getTickAtSqrtRatio(sqrtRatioX96: bigint): number {
-    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 < TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
+    invariant(sqrtRatioX96 >= TickMath.MIN_SQRT_RATIO && sqrtRatioX96 <= TickMath.MAX_SQRT_RATIO, 'SQRT_RATIO')
 
     const sqrtRatioX128 = sqrtRatioX96 << 32n
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useV3DerivedInfo` hook in the V3 app with new imports, type changes, and adjustments to tick space limits.

### Detailed summary
- Added imports for `BIG_INT_ZERO` and `Bound`
- Updated type imports for `PoolState`
- Adjusted tick space limits for lower and upper bounds
- Modified tick calculation logic for fee tiers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->