### PR TITLE
refactor: Use previous data when farms avg info query changes

### DIFF
--- a/apps/web/src/state/farms/hooks.ts
+++ b/apps/web/src/state/farms/hooks.ts
@@ -93,11 +93,7 @@ export const usePollFarmsAvgInfo = (activeFarms: (V3FarmWithoutStakedValue | V2F
         return {}
       }
 
-      const addresses = activeFarms
-        .map((farm) => farm.lpAddress)
-        .map((lpAddress) => {
-          return lpAddress.toLowerCase()
-        })
+      const addresses = activeFarms.map((farm) => farm.lpAddress?.toLowerCase())
 
       const rawResult: any | undefined = await multiQuery(
         (subqueries) => gql`
@@ -118,9 +114,7 @@ export const usePollFarmsAvgInfo = (activeFarms: (V3FarmWithoutStakedValue | V2F
         client,
       )
 
-      const results = mapKeys(rawResult, (_, key) => {
-        return key.substring(1, key.length)
-      })
+      const results = mapKeys(rawResult, (_, key) => key.substring(1, key.length))
 
       return mapValues(results, (value) => {
         const volumes = value.map((d: { volumeUSD: string }) => Number(d.volumeUSD))

--- a/apps/web/src/state/farms/hooks.ts
+++ b/apps/web/src/state/farms/hooks.ts
@@ -79,7 +79,12 @@ export const usePollFarmsAvgInfo = (activeFarms: (V3FarmWithoutStakedValue | V2F
 
   const { data } = useQuery({
     queryKey: ['farmsAvgInfo', chainId, activeFarmAddresses],
-    placeholderData: {},
+    placeholderData: (prev) => {
+      if (!prev) {
+        return {}
+      }
+      return prev
+    },
     queryFn: async () => {
       if (!chainId) return undefined
       const client = v3Clients[chainId]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the placeholder data function in the `useQuery` hook and optimize the manipulation of farm addresses.

### Detailed summary
- Updated `placeholderData` function to return an empty object if previous data is not available
- Optimized the manipulation of farm addresses using the `map` function
- Simplified the key manipulation process in the `mapKeys` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->