### PR TITLE
fix: Crash in swap in unsupported chain

### DIFF
--- a/apps/web/src/hooks/usePermit2Details.ts
+++ b/apps/web/src/hooks/usePermit2Details.ts
@@ -35,15 +35,15 @@ export const usePermit2Details = (
     queryKey: ['/token-permit/', chainId, token?.address, owner, spender],
     queryFn: async () => {
       const permit2Address = getPermit2Address(chainId)
-      if (permit2Address) {
-        return publicClient({ chainId }).readContract({
-          abi: Permit2ABI,
-          address: permit2Address,
-          functionName: 'allowance',
-          args: inputs,
-        })
+      if (!permit2Address) {
+        throw new Error(`Permit2 Contract not deployed on chain ${chainId}`)
       }
-      return undefined
+      return publicClient({ chainId }).readContract({
+        abi: Permit2ABI,
+        address: permit2Address,
+        functionName: 'allowance',
+        args: inputs,
+      })
     },
     placeholderData,
     refetchInterval: FAST_INTERVAL,

--- a/apps/web/src/hooks/usePermit2Details.ts
+++ b/apps/web/src/hooks/usePermit2Details.ts
@@ -33,13 +33,18 @@ export const usePermit2Details = (
 
   return useQuery({
     queryKey: ['/token-permit/', chainId, token?.address, owner, spender],
-    queryFn: async () =>
-      publicClient({ chainId }).readContract({
-        abi: Permit2ABI,
-        address: getPermit2Address(chainId),
-        functionName: 'allowance',
-        args: inputs,
-      }),
+    queryFn: async () => {
+      const permit2Address = getPermit2Address(chainId)
+      if (permit2Address) {
+        return publicClient({ chainId }).readContract({
+          abi: Permit2ABI,
+          address: permit2Address,
+          functionName: 'allowance',
+          args: inputs,
+        })
+      }
+      return undefined
+    },
     placeholderData,
     refetchInterval: FAST_INTERVAL,
     retry: true,

--- a/packages/pcsx-sdk/src/constants.ts
+++ b/packages/pcsx-sdk/src/constants.ts
@@ -10,7 +10,7 @@ export const PERMIT2_MAPPING = {
   [ChainId.ETHEREUM]: getPermit2Address(ChainId.ETHEREUM),
   [ChainId.BSC]: getPermit2Address(ChainId.BSC),
   [ChainId.BSC_TESTNET]: getPermit2Address(ChainId.BSC_TESTNET),
-} as const satisfies Record<XSupportedChainId, Address>
+} as const satisfies Record<XSupportedChainId, Address | undefined>
 
 export const ORDER_QUOTER_MAPPING = {
   [ChainId.ETHEREUM]: '0x54539967a06Fc0E3C3ED0ee320Eb67362D13C5fF',

--- a/packages/pcsx-sdk/src/orders/ExclusiveDutchOrder.ts
+++ b/packages/pcsx-sdk/src/orders/ExclusiveDutchOrder.ts
@@ -83,7 +83,7 @@ const EXCLUSIVE_DUTCH_ORDER_ABI = parseAbiParameters([
 ])
 
 export class ExclusiveDutchOrder extends Order {
-  public permit2Address: Address
+  public permit2Address: Address | undefined
 
   constructor(
     public readonly info: ExclusiveDutchOrderInfo,

--- a/packages/pcsx-sdk/src/utils/NonceManager.ts
+++ b/packages/pcsx-sdk/src/utils/NonceManager.ts
@@ -27,7 +27,7 @@ export class NonceManager {
       })
     } else if (PERMIT2_MAPPING[chainId]) {
       this.contract = getContract({
-        address: PERMIT2_MAPPING[chainId],
+        address: PERMIT2_MAPPING[chainId]!,
         abi: permit2Abi,
         publicClient: client,
       })

--- a/packages/permit2-sdk/src/allowanceTransfer.ts
+++ b/packages/permit2-sdk/src/allowanceTransfer.ts
@@ -77,7 +77,7 @@ export abstract class AllowanceTransfer {
   public static getPermitData<
     TPermit extends PermitSingle | PermitBatch,
     ReturnType = TPermit extends PermitSingle ? PermitSingleData : PermitBatchData,
-  >(permit: TPermit, permit2Address: Address, chainId: number): ReturnType {
+  >(permit: TPermit, permit2Address: Address | undefined, chainId: number): ReturnType {
     invariant(MaxSigDeadline >= BigInt(permit.sigDeadline), 'SIG_DEADLINE_OUT_OF_RANGE')
 
     const domain = permit2Domain(permit2Address, chainId)

--- a/packages/permit2-sdk/src/constants.ts
+++ b/packages/permit2-sdk/src/constants.ts
@@ -34,9 +34,9 @@ const PERMIT2_ADDRESSES: Record<ChainId, Address> = {
   [ChainId.OPBNB_TESTNET]: '0x31c2F6fcFf4F8759b3Bd5Bf0e1084A055615c768',
 }
 
-export const getPermit2Address = (chainId: ChainId | undefined): Address => {
+export const getPermit2Address = (chainId: ChainId | undefined): Address | undefined => {
   if (chainId === undefined) return PERMIT2_ADDRESSES[ChainId.BSC]
-  if (!(chainId in PERMIT2_ADDRESSES)) throw new Error(`Permit2 Contract not deployed on chain ${chainId}`)
+  if (!(chainId in PERMIT2_ADDRESSES)) return undefined
   return PERMIT2_ADDRESSES[chainId]
 }
 

--- a/packages/permit2-sdk/src/domain.ts
+++ b/packages/permit2-sdk/src/domain.ts
@@ -3,7 +3,7 @@ import { TypedDataDomain, TypedDataParameter } from './utils/types'
 
 const PERMIT2_DOMAIN_NAME = 'Permit2'
 
-export function permit2Domain(permit2Address: Address, chainId: number): TypedDataDomain {
+export function permit2Domain(permit2Address: Address | undefined, chainId: number): TypedDataDomain {
   return {
     name: PERMIT2_DOMAIN_NAME,
     chainId,

--- a/packages/permit2-sdk/src/signatureTransfer.ts
+++ b/packages/permit2-sdk/src/signatureTransfer.ts
@@ -134,7 +134,7 @@ export abstract class SignatureTransfer {
       : TWitness extends undefined
       ? PermitBatchTransferFromData
       : PermitBatchWitnessTransferFromData,
-  >(permit: TPermit, permit2Address: Address, chainId: number, witness?: TWitness): ReturnType {
+  >(permit: TPermit, permit2Address: Address | undefined, chainId: number, witness?: TWitness): ReturnType {
     invariant(MaxSigDeadline >= BigInt(permit.deadline), 'SIG_DEADLINE_OUT_OF_RANGE')
     invariant(MaxUnorderedNonce >= BigInt(permit.nonce), 'NONCE_OUT_OF_RANGE')
 


### PR DESCRIPTION
Issue started to happen again with permit2 sdk 

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of `permit2Address` to be optional in various files for better flexibility.

### Detailed summary
- Made `permit2Address` optional in `NonceManager.ts` and `ExclusiveDutchOrder.ts`
- Updated `permit2Domain` to accept an optional `permit2Address`
- Changed `getPermit2Address` to return `Address | undefined`
- Updated functions in `allowanceTransfer.ts` and `signatureTransfer.ts` to accept optional `permit2Address`
- Modified `usePermit2Details.ts` to handle cases where `permit2Address` is not deployed

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->