### PR TITLE
feat: List solvBtcb-btcb farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 164,
+    token0: bscTokens.solvbtc,
+    token1: bscTokens.btcb,
+    lpAddress: '0x4aae823a6a0b376De6A78e74eCC5b079d38cBCf7',
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 163,
     token0: bscTokens.weEth,
     token1: bscTokens.eth,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -79,7 +79,7 @@ export const farmsV3 = defineFarmV3Configs([
     pid: 164,
     token0: bscTokens.solvbtc,
     token1: bscTokens.btcb,
-    lpAddress: '0x4aae823a6a0b376De6A78e74eCC5b079d38cBCf7',
+    lpAddress: '0x12197d7a4fE2d67F9f97ae64D82A44c24B7Ad407',
     feeAmount: FeeAmount.LOW,
   },
   {


### PR DESCRIPTION
SolvBTC-BTCb 0.05% v3 0.1x Farm
Lp Address - `0x12197d7a4fE2d67F9f97ae64D82A44c24B7Ad407`


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new liquidity pool configuration for BSC farms.

### Detailed summary
- Added a new liquidity pool configuration with PID 164
- Tokens involved: `solvbtc` and `btcb`
- LP address: `0x4aae823a6a0b376De6A78e74eCC5b079d38cBCf7`
- Fee amount set to `LOW`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->