### PR TITLE
fix: Pool veCake apr in other chains

### DIFF
--- a/apps/web/src/utils/addressHelpers.ts
+++ b/apps/web/src/utils/addressHelpers.ts
@@ -167,6 +167,10 @@ export const getVeCakeAddress = (chainId?: number) => {
   return getAddressFromMap(addresses.veCake, chainId)
 }
 
+export const getVeCakeAddressNoFallback = (chainId?: number) => {
+  return getAddressFromMapNoFallback(addresses.veCake, chainId)
+}
+
 export const getGaugesVotingAddress = (chainId?: number) => {
   return getAddressFromMap(addresses.gaugesVoting, chainId)
 }
@@ -181,6 +185,10 @@ export const getRevenueSharingCakePoolAddress = (chainId?: number) => {
 
 export const getRevenueSharingVeCakeAddress = (chainId?: number) => {
   return getAddressFromMap(addresses.revenueSharingVeCake, chainId)
+}
+
+export const getRevenueSharingVeCakeAddressNoFallback = (chainId?: number) => {
+  return getAddressFromMapNoFallback(addresses.revenueSharingVeCake, chainId)
 }
 
 export const getRevenueSharingPoolGatewayAddress = (chainId?: number) => {

--- a/apps/web/src/views/CakeStaking/hooks/useAPR.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useAPR.ts
@@ -10,7 +10,11 @@ import { WEEK } from 'config/constants/veCake'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useVeCakeBalance } from 'hooks/useTokenBalance'
 import { useMemo } from 'react'
-import { getMasterChefV2Address, getRevenueSharingVeCakeAddress } from 'utils/addressHelpers'
+import {
+  getMasterChefV2Address,
+  getRevenueSharingVeCakeAddress,
+  getRevenueSharingVeCakeAddressNoFallback,
+} from 'utils/addressHelpers'
 import { publicClient } from 'utils/wagmi'
 import { useReadContract } from 'wagmi'
 import { useCurrentBlockTimestamp } from './useCurrentBlockTimestamp'
@@ -117,9 +121,9 @@ export const useRevShareEmission = () => {
   const currentTimestamp = useCurrentBlockTimestamp()
   const { data: totalDistributed } = useReadContract({
     abi: revenueSharingPoolProxyABI,
-    address: getRevenueSharingVeCakeAddress(chainId) ?? getRevenueSharingVeCakeAddress(ChainId.BSC),
+    address: getRevenueSharingVeCakeAddress(chainId),
     functionName: 'totalDistributed',
-    chainId,
+    chainId: getRevenueSharingVeCakeAddressNoFallback(chainId) ? chainId : ChainId.BSC,
   })
   const lastThursday = useMemo(() => {
     return Math.floor(currentTimestamp / WEEK) * WEEK

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeTotalSupply.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeTotalSupply.ts
@@ -11,7 +11,7 @@ export const useVeCakeTotalSupply = () => {
   const { chainId } = useActiveChainId()
 
   const { status, refetch, data } = useReadContract({
-      chainId: getVeCakeAddressNoFallback(chainId) ? chainId : ChainId.BSC,
+    chainId: getVeCakeAddressNoFallback(chainId) ? chainId : ChainId.BSC,
     address: getVeCakeAddress(chainId),
     functionName: 'totalSupply',
     abi: veCakeABI,

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeTotalSupply.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeTotalSupply.ts
@@ -3,14 +3,15 @@ import BigNumber from 'bignumber.js'
 import { veCakeABI } from 'config/abi/veCake'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useMemo } from 'react'
-import { getVeCakeAddress } from 'utils/addressHelpers'
 import { useReadContract } from 'wagmi'
+import { getVeCakeAddress, getVeCakeAddressNoFallback } from 'utils/addressHelpers'
+import { ChainId } from '@pancakeswap/chains'
 
 export const useVeCakeTotalSupply = () => {
   const { chainId } = useActiveChainId()
 
   const { status, refetch, data } = useReadContract({
-    chainId,
+      chainId: getVeCakeAddressNoFallback(chainId) ? chainId : ChainId.BSC,
     address: getVeCakeAddress(chainId),
     functionName: 'totalSupply',
     abi: veCakeABI,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update address retrieval functions in `useVeCakeTotalSupply` and `useAPR` hooks to handle fallback cases more efficiently.

### Detailed summary
- Added `getVeCakeAddressNoFallback` function
- Added `getRevenueSharingVeCakeAddressNoFallback` function
- Updated address retrieval in `useVeCakeTotalSupply` and `useAPR` hooks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->