### PR TITLE
fix: Use always collection metadata for collection name

### DIFF
--- a/apps/web/src/pages/nfts/collections/[collectionAddress]/[tokenId].tsx
+++ b/apps/web/src/pages/nfts/collections/[collectionAddress]/[tokenId].tsx
@@ -50,7 +50,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       return {
         tokenId,
         collectionAddress: collectionAddress as Address,
-        collectionName: metadata.collection.name,
+        collectionName: collection?.[collectionAddress.toLowerCase()]?.name || metadata.collection.name,
         name: metadata.name,
         description: metadata.description,
         image: metadata.image,

--- a/apps/web/src/views/Nft/market/hooks/useCompleteNft.tsx
+++ b/apps/web/src/views/Nft/market/hooks/useCompleteNft.tsx
@@ -3,7 +3,7 @@ import { NOT_ON_SALE_SELLER } from 'config/constants'
 import { FetchStatus } from 'config/constants/types'
 import { useErc721CollectionContract } from 'hooks/useContract'
 import { useCallback } from 'react'
-import { getNftApi, getNftsMarketData, getNftsOnChainMarketData } from 'state/nftMarket/helpers'
+import { getCollectionApi, getNftApi, getNftsMarketData, getNftsOnChainMarketData } from 'state/nftMarket/helpers'
 import { NftLocation, NftToken, TokenMarketData } from 'state/nftMarket/types'
 import { useProfile } from 'state/profile/hooks'
 import { safeGetAddress } from 'utils'
@@ -57,10 +57,11 @@ export const useCompleteNft = (collectionAddress: Address | undefined, tokenId: 
     queryFn: async () => {
       const metadata = await getNftApi(collectionAddress!, tokenId)
       if (metadata) {
+        const collectionMetadata = await getCollectionApi(collectionAddress!)
         const basicNft: NftToken = {
           tokenId,
           collectionAddress: collectionAddress!,
-          collectionName: metadata.collection.name,
+          collectionName: collectionMetadata?.name || metadata.collection.name,
           name: metadata.name,
           description: metadata.description,
           image: metadata.image,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances NFT page display by dynamically fetching collection names. 

### Detailed summary
- Dynamically fetch collection names for NFTs
- Updated useCompleteNft hook to fetch collection metadata
- Added getCollectionApi function to state/nftMarket/helpers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->