### PR TITLE
fix: Crash when swap accessed from unsupported chain

### DIFF
--- a/apps/web/src/hooks/usePoolsOnChain.ts
+++ b/apps/web/src/hooks/usePoolsOnChain.ts
@@ -36,7 +36,12 @@ function candidatePoolsOnChainHookFactory<TPool extends Pool>(
   ) {
     const fetchingBlock = useRef<string | null>(null)
     const key = useMemo(() => {
-      if (!currencyA || !currencyB || currencyA.wrapped.equals(currencyB.wrapped)) {
+      if (
+        !currencyA ||
+        !currencyB ||
+        currencyA.chainId !== currencyB.chainId ||
+        currencyA.wrapped.equals(currencyB.wrapped)
+      ) {
         return ''
       }
       const symbols = currencyA.wrapped.sortsBefore(currencyB.wrapped)

--- a/apps/web/src/hooks/useV2Pools.ts
+++ b/apps/web/src/hooks/useV2Pools.ts
@@ -37,7 +37,12 @@ export function useV2CandidatePools(
   }, [currencyA])
 
   const key = useMemo(() => {
-    if (!currencyA || !currencyB || currencyA.wrapped.equals(currencyB.wrapped)) {
+    if (
+      !currencyA ||
+      !currencyB ||
+      currencyA.chainId !== currencyB.chainId ||
+      currencyA.wrapped.equals(currencyB.wrapped)
+    ) {
       return ''
     }
     const symbols = currencyA.wrapped.sortsBefore(currencyB.wrapped)

--- a/apps/web/src/hooks/useV3Pools.ts
+++ b/apps/web/src/hooks/useV3Pools.ts
@@ -72,7 +72,12 @@ export function useV3CandidatePoolsWithoutTicks(
   options?: V3PoolsHookParams,
 ) {
   const key = useMemo(() => {
-    if (!currencyA || !currencyB || currencyA.wrapped.equals(currencyB.wrapped)) {
+    if (
+      !currencyA ||
+      !currencyB ||
+      currencyA.chainId !== currencyB.chainId ||
+      currencyA.wrapped.equals(currencyB.wrapped)
+    ) {
       return ''
     }
     const symbols = currencyA.wrapped.sortsBefore(currencyB.wrapped)
@@ -129,7 +134,12 @@ export function useV3PoolsWithTicksOnChain(
 ): V3PoolsResult {
   const gasLimit = useMulticallGasLimit(currencyA?.chainId)
   const key = useMemo(() => {
-    if (!currencyA || !currencyB || currencyA.wrapped.equals(currencyB.wrapped)) {
+    if (
+      !currencyA ||
+      !currencyB ||
+      currencyA.chainId !== currencyB.chainId ||
+      currencyA.wrapped.equals(currencyB.wrapped)
+    ) {
       return ''
     }
     const symbols = currencyA.wrapped.sortsBefore(currencyB.wrapped)

--- a/packages/smart-router/evm/v3-router/functions/getPairCombinations.ts
+++ b/packages/smart-router/evm/v3-router/functions/getPairCombinations.ts
@@ -89,7 +89,12 @@ const getTokenBasesFromGauges = memoize(
 )
 
 const resolver = (currencyA?: Currency, currencyB?: Currency) => {
-  if (!currencyA || !currencyB || currencyA.wrapped.equals(currencyB.wrapped)) {
+  if (
+    !currencyA ||
+    !currencyB ||
+    currencyA.chainId !== currencyB.chainId ||
+    currencyA.wrapped.equals(currencyB.wrapped)
+  ) {
     return `${currencyA?.chainId}_${currencyA?.wrapped?.address}_${currencyB?.wrapped?.address}`
   }
   const [token0, token1] = currencyA.wrapped.sortsBefore(currencyB.wrapped)


### PR DESCRIPTION
Issue happens when trying to access swap page from for example polygon chain. 

- Set wallet chain to polygon
- Try to access https://pancakeswap.finance/swap?outputCurrency=0x55d398326f99059fF775485246999027B3197955
- Crashes

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates multiple files to include a check for different chain IDs before comparing currencies. 

### Detailed summary
- Added a check for different chain IDs before comparing currencies in multiple files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->