### PR TITLE
perf: remove tooltipVisible state in gauge chart

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/ChartTooltip.tsx
+++ b/apps/web/src/views/GaugesVoting/components/ChartTooltip.tsx
@@ -46,11 +46,10 @@ export const OTHERS_GAUGES = '0xOTHERS'
 
 export const ChartTooltip: React.FC<{
   color: string
-  visible: boolean
   gauge?: Gauge
   total?: number
   sort: string
-}> = ({ color, sort, gauge, visible, total }) => {
+}> = ({ color, sort, gauge, total }) => {
   const { isDesktop } = useMatchBreakpoints()
   const percent = useMemo(() => {
     return new Percent(gauge?.weight ?? 0, total || 1).toFixed(2)
@@ -64,7 +63,7 @@ export const ChartTooltip: React.FC<{
     return gauge?.hash === OTHERS_GAUGES ? gauge?.pairName.split('|')[1] : GAUGE_TYPE_NAMES[gauge.type]
   }, [gauge])
 
-  if (!visible) return null
+  if (!gauge) return null
 
   return (
     <Tooltip color={color}>

--- a/apps/web/src/views/GaugesVoting/components/WeightsPieChart.tsx
+++ b/apps/web/src/views/GaugesVoting/components/WeightsPieChart.tsx
@@ -79,7 +79,6 @@ export const WeightsPieChart: React.FC<{
   isLoading?: boolean
 }> = ({ data, totalGaugesWeight, isLoading }) => {
   const tooltipRef = useRef<string | null>(null)
-  const [tooltipVisible, setTooltipVisible] = useState(false)
   const [tooltipPosition, setTooltipPosition] = useState({ left: 0, top: 0 })
   const [selectedGauge, setSelectedGauge] = useState<Gauge>()
   const sortedGauge = useMemo<Gauge[]>(() => data?.sort((a, b) => (a.weight < b.weight ? 1 : -1)) ?? [], [data])
@@ -139,7 +138,6 @@ export const WeightsPieChart: React.FC<{
     ({ tooltip }: { tooltip: TooltipModel<'doughnut'>; chart: ChartJS }) => {
       // hide tooltip
       if (tooltip.opacity === 0) {
-        setTooltipVisible(false)
         setSelectedGauge(undefined)
         tooltipRef.current = null
         return
@@ -153,7 +151,6 @@ export const WeightsPieChart: React.FC<{
       tooltipRef.current = `${tooltip.x},${tooltip.y}`
       setSelectedGauge(topGaugesAndOthers?.find((gauge) => gauge.hash === tooltip.title[0]))
       setColor(tooltip.labelColors[0].backgroundColor as string)
-      setTooltipVisible(true)
       setTooltipPosition({
         // left: tooltip.caretX,
         // top: tooltip.caretY,
@@ -166,7 +163,6 @@ export const WeightsPieChart: React.FC<{
 
   const tooltipComp = (
     <ChartTooltip
-      visible={tooltipVisible}
       total={totalGaugesWeight}
       color={color}
       gauge={selectedGauge}

--- a/apps/web/src/views/GaugesVoting/components/WeightsPieChart.tsx
+++ b/apps/web/src/views/GaugesVoting/components/WeightsPieChart.tsx
@@ -162,12 +162,7 @@ export const WeightsPieChart: React.FC<{
   )
 
   const tooltipComp = (
-    <ChartTooltip
-      total={totalGaugesWeight}
-      color={color}
-      gauge={selectedGauge}
-      sort={selectedGaugeSort}
-    />
+    <ChartTooltip total={totalGaugesWeight} color={color} gauge={selectedGauge} sort={selectedGaugeSort} />
   )
   const tooltipNode = isDesktop ? (
     <Absolute left={tooltipPosition.left} top={tooltipPosition.top}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

Its unnecessary to use tooltipVisible since selectedGauge can cover everything you needed

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes unnecessary tooltip visibility state from `WeightsPieChart` and simplifies `ChartTooltip` component in the GaugesVoting feature.

### Detailed summary
- Removed `tooltipVisible` state from `WeightsPieChart`
- Simplified `ChartTooltip` component by removing `visible` prop
- Updated dependencies and removed unused code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->