### PR TITLE
refactor: use emitter listener

### DIFF
--- a/apps/web/src/hooks/useAccountEventListener.ts
+++ b/apps/web/src/hooks/useAccountEventListener.ts
@@ -1,10 +1,33 @@
+import { useCallback, useEffect } from 'react'
 import { useAccount, useAccountEffect } from 'wagmi'
 import { useAppDispatch } from '../state'
 import { clearUserStates } from '../utils/clearUserStates'
+import { useSwitchNetworkLocal } from './useSwitchNetwork'
+
+export const useChainIdListener = () => {
+  const switchNetworkCallback = useSwitchNetworkLocal()
+  const onChainChanged = useCallback(
+    ({ chainId }: { chainId?: number }) => {
+      if (chainId === undefined) return
+      switchNetworkCallback(chainId)
+    },
+    [switchNetworkCallback],
+  )
+  const { connector } = useAccount()
+
+  useEffect(() => {
+    connector?.emitter?.on('change', onChainChanged)
+
+    return () => {
+      connector?.emitter?.off('change', onChainChanged)
+    }
+  })
+}
 
 export const useAccountEventListener = () => {
   const dispatch = useAppDispatch()
   const { chainId } = useAccount()
+  useChainIdListener()
 
   useAccountEffect({
     onDisconnect() {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new hook `useChainIdListener` to handle chain ID changes in the account event listener.

### Detailed summary
- Added `useChainIdListener` hook to handle chain ID changes
- Invokes `useSwitchNetworkLocal` hook to switch network
- Listens for chain ID changes and triggers network switch
- Cleans up event listener on unmount

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->