### PR TITLE
fix: show skeleton when new quote is fetching

### DIFF
--- a/apps/web/src/state/buyCrypto/reducer.ts
+++ b/apps/web/src/state/buyCrypto/reducer.ts
@@ -13,10 +13,10 @@ export interface BuyCryptoState {
   readonly typedValue: string | undefined
   readonly independentField: Field
   readonly [Field.INPUT]: {
-    readonly currencyId: string | undefined
+    readonly currencyId: string
   }
   readonly [Field.OUTPUT]: {
-    readonly currencyId: string | undefined
+    readonly currencyId: string
   }
 }
 
@@ -63,8 +63,8 @@ export const reducer = createReducer<BuyCryptoState>(
         }
       })
       .addCase(replaceBuyCryptoState, (state, { payload: { typedValue, inputCurrencyId, outputCurrencyId } }) => {
-        state[Field.INPUT].currencyId = inputCurrencyId
-        state[Field.OUTPUT].currencyId = outputCurrencyId
+        state[Field.INPUT].currencyId = inputCurrencyId ?? ''
+        state[Field.OUTPUT].currencyId = outputCurrencyId ?? ''
         state.typedValue = typedValue
       })
       .addCase(switchCurrencies, (state) => {

--- a/apps/web/src/state/buyCrypto/reducer.ts
+++ b/apps/web/src/state/buyCrypto/reducer.ts
@@ -13,10 +13,10 @@ export interface BuyCryptoState {
   readonly typedValue: string | undefined
   readonly independentField: Field
   readonly [Field.INPUT]: {
-    readonly currencyId: string
+    readonly currencyId: string | undefined
   }
   readonly [Field.OUTPUT]: {
-    readonly currencyId: string
+    readonly currencyId: string | undefined
   }
 }
 
@@ -63,8 +63,8 @@ export const reducer = createReducer<BuyCryptoState>(
         }
       })
       .addCase(replaceBuyCryptoState, (state, { payload: { typedValue, inputCurrencyId, outputCurrencyId } }) => {
-        state[Field.INPUT].currencyId = inputCurrencyId ?? ''
-        state[Field.OUTPUT].currencyId = outputCurrencyId ?? ''
+        state[Field.INPUT].currencyId = inputCurrencyId
+        state[Field.OUTPUT].currencyId = outputCurrencyId
         state.typedValue = typedValue
       })
       .addCase(switchCurrencies, (state) => {

--- a/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
+++ b/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency, Token } from '@pancakeswap/sdk'
-import { ArrowDropDownIcon, Box, BoxProps, Flex, Skeleton, Text, useModal } from '@pancakeswap/uikit'
+import { ArrowDropDownIcon, Box, BoxProps, Flex, SkeletonText, Text, useModal } from '@pancakeswap/uikit'
 import { NumberDisplay, NumericalInput } from '@pancakeswap/widgets-internal'
 import OnRampCurrencySearchModal, { CurrencySearchModalProps } from 'components/SearchModal/OnRampCurrencyModal'
 import { fiatCurrencyMap, getNetworkDisplay, onRampCurrencies } from 'views/BuyCrypto/constants'
@@ -101,12 +101,9 @@ export const BuyCryptoSelector = ({
             }}
           />
         ) : (
-          <NumberDisplay value={inputLoading ? '' : value} />
-        )}
-        {inputLoading && (
-          <Flex position="absolute" zIndex={10}>
-            <Skeleton width="105px" height="26px" variant="round" isDark />
-          </Flex>
+          <SkeletonText initialHeight={25} initialWidth={100} loading={inputLoading}>
+            <NumberDisplay value={value} />
+          </SkeletonText>
         )}
 
         <OptionSelectButton

--- a/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
+++ b/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
@@ -1,26 +1,25 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency, Token } from '@pancakeswap/sdk'
 import { ArrowDropDownIcon, Box, BoxProps, Flex, Skeleton, Text, useModal } from '@pancakeswap/uikit'
-import { NumericalInput } from '@pancakeswap/widgets-internal'
+import { NumberDisplay, NumericalInput } from '@pancakeswap/widgets-internal'
 import OnRampCurrencySearchModal, { CurrencySearchModalProps } from 'components/SearchModal/OnRampCurrencyModal'
-import { ReactNode } from 'react'
 import { fiatCurrencyMap, getNetworkDisplay, onRampCurrencies } from 'views/BuyCrypto/constants'
