### PR TITLE
fix: Sub menu fail to close on mobile devices

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -9,7 +9,7 @@ import config, { ConfigMenuDropDownItemsType, ConfigMenuItemsType } from '../con
 import { useMenuItemsStatus } from './useMenuItemsStatus'
 
 export type UseMenuItemsParams = {
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>, item: ConfigMenuDropDownItemsType) => void
+  onClick?: (e: React.MouseEvent<HTMLElement>, item: ConfigMenuDropDownItemsType) => void
 }
 
 export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuItemsType[] => {
@@ -32,7 +32,10 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
     if (menuItemsStatus && Object.keys(menuItemsStatus).length) {
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
-          const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => onClick?.(e, currentItem)
+          const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
+            currentItem.onClick?.(e)
+            onClick?.(e, currentItem)
+          }
           const innerItem = {
             ...currentItem,
             onClick: onClickEvent,

--- a/packages/uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -135,10 +135,11 @@ const DropdownMenu: React.FC<React.PropsWithChildren<DropdownMenuProps>> = ({
                         disabled={disabled || isDisabled}
                         as={linkComponent}
                         href={href}
-                        onClick={() => {
-                          setIsOpen(false);
-                        }}
                         {...itemProps}
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                          setIsOpen(false);
+                          itemProps.onClick?.(e);
+                        }}
                       >
                         {MenuItemContent}
                       </DropdownMenuItem>
@@ -150,12 +151,11 @@ const DropdownMenu: React.FC<React.PropsWithChildren<DropdownMenuProps>> = ({
                         as="a"
                         href={href}
                         target="_blank"
-                        onClick={
-                          (() => {
-                            setIsOpen(false);
-                          }) as any
-                        }
                         {...itemProps}
+                        onClick={(e: any) => {
+                          setIsOpen(false);
+                          itemProps.onClick?.(e);
+                        }}
                       >
                         <Flex alignItems="center" justifyContent="space-between" width="100%">
                           {MenuItemContent}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances DropdownMenu behavior by passing onClick events to individual items. 

### Detailed summary
- Updated `DropdownMenu` component to pass onClick events to individual items
- Updated `useMenuItems` hook to handle onClick events for individual items

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->