### PR TITLE
fix: Farms inactive lists are wrong

### DIFF
--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -9,6 +9,7 @@ import {
 } from '@pancakeswap/farms'
 import { useIntersectionObserver } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
+import partition from 'lodash/partition'
 import {
   ArrowForwardIcon,
   Box,
@@ -257,9 +258,10 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [stableSwapOnly, setStableSwapOnly] = useState(false)
   const [farmTypesEnableCount, setFarmTypesEnableCount] = useState(0)
 
-  const activeFarms = useMemo(
+  const [activeFarms, inactiveFarms] = useMemo(
     () =>
-      farmsLP.filter(
+      partition(
+        farmsLP,
         (farm) =>
           farm.pid !== 0 &&
           (farm.multiplier !== '0X' || (farm.version === 2 && farm?.bCakeWrapperAddress)) &&
@@ -267,8 +269,6 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
       ),
     [farmsLP, v2PoolLength, v3PoolLength],
   )
-
-  const inactiveFarms = useMemo(() => farmsLP.filter((farm) => farm.pid !== 0 && farm.multiplier === '0X'), [farmsLP])
 
   const archivedFarms = farmsLP
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the Farms component in the web app to use the `lodash/partition` function for better code organization.

### Detailed summary
- Refactored the `activeFarms` calculation using `lodash/partition` for improved readability
- Removed redundant calculation of `inactiveFarms` using `useMemo`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->