### PR TITLE
feat: list ezETH linea farm and gauge

### DIFF
--- a/packages/farms/constants/linea.ts
+++ b/packages/farms/constants/linea.ts
@@ -4,6 +4,13 @@ import { defineFarmV3Configs } from '../src/defineFarmV3Configs'
 
 export const farmsV3 = defineFarmV3Configs([
   {
+    pid: 13,
+    lpAddress: '0xfDe733b5DE5B5a06C68353e01E4c1D3415C89560',
+    token0: lineaTokens.ezETH,
+    token1: lineaTokens.weth,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 12,
     lpAddress: '0x1947B87d35E9f1cd53CEDe1aD6F7be44C12212B8',
     token0: lineaTokens.usdt,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -3343,4 +3343,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: bscTokens.usdt.address,
     feeTier: FeeAmount.MEDIUM,
   },
+  {
+    gid: 334,
+    pairName: 'ezETH-ETH',
+    address: '0xfDe733b5DE5B5a06C68353e01E4c1D3415C89560',
+    chainId: ChainId.LINEA,
+    type: GaugeType.V3,
+    token0Address: lineaTokens.ezETH.address,
+    token1Address: lineaTokens.weth.address,
+    feeTier: FeeAmount.LOW,
+  },
 ]

--- a/packages/tokens/src/constants/linea.ts
+++ b/packages/tokens/src/constants/linea.ts
@@ -39,4 +39,12 @@ export const lineaTokens = {
     'Wrapped liquid staked Ether 2.0',
     'https://lido.fi/',
   ),
+  ezETH: new ERC20Token(
+    ChainId.LINEA,
+    '0x2416092f143378750bb29b79eD961ab195CcEea5',
+    18,
+    'ezETH',
+    'Renzo Restaked ETH',
+    'https://www.renzoprotocol.com/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for a new token `ezETH` in the Linea ecosystem and configure farms and gauges accordingly.

### Detailed summary
- Added `ezETH` token with details and URL
- Configured new farm with `ezETH` and `WETH`
- Added a new gauge for `ezETH-ETH` pair

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->