### PR TITLE
chore: Bump nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -73,7 +73,8 @@
     "wrangler": "2.20.2"
   },
   "volta": {
-    "node": "18.16.0"
+    "node": "20.12.2",
+    "pnpm": "8.15.8"
   },
   "dependencies": {
     "encoding": "^0.1.13",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Node version in `package.json` to `>=18.0.0`, upgrades `volta` to use Node `20.12.2` and `pnpm` to `8.15.8`.

### Detailed summary
- Updated Node version requirement to `>=18.0.0`
- Upgraded `volta` to use Node `20.12.2` and `pnpm` to `8.15.8`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->