### PR TITLE
fix: Use new graph api for swap info

### DIFF
--- a/apps/web/src/state/swap/fetch/fetchDerivedPriceData.ts
+++ b/apps/web/src/state/swap/fetch/fetchDerivedPriceData.ts
@@ -1,5 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
-import { STABLESWAP_SUBGRAPHS_URLS, V2_SUBGRAPH_URLS, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
+import { EXPLORER_API, STABLESWAP_SUBGRAPHS_URLS, V2_SUBGRAPH_URLS, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
 import { ONE_DAY_UNIX, ONE_HOUR_SECONDS } from 'config/constants/info'
 import dayjs from 'dayjs'
 import request from 'graphql-request'
@@ -21,7 +21,7 @@ const SWAP_INFO_BY_CHAIN = {
   [ChainId.BSC]: {
     v2: V2_SUBGRAPH_URLS[ChainId.BSC],
     stable: STABLESWAP_SUBGRAPHS_URLS[ChainId.BSC],
-    v3: V3_SUBGRAPH_URLS[ChainId.BSC],
+    v3: `${EXPLORER_API}/subgraphs/v3/bsc/graphql`,
   },
   [ChainId.ETHEREUM]: {
     v2: V2_SUBGRAPH_URLS[ChainId.ETHEREUM],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `fetchDerivedPriceData.ts` file to include a new `EXPLORER_API` constant and modifies the `SWAP_INFO_BY_CHAIN` object to use this constant for V3 subgraph URL.

### Detailed summary
- Added `EXPLORER_API` constant import
- Updated V3 subgraph URL for BSC chain in `SWAP_INFO_BY_CHAIN`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->