### PR TITLE
fix: Missing pair description in trading rewards and farm pair

### DIFF
--- a/apps/web/src/views/TradingReward/config/pairs/edgeCasesFarms/zkEVMFarm.ts
+++ b/apps/web/src/views/TradingReward/config/pairs/edgeCasesFarms/zkEVMFarm.ts
@@ -17,11 +17,4 @@ export const tradingRewardZkEvmV3Pair = defineFarmV3Configs([
     token1: polygonZkEvmTokens.usdc,
     feeAmount: FeeAmount.HIGH,
   },
-  {
-    pid: null as any,
-    lpAddress: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
-    token0: polygonZkEvmTokens.usdt,
-    token1: polygonZkEvmTokens.usdc,
-    feeAmount: FeeAmount.LOW,
-  },
 ])

--- a/apps/web/src/views/TradingReward/config/pairs/edgeCasesFarms/zkEVMFarm.ts
+++ b/apps/web/src/views/TradingReward/config/pairs/edgeCasesFarms/zkEVMFarm.ts
@@ -17,4 +17,11 @@ export const tradingRewardZkEvmV3Pair = defineFarmV3Configs([
     token1: polygonZkEvmTokens.usdc,
     feeAmount: FeeAmount.HIGH,
   },
+  {
+    pid: null as any,
+    lpAddress: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
+    token0: polygonZkEvmTokens.usdt,
+    token1: polygonZkEvmTokens.usdc,
+    feeAmount: FeeAmount.LOW,
+  },
 ])

--- a/packages/farms/constants/polygonZkEVM.ts
+++ b/packages/farms/constants/polygonZkEVM.ts
@@ -26,6 +26,13 @@ const v3TopFixedFarms: FarmConfigV3[] = [
     feeAmount: FeeAmount.LOW,
   },
   {
+    pid: 3,
+    lpAddress: '0xca06375be938a2d6eF311dfaFab7E326d55D23Cc',
+    token0: polygonZkEvmTokens.usdt,
+    token1: polygonZkEvmTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 16,
     lpAddress: '0xb5d9E1622BFA6Efb3FB50c0bDc6a0EE2b2d046fA',
     token0: polygonZkEvmTokens.weth,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new liquidity pool configuration for PID 3 on PolygonZkEVM.

### Detailed summary
- Added a new liquidity pool configuration for PID 3
- Defines LP address, token0, token1, and fee amount
- Updates fee amount to `LOWEST`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->