### PR TITLE
feat: open 20%

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -31,7 +31,7 @@ export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   },
   {
     feature: EXPERIMENTAL_FEATURES.UniversalRouter,
-    percentage: 0.05,
+    percentage: 0.2,
     whitelist: [],
   },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR increases the percentage for the `UniversalRouter` experimental feature from 0.05 to 0.2 in `experimentalFeatures.ts`.

### Detailed summary
- Updated percentage for the `UniversalRouter` experimental feature from 0.05 to 0.2

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->