### PR TITLE
fix: Exception throws when invalidate query

### DIFF
--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -119,7 +119,7 @@ function useChartHoverMutate() {
       if (data) {
         queryClient.setQueryData(['chainlinkChartHover'], data)
       } else {
-        queryClient.resetQueries({ queryKey: ['chainlinkChartHover'], exact: true })
+        queryClient.resetQueries({ queryKey: ['chainlinkChartHover'] })
       }
     },
     [queryClient],

--- a/packages/wagmi/src/hooks/useBalance.ts
+++ b/packages/wagmi/src/hooks/useBalance.ts
@@ -22,7 +22,7 @@ export function useBalance<config extends Config = ResolvedRegister['config'], s
 
   useEffect(() => {
     if (watch) {
-      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey, exact: true }, { cancelRefetch: false })
+      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blockNumber, queryClient, watch])

--- a/packages/wagmi/src/hooks/useBlock.ts
+++ b/packages/wagmi/src/hooks/useBlock.ts
@@ -41,7 +41,6 @@ export function useWatchBlock({ chainId, enabled }: Params) {
     if (
       !queryClient.getQueryCache().find({
         queryKey: initialBlockNumberQueryKey,
-        exact: true,
       })?.state?.data
     ) {
       queryClient.setQueryData(initialBlockNumberQueryKey, blockNumber)
@@ -51,7 +50,6 @@ export function useWatchBlock({ chainId, enabled }: Params) {
     if (
       !queryClient.getQueryCache().find({
         queryKey: initialBlockTimestampQueryKey,
-        exact: true,
       })?.state?.data
     ) {
       queryClient.setQueryData(initialBlockTimestampQueryKey, Number(blockTimestamp))

--- a/packages/wagmi/src/hooks/useFeeData.ts
+++ b/packages/wagmi/src/hooks/useFeeData.ts
@@ -27,7 +27,7 @@ export function useFeeData<
 
   useEffect(() => {
     if (watch) {
-      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey, exact: true }, { cancelRefetch: false })
+      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blockNumber, queryClient, watch])

--- a/packages/wagmi/src/hooks/useReadContract.ts
+++ b/packages/wagmi/src/hooks/useReadContract.ts
@@ -29,7 +29,7 @@ export function useReadContract<
 
   useEffect(() => {
     if (watch) {
-      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey, exact: true }, { cancelRefetch: false })
+      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blockNumber, queryClient, watch])

--- a/packages/wagmi/src/hooks/useReadContracts.ts
+++ b/packages/wagmi/src/hooks/useReadContracts.ts
@@ -27,7 +27,7 @@ export function useReadContracts<
 
   useEffect(() => {
     if (watch) {
-      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey, exact: true }, { cancelRefetch: false })
+      queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blockNumber, queryClient, watch])


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates queryClient calls by removing the `exact: true` parameter in multiple files within the `wagmi` package.

### Detailed summary
- Removed `exact: true` parameter from `queryClient.resetQueries` and `queryClient.invalidateQueries` calls in multiple hooks within the `wagmi` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->