### PR TITLE
fix: Network switcher not working when wallet is in unsupported chain

### DIFF
--- a/apps/web/src/components/NetworkModal/NetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/NetworkModal.tsx
@@ -52,7 +52,7 @@ export const NetworkModal = ({ pageSupportedChains = SUPPORT_ONLY_BSC }: { pageS
       .find((c) => c?.id === chainId)
     if (!currentChain) return null
     return (
-      <ModalV2 isOpen={isWrongNetwork} closeOnOverlayClick onDismiss={handleDismiss}>
+      <ModalV2 isOpen={isWrongNetwork} closeOnOverlayClick={false} onDismiss={handleDismiss}>
         <WrongNetworkModal currentChain={currentChain} onDismiss={handleDismiss} />
       </ModalV2>
     )

--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -34,7 +34,7 @@ const AptosChain = {
   name: 'Aptos',
 }
 
-const NetworkSelect = ({ switchNetwork, chainId }) => {
+const NetworkSelect = ({ switchNetwork, chainId, isWrongNetwork }) => {
   const { t } = useTranslation()
   const [showTestnet] = useUserShowTestnet()
 
@@ -56,10 +56,14 @@ const NetworkSelect = ({ switchNetwork, chainId }) => {
           <UserMenuItem
             key={chain.id}
             style={{ justifyContent: 'flex-start' }}
-            onClick={() => chain.id !== chainId && switchNetwork(chain.id)}
+            onClick={() => (chain.id !== chainId || isWrongNetwork) && switchNetwork(chain.id)}
           >
             <ChainLogo chainId={chain.id} />
-            <Text color={chain.id === chainId ? 'secondary' : 'text'} bold={chain.id === chainId} pl="12px">
+            <Text
+              color={chain.id === chainId && !isWrongNetwork ? 'secondary' : 'text'}
+              bold={chain.id === chainId && !isWrongNetwork}
+              pl="12px"
+            >
               {chainNameConverter(chain.name)}
             </Text>
           </UserMenuItem>
@@ -215,7 +219,7 @@ export const NetworkSwitcher = () => {
           isNotMatched ? (
             <WrongNetworkSelect switchNetwork={switchNetworkAsync} chainId={chainId} />
           ) : (
-            <NetworkSelect switchNetwork={switchNetworkAsync} chainId={chainId} />
+            <NetworkSelect switchNetwork={switchNetworkAsync} chainId={chainId} isWrongNetwork={isWrongNetwork} />
           )
         }
       </UserMenu>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the network switching functionality by adding a check for wrong network status before switching.

### Detailed summary
- Added `isWrongNetwork` prop to `NetworkSelect` component
- Modified `onClick` logic in `NetworkSelect` to consider `isWrongNetwork`
- Passed `isWrongNetwork` prop to `NetworkSelect` component in `NetworkSwitcher`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->