### PR TITLE
fix: Lp total liquidity value wrong

### DIFF
--- a/packages/farms/src/v2/fetchFarmsV2.ts
+++ b/packages/farms/src/v2/fetchFarmsV2.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { CurrencyParams, getCurrencyKey, getCurrencyListUsdPrice } from '@pancakeswap/price-api-sdk'
-import { BIG_TWO, BIG_ZERO } from '@pancakeswap/utils/bigNumber'
+import { BIG_ONE, BIG_TWO, BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import BN from 'bignumber.js'
 import { Address, PublicClient, formatUnits } from 'viem'
 import { FarmV2SupportedChainId, supportedChainIdV2 } from '../const'
@@ -362,7 +362,7 @@ const getStableFarmDynamicData = ({
   // Amount of token in the LP that are staked in the MC
   const tokenAmountMcFixed = tokenAmountTotal.times(lpTokenRatio)
 
-  const quoteTokenAmountMcFixedByTokenAmount = tokenAmountMcFixed.times(tokenPriceVsQuote)
+  const quoteTokenAmountMcFixedByTokenAmount = tokenAmountMcFixed.times(BIG_ONE.div(tokenPriceVsQuote))
 
   const lpTotalInQuoteToken = quoteTokenAmountMcFixed.plus(quoteTokenAmountMcFixedByTokenAmount)
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `BIG_TWO` import to include `BIG_ONE` in `fetchFarmsV2.ts` and adjusts a calculation using `BIG_ONE`.

### Detailed summary
- Updated `BIG_TWO` import to include `BIG_ONE`
- Adjusted calculation using `BIG_ONE` instead of `tokenPriceVsQuote`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->