### PR TITLE
fix: magic token name

### DIFF
--- a/.changeset/heavy-bulldogs-teach.md
+++ b/.changeset/heavy-bulldogs-teach.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/tokens': patch
+---
+
+Correction of $MAGIC token name from "Magic Internet Money" to "MAGIC"

--- a/packages/tokens/src/constants/arb.ts
+++ b/packages/tokens/src/constants/arb.ts
@@ -108,7 +108,7 @@ export const arbitrumTokens = {
     '0x539bdE0d7Dbd336b79148AA742883198BBF60342',
     18,
     'MAGIC',
-    'Magic Internet Money',
+    'MAGIC',
     'https://treasure.lol/',
   ),
   wstETH: new ERC20Token(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to correct the token name from "Magic Internet Money" to "MAGIC" in the `arb.ts` file.

### Detailed summary
- Corrected token name from "Magic Internet Money" to "MAGIC" in `arb.ts` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->