### PR TITLE
fix: Use sg indicator the places where it is used

### DIFF
--- a/apps/web/src/pages/liquidity/index.tsx
+++ b/apps/web/src/pages/liquidity/index.tsx
@@ -22,7 +22,6 @@ import { Liquidity } from '@pancakeswap/widgets-internal'
 import { AppBody, AppHeader } from 'components/App'
 import TransactionsModal from 'components/App/Transactions/TransactionsModal'
 import { RangeTag } from 'components/RangeTag'
-import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import { V3_MIGRATION_SUPPORTED_CHAINS } from 'config/constants/supportChains'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import useV2PairsByAccount from 'hooks/useV2Pairs'
@@ -362,7 +361,6 @@ export default function PoolListPage() {
             </Button>
           </NextLink>
         </CardFooter>
-        <V3SubgraphHealthIndicator />
       </AppBody>
     </Page>
   )

--- a/apps/web/src/views/Pools/index.tsx
+++ b/apps/web/src/views/Pools/index.tsx
@@ -159,7 +159,6 @@ const Pools: React.FC<React.PropsWithChildren> = () => {
             </>
           )}
         </PoolControls>
-        <V3SubgraphHealthIndicator />
       </Page>
     </>
   )

--- a/apps/web/src/views/PositionManagers/index.tsx
+++ b/apps/web/src/views/PositionManagers/index.tsx
@@ -1,5 +1,6 @@
 import Page from 'components/Layout/Page'
 
+import { V3SubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import { Header } from './components'
 import { Controls, VaultContent } from './containers'
 
@@ -10,6 +11,7 @@ export function PositionManagers() {
       <Page>
         <Controls />
         <VaultContent />
+        <V3SubgraphHealthIndicator />
       </Page>
     </>
   )

--- a/apps/web/src/views/Predictions/Leaderboard/index.tsx
+++ b/apps/web/src/views/Predictions/Leaderboard/index.tsx
@@ -9,6 +9,7 @@ import { filterLeaderboard } from 'state/predictions'
 import { useGetLeaderboardFilters, useGetLeaderboardLoadingState } from 'state/predictions/hooks'
 import { usePredictionConfigs } from 'views/Predictions/hooks/usePredictionConfigs'
 import { useAccount } from 'wagmi'
+import { PredictionSubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import Filters from './components/Filters'
 import Hero from './components/Hero'
 import Results from './components/Results'
@@ -74,6 +75,7 @@ const Leaderboard = () => {
         token={predictionConfigs?.[pickedTokenSymbol]?.token}
         api={predictionConfigs?.[pickedTokenSymbol]?.api ?? ''}
       />
+      <PredictionSubgraphHealthIndicator />
     </>
   )
 }

--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -1,6 +1,5 @@
 import { PredictionsChartView } from '@pancakeswap/prediction'
 import { useMatchBreakpoints, useModal } from '@pancakeswap/uikit'
-import { PredictionSubgraphHealthIndicator } from 'components/SubgraphHealthIndicator'
 import { useAccountLocalEventListener } from 'hooks/useAccountLocalEventListener'
 import { useEffect, useRef } from 'react'
 import { useChartView, useIsChartPaneOpen } from 'state/predictions/hooks'

--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -63,7 +63,6 @@ const Predictions = () => {
           <CollectWinningsPopup />
         </Container>
       </SwiperProvider>
-      <PredictionSubgraphHealthIndicator />
     </>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `V3SubgraphHealthIndicator` and `PredictionSubgraphHealthIndicator` components to various views for monitoring subgraph health.

### Detailed summary
- Added `V3SubgraphHealthIndicator` to `PositionManagers` view
- Removed `V3SubgraphHealthIndicator` from `liquidity` index
- Added `PredictionSubgraphHealthIndicator` to `Leaderboard` view

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->