### PR TITLE
fix: liq range select by nearset tickSpacing

### DIFF
--- a/apps/web/src/hooks/v3/useV3DerivedInfo.ts
+++ b/apps/web/src/hooks/v3/useV3DerivedInfo.ts
@@ -64,6 +64,7 @@ export default function useV3DerivedInfo(
   depositBDisabled: boolean
   invertPrice: boolean
   ticksAtLimit: { [bound in Bound]?: boolean | undefined }
+  tickSpaceLimits: { [bound in Bound]: number | undefined }
 } {
   const { t } = useTranslation()
 
@@ -421,5 +422,6 @@ export default function useV3DerivedInfo(
     depositBDisabled,
     invertPrice,
     ticksAtLimit,
+    tickSpaceLimits,
   }
 }

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/form/hooks/useRangeHopCallbacks.ts
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/form/hooks/useRangeHopCallbacks.ts
@@ -1,5 +1,5 @@
 import { Currency } from '@pancakeswap/sdk'
-import { FeeAmount, Pool, TICK_SPACINGS, tickToPrice } from '@pancakeswap/v3-sdk'
+import { FeeAmount, Pool, TICK_SPACINGS, nearestUsableTick, tickToPrice } from '@pancakeswap/v3-sdk'
 import { useCallback, useMemo } from 'react'
 import { setFullRange } from 'views/AddLiquidityV3/formViews/V3FormView/form/actions'
 import { useV3FormDispatch } from '../reducer'
@@ -19,44 +19,76 @@ export function useRangeHopCallbacks(
 
   const getDecrementLower = useCallback(() => {
     if (baseToken && quoteToken && typeof tickLower === 'number' && feeAmount) {
-      return tickToPrice(baseToken, quoteToken, tickLower - TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(tickLower - TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     // use pool current tick as starting tick if we have pool but no tick input
     if (!(typeof tickLower === 'number') && baseToken && quoteToken && feeAmount && pool) {
-      return tickToPrice(baseToken, quoteToken, pool.tickCurrent - TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(pool.tickCurrent - TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     return undefined
   }, [baseToken, quoteToken, tickLower, feeAmount, pool])
 
   const getIncrementLower = useCallback(() => {
     if (baseToken && quoteToken && typeof tickLower === 'number' && feeAmount) {
-      return tickToPrice(baseToken, quoteToken, tickLower + TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(tickLower + TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     // use pool current tick as starting tick if we have pool but no tick input
     if (!(typeof tickLower === 'number') && baseToken && quoteToken && feeAmount && pool) {
-      return tickToPrice(baseToken, quoteToken, pool.tickCurrent + TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(pool.tickCurrent + TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     return undefined
   }, [baseToken, quoteToken, tickLower, feeAmount, pool])
 
   const getDecrementUpper = useCallback(() => {
     if (baseToken && quoteToken && typeof tickUpper === 'number' && feeAmount) {
-      return tickToPrice(baseToken, quoteToken, tickUpper - TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(tickUpper - TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     // use pool current tick as starting tick if we have pool but no tick input
     if (!(typeof tickUpper === 'number') && baseToken && quoteToken && feeAmount && pool) {
-      return tickToPrice(baseToken, quoteToken, pool.tickCurrent - TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(pool.tickCurrent - TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     return undefined
   }, [baseToken, quoteToken, tickUpper, feeAmount, pool])
 
   const getIncrementUpper = useCallback(() => {
     if (baseToken && quoteToken && typeof tickUpper === 'number' && feeAmount) {
-      return tickToPrice(baseToken, quoteToken, tickUpper + TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(tickUpper + TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     // use pool current tick as starting tick if we have pool but no tick input
     if (!(typeof tickUpper === 'number') && baseToken && quoteToken && feeAmount && pool) {
-      return tickToPrice(baseToken, quoteToken, pool.tickCurrent + TICK_SPACINGS[feeAmount])
+      return tickToPrice(
+        baseToken,
+        quoteToken,
+        nearestUsableTick(pool.tickCurrent + TICK_SPACINGS[feeAmount], TICK_SPACINGS[feeAmount]),
+      )
     }
     return undefined
   }, [baseToken, quoteToken, tickUpper, feeAmount, pool])

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -261,6 +261,11 @@ export default function V3FormView({
       return
     }
 
+    if (position?.liquidity === 0n) {
+      setTxnErrorMessage(t('The liquidity of this position is 0. Please try increasing the amount.'))
+      return
+    }
+
     if (position && account && deadline) {
       const useNative = baseCurrency.isNative ? baseCurrency : quoteCurrency.isNative ? quoteCurrency : undefined
 

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -156,6 +156,7 @@ export default function V3FormView({
     depositBDisabled,
     invertPrice,
     ticksAtLimit,
+    tickSpaceLimits,
   } = useV3DerivedInfo(
     baseCurrency ?? undefined,
     quoteCurrency ?? undefined,
@@ -673,6 +674,7 @@ export default function V3FormView({
               currencyB={quoteCurrency}
               feeAmount={feeAmount}
               ticksAtLimit={ticksAtLimit}
+              tickSpaceLimits={tickSpaceLimits}
             />
             {showCapitalEfficiencyWarning ? (
               <Message variant="warning">

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3267,5 +3267,6 @@
   "%stakedToken% Syrup Pool": "%stakedToken% Syrup Pool",
   "If more %lpLabel% LP is deposited in our Farm this week, we'll increase APT rewards for %stakedToken% Syrup Pool next week.": "If more %lpLabel% LP is deposited in our Farm this week, we'll increase APT rewards for %stakedToken% Syrup Pool next week.",
   "Enjoying the %stakingToken% Staking APR? Get more rewards with the %lpLabel% LP on our": "Enjoying the %stakingToken% Staking APR? Get more rewards with the %lpLabel% LP on our",
-  "The rewards for this Syrup Pool will not be applicable to or claimable by": "The rewards for this Syrup Pool will not be applicable to or claimable by"
+  "The rewards for this Syrup Pool will not be applicable to or claimable by": "The rewards for this Syrup Pool will not be applicable to or claimable by",
+  "The liquidity of this position is 0. Please try increasing the amount.": "The liquidity of this position is 0. Please try increasing the amount."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the V3 liquidity form view by adding `tickSpaceLimits` for tick space control.

### Detailed summary
- Added `tickSpaceLimits` for controlling tick space in V3 liquidity form view
- Updated translations for clarity
- Implemented `priceToClosestTick` function for tick calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->