### PR TITLE
chore: list syrup pool on BSC

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -19,7 +19,7 @@ export const livePools: SerializedPool[] = [
     earningToken: bscTokens.pepe,
     contractAddress: '0x9f84B0684FB7D4055d672884BDdABA90A7FD5b9f',
     poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '2,445.2269',
+    tokenPerBlock: '2445.2269',
   },
   {
     sousId: 379,

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,14 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 380,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.pepe,
+    contractAddress: '0x9f84B0684FB7D4055d672884BDdABA90A7FD5b9f',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '2,445.2269',
+  },
+  {
     sousId: 379,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.solvbtc,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool with `sousId: 380` featuring `bscTokens.cake` as staking token and `bscTokens.pepe` as earning token.

### Detailed summary
- Added a new pool with `sousId: 380`
- Staking token: `bscTokens.cake`
- Earning token: `bscTokens.pepe`
- Contract address: '0x9f84B0684FB7D4055d672884BDdABA90A7FD5b9f'
- Pool category: `CORE`
- Token per block: '2445.2269'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->