### PR TITLE
chore: Remove deprecated zksync testnet

### DIFF
--- a/apps/web/src/config/chains.ts
+++ b/apps/web/src/config/chains.ts
@@ -21,7 +21,6 @@ import {
   scrollSepolia,
   sepolia,
   zkSync,
-  zkSyncTestnet,
 } from 'wagmi/chains'
 
 export const CHAIN_QUERY_NAME = chainNames
@@ -83,7 +82,6 @@ export const CHAINS = [
   polygonZkEvm,
   polygonZkEvmTestnet,
   zkSync,
-  zkSyncTestnet,
   arbitrum,
   arbitrumGoerli,
   arbitrumSepolia,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `zkSyncTestnet` entry from the `CHAINS` array in `chains.ts`.

### Detailed summary
- Removed `zkSyncTestnet` entry from the `CHAINS` array in `chains.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->