-import { DropDownContainer, OptionSelectButton, StyledCircle } from 'views/BuyCrypto/styles'
+import { DropDownContainer, OptionSelectButton } from 'views/BuyCrypto/styles'
 import { OnRampUnit } from 'views/BuyCrypto/types'
 import { OnRampCurrencyLogo } from '../OnRampProviderLogo/OnRampProviderLogo'
 
 interface BuyCryptoSelectorProps extends Omit<CurrencySearchModalProps, 'mode'>, BoxProps {
   id: 'onramp-fiat' | 'onramp-crypto'
+  currencyLoading: boolean
+  inputLoading?: boolean
   value: string
   onUserInput?: (value: string) => void
   disableCurrencySelect?: boolean
   error?: boolean
   errorText?: string
   onInputBlur?: () => void
-  disabled?: boolean
-  loading?: boolean
-  topElement?: ReactNode
-  bottomElement?: ReactNode
+  disableInput?: boolean
+  unit: OnRampUnit
 }
 
 const ButtonAsset = ({
@@ -59,19 +58,6 @@ const ButtonAsset = ({
   )
 }
 
-interface BuyCryptoSelectorProps extends Omit<CurrencySearchModalProps, 'mode'>, BoxProps {
-  id: 'onramp-fiat' | 'onramp-crypto'
-  currencyLoading: boolean
-  value: string
-  onUserInput?: (value: string) => void
-  disableCurrencySelect?: boolean
-  error?: boolean
-  errorText?: string
-  onInputBlur?: () => void
-  disableInput?: boolean
-  unit: OnRampUnit
-}
-
 export const BuyCryptoSelector = ({
   onCurrencySelect,
   onUserInput,
@@ -80,6 +66,7 @@ export const BuyCryptoSelector = ({
   otherSelectedCurrency,
   id,
   currencyLoading,
+  inputLoading = false,
   error,
   value,
   disableInput = false,
@@ -99,34 +86,36 @@ export const BuyCryptoSelector = ({
   )
 
   return (
-    <Box width="100%" {...props}>
-      <DropDownContainer error={error as any}>
-        {!disableInput && <StyledCircle />}
-        <NumericalInput
-          error={error}
-          disabled={disableInput || !selectedCurrency}
-          loading={!selectedCurrency}
-          className="token-amount-input"
-          value={value}
-          onBlur={onInputBlur}
-          onUserInput={(val) => {
-            onUserInput?.(val)
-          }}
-          align="left"
-        />
+    <Box width="100%" {...props} position="relative">
+      <DropDownContainer error={Boolean(error)}>
+        {!disableInput ? (
+          <NumericalInput
+            error={error}
+            align="left"
+            loading={!selectedCurrency}
+            className="token-amount-input"
+            value={inputLoading ? '' : value}
+            onBlur={onInputBlur}
+            onUserInput={(val) => {
+              onUserInput?.(val)
+            }}
+          />
+        ) : (
+          <NumberDisplay value={inputLoading ? '' : value} />
+        )}
+        {inputLoading && (
+          <Flex position="absolute" zIndex={10}>
+            <Skeleton width="105px" height="26px" variant="round" isDark />
+          </Flex>
+        )}
+
         <OptionSelectButton
           className="open-currency-select-button"
           selected={!!selectedCurrency}
           onClick={onPresentCurrencyModal}
         >
-          {selectedCurrency ? (
-            <ButtonAsset id={id} selectedCurrency={selectedCurrency as Currency} currencyLoading={currencyLoading} />
-          ) : (
-            <Flex>
-              <Skeleton width="105px" height="26px" variant="round" isDark />
-            </Flex>
-          )}
-          {selectedCurrency && <ArrowDropDownIcon color="primary" />}
+          <ButtonAsset id={id} selectedCurrency={selectedCurrency as Currency} currencyLoading={currencyLoading} />
+          <ArrowDropDownIcon color="primary" />
         </OptionSelectButton>
       </DropDownContainer>
     </Box>

--- a/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
@@ -77,7 +77,7 @@ export function BuyCryptoForm() {
     unit,
   })
 
-  const { data, isFetching, isError, refetch } = useOnRampQuotes({
+  const { data, isLoading, isError, refetch } = useOnRampQuotes({
     cryptoCurrency: cryptoCurrency?.symbol,
     fiatCurrency: fiatCurrency?.symbol,
     network: cryptoCurrency?.chainId,
@@ -142,7 +142,7 @@ export function BuyCryptoForm() {
         selectedQuote={selectedQuote}
         isError={isError}
         inputError={inputError}
-        isFetching={isFetching}
+        isFetching={isLoading}
         setSelectedQuote={setSelectedQuote}
         setShowProvidersPopOver={setShowProvidersPopOver}
         showProivdersPopOver={showProivdersPopOver}
@@ -172,6 +172,7 @@ export function BuyCryptoForm() {
           value={outputValue ?? ''}
           disableInput
           unit={unit}
+          inputLoading={Boolean(isLoading || inputError || quotesError)}
         />
         <BitcoinAddressInput
           isBtc={isBtc}
@@ -183,7 +184,7 @@ export function BuyCryptoForm() {
           id="provider-select"
           onQuoteSelect={setShowProvidersPopOver}
           selectedQuote={selectedQuote || bestQuoteRef.current}
-          quoteLoading={Boolean(isFetching || inputError || quotesError)}
+          quoteLoading={Boolean(isLoading || inputError || quotesError)}
           quotes={quotes}
         />
 
@@ -201,7 +202,7 @@ export function BuyCryptoForm() {
             cryptoCurrency={cryptoCurrency}
             selectedQuote={selectedQuote}
             disabled={Boolean(isError || quotesError || inputError || btcError)}
-            loading={Boolean(quotesError || isFetching)}
+            loading={Boolean(quotesError || isLoading)}
             resetBuyCryptoState={resetBuyCryptoState}
             btcAddress={debouncedQuery}
             errorText={amountError}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `BuyCryptoForm` component and improve loading states in the `BuyCryptoSelector` component.

### Detailed summary
- Refactored `useOnRampQuotes` hook to use `isLoading` instead of `isFetching`
- Updated loading states in `BuyCryptoForm` component
- Updated loading states and components in `BuyCryptoSelector` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->