### PR TITLE
feat: Link to options

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -25,6 +25,7 @@ import {
   SUPPORT_FARMS,
   SUPPORT_ONLY_BSC,
 } from 'config/constants/supportChains'
+import { getOptionsUrl } from 'utils/getOptionsUrl'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 import { nftsBaseUrl } from 'views/Nft/market/constants'
 
@@ -75,7 +76,13 @@ const config: (
             languageCode,
             isDark,
           }),
-          confirmModalId: 'usCitizenConfirmModal',
+          confirmModalId: 'perpConfirmModal',
+          type: DropdownMenuItemType.EXTERNAL_LINK,
+        },
+        {
+          label: t('Options'),
+          href: getOptionsUrl(),
+          confirmModalId: 'optionsConfirmModal',
           type: DropdownMenuItemType.EXTERNAL_LINK,
         },
         {

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -12,7 +12,7 @@ export type UseMenuItemsParams = {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>, item: ConfigMenuDropDownItemsType) => void
 }
 
-export const useMenuItems = ({ onClick }: UseMenuItemsParams): ConfigMenuItemsType[] => {
+export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuItemsType[] => {
   const {
     t,
     currentLanguage: { code: languageCode },

--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -52,7 +52,7 @@ const Menu = (props) => {
       desc={
         <Text mt="0.5rem">
           {t(
-            'Please note that you are being redirected to an externally hosted website associated with our partner Dopex.',
+            'Please note that you are being redirected to an externally hosted website associated with our partner Stryke (formerly Dopex).',
           )}
         </Text>
       }

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -58,7 +58,7 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
       footer={
         <>
           <Text as="span">{t('By proceeding, you agree to comply with our')}</Text>
-          <Link external m="0 4px" display="inline" href="/terms-of-service">
+          <Link external m="0 4px" style={{ display: 'inline' }} href="/terms-of-service">
             {t('terms and conditions')}
           </Link>
           <Text as="span">{t('and all relevant laws and regulations.')}</Text>

--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -1,9 +1,6 @@
 import DisclaimerModal, { CheckType } from 'components/DisclaimerModal'
 import { useUserNotUsCitizenAcknowledgement, IdType } from 'hooks/useUserIsUsCitizenAcknowledgement'
-import { memo, useCallback, useEffect } from 'react'
-import { getPerpetualUrl } from 'utils/getPerpetualUrl'
-import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useTheme } from 'styled-components'
+import { ReactNode, memo, useCallback, useEffect } from 'react'
 import { Text, Link } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
 import { useRouter } from 'next/router'
@@ -12,7 +9,9 @@ import { usePreviousValue } from '@pancakeswap/hooks'
 interface USCitizenConfirmModalProps {
   id: IdType
   title: string
+  desc?: ReactNode
   checks?: CheckType[]
+  href?: string
   onDismiss?: () => void
 }
 
@@ -21,25 +20,19 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
   title,
   checks,
   onDismiss,
+  href,
+  desc,
 }) => {
-  const {
-    t,
-    currentLanguage: { code },
-  } = useTranslation()
+  const { t } = useTranslation()
   const { pathname } = useRouter()
   const previousPathname = usePreviousValue(pathname)
   const [, setHasAcceptedRisk] = useUserNotUsCitizenAcknowledgement(id)
-  const { chainId } = useActiveChainId()
-  const { isDark } = useTheme()
 
   const handleSuccess = useCallback(() => {
     setHasAcceptedRisk(true)
-    if (id === IdType.PERPETUALS) {
-      const url = getPerpetualUrl({ chainId, languageCode: code, isDark })
-      window.open(url, '_blank', 'noopener noreferrer')
-    }
+    window.open(href, '_blank', 'noopener noreferrer')
     onDismiss?.()
-  }, [id, setHasAcceptedRisk, onDismiss, chainId, code, isDark])
+  }, [id, setHasAcceptedRisk, onDismiss, href])
 
   useEffect(() => {
     if (previousPathname && pathname !== previousPathname) {
@@ -69,6 +62,7 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
             {t('terms and conditions')}
           </Link>
           <Text as="span">{t('and all relevant laws and regulations.')}</Text>
+          {desc}
         </>
       }
       onSuccess={handleSuccess}

--- a/apps/web/src/hooks/usePerpUrl.ts
+++ b/apps/web/src/hooks/usePerpUrl.ts
@@ -1,0 +1,7 @@
+import { useMemo } from 'react'
+
+import { getPerpetualUrl, GetPerpetualUrlProps } from 'utils/getPerpetualUrl'
+
+export function usePerpUrl({ chainId, isDark, languageCode }: GetPerpetualUrlProps) {
+  return useMemo(() => getPerpetualUrl({ chainId, isDark, languageCode }), [chainId, isDark, languageCode])
+}

--- a/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
+++ b/apps/web/src/hooks/useUserIsUsCitizenAcknowledgement.ts
@@ -6,11 +6,13 @@ export enum IdType {
   IFO = 'ifo',
   PERPETUALS = 'perpetuals',
   AFFILIATE_PROGRAM = 'affiliate-program',
+  OPTIONS = 'options',
 }
 
 const perpetuals = atomWithStorage('pcs:NotUsCitizenAcknowledgement-perpetuals', false)
 const ifo = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement-ifo', false)
 const affiliateProgram = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement-affiliate-program', false)
+const options = atomWithStorage<boolean>('pcs:NotUsCitizenAcknowledgement-options', false)
 
 export function useUserNotUsCitizenAcknowledgement(id: IdType) {
   switch (id) {
@@ -18,6 +20,10 @@ export function useUserNotUsCitizenAcknowledgement(id: IdType) {
       return useAtom(ifo)
     case IdType.AFFILIATE_PROGRAM:
       return useAtom(affiliateProgram)
+    case IdType.PERPETUALS:
+      return useAtom(perpetuals)
+    case IdType.OPTIONS:
+      return useAtom(options)
     default:
       return useAtom(perpetuals)
   }

--- a/apps/web/src/utils/getOptionsUrl.ts
+++ b/apps/web/src/utils/getOptionsUrl.ts
@@ -1,0 +1,3 @@
+export function getOptionsUrl() {
+  return 'https://pancakeswap.stryke.xyz'
+}

--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@pancakeswap/chains'
 import { perpLangMap } from 'utils/getPerpetualLanguageCode'
 import { perpTheme } from 'utils/getPerpetualTheme'
 
-interface GetPerpetualUrlProps {
+export interface GetPerpetualUrlProps {
   chainId: ChainId | undefined
   languageCode: string | undefined
   isDark: boolean

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3332,8 +3332,11 @@
   "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.": "bCAKE only boosts token incentive (often CAKE) APR. Actual multiplier is subject to position manager and veCAKE pool condition.",
   "Booster Update": "Booster Update",
   "Booster has been updated.": "Booster has been updated.",
-  "Migrate to new v2 bCake here": "Migrate to new v2 bCake here",
   "Try it now": "Try it now",
   "Trade Options & Build On-Chain Liquidity": "Trade Options & Build On-Chain Liquidity",
-  "Trade Options & Build On-Chain Options Liquidity": "Trade Options & Build On-Chain Options Liquidity"
+  "Trade Options & Build On-Chain Options Liquidity": "Trade Options & Build On-Chain Options Liquidity",
+  "Options": "Options",
+  "PancakeSwap Options": "PancakeSwap Options",
+  "Please note that you are being redirected to an externally hosted website associated with our partner Dopex.": "Please note that you are being redirected to an externally hosted website associated with our partner Dopex.",
+  "Migrate to new v2 bCake here": "Migrate to new v2 bCake here"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3337,6 +3337,6 @@
   "Trade Options & Build On-Chain Options Liquidity": "Trade Options & Build On-Chain Options Liquidity",
   "Options": "Options",
   "PancakeSwap Options": "PancakeSwap Options",
-  "Please note that you are being redirected to an externally hosted website associated with our partner Dopex.": "Please note that you are being redirected to an externally hosted website associated with our partner Dopex.",
+  "Please note that you are being redirected to an externally hosted website associated with our partner Stryke (formerly Dopex).": "Please note that you are being redirected to an externally hosted website associated with our partner Stryke (formerly Dopex).",
   "Migrate to new v2 bCake here": "Migrate to new v2 bCake here"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for options trading on PancakeSwap, including new URLs and confirmation modals. 

### Detailed summary
- Added `getOptionsUrl` function
- Added `usePerpUrl` hook
- Updated menu items with options trading
- Added `options` atom and related functionalities
- Updated translations for options trading
- Updated confirmation modals for perpetuals and options trading

> The following files were skipped due to too many changes: `apps/web/src/components/Menu/index.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->