### PR TITLE
chore: fix bcake issues

### DIFF
--- a/apps/web/src/utils/calls/farms.ts
+++ b/apps/web/src/utils/calls/farms.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { DEFAULT_GAS_LIMIT, DEFAULT_TOKEN_DECIMAL } from 'config'
+import { BOOSTED_FARM_GAS_LIMIT, DEFAULT_GAS_LIMIT, DEFAULT_TOKEN_DECIMAL } from 'config'
 import { getMasterChefContract, getNonBscVaultContract, getV2SSBCakeWrapperContract } from 'utils/contractHelpers'
 import { logGTMClickStakeFarmEvent } from 'utils/customGTMEventTracking'
 import { MessageTypes, getNonBscVaultContractFee } from 'views/Farms/hooks/getNonBscVaultFee'
@@ -74,7 +74,7 @@ export const harvestFarm = async (masterChefContract: MasterChefContract, pid, g
 
 export const bCakeHarvestFarm = async (v2SSContract: V2SSBCakeContract, gasPrice, gasLimit?: bigint) => {
   return v2SSContract.write.deposit([0n, false], {
-    gas: gasLimit || DEFAULT_GAS_LIMIT,
+    gas: gasLimit || BOOSTED_FARM_GAS_LIMIT,
     gasPrice,
     account: v2SSContract.account ?? '0x',
     chain: v2SSContract.chain,

--- a/apps/web/src/views/Farms/components/FarmCard/ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/ApyButton.tsx
@@ -146,7 +146,7 @@ const ApyButton: React.FC<React.PropsWithChildren<ApyButtonProps>> = ({
                     <RocketIcon color="success" />
                     <Text bold color="success" fontSize={16}>
                       <>
-                        {boosterMultiplier === 3 && (
+                        {boosterMultiplier === 2.5 && (
                           <Text bold color="success" fontSize={14} display="inline-block" mr="3px">
                             {t('Up to')}
                           </Text>

--- a/apps/web/src/views/Farms/components/FarmCard/FarmCard.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/FarmCard.tsx
@@ -178,7 +178,7 @@ const FarmCard: React.FC<React.PropsWithChildren<FarmCardProps>> = ({
                         ? farm?.bCakeUserData?.boosterMultiplier === 0 ||
                           farm?.bCakeUserData?.stakedBalance.eq(0) ||
                           !locked
-                          ? 3
+                          ? 2.5
                           : farm?.bCakeUserData?.boosterMultiplier
                         : 1
                     }

--- a/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -274,7 +274,7 @@ const StakeAction: React.FC<React.PropsWithChildren<FarmCardActionsProps>> = ({
       boosterMultiplier={
         isBoosterAndRewardInRange
           ? bCakeUserData?.boosterMultiplier === 0 || bCakeUserData?.stakedBalance.eq(0) || !locked
-            ? 3
+            ? 2.5
             : bCakeUserData?.boosterMultiplier
           : 1
       }

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -365,7 +365,6 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
   const isBooster = Boolean(details?.bCakeWrapperAddress)
   const isRewardInRange = details?.bCakePublicData?.isRewardInRange
   const hasStakedInBCake = Boolean(details?.bCakeUserData?.stakedBalance?.gt(0))
-  if (details?.pid === 180) console.log(details, 'details????', hasStakedInBCake)
 
   const { status } = useBoostStatusPM(isBooster, details?.bCakeUserData?.boosterMultiplier)
   const { shouldUpdate, veCakeUserMultiplierBeforeBoosted } = useWrapperBooster(
@@ -421,7 +420,7 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
                         ? details?.bCakeUserData?.boosterMultiplier === 0 ||
                           details?.bCakeUserData?.stakedBalance.eq(0) ||
                           !locked
-                          ? 3
+                          ? 2.5
                           : details?.bCakeUserData?.boosterMultiplier
                         : 1
                     }
@@ -544,7 +543,7 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
                               status={status}
                               isFarmStaking={farm?.bCakeUserData?.stakedBalance?.gt(0)}
                               boostedMultiplier={details?.bCakeUserData?.boosterMultiplier}
-                              maxBoostMultiplier={3}
+                              maxBoostMultiplier={2.5}
                               shouldUpdate={shouldUpdate}
                               expectMultiplier={veCakeUserMultiplierBeforeBoosted}
                             />

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -392,7 +392,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
       boosterMultiplier={
         isBoosterAndRewardInRange
           ? bCakeUserData?.boosterMultiplier === 0 || bCakeUserData?.stakedBalance.eq(0) || !locked
-            ? 3
+            ? 2.5
             : bCakeUserData?.boosterMultiplier
           : 1
       }

--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -84,7 +84,7 @@ const CellInner = styled.div`
   padding-right: 8px;
 
   ${({ theme }) => theme.mediaQueries.xl} {
-    padding-right: 32px;
+    padding-right: 12px;
   }
 `
 
@@ -158,7 +158,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
               case 'type':
                 return (
                   <td key={key}>
-                    <CellInner style={{ minWidth: '140px', gap: '4px' }}>
+                    <CellInner style={{ minWidth: '120px', gap: '4px', paddingRight: isDesktop ? 24 : undefined }}>
                       {(props[key] === 'community' || props?.farm?.isCommunity) && <FarmAuctionTag scale="sm" />}
                       {props.type === 'v2' ? (
                         props?.details?.isStable ? (
@@ -179,7 +179,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                 )
               case 'details':
                 return (
-                  <td key={key} colSpan={props.type === 'v3' ? 1 : 3}>
+                  <td key={key} colSpan={props.type === 'v3' ? 1 : 2}>
                     <CellInner
                       style={{
                         justifyContent: props.type !== 'v3' ? 'flex-end' : 'center',
@@ -258,7 +258,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                     </td>
                   )
                 }
-                return null
+                return <td />
 
               default:
                 if (cells[key]) {
@@ -292,7 +292,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                   mr="16px"
                   alignItems={isMobile ? 'end' : 'center'}
                   flexDirection={isMobile ? 'column' : 'row'}
-                  flexWrap="nowrap"
+                  // flexWrap="nowrap"
                   style={{ gap: '4px' }}
                 >
                   {props.type === 'v2' ? (

--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -225,7 +225,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                               ? props?.details?.bCakeUserData?.boosterMultiplier === 0 ||
                                 props?.details?.bCakeUserData?.stakedBalance.eq(0) ||
                                 !locked
-                                ? 3
+                                ? 2.5
                                 : props?.details?.bCakeUserData?.boosterMultiplier
                               : 1
                           }
@@ -349,7 +349,7 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                             ? props?.details?.bCakeUserData?.boosterMultiplier === 0 ||
                               props?.details?.bCakeUserData?.stakedBalance.eq(0) ||
                               !locked
-                              ? 3
+                              ? 2.5
                               : props?.details?.bCakeUserData?.boosterMultiplier
                             : 1
                         }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to adjust booster multipliers from 3 to 2.5 in various components and update gas limits in farm-related functions.

### Detailed summary
- Changed booster multipliers from 3 to 2.5 in multiple components
- Updated gas limits for boosted farms
- Adjusted styles for padding in certain components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->