### PR TITLE
perf: Memoize vecake apr

### DIFF
--- a/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
@@ -32,8 +32,11 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
   const { veCAKEPoolApr, revShareEmissionApr } = useFourYearTotalVeCakeApr()
   const { data: totalSupply } = useVeCakeTotalSupply()
   // CAKE Pool APR
-  const userCakeTvl = getDecimalAmount(new BigNumber(cakeAmount))
-  const userSharesPercentage = getDecimalAmount(new BigNumber(veCake)).div(totalSupply).times(100)
+  const userCakeTvl = useMemo(() => getDecimalAmount(new BigNumber(cakeAmount)), [cakeAmount])
+  const userSharesPercentage = useMemo(
+    () => getDecimalAmount(new BigNumber(veCake)).div(totalSupply).times(100),
+    [totalSupply],
+  )
 
   const shouldShow4yrApr = useMemo(() => cakeAmount === 0 || cakeLockWeeks === '', [cakeAmount, cakeLockWeeks])
 

--- a/apps/web/src/views/CakeStaking/hooks/useAPR.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useAPR.ts
@@ -171,14 +171,22 @@ export const useFourYearTotalVeCakeApr = () => {
   const cakePoolEmission = useCakePoolEmission()
   const { data: totalSupply } = useVeCakeTotalSupply()
 
-  const veCAKEPoolApr = new BigNumber(new BigNumber(cakePoolEmission).div(3).times(24 * 60 * 60 * 365))
-    .div(totalSupply.div(1e18))
-    .times(100)
+  const veCAKEPoolApr = useMemo(
+    () =>
+      new BigNumber(new BigNumber(cakePoolEmission).div(3).times(24 * 60 * 60 * 365))
+        .div(totalSupply.div(1e18))
+        .times(100),
+    [cakePoolEmission, totalSupply],
+  )
 
-  const revShareEmissionApr = new BigNumber(revShareEmission)
-    .times(24 * 60 * 60 * 365)
-    .div(totalSupply)
-    .times(100)
+  const revShareEmissionApr = useMemo(
+    () =>
+      new BigNumber(revShareEmission)
+        .times(24 * 60 * 60 * 365)
+        .div(totalSupply)
+        .times(100),
+    [revShareEmission, totalSupply],
+  )
 
   const total = useMemo(
     () => veCAKEPoolApr.plus(revShareEmissionApr).plus(BRIBE_APR),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves performance by optimizing the calculation of APR in Cake Staking views.

### Detailed summary
- Refactored calculations for `userCakeTvl` and `userSharesPercentage` using `useMemo`
- Optimized APR calculations for `veCAKEPoolApr` and `revShareEmissionApr` using `useMemo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->