### PR TITLE
perf: Memoize modalv2 provider to prevent redundant rerenders

### DIFF
--- a/apps/web/src/components/GlobalCheckClaimStatus/AnniversaryAchievementModal.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/AnniversaryAchievementModal.tsx
@@ -10,7 +10,7 @@ import { useAnniversaryAchievementContract } from 'hooks/useContract'
 import { useShowOnceAnniversaryModal } from 'hooks/useShowOnceAnniversaryModal'
 import delay from 'lodash/delay'
 import { useRouter } from 'next/router'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { styled } from 'styled-components'
 import { useAccount } from 'wagmi'
 
@@ -102,16 +102,16 @@ const AnniversaryAchievementModal: React.FC<AnniversaryModalProps> = ({ excludeL
     setIsFirstTime(true)
   }, [account, hasDisplayedModal])
 
-  const closeOnceAnniversaryModal = () => {
+  const closeOnceAnniversaryModal = useCallback(() => {
     if (account && !Object.keys(showOnceAnniversaryModal).includes(account)) {
       setShowOnceAnniversaryModal({ ...showOnceAnniversaryModal, [account]: false })
     }
-  }
+  }, [account, showOnceAnniversaryModal, setShowOnceAnniversaryModal])
 
-  const handleCloseModal = () => {
+  const handleCloseModal = useCallback(() => {
     setShow(false)
     closeOnceAnniversaryModal()
-  }
+  }, [closeOnceAnniversaryModal])
 
   const handleClick = async () => {
     setIsLoading(true)
@@ -143,7 +143,7 @@ const AnniversaryAchievementModal: React.FC<AnniversaryModalProps> = ({ excludeL
   }
 
   return (
-    <ModalV2 isOpen={show} onDismiss={() => handleCloseModal()} closeOnOverlayClick>
+    <ModalV2 isOpen={show} onDismiss={handleCloseModal} closeOnOverlayClick>
       <Modal title={t('Congratulations!')}>
         <Flex flexDirection="column" alignItems="center" justifyContent="center" maxWidth="450px">
           <Box>

--- a/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
+++ b/apps/web/src/components/GlobalCheckClaimStatus/V3AirdropModal.tsx
@@ -169,7 +169,7 @@ const V3AirdropModal: React.FC = () => {
   }
 
   return (
-    <ModalV2 isOpen={show} onDismiss={() => handleCloseModal()} closeOnOverlayClick>
+    <ModalV2 isOpen={show} onDismiss={handleCloseModal} closeOnOverlayClick>
       <Modal title={t('Congratulations!')}>
         <Flex
           flexDirection="column"

--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -326,6 +326,7 @@ export function RoutingSettingsButton({
   const [show, setShow] = useState(false)
   const { t } = useTranslation()
   const [isRoutingSettingChange] = useRoutingSettingChanged()
+  const handleDismiss = useCallback(() => setShow(false), [])
   return (
     <>
       <AtomBox textAlign="center">
@@ -335,7 +336,7 @@ export function RoutingSettingsButton({
           </Button>
         </NotificationDot>
       </AtomBox>
-      <ModalV2 isOpen={show} onDismiss={() => setShow(false)} closeOnOverlayClick>
+      <ModalV2 isOpen={show} onDismiss={handleDismiss} closeOnOverlayClick>
         <RoutingSettings />
       </ModalV2>
     </>

--- a/apps/web/src/components/NetworkModal/NetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/NetworkModal.tsx
@@ -4,7 +4,7 @@ import { SUPPORT_ONLY_BSC } from 'config/constants/supportChains'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { atom, useAtom } from 'jotai'
 import dynamic from 'next/dynamic'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { viemClients } from 'utils/viem'
 import { CHAIN_IDS } from 'utils/wagmi'
 
@@ -34,6 +34,8 @@ export const NetworkModal = ({ pageSupportedChains = SUPPORT_ONLY_BSC }: { pageS
     () => Boolean(pageSupportedChains.length) && chainId && !pageSupportedChains.includes(chainId),
     [chainId, pageSupportedChains],
   )
+  const handleDismiss = useCallback(() => setDismissWrongNetwork(true), [setDismissWrongNetwork])
+
   if (pageSupportedChains?.length === 0) return null // open to all chains
 
   if (isPageNotSupported && isBNBOnlyPage) {
@@ -50,8 +52,8 @@ export const NetworkModal = ({ pageSupportedChains = SUPPORT_ONLY_BSC }: { pageS
       .find((c) => c?.id === chainId)
     if (!currentChain) return null
     return (
-      <ModalV2 isOpen={isWrongNetwork} closeOnOverlayClick onDismiss={() => setDismissWrongNetwork(true)}>
-        <WrongNetworkModal currentChain={currentChain} onDismiss={() => setDismissWrongNetwork(true)} />
+      <ModalV2 isOpen={isWrongNetwork} closeOnOverlayClick onDismiss={handleDismiss}>
+        <WrongNetworkModal currentChain={currentChain} onDismiss={handleDismiss} />
       </ModalV2>
     )
   }

--- a/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/OnBoardingModal/Congratulations.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Flex, Text, Button, Link, ModalV2 } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import USCitizenConfirmModal from 'components/Modal/USCitizenConfirmModal'
@@ -8,10 +8,11 @@ const Congratulations = () => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
   const [userNotUsCitizenAcknowledgement] = useUserNotUsCitizenAcknowledgement(IdType.AFFILIATE_PROGRAM)
+  const handleDismiss = useCallback(() => setIsOpen(false), [])
 
   return (
     <>
-      <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} onDismiss={() => setIsOpen(false)}>
+      <ModalV2 style={{ zIndex: 100 }} isOpen={isOpen} onDismiss={handleDismiss}>
         <USCitizenConfirmModal title={t('PancakeSwap Affiliate Program')} id={IdType.AFFILIATE_PROGRAM} />
       </ModalV2>
       <Flex flexDirection="column" padding={['24px', '24px', '24px', '24px', '80px 24px']}>

--- a/apps/web/src/views/CakeStaking/index.tsx
+++ b/apps/web/src/views/CakeStaking/index.tsx
@@ -5,7 +5,7 @@ import { formatAmount } from '@pancakeswap/utils/formatInfoNumbers'
 import Page from 'components/Layout/Page'
 import { useCakeDistributed } from 'hooks/useCakeDistributed'
 import useTheme from 'hooks/useTheme'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { BenefitCard } from './components/BenefitCard'
 import { CakeRewardsCard } from './components/CakeRewardsCard'
@@ -24,11 +24,12 @@ const CakeStaking = () => {
   const totalIFOSold = useTotalIFOSold()
   const { isDesktop, isMobile } = useMatchBreakpoints()
   const { theme } = useTheme()
+  const handleDismiss = useCallback(() => setCakeRewardModalVisible(false), [])
 
   return (
     <>
-      <ModalV2 isOpen={cakeRewardModalVisible} closeOnOverlayClick onDismiss={() => setCakeRewardModalVisible(false)}>
-        <CakeRewardsCard onDismiss={() => setCakeRewardModalVisible(false)} />
+      <ModalV2 isOpen={cakeRewardModalVisible} closeOnOverlayClick onDismiss={handleDismiss}>
+        <CakeRewardsCard onDismiss={handleDismiss} />
       </ModalV2>
       <StyledPageHeader background={isMobile ? theme.colors.gradientInverseBubblegum : undefined}>
         <PageHead />

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmInfo.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmInfo.tsx
@@ -3,7 +3,7 @@ import { FarmWidget } from '@pancakeswap/widgets-internal'
 import { formatBigInt } from '@pancakeswap/utils/formatBalance'
 import { BigNumber } from 'bignumber.js'
 import { TokenPairImage } from 'components/TokenImage'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useCakePrice } from 'hooks/useCakePrice'
 import FarmV3CardList from 'views/Farms/components/FarmCard/V3/FarmV3CardList'
 import { V3Farm } from 'views/Farms/FarmsV3'
@@ -58,6 +58,8 @@ const FarmInfo: React.FunctionComponent<React.PropsWithChildren<FarmInfoProps>> 
     [cakePrice, totalEarnings],
   )
 
+  const handleDismiss = useCallback(() => setShow(false), [])
+
   return (
     <Flex flexDirection="column">
       {onlyOnePosition ? (
@@ -91,7 +93,7 @@ const FarmInfo: React.FunctionComponent<React.PropsWithChildren<FarmInfoProps>> 
           )}
         </>
       )}
-      <ModalV2 isOpen={show} onDismiss={() => setShow(false)} closeOnOverlayClick>
+      <ModalV2 isOpen={show} onDismiss={handleDismiss} closeOnOverlayClick>
         <ViewAllFarmModal
           title={lpSymbol}
           isReady={isReady}

--- a/apps/web/src/views/FixedStaking/components/FixedStakingCalculator.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingCalculator.tsx
@@ -14,7 +14,7 @@ import {
 } from '@pancakeswap/uikit'
 import { useStablecoinPriceAmount } from 'hooks/useStablecoinPrice'
 import toNumber from 'lodash/toNumber'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useCalculateProjectedReturnAmount } from '../hooks/useCalculateProjectedReturnAmount'
 import { useCurrentDay } from '../hooks/useStakedPools'
@@ -96,6 +96,9 @@ export function FixedStakingCalculator({
 
   const { t } = useTranslation()
   const stakeModal = useModalV2()
+  const handleDismiss = useCallback(() => {
+    stakeModal.onDismiss()
+  }, [stakeModal])
 
   return (
     <>
@@ -110,13 +113,7 @@ export function FixedStakingCalculator({
       >
         <CalculateIcon color="textSubtle" ml="0.25em" width="24px" />
       </IconButton>
-      <ModalV2
-        {...stakeModal}
-        onDismiss={() => {
-          stakeModal.onDismiss()
-        }}
-        closeOnOverlayClick
-      >
+      <ModalV2 {...stakeModal} onDismiss={handleDismiss} closeOnOverlayClick>
         <StakingModalTemplate
           useNative
           title={t('ROI Calculator')}

--- a/apps/web/src/views/FixedStaking/components/FixedStakingModal.tsx
+++ b/apps/web/src/views/FixedStaking/components/FixedStakingModal.tsx
@@ -3,7 +3,7 @@ import { Token } from '@pancakeswap/sdk'
 import { Box, Button, Flex, Message, MessageText, ModalV2, PreTitle, useModalV2 } from '@pancakeswap/uikit'
 import Divider from 'components/Divider'
 import dayjs from 'dayjs'
-import { ReactNode, useMemo } from 'react'
+import { ReactNode, useCallback, useMemo } from 'react'
 
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
@@ -48,17 +48,15 @@ export function FixedStakingModal({
 
   const currentDay = useCurrentDay()
 
+  const handleDismiss = useCallback(() => {
+    if (setSelectedPeriodIndex) setSelectedPeriodIndex(null)
+    stakeModal.onDismiss()
+  }, [stakeModal, setSelectedPeriodIndex])
+
   return account ? (
     <>
       {children(stakeModal.onOpen, hideStakeButton)}
-      <ModalV2
-        {...stakeModal}
-        onDismiss={() => {
-          if (setSelectedPeriodIndex) setSelectedPeriodIndex(null)
-          stakeModal.onDismiss()
-        }}
-        closeOnOverlayClick
-      >
+      <ModalV2 {...stakeModal} onDismiss={handleDismiss} closeOnOverlayClick>
         <StakingModalTemplate
           useNative
           stakingToken={stakingToken}

--- a/apps/web/src/views/Migration/components/v3/Step4.tsx
+++ b/apps/web/src/views/Migration/components/v3/Step4.tsx
@@ -26,7 +26,7 @@ import useNativeCurrency from 'hooks/useNativeCurrency'
 import { useV3Positions } from 'hooks/v3/useV3Positions'
 import { useAtom } from 'jotai'
 import Image from 'next/image'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 import { LiquidityCardRow } from 'views/AddLiquidity/components/LiquidityCardRow'
 import { AddLiquidityV3Modal } from 'views/AddLiquidityV3/Modal'
@@ -54,6 +54,14 @@ export function Step4() {
   const addLiquidityModal = useModalV2()
 
   const native = useNativeCurrency()
+
+  const closeModal = useCallback(() => {
+    setOpen(false)
+  }, [])
+
+  const openModal = useCallback(() => {
+    setOpen(true)
+  }, [])
 
   return (
     <AppBody style={{ maxWidth: '700px' }} m="auto">
@@ -108,8 +116,8 @@ export function Step4() {
           ))
         )}
       </AtomBox>
-      <ModalV2 isOpen={open} closeOnOverlayClick onDismiss={() => setOpen(false)}>
-        <Modal title={t('List of removed v2 liquidity')} onDismiss={() => setOpen(false)}>
+      <ModalV2 isOpen={open} closeOnOverlayClick onDismiss={closeModal}>
+        <Modal title={t('List of removed v2 liquidity')} onDismiss={closeModal}>
           <PreTitle mb="12px">{t('Previous LP')}</PreTitle>
           {removedPairsCurrentChainAsArray.map((tokenAddresses) => (
             <Flex key={tokenAddresses} alignItems="center" justifyContent="space-between" mb="8px">
@@ -131,7 +139,7 @@ export function Step4() {
             </Button>
           </>
         ) : (
-          <CommitButton onClick={() => setOpen(true)} width="100%">
+          <CommitButton onClick={openModal} width="100%">
             {t('Add Liquidity')}
           </CommitButton>
         )}

--- a/apps/web/src/views/Pools/components/RevenueSharing/JoinRevenueModal/VCakeModal.tsx
+++ b/apps/web/src/views/Pools/components/RevenueSharing/JoinRevenueModal/VCakeModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ModalV2 } from '@pancakeswap/uikit'
 import { ChainId } from '@pancakeswap/chains'
 import { useAccount } from 'wagmi'
@@ -14,6 +14,10 @@ const VCakeModal = () => {
   const [open, setOpen] = useState(false)
   const { data: cakeBenefits, status: cakeBenefitsFetchStatus } = useCakeBenefits()
 
+  const closeModal = useCallback(() => {
+    setOpen(false)
+  }, [])
+
   useEffect(() => {
     if (
       account &&
@@ -28,18 +32,14 @@ const VCakeModal = () => {
 
   useAccount({
     onConnect: ({ connector }) => {
-      connector?.addListener('change', () => closeModal())
+      connector?.addListener('change', closeModal)
     },
-    onDisconnect: () => closeModal(),
+    onDisconnect: closeModal,
   })
 
-  const closeModal = () => {
-    setOpen(false)
-  }
-
   return (
-    <ModalV2 isOpen={open} onDismiss={() => closeModal()}>
-      <JoinRevenueModal refresh={refresh} onDismiss={() => closeModal()} />
+    <ModalV2 isOpen={open} onDismiss={closeModal}>
+      <JoinRevenueModal refresh={refresh} onDismiss={closeModal} />
     </ModalV2>
   )
 }

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
@@ -263,6 +263,7 @@ export const ConfirmSwapModalV2: React.FC<ConfirmSwapModalProps> = ({
     token,
     trade,
     txHash,
+    showAddToWalletButton,
   ])
 
   if (!chainId) return null

--- a/packages/uikit/src/widgets/Modal/ModalV2.tsx
+++ b/packages/uikit/src/widgets/Modal/ModalV2.tsx
@@ -1,6 +1,6 @@
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
 import { AnimatePresence, LazyMotion } from "framer-motion";
-import React, { createContext, useCallback, useRef, useState } from "react";
+import React, { createContext, useCallback, useMemo, useRef, useState } from "react";
 import { isMobile } from "react-device-detect";
 import { createPortal } from "react-dom";
 import { BoxProps } from "../../components/Box";
@@ -30,12 +30,15 @@ export function useModalV2() {
   const onDismiss = useCallback(() => setIsOpen(false), []);
   const onOpen = useCallback(() => setIsOpen(true), []);
 
-  return {
-    onDismiss,
-    onOpen,
-    isOpen,
-    setIsOpen,
-  };
+  return useMemo(
+    () => ({
+      onDismiss,
+      onOpen,
+      isOpen,
+      setIsOpen,
+    }),
+    [onDismiss, onOpen, isOpen]
+  );
 }
 
 export function ModalV2({
@@ -57,9 +60,11 @@ export function ModalV2({
   };
   const portal = getPortalRoot();
 
+  const providerValue = useMemo(() => ({ onDismiss }), [onDismiss]);
+
   if (portal) {
     return createPortal(
-      <ModalV2Context.Provider value={{ onDismiss }}>
+      <ModalV2Context.Provider value={providerValue}>
         <LazyMotion features={isMobile ? DomMax : DomAnimation}>
           <AnimatePresence>
             {isOpen && (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces consistent handling of modal dismissals across various components by implementing `handleDismiss` functions.

### Detailed summary
- Added `handleDismiss` functions for modal dismissals in multiple components
- Replaced inline dismissal functions with `handleDismiss` functions for improved code readability and maintainability

> The following files were skipped due to too many changes: `apps/web/src/views/Migration/components/v3/Step4.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->