### PR TITLE
fix: Crash in widgets internal

### DIFF
--- a/apps/web/src/views/Migration/components/v3/Step4.tsx
+++ b/apps/web/src/views/Migration/components/v3/Step4.tsx
@@ -45,7 +45,8 @@ export function Step4() {
 
   const [removedPairs] = useAtom(removedPairsAtom)
 
-  const removedPairsCurrentChainAndAccount = chainId && account ? removedPairs[chainId as ChainId][account] : undefined
+  const removedPairsCurrentChainAndAccount =
+    chainId && account ? removedPairs[chainId as ChainId]?.[account] : undefined
 
   const removedPairsCurrentChainAsArray = removedPairsCurrentChainAndAccount
     ? Object.keys(removedPairsCurrentChainAndAccount)

--- a/packages/widgets-internal/tsconfig.json
+++ b/packages/widgets-internal/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@pancakeswap/tsconfig/react-library",
   "compilerOptions": {
     "resolveJsonModule": true,
+    "target": "ES2020",
     "baseUrl": "./",
     "paths": {
       "@pancakeswap/uikit": ["../../packages/uikit/src/index.ts"],

--- a/packages/widgets-internal/tsconfig.json
+++ b/packages/widgets-internal/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@pancakeswap/tsconfig/react-library",
   "compilerOptions": {
     "resolveJsonModule": true,
-    "target": "ES2020",
     "baseUrl": "./",
     "paths": {
       "@pancakeswap/uikit": ["../../packages/uikit/src/index.ts"],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates how `removedPairsCurrentChainAndAccount` is accessed in `Step4.tsx`.

### Detailed summary
- Changed access to `removedPairsCurrentChainAndAccount` using optional chaining (`?.`) for better null safety.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->