### PR TITLE
fix: Limit order not visible when handler is null

### DIFF
--- a/apps/web/src/views/LimitOrders/components/LimitOrderTable/DetailLimitOrderModal.tsx
+++ b/apps/web/src/views/LimitOrders/components/LimitOrderTable/DetailLimitOrderModal.tsx
@@ -126,8 +126,6 @@ export const DetailLimitOrderModal: React.FC<React.PropsWithChildren<DetailLimit
         />
       </Flex>
       <LimitTradeInfoCard
-        currentPriceExchangeRateText="0.002474 BNB = 1 BUSD"
-        currentPriceExchangeRateTextReversed="404.11169 BUSD = 1 BNB"
         limitPriceExchangeRateText={limitPriceExchangeRateText}
         limitPriceExchangeRateTextReversed={limitPriceExchangeRateTextReversed}
         isOpen={isOpen}
@@ -195,8 +193,6 @@ export const DetailLimitOrderModal: React.FC<React.PropsWithChildren<DetailLimit
 }
 
 interface LimitTradeInfoCardProps {
-  currentPriceExchangeRateText: string
-  currentPriceExchangeRateTextReversed: string
   limitPriceExchangeRateText: string
   limitPriceExchangeRateTextReversed: string
   isOpen: boolean

--- a/apps/web/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
+++ b/apps/web/src/views/LimitOrders/hooks/useGelatoLimitOrdersHistory.ts
@@ -84,7 +84,7 @@ const useOpenOrders = (turnOn: boolean): Order[] => {
         throw new Error('Missing gelatoLimitOrders, account or chainId')
       }
       try {
-        const orders = await gelatoLimitOrders.getOpenOrders(account.toLowerCase(), false)
+        const orders = await gelatoLimitOrders.getOpenOrders(account.toLowerCase(), true)
 
         await syncOrderToLocalStorage({
           orders,
@@ -138,8 +138,8 @@ const useHistoryOrders = (turnOn: boolean): Order[] => {
         const acc = account.toLowerCase()
 
         const [canOrders, exeOrders] = await Promise.all([
-          gelatoLimitOrders.getCancelledOrders(acc, false),
-          gelatoLimitOrders.getExecutedOrders(acc, false),
+          gelatoLimitOrders.getCancelledOrders(acc, true),
+          gelatoLimitOrders.getExecutedOrders(acc, true),
         ])
 
         await syncOrderToLocalStorage({
@@ -187,7 +187,7 @@ const useExpiredOrders = (turnOn: boolean): Order[] => {
         throw new Error('Missing gelatoLimitOrders, account or chainId')
       }
       try {
-        const orders = await gelatoLimitOrders.getOpenOrders(account.toLowerCase(), false)
+        const orders = await gelatoLimitOrders.getOpenOrders(account.toLowerCase(), true)
         await syncOrderToLocalStorage({
           orders,
           chainId,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates limit order functionality in the web app. 

### Detailed summary
- Updated limit order exchange rate text
- Changed conditions for fetching open, cancelled, and executed orders

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->