### PR TITLE
fix: Farm staked only on bcake farms

### DIFF
--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -265,7 +265,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
           (farm.multiplier !== '0X' || (farm.version === 2 && farm?.bCakeWrapperAddress)) &&
           (farm.version === 3 ? !v3PoolLength || v3PoolLength >= farm.pid : !v2PoolLength || v2PoolLength > farm.pid),
       ),
-    [farmsLP],
+    [farmsLP, v2PoolLength, v3PoolLength],
   )
 
   const inactiveFarms = useMemo(() => farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X'), [farmsLP])

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -257,14 +257,18 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [stableSwapOnly, setStableSwapOnly] = useState(false)
   const [farmTypesEnableCount, setFarmTypesEnableCount] = useState(0)
 
-  const activeFarms = farmsLP.filter(
-    (farm) =>
-      farm.pid !== 0 &&
-      (farm.multiplier !== '0X' || (farm.version === 2 && farm?.bCakeWrapperAddress)) &&
-      (farm.version === 3 ? !v3PoolLength || v3PoolLength >= farm.pid : !v2PoolLength || v2PoolLength > farm.pid),
+  const activeFarms = useMemo(
+    () =>
+      farmsLP.filter(
+        (farm) =>
+          farm.pid !== 0 &&
+          (farm.multiplier !== '0X' || (farm.version === 2 && farm?.bCakeWrapperAddress)) &&
+          (farm.version === 3 ? !v3PoolLength || v3PoolLength >= farm.pid : !v2PoolLength || v2PoolLength > farm.pid),
+      ),
+    [farmsLP],
   )
 
-  const inactiveFarms = farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X')
+  const inactiveFarms = useMemo(() => farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X'), [farmsLP])
 
   const archivedFarms = farmsLP
 
@@ -306,10 +310,6 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
     },
     [query, isActive, chainId, cakePrice, regularCakePerBlock, mockApr],
   )
-
-  const handleChangeQuery = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value)
-  }
 
   const [numberOfFarmsVisible, setNumberOfFarmsVisible] = useState(NUMBER_OF_FARMS_VISIBLE)
 
@@ -417,9 +417,13 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
     }
   }, [isIntersecting])
 
-  const handleSortOptionChange = (option: OptionProps): void => {
+  const handleSortOptionChange = useCallback((option: OptionProps): void => {
     setSortOption(option.value)
-  }
+  }, [])
+
+  const handleChangeQuery = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value)
+  }, [])
 
   const providerValue = useMemo(() => ({ chosenFarmsMemoized }), [chosenFarmsMemoized])
 

--- a/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -85,7 +85,7 @@ const StakeAction: React.FC<React.PropsWithChildren<FarmCardActionsProps>> = ({
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, fetchTxResponse, loading: pendingTx } = useCatchTxError()
   const { boosterState } = useContext(YieldBoosterStateContext)
-  const [bCakeMultiplier, setBCakeMultiplier] = useState<number | null>(() => null)
+  const [bCakeMultiplier, setBCakeMultiplier] = useState<number | null>(null)
   const pendingFarm = useNonBscFarmPendingTransaction(lpAddress)
   const { isFirstTime, refresh: refreshFirstTime } = useFirstTimeCrossFarming(vaultPid)
   const isBloctoETH = useIsBloctoETH()

--- a/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/FarmTable.tsx
@@ -198,7 +198,10 @@ const FarmTable: React.FC<React.PropsWithChildren<ITableProps>> = ({ farms, cake
             token: farm.token,
             quoteToken: farm.quoteToken,
             isReady: farm.multiplier !== undefined,
-            isStaking: farm.userData?.proxy?.stakedBalance.gt(0) || farm.userData?.stakedBalance.gt(0),
+            isStaking:
+              farm.userData?.proxy?.stakedBalance.gt(0) ||
+              farm.userData?.stakedBalance.gt(0) ||
+              farm.bCakeUserData?.stakedBalance.gt(0),
             rewardCakePerSecond: farmV2Multiplier.getNumberFarmCakePerSecond(farm.poolWeight),
           },
           earned: {

--- a/apps/web/src/views/Farms/utils/getStakedFarms.ts
+++ b/apps/web/src/views/Farms/utils/getStakedFarms.ts
@@ -9,9 +9,9 @@ export const getStakedFarms = (
       return farm.stakedPositions.length > 0
     }
     return (
-      farm.userData &&
-      (new BigNumber(farm.userData.stakedBalance).isGreaterThan(0) ||
-        new BigNumber(farm?.userData?.proxy?.stakedBalance ?? 0).isGreaterThan(0))
+      new BigNumber(farm?.userData?.stakedBalance ?? 0).isGreaterThan(0) ||
+      new BigNumber(farm?.userData?.proxy?.stakedBalance ?? 0).isGreaterThan(0) ||
+      new BigNumber(farm?.bCakeUserData?.stakedBalance ?? 0).isGreaterThan(0)
     )
   })
 }

--- a/apps/web/src/views/Farms/utils/getStakedFarms.ts
+++ b/apps/web/src/views/Farms/utils/getStakedFarms.ts
@@ -9,9 +9,9 @@ export const getStakedFarms = (
       return farm.stakedPositions.length > 0
     }
     return (
-      new BigNumber(farm?.userData?.stakedBalance ?? 0).isGreaterThan(0) ||
-      new BigNumber(farm?.userData?.proxy?.stakedBalance ?? 0).isGreaterThan(0) ||
-      new BigNumber(farm?.bCakeUserData?.stakedBalance ?? 0).isGreaterThan(0)
+      new BigNumber(farm?.userData?.stakedBalance ?? 0).gt(0) ||
+      new BigNumber(farm?.userData?.proxy?.stakedBalance ?? 0).gt(0) ||
+      new BigNumber(farm?.bCakeUserData?.stakedBalance ?? 0).gt(0)
     )
   })
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the staking logic and UI components in the Farms feature, introducing new staking conditions and optimizations.

### Detailed summary
- Updated staking conditions in `getStakedFarms.ts`
- Modified staking checks in `FarmTable.tsx`
- Refactored state initialization in `StakeAction.tsx`
- Optimized active and inactive farms filtering in `FarmsV3.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->