### PR TITLE
fix: gauges pair name

### DIFF
--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -3401,7 +3401,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
   },
   {
     gid: 340,
-    pairName: 'RDNT-USDC',
+    pairName: 'RDNT-WETH',
     address: '0xD6d29209C256aD605cAB2a0aa3A7e68BA25bD9E6',
     chainId: ChainId.ARBITRUM_ONE,
     type: GaugeType.ALM,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the pair name in the production config for the `RDNT` gauge from 'RDNT-USDC' to 'RDNT-WETH'.

### Detailed summary
- Updated `pairName` in production config for `RDNT` gauge to 'RDNT-WETH'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->