### PR TITLE
feat: Run only when block number changes

### DIFF
--- a/packages/wagmi/src/hooks/useBalance.ts
+++ b/packages/wagmi/src/hooks/useBalance.ts
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
 import {
   useBalance as useWagmiBalance,
   type Config,
@@ -10,6 +9,7 @@ import {
 
 import { GetBalanceData } from '../types'
 import { useBlockNumber } from './useBlock'
+import useDidMountEffect from './useDidMountEffect'
 
 export function useBalance<config extends Config = ResolvedRegister['config'], selectData = GetBalanceData>(
   params: UseBalanceParameters<config, selectData> & { watch?: boolean } = {},
@@ -20,12 +20,11 @@ export function useBalance<config extends Config = ResolvedRegister['config'], s
 
   const readContractResult = useWagmiBalance(queryParameters)
 
-  useEffect(() => {
+  useDidMountEffect(() => {
     if (watch) {
       queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber, queryClient, watch])
+  }, blockNumber)
 
-  return readContractResult
+  return readContractResult as UseBalanceReturnType<selectData>
 }

--- a/packages/wagmi/src/hooks/useDidMountEffect.ts
+++ b/packages/wagmi/src/hooks/useDidMountEffect.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react'
+
+const useDidMountEffect = (func: () => void, checkObject: any) => {
+  const isFirstRun = useRef(true)
+  const prevParams = useRef(checkObject)
+
+  useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false
+      return
+    }
+
+    if (prevParams.current !== undefined && checkObject !== prevParams.current) {
+      func()
+    }
+
+    prevParams.current = checkObject
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkObject])
+}
+
+export default useDidMountEffect

--- a/packages/wagmi/src/hooks/useFeeData.ts
+++ b/packages/wagmi/src/hooks/useFeeData.ts
@@ -7,10 +7,10 @@ import {
 } from 'wagmi'
 import { useQueryClient } from '@tanstack/react-query'
 import { EstimateFeesPerGasData } from 'wagmi/query'
-import { useEffect } from 'react'
 import type { FeeValuesType } from 'viem'
 
 import { useBlockNumber } from './useBlock'
+import useDidMountEffect from './useDidMountEffect'
 
 export function useFeeData<
   config extends Config = ResolvedRegister['config'],
@@ -25,12 +25,11 @@ export function useFeeData<
 
   const readContractResult = useWagmiBalance(queryParameters as any)
 
-  useEffect(() => {
+  useDidMountEffect(() => {
     if (watch) {
       queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber, queryClient, watch])
+  }, blockNumber)
 
   return readContractResult as UseEstimateFeesPerGasReturnType<type, selectData>
 }

--- a/packages/wagmi/src/hooks/useReadContract.ts
+++ b/packages/wagmi/src/hooks/useReadContract.ts
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
 import type { Abi, ContractFunctionArgs, ContractFunctionName } from 'viem'
 import {
   useReadContract as useWagmiReadContract,
@@ -11,6 +10,7 @@ import {
 import type { ReadContractData } from 'wagmi/query'
 
 import { useBlockNumber } from './useBlock'
+import useDidMountEffect from './useDidMountEffect'
 
 export function useReadContract<
   const abi extends Abi | readonly unknown[],
@@ -27,12 +27,11 @@ export function useReadContract<
 
   const readContractResult = useWagmiReadContract(queryParameters as any)
 
-  useEffect(() => {
+  useDidMountEffect(() => {
     if (watch) {
       queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber, queryClient, watch])
+  }, blockNumber)
 
   return readContractResult as UseReadContractReturnType<abi, functionName, args, selectData>
 }

--- a/packages/wagmi/src/hooks/useReadContracts.ts
+++ b/packages/wagmi/src/hooks/useReadContracts.ts
@@ -6,10 +6,10 @@ import {
   type UseReadContractsReturnType,
 } from 'wagmi'
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect } from 'react'
 import type { ReadContractsData } from 'wagmi/query'
 
 import { useBlockNumber } from './useBlock'
+import useDidMountEffect from './useDidMountEffect'
 
 export function useReadContracts<
   const contracts extends readonly unknown[],
@@ -25,12 +25,11 @@ export function useReadContracts<
 
   const readContractResult = useWagmiReadContracts(queryParameters as any)
 
-  useEffect(() => {
+  useDidMountEffect(() => {
     if (watch) {
       queryClient.invalidateQueries({ queryKey: readContractResult.queryKey }, { cancelRefetch: false })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber, queryClient, watch])
+  }, blockNumber)
 
   return readContractResult as UseReadContractsReturnType<contracts, allowFailure, selectData>
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors multiple hooks in `wagmi` package to use a custom `useDidMountEffect` hook instead of `useEffect` for better performance.

### Detailed summary
- Refactored `useFeeData`, `useReadContracts`, `useReadContract`, and `useBalance` hooks
- Replaced `useEffect` with `useDidMountEffect` for conditional logic
- Improved performance by reducing unnecessary re-renders

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->