### PR TITLE
chore: check v3 max tick part2

### DIFF
--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -24,6 +24,16 @@ import { usePool } from './usePools'
 import { tryParseTick } from './utils'
 import { getTickToPrice } from './utils/getTickToPrice'
 
+/**
+ * if fee tier = 100 then TickMath.MAX_TICK will cause overflow, so minus 1 here
+ */
+const checkAndParseMaxTick = (tick: number) => {
+  if (tick === TickMath.MAX_TICK) {
+    return TickMath.MAX_TICK - 1
+  }
+  return tick
+}
+
 export default function useV3DerivedInfo(
   currencyA?: Currency,
   currencyB?: Currency,
@@ -183,13 +193,11 @@ export default function useV3DerivedInfo(
           : tryParseTick(feeAmount, leftRangeTypedValue),
       [Bound.UPPER]:
         typeof existingPosition?.tickUpper === 'number'
-          ? existingPosition.tickUpper
+          ? checkAndParseMaxTick(existingPosition.tickUpper)
           : (!invertPrice && typeof rightRangeTypedValue === 'boolean') ||
             (invertPrice && typeof leftRangeTypedValue === 'boolean')
           ? tickSpaceLimits[Bound.UPPER]
-            ? tickSpaceLimits[Bound.UPPER] === TickMath.MAX_TICK // if fee tier = 100 then TickMath.MAX_TICK will cause overflow, so minus 1 here
-              ? TickMath.MAX_TICK - 1
-              : tickSpaceLimits[Bound.UPPER]
+            ? checkAndParseMaxTick(tickSpaceLimits[Bound.UPPER])
             : tickSpaceLimits[Bound.UPPER]
           : invertPrice
           ? tryParseTick(feeAmount, leftRangeTypedValue)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR addresses potential overflow issues in `useV3DerivedInfo` by implementing a `checkAndParseMaxTick` function to handle TickMath.MAX_TICK values correctly.

### Detailed summary
- Added `checkAndParseMaxTick` function to handle TickMath.MAX_TICK values
- Updated logic to use `checkAndParseMaxTick` for tickUpper values
- Improved handling of TickMath.MAX_TICK in tickSpaceLimits[Bound.UPPER] calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->