### PR TITLE
fix: multi chain bCake UI issue

### DIFF
--- a/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/StakeAction.tsx
@@ -292,7 +292,7 @@ const StakeAction: React.FC<React.PropsWithChildren<FarmCardActionsProps>> = ({
       onConfirm={handleUnstake}
       lpPrice={lpTokenPrice}
       tokenName={lpSymbol}
-      showCrossChainFarmWarning={chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET}
+      showCrossChainFarmWarning={chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET && !bCakeWrapperAddress}
       decimals={18}
     />,
   )

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -414,7 +414,11 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
                         : multiplier.farmCakePerSecond
                     }
                     totalMultipliers={multiplier.totalMultipliers}
-                    isBooster={Boolean(details?.bCakeWrapperAddress) && details?.bCakePublicData?.isRewardInRange}
+                    isBooster={
+                      Boolean(details?.bCakeWrapperAddress) &&
+                      details?.bCakePublicData?.isRewardInRange &&
+                      chainId !== ChainId.BSC
+                    }
                     boosterMultiplier={
                       details?.bCakeWrapperAddress
                         ? details?.bCakeUserData?.boosterMultiplier === 0 ||

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/ActionPanel.tsx
@@ -415,9 +415,9 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
                     }
                     totalMultipliers={multiplier.totalMultipliers}
                     isBooster={
+                      chainId === ChainId.BSC &&
                       Boolean(details?.bCakeWrapperAddress) &&
-                      details?.bCakePublicData?.isRewardInRange &&
-                      chainId !== ChainId.BSC
+                      details?.bCakePublicData?.isRewardInRange
                     }
                     boosterMultiplier={
                       details?.bCakeWrapperAddress
@@ -430,10 +430,12 @@ export const ActionPanelV2: React.FunctionComponent<React.PropsWithChildren<Acti
                     }
                   />
                 </ValueWrapper>
-                <ValueWrapper>
-                  <Text>{t('Multiplier')}</Text>
-                  <Multiplier {...multiplier} />
-                </ValueWrapper>
+                {!details?.bCakeWrapperAddress && (
+                  <ValueWrapper>
+                    <Text>{t('Multiplier')}</Text>
+                    <Multiplier {...multiplier} />
+                  </ValueWrapper>
+                )}
                 <ValueWrapper>
                   <Text>{t('Staked Liquidity')}</Text>
                   <Liquidity {...liquidity} />

--- a/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Actions/StakedAction.tsx
@@ -411,7 +411,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
       lpPrice={lpTokenPrice}
       tokenName={lpSymbol}
       decimals={18}
-      showCrossChainFarmWarning={chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET}
+      showCrossChainFarmWarning={chainId !== ChainId.BSC && chainId !== ChainId.BSC_TESTNET && !bCakeWrapperAddress}
     />,
   )
 

--- a/apps/web/src/views/Farms/components/FarmTable/Row.tsx
+++ b/apps/web/src/views/Farms/components/FarmTable/Row.tsx
@@ -359,7 +359,8 @@ const Row: React.FunctionComponent<React.PropsWithChildren<RowPropsWithLoading>>
                         totalMultipliers={multiplier.totalMultipliers}
                         isBooster={
                           Boolean(props?.details?.bCakeWrapperAddress) &&
-                          props?.details?.bCakePublicData?.isRewardInRange
+                          props?.details?.bCakePublicData?.isRewardInRange &&
+                          chainId === ChainId.BSC
                         }
                         boosterMultiplier={
                           props?.details?.bCakeWrapperAddress

--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -323,7 +323,7 @@ const farms: SerializedFarmConfig[] = [
     infoStableSwapAddress: '0x58B2F00f74a1877510Ec37b22f116Bf5D63Ab1b0',
     stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
-    bCakeWrapperAddress: '0xBe03730EE3692B0f78C8E50597377edA96C9Da7E',
+    bCakeWrapperAddress: '0xC6B6926ef8B7218F054d64B52Ac455aEd22D690B',
     allocPoint: 1,
   },
   {
@@ -336,7 +336,7 @@ const farms: SerializedFarmConfig[] = [
     infoStableSwapAddress: '0x58B2F00f74a1877510Ec37b22f116Bf5D63Ab1b0',
     stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
-    bCakeWrapperAddress: '0xaa85658A18e5176D5b3e5b72Ebe0e5750399Ed32',
+    bCakeWrapperAddress: '0x7Fa4536b3E78643E027Dc34bB5A055517B4D9096',
     allocPoint: 1,
   },
 ].map(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update farm-related components to include a check for the `chainId` being BSC before rendering certain elements.

### Detailed summary
- Added `chainId === ChainId.BSC` check in `Row.tsx`, `StakedAction.tsx`, `StakeAction.tsx`, and `ActionPanel.tsx`
- Updated `bCakeWrapperAddress` in `arb.ts` constants
- Conditionally render `Multiplier` component based on `bCakeWrapperAddress` in `ActionPanel.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->