### PR TITLE
fix: Duplicate token address

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -34,7 +34,7 @@ export const livePools: SerializedPool[] = [
   {
     sousId: 376,
     stakingToken: bscTokens.cake,
-    earningToken: bscTokens.via,
+    earningToken: bscTokens.octavia,
     contractAddress: '0x0043bc9b395245B63eA548Bb11c7d2609Bf7B327',
     poolCategory: PoolCategory.CORE,
     tokenPerBlock: '0.01157',

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3109,14 +3109,6 @@ export const bscTokens = {
     'Grape coin',
     'https://www.joingrapes.com/',
   ),
-  via: new ERC20Token(
-    ChainId.BSC,
-    '0x21ac3bB914f90A2Bb1a16088E673a9fdDa641434',
-    18,
-    'VIA',
-    'Octavia',
-    'https://octavia.one/',
-  ),
   ego: new ERC20Token(
     ChainId.BSC,
     '0x44a21B3577924DCD2e9C81A3347D204C36a55466',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the earning token for pool 56 from `bscTokens.via` to `bscTokens.octavia` and changes the token information for `bscTokens.octavia`.

### Detailed summary
- Updated earning token for pool 56 to `bscTokens.octavia`
- Changed token details for `bscTokens.octavia`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->