### PR TITLE
feat: veCake APR display

### DIFF
--- a/apps/web/src/views/CakeStaking/components/DataSet/NewStakingDataSet.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/NewStakingDataSet.tsx
@@ -61,7 +61,7 @@ export const NewStakingDataSet: React.FC<React.PropsWithChildren<NewStakingDataS
         {customVeCakeCard ?? <MyVeCakeCard type="row" value={veCake} />}
         <AutoRow px={['0px', '0px', '16px']} py={['16px', '16px', '12px']} gap="8px">
           {customDataRow}
-          <TotalApy veCake={veCake} cakeAmount={cakeAmount} />
+          <TotalApy veCake={veCake} cakeAmount={cakeAmount} cakeLockWeeks={cakeLockWeeks} />
           <DataRow
             label={
               <Text fontSize={14} color="textSubtle" textTransform="uppercase">

--- a/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
@@ -14,8 +14,13 @@ const GradientText = styled(Text)`
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 `
+interface TotalApyProps {
+  veCake: string
+  cakeAmount: number
+  cakeLockWeeks: string
+}
 
-export const TotalApy = ({ veCake, cakeAmount }: { veCake: string; cakeAmount: number }) => {
+export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veCake, cakeAmount, cakeLockWeeks }) => {
   const { t } = useTranslation()
   const cakePoolEmission = useCakePoolEmission()
   const revShareEmission = useRevShareEmission()
@@ -46,9 +51,15 @@ export const TotalApy = ({ veCake, cakeAmount }: { veCake: string; cakeAmount: n
     return Number.isNaN(apr) ? 0 : apr
   }, [revShareEmission, userCakeTvl, userSharesPercentage])
 
+  // Bribe Apr
+  const bribeApr = useMemo(
+    () => new BigNumber(BRIBE_APR).times(new BigNumber(cakeLockWeeks).div(208)).toNumber(),
+    [cakeLockWeeks],
+  )
+
   const totalApy = useMemo(
-    () => new BigNumber(cakePoolApr).plus(revenueSharingApr).plus(BRIBE_APR).toNumber(),
-    [cakePoolApr, revenueSharingApr],
+    () => new BigNumber(cakePoolApr).plus(revenueSharingApr).plus(bribeApr).toNumber(),
+    [bribeApr, cakePoolApr, revenueSharingApr],
   )
 
   const {
@@ -162,19 +173,31 @@ export const TotalApy = ({ veCake, cakeAmount }: { veCake: string; cakeAmount: n
           <TooltipText fontSize="14px" color="textSubtle" ref={veCakePoolAprRef}>
             {t('veCAKE Pool APR')}
           </TooltipText>
-          <Text>{`${cakePoolApr.toFixed(2)}%`}</Text>
+          {cakePoolApr > 0 ? (
+            <Text>{t('Up to %apr%%', { apr: cakePoolApr.toFixed(2) })} </Text>
+          ) : (
+            <Text>{t('4Y APR%')} </Text>
+          )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
           <TooltipText fontSize="14px" color="textSubtle" ref={revenueSharingPoolAprRef}>
             {t('Revenue Sharing APR')}
           </TooltipText>
-          <Text>{`${revenueSharingApr.toFixed(2)}%`}</Text>
+          {revenueSharingApr > 0 ? (
+            <Text>{t('Up to %apr%%', { apr: revenueSharingApr.toFixed(2) })} </Text>
+          ) : (
+            <Text>{t('4Y APR%')} </Text>
+          )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
           <TooltipText fontSize="14px" color="textSubtle" ref={bribeAprRef}>
             {t('Bribe APR')}
           </TooltipText>
-          <GradientText>{`${BRIBE_APR.toFixed(2)}%`}</GradientText>
+          {bribeApr > 0 ? (
+            <GradientText>{t('Up to %apr%%', { apr: bribeApr.toFixed(2) })} </GradientText>
+          ) : (
+            <Text>{t('4Y APR%')} </Text>
+          )}
         </Flex>
       </Box>
       {totalAprTooltipVisible && totalAprTooltips}

--- a/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
@@ -174,9 +174,9 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
             {t('veCAKE Pool APR')}
           </TooltipText>
           {cakePoolApr > 0 ? (
-            <Text>{t('Up to %apr%%', { apr: cakePoolApr.toFixed(2) })} </Text>
+            <Text>{`${cakePoolApr.toFixed(2)}%`} </Text>
           ) : (
-            <Text>{t('4Y APR%')} </Text>
+            <Text>{t('Up to %apr%%', { apr: 0 })} </Text>
           )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
@@ -184,19 +184,19 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
             {t('Revenue Sharing APR')}
           </TooltipText>
           {revenueSharingApr > 0 ? (
-            <Text>{t('Up to %apr%%', { apr: revenueSharingApr.toFixed(2) })} </Text>
+            <Text>{`${revenueSharingApr.toFixed(2)}%`} </Text>
           ) : (
-            <Text>{t('4Y APR%')} </Text>
+            <Text>{t('Up to %apr%%', { apr: 0 })} </Text>
           )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
           <TooltipText fontSize="14px" color="textSubtle" ref={bribeAprRef}>
             {t('Bribe APR')}
           </TooltipText>
-          {bribeApr > 0 ? (
-            <GradientText>{t('Up to %apr%%', { apr: bribeApr.toFixed(2) })} </GradientText>
+          {revenueSharingApr > 0 ? (
+            <GradientText>{`${bribeApr.toFixed(2)}%`} </GradientText>
           ) : (
-            <Text>{t('4Y APR%')} </Text>
+            <GradientText>{t('Up to %apr%%', { apr: 0 })} </GradientText>
           )}
         </Flex>
       </Box>

--- a/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
@@ -4,7 +4,12 @@ import { getDecimalAmount } from '@pancakeswap/utils/formatBalance'
 import { BigNumber } from 'bignumber.js'
 import { useMemo } from 'react'
 import styled from 'styled-components'
-import { BRIBE_APR, useCakePoolEmission, useRevShareEmission } from 'views/CakeStaking/hooks/useAPR'
+import {
+  BRIBE_APR,
+  useCakePoolEmission,
+  useFourYearTotalVeCakeApr,
+  useRevShareEmission,
+} from 'views/CakeStaking/hooks/useAPR'
 import { useVeCakeTotalSupply } from 'views/CakeStaking/hooks/useVeCakeTotalSupply'
 
 const GradientText = styled(Text)`
@@ -24,12 +29,19 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
   const { t } = useTranslation()
   const cakePoolEmission = useCakePoolEmission()
   const revShareEmission = useRevShareEmission()
+  const { veCAKEPoolApr, revShareEmissionApr } = useFourYearTotalVeCakeApr()
   const { data: totalSupply } = useVeCakeTotalSupply()
   // CAKE Pool APR
   const userCakeTvl = getDecimalAmount(new BigNumber(cakeAmount))
   const userSharesPercentage = getDecimalAmount(new BigNumber(veCake)).div(totalSupply).times(100)
 
+  const shouldShow4yrApr = useMemo(() => cakeAmount === 0 || cakeLockWeeks === '', [cakeAmount, cakeLockWeeks])
+
   const cakePoolApr = useMemo(() => {
+    if (shouldShow4yrApr) {
+      return Number(veCAKEPoolApr)
+    }
+
     const apr = new BigNumber(userSharesPercentage)
       .times(cakePoolEmission)
       .div(3)
@@ -38,10 +50,14 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
       .toNumber()
 
     return Number.isNaN(apr) ? 0 : apr
-  }, [cakePoolEmission, userCakeTvl, userSharesPercentage])
+  }, [cakePoolEmission, shouldShow4yrApr, userCakeTvl, userSharesPercentage, veCAKEPoolApr])
 
   // Revenue Sharing
   const revenueSharingApr = useMemo(() => {
+    if (shouldShow4yrApr) {
+      return Number(revShareEmissionApr)
+    }
+
     const apr = new BigNumber(userSharesPercentage)
       .times(revShareEmission)
       .times(24 * 60 * 60 * 365)
@@ -49,18 +65,21 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
       .toNumber()
 
     return Number.isNaN(apr) ? 0 : apr
-  }, [revShareEmission, userCakeTvl, userSharesPercentage])
+  }, [revShareEmission, revShareEmissionApr, shouldShow4yrApr, userCakeTvl, userSharesPercentage])
 
   // Bribe Apr
-  const bribeApr = useMemo(
-    () => new BigNumber(BRIBE_APR).times(new BigNumber(cakeLockWeeks).div(208)).toNumber(),
-    [cakeLockWeeks],
-  )
+  const bribeApr = useMemo(() => {
+    if (shouldShow4yrApr) {
+      return BRIBE_APR
+    }
 
-  const totalApy = useMemo(
-    () => new BigNumber(cakePoolApr).plus(revenueSharingApr).plus(bribeApr).toNumber(),
-    [bribeApr, cakePoolApr, revenueSharingApr],
-  )
+    return new BigNumber(BRIBE_APR).times(new BigNumber(cakeLockWeeks).div(208)).toNumber()
+  }, [cakeLockWeeks, shouldShow4yrApr])
+
+  const totalApy = useMemo(() => {
+    const total = new BigNumber(cakePoolApr).plus(revenueSharingApr).plus(bribeApr).toNumber()
+    return Number.isNaN(total) ? 0 : total
+  }, [bribeApr, cakePoolApr, revenueSharingApr])
 
   const {
     targetRef: totalAprRef,
@@ -173,30 +192,30 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
           <TooltipText fontSize="14px" color="textSubtle" ref={veCakePoolAprRef}>
             {t('veCAKE Pool APR')}
           </TooltipText>
-          {cakePoolApr > 0 ? (
-            <Text>{`${cakePoolApr.toFixed(2)}%`} </Text>
+          {shouldShow4yrApr ? (
+            <Text>{t('Up to %apr%%', { apr: cakePoolApr.toFixed(2) })} </Text>
           ) : (
-            <Text>{t('Up to %apr%%', { apr: 0 })} </Text>
+            <Text>{`${cakePoolApr.toFixed(2)}%`} </Text>
           )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
           <TooltipText fontSize="14px" color="textSubtle" ref={revenueSharingPoolAprRef}>
             {t('Revenue Sharing APR')}
           </TooltipText>
-          {revenueSharingApr > 0 ? (
-            <Text>{`${revenueSharingApr.toFixed(2)}%`} </Text>
+          {shouldShow4yrApr ? (
+            <Text>{t('Up to %apr%%', { apr: revenueSharingApr.toFixed(2) })} </Text>
           ) : (
-            <Text>{t('Up to %apr%%', { apr: 0 })} </Text>
+            <Text>{`${revenueSharingApr.toFixed(2)}%`} </Text>
           )}
         </Flex>
         <Flex mt="4px" justifyContent="space-between">
           <TooltipText fontSize="14px" color="textSubtle" ref={bribeAprRef}>
             {t('Bribe APR')}
           </TooltipText>
-          {revenueSharingApr > 0 ? (
-            <GradientText>{`${bribeApr.toFixed(2)}%`} </GradientText>
+          {shouldShow4yrApr ? (
+            <GradientText>{t('Up to %apr%%', { apr: bribeApr.toFixed(2) })} </GradientText>
           ) : (
-            <GradientText>{t('Up to %apr%%', { apr: 0 })} </GradientText>
+            <GradientText>{`${bribeApr.toFixed(2)}%`} </GradientText>
           )}
         </Flex>
       </Box>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3331,5 +3331,6 @@
   "Your funds have been Staked in new BCake farm Wrapper.": "Your funds have been Staked in new BCake farm Wrapper.",
   "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.": "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.",
   "Booster Update": "Booster Update",
-  "Booster has been updated.": "Booster has been updated."
+  "Booster has been updated.": "Booster has been updated.",
+  "4Y APR%": "4Y APR%"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3331,6 +3331,5 @@
   "Your funds have been Staked in new BCake farm Wrapper.": "Your funds have been Staked in new BCake farm Wrapper.",
   "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.": "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.",
   "Booster Update": "Booster Update",
-  "Booster has been updated.": "Booster has been updated.",
-  "4Y APR%": "4Y APR%"
+  "Booster has been updated.": "Booster has been updated."
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the `TotalApy` component in the Cake Staking feature by adding support for displaying APY for a 4-year lock period.

### Detailed summary
- Added `cakeLockWeeks` prop to `TotalApy` component
- Updated calculations for `cakePoolApr`, `revenueSharingApr`, and `bribeApr`
- Modified display logic based on the lock period
- Introduced `useFourYearTotalVeCakeApr` hook for 4-year APY calculations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->