### PR TITLE
fix: Token highlight displayed in swap when chart enabled in twap

### DIFF
--- a/apps/web/src/views/Swap/Twap/Twap.tsx
+++ b/apps/web/src/views/Swap/Twap/Twap.tsx
@@ -55,6 +55,7 @@ import { styled } from 'styled-components'
 import { getBlockExploreLink, getBlockExploreName } from 'utils'
 import currencyId from 'utils/currencyId'
 import { useAccount } from 'wagmi'
+import { useSwapHotTokenDisplay } from 'hooks/useSwapHotTokenDisplay'
 import { Wrapper } from '../components/styleds'
 import { SwapTransactionErrorContent } from '../components/SwapTransactionErrorContent'
 import useWarningImport from '../hooks/useWarningImport'
@@ -162,9 +163,16 @@ export function TWAPPanel({ limit }: { limit?: boolean }) {
     [onCurrencySelection, warningSwapHandler, inputCurrencyId, outputCurrencyId],
   )
 
+  const [, setIsSwapHotTokenDisplay] = useSwapHotTokenDisplay()
+
   const toggleChartDisplayed = useCallback(() => {
-    setIsChartDisplayed?.((currentIsChartDisplayed) => !currentIsChartDisplayed)
-  }, [setIsChartDisplayed])
+    setIsChartDisplayed?.((currentIsChartDisplayed) => {
+      if (!currentIsChartDisplayed) {
+        setIsSwapHotTokenDisplay(false)
+      }
+      return !currentIsChartDisplayed
+    })
+  }, [setIsChartDisplayed, setIsSwapHotTokenDisplay])
 
   const onSrcTokenSelected = useCallback(
     (token: Currency) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new hook `useSwapHotTokenDisplay` and updates the logic in `TWAPPanel` component to handle hot token display during chart toggling.

### Detailed summary
- Added `useSwapHotTokenDisplay` hook
- Updated logic in `TWAPPanel` component to handle hot token display during chart toggling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->