### PR TITLE
fix: bCake stake amount for v2 farm

### DIFF
--- a/packages/farms/src/v2/fetchPublicFarmData.ts
+++ b/packages/farms/src/v2/fetchPublicFarmData.ts
@@ -1,8 +1,8 @@
 import { ChainId } from '@pancakeswap/chains'
-import { Address, PublicClient } from 'viem'
 import chunk from 'lodash/chunk'
-import { SerializedFarmPublicData, SerializedFarmConfig } from '../types'
+import { Address, PublicClient } from 'viem'
 import { nonBSCVaultAddresses } from '../const'
+import { SerializedFarmConfig, SerializedFarmPublicData } from '../types'
 
 const abi = [
   {
@@ -41,7 +41,7 @@ const abi = [
 ] as const
 
 const fetchFarmCalls = (farm: SerializedFarmPublicData, masterChefAddress: string, vaultAddress?: string) => {
-  const { lpAddress, token, quoteToken } = farm
+  const { lpAddress, token, quoteToken, bCakeWrapperAddress } = farm
   return [
     // Balance of token in the LP contract
     {
@@ -62,7 +62,7 @@ const fetchFarmCalls = (farm: SerializedFarmPublicData, masterChefAddress: strin
       abi,
       address: lpAddress,
       functionName: 'balanceOf',
-      args: [(vaultAddress || masterChefAddress) as Address],
+      args: [bCakeWrapperAddress ?? ((vaultAddress || masterChefAddress) as Address)],
     },
     // Total supply of LP tokens
     {

--- a/packages/farms/src/v2/fetchPublicFarmData.ts
+++ b/packages/farms/src/v2/fetchPublicFarmData.ts
@@ -62,7 +62,7 @@ const fetchFarmCalls = (farm: SerializedFarmPublicData, masterChefAddress: strin
       abi,
       address: lpAddress,
       functionName: 'balanceOf',
-      args: [bCakeWrapperAddress ?? ((vaultAddress || masterChefAddress) as Address)],
+      args: [(bCakeWrapperAddress || vaultAddress || masterChefAddress) as Address],
     },
     // Total supply of LP tokens
     {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `fetchFarmCalls` function in `fetchPublicFarmData.ts` to include `bCakeWrapperAddress` in the farm data.

### Detailed summary
- Added `bCakeWrapperAddress` to farm data destructuring in `fetchFarmCalls` function.
- Updated args array to include `bCakeWrapperAddress` as a fallback option.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->