### PR TITLE
chore: Remove Litepaper

### DIFF
--- a/apps/aptos/components/Menu/footerConfig.ts
+++ b/apps/aptos/components/Menu/footerConfig.ts
@@ -26,10 +26,6 @@ export const footerLinks: (t: ContextApi['t']) => FooterLinkType[] = (t) => [
         href: 'https://docs.pancakeswap.finance/governance-and-tokenomics/cake-tokenomics',
       },
       {
-        label: t('Litepaper'),
-        href: 'https://assets.pancakeswap.finance/litepaper/v2litepaper.pdf',
-      },
-      {
         label: t('CAKE Emission Projection'),
         href: 'https://analytics.pancakeswap.finance/',
       },

--- a/packages/uikit/src/widgets/Menu/components/footerConfig.ts
+++ b/packages/uikit/src/widgets/Menu/components/footerConfig.ts
@@ -26,10 +26,6 @@ export const footerLinks: (t: ContextApi["t"]) => FooterLinkType[] = (t) => [
         href: "https://docs.pancakeswap.finance/governance-and-tokenomics/cake-tokenomics",
       },
       {
-        label: t("Litepaper"),
-        href: "https://assets.pancakeswap.finance/litepaper/v2litepaper.pdf",
-      },
-      {
         label: t("CAKE Emission Projection"),
         href: "https://analytics.pancakeswap.finance/",
       },


### PR DESCRIPTION
I think the content of the Litepaper is outdated and should either be removed or marked as obsolete.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates footer links in the `Menu` component. Removed `Litepaper` link and updated `CAKE Emission Projection` link.

### Detailed summary
- Removed `Litepaper` link from footer in `Menu` component
- Updated `CAKE Emission Projection` link in footer in `Menu` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->