### PR TITLE
fix: useActiveChainId should always return support chainId

### DIFF
--- a/apps/web/src/hooks/useActiveChainId.ts
+++ b/apps/web/src/hooks/useActiveChainId.ts
@@ -57,7 +57,7 @@ export const useActiveChainId = () => {
   )
 
   return {
-    chainId: isWrongNetwork ? ChainId.BSC : chainId,
+    chainId: chainId && isChainSupported(chainId) ? chainId : ChainId.BSC,
     isWrongNetwork,
     isNotMatched,
   }

--- a/apps/web/src/hooks/useActiveChainId.ts
+++ b/apps/web/src/hooks/useActiveChainId.ts
@@ -51,13 +51,14 @@ export const useActiveChainId = () => {
   const chainId = localChainId ?? wagmiChainId ?? (queryChainId >= 0 ? ChainId.BSC : undefined)
 
   const isNotMatched = useDeferredValue(wagmiChainId && localChainId && wagmiChainId !== localChainId)
+  const isWrongNetwork = useMemo(
+    () => Boolean(((wagmiChainId && !isChainSupported(wagmiChainId)) ?? false) || isNotMatched),
+    [wagmiChainId, isNotMatched],
+  )
 
   return {
-    chainId,
-    isWrongNetwork: useMemo(
-      () => Boolean(((wagmiChainId && !isChainSupported(wagmiChainId)) ?? false) || isNotMatched),
-      [wagmiChainId, isNotMatched],
-    ),
+    chainId: isWrongNetwork ? ChainId.BSC : chainId,
+    isWrongNetwork,
     isNotMatched,
   }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useActiveChainId` hook to handle network mismatch and unsupported chains efficiently.

### Detailed summary
- Added `isWrongNetwork` to check for unsupported or mismatched chains
- Updated `chainId` logic to fallback to BSC if not supported

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->