### PR TITLE
feat: list new ad-hoc farms

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -38,6 +38,13 @@ const v3TopFixedLps: FarmConfigV3[] = [
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
   {
+    pid: 48,
+    lpAddress: '0x843aC8dc6D34AEB07a56812b8b36429eE46BDd07',
+    token0: arbitrumTokens.wbtc,
+    token1: arbitrumTokens.usdc,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 47,
     lpAddress: '0xB19005B42E2Dcc65FB6A5598db329EDFe365A0b2',
     token0: arbitrumTokens.arb,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 163,
+    token0: bscTokens.weEth,
+    token1: bscTokens.eth,
+    lpAddress: '0x0eC7a280709a03877E69D1b80C115F8e8D3abC02',
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 162,
     token0: bscTokens.masa,
     token1: bscTokens.wbnb,

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3149,4 +3149,12 @@ export const bscTokens = {
     'Masa Token',
     'https://www.masa.finance/',
   ),
+  weEth: new ERC20Token(
+    ChainId.BSC,
+    '0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A',
+    18,
+    'weETH',
+    'Wrapped eETH',
+    'https://www.ether.fi/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new LP configurations for BSC and Arbitrum farms. It adds `weEth` token for BSC farms and new LP setups for Arbitrum farms.

### Detailed summary
- Added `weEth` token for BSC farms
- Defined new LP configuration for BSC farms with `weEth` and `eth`
- Added new LP configuration for Arbitrum farms with `wbtc` and `usdc`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->