### PR TITLE
perf: Countdown dynamic style

### DIFF
--- a/apps/web/src/components/PhishingWarningBanner/Countdown.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/Countdown.tsx
@@ -1,7 +1,7 @@
 import { ArrowForwardIcon } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
 
-const CountdownContainer = styled.div<{ $percentage: number }>`
+const CountdownContainer = styled.div`
   position: relative;
   margin-left: auto;
   height: 20px;
@@ -29,7 +29,6 @@ const CountdownContainer = styled.div<{ $percentage: number }>`
     }
     > circle:nth-child(2) {
       stroke: ${({ theme }) => theme.colors.primaryBright};
-      stroke-dashoffset: ${({ $percentage }) => `${120 * $percentage}px`};
     }
   }
 
@@ -43,10 +42,17 @@ const CountdownContainer = styled.div<{ $percentage: number }>`
 
 export const Countdown = ({ percentage, onClick }: { percentage: number; onClick?: () => void }) => {
   return (
-    <CountdownContainer $percentage={percentage} onClick={onClick}>
+    <CountdownContainer onClick={onClick}>
       <svg>
         <circle r="9" cx="10" cy="10" />
-        <circle r="9" cx="10" cy="10" />
+        <circle
+          r="9"
+          cx="10"
+          cy="10"
+          style={{
+            strokeDashoffset: `${120 * percentage}px`,
+          }}
+        />
       </svg>
       <ArrowForwardIcon color="primary" />
     </CountdownContainer>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove the `$percentage` prop from the `CountdownContainer` styled component and apply the `strokeDashoffset` style directly to the second circle in the Countdown component.

### Detailed summary
- Removed `$percentage` prop from `CountdownContainer` styled component
- Applied `strokeDashoffset` style directly to the second circle in the Countdown component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->