### PR TITLE
chore: Disable stable swap for exact output

### DIFF
--- a/.changeset/cuddly-mails-speak.md
+++ b/.changeset/cuddly-mails-speak.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': patch
+---
+
+Disable stable swap for exact output

--- a/packages/smart-router/evm/v4-router/graph/graph.ts
+++ b/packages/smart-router/evm/v4-router/graph/graph.ts
@@ -6,7 +6,7 @@ import memoize from 'lodash/memoize.js'
 
 import { Pool } from '../../v3-router/types'
 import { createPoolQuoteGetter } from '../../v3-router/providers'
-import { buildBaseRoute, getPoolAddress } from '../../v3-router/utils'
+import { buildBaseRoute, getPoolAddress, isStablePool } from '../../v3-router/utils'
 import { V4Trade, Edge, Vertice, Graph, TradeConfig, V4Route } from '../types'
 import { getCurrencyPairs } from '../pool'
 import { getNeighbour } from './edge'
@@ -222,7 +222,8 @@ export async function findBestTrade(params: FindBestTradeParams): Promise<V4Trad
   }
 
   // Exact output doesn't support mixed route
-  const poolsByType = groupPoolsByType(candidatePools)
+  // Disable stable swap for exact output as it's not natively supported. TX may fail if multiple swaps are executed within the same block
+  const poolsByType = groupPoolsByType(candidatePools).filter((pools) => !isStablePool(pools[0]))
   const trades = await Promise.allSettled(
     poolsByType.map((pools) => getBestTrade({ tradeType, candidatePools: pools, ...rest })),
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on disabling stable swap for exact output in the `smart-router` package to prevent potential transaction failures due to unsupported features.

### Detailed summary
- Added `isStablePool` function to check for stable pools
- Filtered out stable pools when grouping pools by type to find the best trade

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->