### PR TITLE
fix: Nft subgraph indicator shows Down initially

### DIFF
--- a/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
+import { ChainId } from '@pancakeswap/chains'
 
 const SubgraphHealthIndicator = dynamic(() => import('components/SubgraphHealthIndicator'), { ssr: false })
 
 export const FixedSubgraphHealthIndicator = () => {
   const { pathname } = useRouter()
   const isOnNftPages = pathname.includes('nfts')
-  return isOnNftPages ? <SubgraphHealthIndicator subgraphName="pancakeswap/nft-market" /> : null
+  return isOnNftPages ? <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="pancakeswap/nft-market" /> : null
 }

--- a/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
@@ -18,7 +18,16 @@ type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export function subgraphHealthIndicatorFactory({ getSubgraphName }: FactoryParams) {
   return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraphName' | 'chainId'>) {
     const { chainId } = useActiveChainId()
-    const subgraphName = useMemo(() => chainId && getSubgraphName(chainId), [chainId])
+
+    const subgraphName = useMemo(() => {
+      if (props.chainId) {
+        return getSubgraphName(props.chainId)
+      }
+      if (chainId) {
+        return getSubgraphName(chainId)
+      }
+      return undefined
+    }, [chainId, props?.chainId])
 
     if (!subgraphName) {
       return null

--- a/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
@@ -94,7 +94,7 @@ export interface BlockResponse {
 }
 
 export type SubgraphHealthIndicatorProps = React.PropsWithChildren<{
-  chainId?: ChainId
+  chainId: ChainId
   subgraphName: string
   inline?: boolean
   customDescriptions?: CustomDescriptions
@@ -109,7 +109,7 @@ export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = (
   obeyGlobalSetting = true,
 }) => {
   const { t } = useTranslation()
-  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth(chainId, subgraphName)
+  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth({ chainId, subgraphName })
   const [alwaysShowIndicator] = useSubgraphHealthIndicatorManager()
   const forceIndicatorDisplay =
     status === SubgraphStatus.WARNING || status === SubgraphStatus.NOT_OK || status === SubgraphStatus.DOWN

--- a/apps/web/src/hooks/useSubgraphHealth.ts
+++ b/apps/web/src/hooks/useSubgraphHealth.ts
@@ -24,7 +24,7 @@ export type SubgraphHealthState = {
 const NOT_OK_BLOCK_DIFFERENCE = 200 // ~15 minutes delay
 const WARNING_BLOCK_DIFFERENCE = 50 // ~2.5 minute delay
 
-const useSubgraphHealth = (chainId?: ChainId, subgraphName?: string) => {
+const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgraphName?: string }) => {
   const [sgHealth, setSgHealth] = useState<SubgraphHealthState>({
     status: SubgraphStatus.UNKNOWN,
     currentBlock: 0,

--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -85,6 +85,5 @@ export const publicClient = ({ chainId }: { chainId?: ChainId }) => {
   }
 
   const chain = CHAINS.find((c) => c.id === chainId)
-
   return createPublicClient({ chain, transport: http(httpString), ...CLIENT_CONFIG })
 }

--- a/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
@@ -8,14 +8,9 @@ const useShowWarningMessage = () => {
   const subgraphName = chainId
     ? V3_SUBGRAPH_URLS[chainId]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
     : ''
-  const { status } = useSubgraphHealth(subgraphName)
+  const { status } = useSubgraphHealth({ chainId, subgraphName })
 
-  return useMemo(() => {
-    if (status === SubgraphStatus.DOWN) {
-      return true
-    }
-    return false
-  }, [status])
+  return status === SubgraphStatus.DOWN
 }
 
 export default useShowWarningMessage

--- a/apps/web/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
+++ b/apps/web/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
@@ -3,6 +3,7 @@ import { Text, Flex, Box, Grid, ArrowBackIcon, ArrowForwardIcon } from '@pancake
 import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
+import { ChainId } from '@pancakeswap/chains'
 import NoOrdersMessage from './NoOrdersMessage'
 import { ORDER_CATEGORY } from '../../types'
 import LoadingTable from './LoadingTable'
@@ -86,7 +87,7 @@ const TableNavigation: React.FC<TableNavigationProps> = ({
           </Arrow>
         </Flex>
         <Flex width="100%" justifyContent={['center', null, null, null, 'flex-end']}>
-          <SubgraphHealthIndicator subgraphName="gelatodigital/limit-orders-bsc" inline />
+          <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="gelatodigital/limit-orders-bsc" inline />
         </Flex>
       </Grid>
     </>

--- a/apps/web/src/views/Pottery/components/Pot/Claim/index.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/Claim/index.tsx
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js'
 import { BIG_ONE } from '@pancakeswap/utils/bigNumber'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
 import { useAccount } from 'wagmi'
+import { ChainId } from '@pancakeswap/chains'
 import YourDeposit from '../YourDeposit'
 import WalletNotConnected from './WalletNotConnected'
 import AvailableWithdraw from './AvailableWithdraw'
@@ -40,7 +41,7 @@ const Claim: React.FC<React.PropsWithChildren> = () => {
       {account ? (
         <Container>
           <GreyCard>
-            <SubgraphHealthIndicator inline subgraphName="pancakeswap/pottery" />
+            <SubgraphHealthIndicator inline chainId={ChainId.BSC} subgraphName="pancakeswap/pottery" />
             <Flex justifyContent="space-between" mb="20px">
               <YourDeposit depositBalance={allDeposit} />
             </Flex>

--- a/apps/web/src/views/Pottery/index.tsx
+++ b/apps/web/src/views/Pottery/index.tsx
@@ -6,6 +6,7 @@ import Banner from 'views/Pottery/components/Banner/index'
 import Pot from 'views/Pottery/components/Pot/index'
 import { useTranslation } from '@pancakeswap/localization'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
+import { ChainId } from '@pancakeswap/chains'
 import FinishedRounds from './components/FinishedRounds'
 import HowToPlay from './components/HowToPlay'
 import PrizeFunds from './components/PrizeFunds'
@@ -52,7 +53,7 @@ const Pottery: React.FC<React.PropsWithChildren> = () => {
       <FAQ />
       {createPortal(
         <>
-          <SubgraphHealthIndicator subgraphName="pancakeswap/pottery" />
+          <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="pancakeswap/pottery" />
         </>,
         document.body,
       )}

--- a/apps/web/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
+++ b/apps/web/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@pancakeswap/uikit'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
 import { useTranslation } from '@pancakeswap/localization'
+import { ChainId } from '@pancakeswap/chains'
 import { LeaderboardDataItem, TeamRanksProps } from '../../../types'
 import TopTradersGrid from './TopTradersGrid'
 
@@ -77,6 +78,7 @@ const TopTradersCard: React.FC<React.PropsWithChildren<TeamRanksProps & { subgra
             </Flex>
             {subgraphName && (
               <SubgraphHealthIndicator
+                chainId={ChainId.BSC}
                 subgraphName={subgraphName}
                 inline
                 obeyGlobalSetting={false}

--- a/apps/web/src/views/TradingCompetition/components/YourScore/ScoreCard.tsx
+++ b/apps/web/src/views/TradingCompetition/components/YourScore/ScoreCard.tsx
@@ -17,6 +17,7 @@ import { CLAIM, OVER } from 'config/constants/trading-competition/phases'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
 import { useTranslation } from '@pancakeswap/localization'
+import { ChainId } from '@pancakeswap/chains'
 import ClaimModal from '../ClaimModal'
 import CardUserInfo from './CardUserInfo'
 import ShareImageModal from '../ShareImageModal'
@@ -151,6 +152,7 @@ const ScoreCard: React.FC<React.PropsWithChildren<ScoreCardProps>> = ({
       {subgraphName && hasRegistered && (
         <Flex p="16px" justifyContent="flex-end">
           <SubgraphHealthIndicator
+            chainId={ChainId.BSC}
             subgraphName={subgraphName}
             inline
             obeyGlobalSetting={false}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates multiple components to pass `chainId` along with `subgraphName` for better health indicator tracking.

### Detailed summary
- Updated `useSubgraphHealth` to accept an object with `chainId` and `subgraphName`
- Added `chainId` prop to `SubgraphHealthIndicator` in various components
- Modified `SubgraphHealthIndicatorProps` to require `chainId` instead of optional
- Refactored usage of `useSubgraphHealth` to pass `chainId` and `subgraphName` as an object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->