### PR TITLE
chore: fix v2 farm mock alloc point

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -1320,7 +1320,6 @@ const farms: SerializedFarmConfig[] = [
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
-    allocPoint: 5,
   },
   {
     pid: 160,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `stableLpFee` and `stableLpFeeRateOfTotalFee` values in the BSC constants file.

### Detailed summary
- Updated `stableLpFee` value to 0.0002
- Updated `stableLpFeeRateOfTotalFee` value to 0.5

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->