### PR TITLE
chore: update bribe tooltip, remove aptos reward farm

### DIFF
--- a/apps/aptos/config/constants/aptRewardFarm/1.ts
+++ b/apps/aptos/config/constants/aptRewardFarm/1.ts
@@ -1,9 +1,3 @@
 import { AptRewardFarm } from './type'
 
-export const farms: AptRewardFarm[] = [
-  {
-    lpSymbol: 'GUI-APT LP',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xe4ccb6d39136469f376242c31b34d10515c8eaaa38092f804db8e08a8f53c5b2::assets_v1::EchoCoin002>',
-  },
-]
+export const farms: AptRewardFarm[] = []

--- a/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
+++ b/apps/web/src/views/CakeStaking/components/DataSet/TotalApy.tsx
@@ -173,6 +173,9 @@ export const TotalApy: React.FC<React.PropsWithChildren<TotalApyProps>> = ({ veC
       <Link mt="8px" external href="https://hiddenhand.finance/pancakeswap">
         {t('Hiddenhand')}
       </Link>
+      <Link mt="8px" external href="https://www.pancake.magpiexyz.io/vecake-bribe">
+        {t('Cakepie')}
+      </Link>
     </Box>,
     {
       placement: 'top',

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3361,5 +3361,6 @@
   "Get up to $8M USD in interface fees refunded on PancakeSwap": "Get up to $8M USD in interface fees refunded on PancakeSwap",
   "Match your Uni volume on PancakeSwap to get a refund of up to": "Match your Uni volume on PancakeSwap to get a refund of up to",
   "$8M USD": "$8M USD",
-  "in Uniswap interface fees paid": "in Uniswap interface fees paid"
+  "in Uniswap interface fees paid": "in Uniswap interface fees paid",
+  "Cakepie": "Cakepie"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new external link in `TotalApy.tsx` and updates translations in `translations.json`. It also removes an item from `farms` in `1.ts`.

### Detailed summary
- Added external link for Cakepie in `TotalApy.tsx`
- Updated translations in `translations.json`
- Removed an item from `farms` in `1.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

#### Add Cakepie to Bribe tooltip in Cake Staking
#### Remove GUI-APT LP from reward farms