### PR TITLE
chore: remove unnecessary submenu for Buy

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -108,6 +108,7 @@ const config: (
       href: '/buy-crypto',
       icon: ShoppingBasketIcon,
       fillIcon: ShoppingBasketFilledIcon,
+      showItemsOnMobile: false,
       items: [],
     },
     {

--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -108,12 +108,7 @@ const config: (
       href: '/buy-crypto',
       icon: ShoppingBasketIcon,
       fillIcon: ShoppingBasketFilledIcon,
-      items: [
-        {
-          label: t('Buy Crypto'),
-          href: '/buy-crypto',
-        },
-      ].map((item) => addMenuItemSupported(item, chainId)),
+      items: [],
     },
     {
       label: t('Earn'),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the "Buy Crypto" menu item and adds a new configuration option `showItemsOnMobile` to the Menu component.

### Detailed summary
- Removed "Buy Crypto" menu item
- Added `showItemsOnMobile: false` configuration option
- Cleared out the `items` array

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->