### PR TITLE
fix: Add native token to wallet not working in transaction modal

### DIFF
--- a/apps/web/src/components/TransactionConfirmationModal/index.tsx
+++ b/apps/web/src/components/TransactionConfirmationModal/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@pancakeswap/uikit'
 import { ConfirmationPendingContent, TransactionErrorContent } from '@pancakeswap/widgets-internal'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { styled } from 'styled-components'
 import { getBlockExploreLink, getBlockExploreName } from 'utils'
 import { wrappedCurrency } from 'utils/wrappedCurrency'
@@ -48,6 +48,13 @@ export function TransactionSubmittedContent({
 
   const token: Token | undefined = wrappedCurrency(currencyToAdd, chainId)
 
+  const showAddToWalletButton = useMemo(() => {
+    if (token && currencyToAdd) {
+      return !currencyToAdd.isNative
+    }
+    return false
+  }, [token, currencyToAdd])
+
   return (
     <Wrapper>
       <Section>
@@ -64,7 +71,7 @@ export function TransactionSubmittedContent({
               {chainId === ChainId.BSC && <BscScanIcon color="primary" ml="4px" />}
             </Link>
           )}
-          {currencyToAdd && (
+          {showAddToWalletButton && (
             <AddToWalletButton
               variant="tertiary"
               mt="12px"
@@ -72,7 +79,7 @@ export function TransactionSubmittedContent({
               marginTextBetweenLogo="6px"
               textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
               tokenAddress={token?.address}
-              tokenSymbol={currencyToAdd.symbol}
+              tokenSymbol={currencyToAdd!.symbol}
               tokenDecimals={token?.decimals}
               tokenLogo={token instanceof WrappedTokenInfo ? token.logoURI : undefined}
             />

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
@@ -78,6 +78,13 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
 
   const token: Token | undefined = wrappedCurrency(trade?.outputAmount?.currency, chainId)
 
+  const showAddToWalletButton = useMemo(() => {
+    if (token && trade?.outputAmount?.currency) {
+      return !trade?.outputAmount?.currency?.isNative
+    }
+    return false
+  }, [token, trade])
+
   const handleDismiss = useCallback(() => {
     if (customOnDismiss) {
       customOnDismiss?.()
@@ -143,19 +150,21 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
           amountA={amountA}
           amountB={amountB}
         >
-          <AddToWalletButton
-            mt="39px"
-            height="auto"
-            variant="tertiary"
-            width="fit-content"
-            padding="6.5px 20px"
-            marginTextBetweenLogo="6px"
-            textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
-            tokenAddress={token?.address}
-            tokenSymbol={currencyB?.symbol}
-            tokenDecimals={token?.decimals}
-            tokenLogo={token instanceof WrappedTokenInfo ? token?.logoURI : undefined}
-          />
+          {showAddToWalletButton && (
+            <AddToWalletButton
+              mt="39px"
+              height="auto"
+              variant="tertiary"
+              width="fit-content"
+              padding="6.5px 20px"
+              marginTextBetweenLogo="6px"
+              textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
+              tokenAddress={token?.address}
+              tokenSymbol={currencyB?.symbol}
+              tokenDecimals={token?.decimals}
+              tokenLogo={token instanceof WrappedTokenInfo ? token?.logoURI : undefined}
+            />
+          )}
         </SwapPendingModalContentV1>
       )
     }
@@ -169,19 +178,21 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
               {chainId === ChainId.BSC && <BscScanIcon color="primary" ml="4px" />}
             </Link>
           )}
-          <AddToWalletButton
-            mt="39px"
-            height="auto"
-            variant="tertiary"
-            width="fit-content"
-            padding="6.5px 20px"
-            marginTextBetweenLogo="6px"
-            textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
-            tokenAddress={token?.address}
-            tokenSymbol={currencyB?.symbol}
-            tokenDecimals={token?.decimals}
-            tokenLogo={token instanceof WrappedTokenInfo ? token?.logoURI : undefined}
-          />
+          {showAddToWalletButton && (
+            <AddToWalletButton
+              mt="39px"
+              height="auto"
+              variant="tertiary"
+              width="fit-content"
+              padding="6.5px 20px"
+              marginTextBetweenLogo="6px"
+              textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
+              tokenAddress={token?.address}
+              tokenSymbol={currencyB?.symbol}
+              tokenDecimals={token?.decimals}
+              tokenLogo={token instanceof WrappedTokenInfo ? token?.logoURI : undefined}
+            />
+          )}
         </SwapTransactionReceiptModalContentV1>
       )
     }
@@ -220,6 +231,7 @@ export const ConfirmSwapModal = memo<InjectedModalProps & ConfirmSwapModalProps>
     startSwapFlow,
     onAcceptChanges,
     openSettingModal,
+    showAddToWalletButton,
   ])
 
   const isShowingLoadingAnimation = useMemo(

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
@@ -105,6 +105,13 @@ export const ConfirmSwapModalV2: React.FC<ConfirmSwapModalProps> = ({
     [chainId, trade?.outputAmount?.currency],
   )
 
+  const showAddToWalletButton = useMemo(() => {
+    if (token && trade?.outputAmount?.currency) {
+      return !trade?.outputAmount?.currency?.isNative
+    }
+    return false
+  }, [token, trade])
+
   const handleDismiss = useCallback(() => {
     if (typeof customOnDismiss === 'function') {
       customOnDismiss()
@@ -171,7 +178,7 @@ export const ConfirmSwapModalV2: React.FC<ConfirmSwapModalProps> = ({
           amountB={amountB}
           currentStep={confirmModalState}
         >
-          {txHash ? (
+          {showAddToWalletButton && txHash ? (
             <AddToWalletButton
               mt="39px"
               height="auto"
@@ -204,19 +211,21 @@ export const ConfirmSwapModalV2: React.FC<ConfirmSwapModalProps> = ({
             )
           }
         >
-          <AddToWalletButton
-            mt="39px"
-            height="auto"
-            variant="tertiary"
-            width="fit-content"
-            padding="6.5px 20px"
-            marginTextBetweenLogo="6px"
-            textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
-            tokenAddress={token?.address}
-            tokenSymbol={currencyB?.symbol}
-            tokenDecimals={token?.decimals}
-            tokenLogo={token instanceof WrappedTokenInfo ? (token as WrappedTokenInfo)?.logoURI : undefined}
-          />
+          {showAddToWalletButton && (
+            <AddToWalletButton
+              mt="39px"
+              height="auto"
+              variant="tertiary"
+              width="fit-content"
+              padding="6.5px 20px"
+              marginTextBetweenLogo="6px"
+              textOptions={AddToWalletTextOptions.TEXT_WITH_ASSET}
+              tokenAddress={token?.address}
+              tokenSymbol={currencyB?.symbol}
+              tokenDecimals={token?.decimals}
+              tokenLogo={token instanceof WrappedTokenInfo ? (token as WrappedTokenInfo)?.logoURI : undefined}
+            />
+          )}
         </SwapTransactionReceiptModalContent>
       )
     }


### PR DESCRIPTION
MetaMask - RPC Error: The symbol in the request (BNB) does not match the symbol in the contract (WBNB) 
Object { code: -32602, message: "The symbol in the request (BNB) does not match the symbol in the contract (WBNB)" }


Since the native token should always be in the wallet, button should be disabled like in the currency input panel

Button for Wrapped tokens (wbnb , weth) will still be visible

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a `showAddToWalletButton` logic to conditionally render wallet buttons based on token type.

### Detailed summary
- Added `showAddToWalletButton` logic to conditionally render wallet buttons based on token type in multiple components.
- Imported `useMemo` in `TransactionConfirmationModal` and `ConfirmSwapModalV2`.
- Updated rendering of wallet buttons based on `showAddToWalletButton` in affected components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->