### PR TITLE
fix: V2 inactive farms

### DIFF
--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -330,7 +330,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
       const filterFarmsWithTypes = chosenFs.filter(
         (farm) =>
           (v3FarmOnly && farm.version === 3) ||
-          (v2FarmOnly && farm.version === 2) ||
+          (v2FarmOnly && farm.version === 2 && !farm.isStable) ||
           (boostedOnly && farm.boosted && farm.version === 3) ||
           (stableSwapOnly && farm.version === 2 && farm.isStable),
       )

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -264,7 +264,8 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
         farmsLP,
         (farm) =>
           farm.pid !== 0 &&
-          (farm.multiplier !== '0X' || (farm.version === 2 && farm?.bCakeWrapperAddress)) &&
+          (farm.multiplier !== '0X' ||
+            Boolean(farm.version === 2 && farm?.bCakeWrapperAddress && farm?.bCakePublicData?.isRewardInRange)) &&
           (farm.version === 3 ? !v3PoolLength || v3PoolLength >= farm.pid : !v2PoolLength || v2PoolLength > farm.pid),
       ),
     [farmsLP, v2PoolLength, v3PoolLength],


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update filtering conditions in the FarmsV3 component based on farm properties like multiplier, version, and stability.

### Detailed summary
- Updated filtering condition in FarmsV3 component based on farm properties like multiplier and version
- Added a check for `bCakePublicData.isRewardInRange` in FarmsV3 component
- Updated filtering condition for farms with specific types based on stability and version properties

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->