### PR TITLE
fix: on-ramp provider iframe content

### DIFF
--- a/apps/web/src/components/FiatOnRampModal/ProviderIframe.tsx
+++ b/apps/web/src/components/FiatOnRampModal/ProviderIframe.tsx
@@ -42,7 +42,7 @@ export const ProviderIFrame = ({ provider, loading, signedIframeUrl }: IProvider
   return (
     <>
       <LoadingBuffer loading={loading} />
-      <IFrameWrapper id="mercuryo-widget" />;
+      <IFrameWrapper id="mercuryo-widget" />
     </>
   )
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes a semicolon from the `IFrameWrapper` component in `ProviderIframe.tsx`.

### Detailed summary
- Removed a semicolon after the `IFrameWrapper` component in `ProviderIframe.tsx`

<img width="700" alt="screenshot" src="https://github.com/pancakeswap/pancake-frontend/assets/93512419/0081487e-2df9-4efa-8a9e-3b6839be2dae">


> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->