### PR TITLE
fix: Citizen confirm modal opens empty page for ifo when accepted

### DIFF
--- a/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
+++ b/apps/web/src/components/Modal/USCitizenConfirmModal.tsx
@@ -30,7 +30,9 @@ const USCitizenConfirmModal: React.FC<React.PropsWithChildren<USCitizenConfirmMo
 
   const handleSuccess = useCallback(() => {
     setHasAcceptedRisk(true)
-    window.open(href, '_blank', 'noopener noreferrer')
+    if (href) {
+      window.open(href, '_blank', 'noopener noreferrer')
+    }
     onDismiss?.()
   }, [id, setHasAcceptedRisk, onDismiss, href])
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a conditional check before opening a new window in the `handleSuccess` function in `USCitizenConfirmModal.tsx`.

### Detailed summary
- Added a conditional check to only open a new window if `href` is provided

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->