### PR TITLE
chore: Increase cover rate for ab testing features

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -27,17 +27,17 @@ export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   },
   {
     feature: EXPERIMENTAL_FEATURES.SpeedQuote,
-    percentage: 0.6,
+    percentage: 0.7,
     whitelist: [],
   },
   {
     feature: EXPERIMENTAL_FEATURES.UniversalRouter,
-    percentage: 0.6,
+    percentage: 0.7,
     whitelist: [],
   },
   {
     feature: EXPERIMENTAL_FEATURES.PriceAPI,
-    percentage: 0.05,
+    percentage: 0.1,
     whitelist: [],
   },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to increase the percentage values for experimental features SpeedQuote, UniversalRouter, and PriceAPI.

### Detailed summary
- Increased percentage value for `EXPERIMENTAL_FEATURES.SpeedQuote` from 0.6 to 0.7
- Increased percentage value for `EXPERIMENTAL_FEATURES.UniversalRouter` from 0.6 to 0.7
- Increased percentage value for `EXPERIMENTAL_FEATURES.PriceAPI` from 0.05 to 0.1

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->