### PR TITLE
fix: Farm BCakeBoosterCard buttons not clickable on mobile

### DIFF
--- a/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/BCakeBoosterCard.tsx
+++ b/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/BCakeBoosterCard.tsx
@@ -36,7 +36,6 @@ export const CardWrapper = styled.div`
 `
 export const ImageWrapper = styled.div`
   position: absolute;
-  top: 50%;
   transform: translateY(-50%) scale(75%);
   right: auto;
   ${({ theme }) => theme.mediaQueries.sm} {

--- a/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/BCakeBoosterCard.tsx
+++ b/apps/web/src/views/Farms/components/YieldBooster/components/bCakeV3/BCakeBoosterCard.tsx
@@ -36,13 +36,10 @@ export const CardWrapper = styled.div`
 `
 export const ImageWrapper = styled.div`
   position: absolute;
-  top: -50px;
+  top: 50%;
   transform: translateY(-50%) scale(75%);
-  right: 10px;
+  right: auto;
   ${({ theme }) => theme.mediaQueries.sm} {
-    right: auto;
-    top: 50%;
-    left: -70px;
     transform: translateY(-50%);
   }
   z-index: 2;
@@ -98,7 +95,7 @@ export const BCakeBoosterCard: React.FC<{ variants?: 'farm' | 'pm' }> = ({ varia
   })
   return (
     <CardWrapper>
-      <ImageWrapper style={{ left: variants === 'pm' ? -185 : isMobile ? -110 : -70, top: 105 }}>
+      <ImageWrapper style={{ left: variants === 'pm' ? -185 : isMobile ? -65 : -70, top: 105 }}>
         <Image
           src={variants === 'pm' ? boosterCardImagePM : boosterCardImage}
           alt="booster-card-image"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adjusting the positioning of an image in the `BCakeBoosterCard` component based on the `variants` and device type.

### Detailed summary
- Updated the `right` positioning in `ImageWrapper` styled component.
- Adjusted the `left` positioning of the image based on `variants` and device type in `BCakeBoosterCard`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->