### PR TITLE
perf: Add exact to initial block number cache

### DIFF
--- a/packages/wagmi/src/hooks/useBlock.ts
+++ b/packages/wagmi/src/hooks/useBlock.ts
@@ -41,6 +41,7 @@ export function useWatchBlock({ chainId, enabled }: Params) {
     if (
       !queryClient.getQueryCache().find({
         queryKey: initialBlockNumberQueryKey,
+        exact: true,
       })?.state?.data
     ) {
       queryClient.setQueryData(initialBlockNumberQueryKey, blockNumber)
@@ -50,6 +51,7 @@ export function useWatchBlock({ chainId, enabled }: Params) {
     if (
       !queryClient.getQueryCache().find({
         queryKey: initialBlockTimestampQueryKey,
+        exact: true,
       })?.state?.data
     ) {
       queryClient.setQueryData(initialBlockTimestampQueryKey, Number(blockTimestamp))


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the efficiency of `useBlock.ts` hooks by adding an `exact: true` option to query searches for initial block number and timestamp.

### Detailed summary
- Added `exact: true` option to query searches for initial block number and timestamp in `useBlock.ts` hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->