### PR TITLE
fix: only fire event when trigger switch

### DIFF
--- a/apps/web/src/hooks/useAccountEventListener.ts
+++ b/apps/web/src/hooks/useAccountEventListener.ts
@@ -1,8 +1,9 @@
 import replaceBrowserHistory from '@pancakeswap/utils/replaceBrowserHistory'
 import { CHAIN_QUERY_NAME } from 'config/chains'
-import { useEffect } from 'react'
+import { ExtendEthereum } from 'global'
+import { useEffect, useMemo, useRef } from 'react'
 import { isChainSupported } from 'utils/wagmi'
-import { useAccount, useAccountEffect } from 'wagmi'
+import { useAccount, useAccountEffect, useSwitchChain } from 'wagmi'
 import { useAppDispatch } from '../state'
 import { clearUserStates } from '../utils/clearUserStates'
 import { useSessionChainId } from './useSessionChainId'
@@ -11,6 +12,12 @@ export const useAccountEventListener = () => {
   const [, setSessionChainId] = useSessionChainId()
   const dispatch = useAppDispatch()
   const { chainId } = useAccount()
+  const { status } = useSwitchChain()
+  const chainSwitchStatus = useRef<'idle' | 'pending' | 'error' | 'success'>(status)
+
+  const isBloctoMobileApp = useMemo(() => {
+    return typeof window !== 'undefined' && Boolean((window.ethereum as ExtendEthereum)?.isBlocto)
+  }, [])
 
   useAccountEffect({
     onDisconnect() {
@@ -19,9 +26,21 @@ export const useAccountEventListener = () => {
   })
 
   useEffect(() => {
-    if (chainId && isChainSupported(chainId)) {
-      replaceBrowserHistory('chain', CHAIN_QUERY_NAME[chainId])
-      setSessionChainId(chainId)
+    const handleUpdate = () => {
+      if (chainId && isChainSupported(chainId)) {
+        replaceBrowserHistory('chain', CHAIN_QUERY_NAME[chainId])
+        setSessionChainId(chainId)
+      }
+      // Blocto in-app browser throws change event when no account change which causes user state reset therefore
+      // this event should not be handled to avoid unexpected behaviour.
+      if (!isBloctoMobileApp) {
+        clearUserStates(dispatch, { chainId, newChainId: chainId })
+      }
     }
-  }, [chainId, setSessionChainId])
+
+    if (chainSwitchStatus.current !== 'success' && status === 'success') {
+      handleUpdate()
+    }
+    chainSwitchStatus.current = 'success'
+  }, [chainId, dispatch, isBloctoMobileApp, setSessionChainId, status])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useAccountEventListener` hook by adding `useSwitchChain` and handling chain switching events more effectively.

### Detailed summary
- Added `useSwitchChain` for chain switching status
- Improved handling of chain switching events
- Prevented unexpected behavior in Blocto in-app browser

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->