### PR TITLE
perf: Deduplicate candidate pool calls

### DIFF
--- a/apps/web/src/hooks/usePoolsOnChain.ts
+++ b/apps/web/src/hooks/usePoolsOnChain.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-shadow, no-await-in-loop, no-constant-condition, no-console */
 import { BigintIsh, Currency } from '@pancakeswap/sdk'
 import { OnChainProvider, Pool, SmartRouter } from '@pancakeswap/smart-router'
-
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useRef } from 'react'
+import { useMemo } from 'react'
 
-import { getViemClients } from 'utils/viem'
+import { createViemPublicClientGetter } from 'utils/viem'
+import { POOLS_FAST_REVALIDATE } from 'config/pools'
 
 interface Options {
   blockNumber?: number
@@ -34,7 +34,14 @@ function candidatePoolsOnChainHookFactory<TPool extends Pool>(
     currencyB?: Currency,
     { blockNumber, enabled = true }: Options = {},
   ) {
-    const fetchingBlock = useRef<string | null>(null)
+    const refetchInterval = useMemo(() => {
+      const chainId = currencyA?.chainId
+      if (!chainId) {
+        return 0
+      }
+      return POOLS_FAST_REVALIDATE[chainId] || 0
+    }, [currencyA?.chainId])
+
     const key = useMemo(() => {
       if (
         !currencyA ||
@@ -58,44 +65,29 @@ function candidatePoolsOnChainHookFactory<TPool extends Pool>(
     const poolState = useQuery({
       queryKey: [poolType, 'pools', key],
 
-      queryFn: async () => {
+      queryFn: async ({ signal }) => {
         if (!blockNumber || !pairs) {
           throw new Error('Failed to get pools on chain. Missing valid params')
         }
-        fetchingBlock.current = blockNumber.toString()
-        try {
-          const label = `[POOLS_ONCHAIN](${poolType}) ${key} at block ${fetchingBlock.current}`
-          SmartRouter.logger.metric(label)
-          const pools = await getPoolsOnChain(pairs, getViemClients, blockNumber)
-          SmartRouter.logger.metric(label, pools)
+        const label = `[POOLS_ONCHAIN](${poolType}) ${key} at block ${blockNumber}`
+        SmartRouter.logger.metric(label)
+        const getViemClients = createViemPublicClientGetter({ transportSignal: signal })
+        const pools = await getPoolsOnChain(pairs, getViemClients, blockNumber)
+        SmartRouter.logger.metric(label, pools)
 
-          return {
-            pools,
-            key,
-            blockNumber,
-          }
-        } finally {
-          fetchingBlock.current = null
+        return {
+          pools,
+          key,
+          blockNumber,
         }
       },
 
       enabled: queryEnabled,
+      refetchInterval,
       refetchOnWindowFocus: false,
     })
 
     const { refetch, data, isLoading, isFetching: isValidating, dataUpdatedAt } = poolState
-    useEffect(() => {
-      // Revalidate pools if block number increases
-      if (
-        queryEnabled &&
-        blockNumber &&
-        fetchingBlock.current !== blockNumber.toString() &&
-        (!data?.blockNumber || blockNumber > data.blockNumber)
-      ) {
-        refetch()
-      }
-      // eslint-disable-next-line
-    }, [blockNumber, data?.blockNumber, queryEnabled])
 
     return {
       refresh: refetch,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the `usePoolsOnChain` hook by removing unnecessary dependencies and adding a `refetchInterval` feature.

### Detailed summary
- Removed `useEffect` and `useRef` imports
- Added `refetchInterval` based on `currencyA` chainId
- Replaced `getViemClients` with `createViemPublicClientGetter`
- Added `POOLS_FAST_REVALIDATE` constant from config
- Utilized `signal` in `queryFn` for cancellation
- Updated pool state return object properties
- Added `refetchInterval` to pool state options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->