### PR TITLE
fix: Unfocused toast shown again if dismissed by user

### DIFF
--- a/packages/uikit/src/contexts/ToastsContext/Provider.tsx
+++ b/packages/uikit/src/contexts/ToastsContext/Provider.tsx
@@ -57,7 +57,10 @@ export const ToastsProvider: React.FC<React.PropsWithChildren> = ({ children }) 
               description,
               type: types.DANGER,
             }}
-            onRemove={() => sonnerToast.dismiss(t)}
+            onRemove={() => {
+              toasts.delete(t);
+              sonnerToast.dismiss(t);
+            }}
           >
             {description}
           </Toast>
@@ -88,7 +91,10 @@ export const ToastsProvider: React.FC<React.PropsWithChildren> = ({ children }) 
               description,
               type: types.INFO,
             }}
-            onRemove={() => sonnerToast.dismiss(t)}
+            onRemove={() => {
+              toasts.delete(t);
+              sonnerToast.dismiss(t);
+            }}
           >
             {description}
           </Toast>
@@ -119,7 +125,10 @@ export const ToastsProvider: React.FC<React.PropsWithChildren> = ({ children }) 
               description,
               type: types.SUCCESS,
             }}
-            onRemove={() => sonnerToast.dismiss(t)}
+            onRemove={() => {
+              toasts.delete(t);
+              sonnerToast.dismiss(t);
+            }}
           >
             {description}
           </Toast>
@@ -150,7 +159,10 @@ export const ToastsProvider: React.FC<React.PropsWithChildren> = ({ children }) 
               description,
               type: types.WARNING,
             }}
-            onRemove={() => sonnerToast.dismiss(t)}
+            onRemove={() => {
+              toasts.delete(t);
+              sonnerToast.dismiss(t);
+            }}
           >
             {description}
           </Toast>
@@ -162,8 +174,12 @@ export const ToastsProvider: React.FC<React.PropsWithChildren> = ({ children }) 
     [deleteCallback]
   );
 
-  const clear = useCallback(() => sonnerToast.dismiss(), []);
+  const clear = useCallback(() => {
+    toasts.clear();
+    sonnerToast.dismiss();
+  }, []);
   const remove = useCallback((id: string | number) => {
+    toasts.delete(id);
     sonnerToast.dismiss(id);
   }, []);
 


### PR DESCRIPTION
Steps to reproduce:

- Make toast appear when tab is not focused
- Dismiss the toast by clicking close button
- Unfocus and focus again
- Dismissed Toast appears


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `ToastsProvider` component to manage toast removal using a `Map` data structure efficiently.

### Detailed summary
- Refactored `onRemove` functions to delete toast from a `Map`
- Implemented `toasts.clear()` to clear all toasts
- Updated `remove` function to delete toast from `Map` before dismissing

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->