### PR TITLE
chore: typo

### DIFF
--- a/apps/web/src/components/SearchModal/OnRampCurrencyList.tsx
+++ b/apps/web/src/components/SearchModal/OnRampCurrencyList.tsx
@@ -42,7 +42,7 @@ const NativeBTCToggle = ({
     <Flex left="82%" top="5%" position="absolute" zIndex={999}>
       <QuestionHelper
         text={t(
-          'Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. you cannot use your EVM addresses for native BTC.',
+          'Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. You cannot use your EVM addresses for native BTC.',
         )}
         placement="top"
         size="16px"

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3232,7 +3232,7 @@
   "Buy with %provider%": "Buy with %provider%",
   "Token by network": "Token by network",
   "Bitcoin Network": "Bitcoin Network",
-  "Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. you cannot use your EVM addresses for native BTC.": "Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. you cannot use your EVM addresses for native BTC.",
+  "Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. You cannot use your EVM addresses for native BTC.": "Enable Native BTC purchases. Only do this is you have a Bitcoin address to receive the funds to. You cannot use your EVM addresses for native BTC.",
   "All Networks": "All Networks",
   "Select a Token to Purchase": "Select a Token to Purchase",
   "Select Tokens by network": "Select Tokens by network",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates text in the `OnRampCurrencyList` component to clarify that EVM addresses cannot be used for native BTC purchases.

### Detailed summary
- Updated text to clarify EVM address restriction for native BTC purchases
- Updated translations for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->