### PR TITLE
feat: List farms

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 162,
+    token0: bscTokens.masa,
+    token1: bscTokens.wbnb,
+    lpAddress: '0x6AFe0F2b39B98857e49af22cEf4e4525551B46ac',
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 161,
     token0: bscTokens.sdt,
     token1: bscTokens.wbnb,

--- a/packages/farms/constants/eth.ts
+++ b/packages/farms/constants/eth.ts
@@ -69,6 +69,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 66,
+    lpAddress: '0x021E6270091a926D08d43681978d65F9A9b024ca',
+    token0: ethereumTokens.masa,
+    token1: ethereumTokens.weth,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 65,
     lpAddress: '0x7B94A5622035207d3f527d236d47B7714Ee0acBa',
     token0: ethereumTokens.weth,

--- a/packages/farms/constants/eth.ts
+++ b/packages/farms/constants/eth.ts
@@ -73,7 +73,7 @@ export const farmsV3 = defineFarmV3Configs([
     lpAddress: '0x021E6270091a926D08d43681978d65F9A9b024ca',
     token0: ethereumTokens.masa,
     token1: ethereumTokens.weth,
-    feeAmount: FeeAmount.LOW,
+    feeAmount: FeeAmount.MEDIUM,
   },
   {
     pid: 65,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new liquidity pool configurations for BSC and Ethereum farms. It includes PID, token pairs, LP addresses, and fee amounts.

### Detailed summary
- Added new BSC liquidity pool configuration with PID 162
- Added new Ethereum liquidity pool configuration with PID 66

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->