### PR TITLE
fix: ignore expired proxy vote

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useUserVote.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVote.ts
@@ -122,12 +122,14 @@ export const useUserVote = (gauge: Gauge | undefined, submitted?: boolean, usePr
         let ignoredSlope = 0n
         let ignoredPower = 0n
         let ignoredSide: 'native' | 'proxy' | undefined
+        const nativeExpired = nativeEnd > 0n && nativeEnd < currentEpochStart
+        const proxyExpired = proxyEnd > 0n && proxyEnd < currentEpochStart
         const nativeWillExpire = nativeEnd > 0n && nativeEnd > currentEpochStart && nativeEnd < nextEpochStart
         const proxyWillExpire = proxyEnd > 0n && proxyEnd > currentEpochStart && proxyEnd < nextEpochStart
 
         // when native slope will expire before current epochEnd
         // use proxy slope only
-        if (nativeWillExpire && !proxyWillExpire) {
+        if ((nativeWillExpire && !proxyWillExpire) || (nativeExpired && !proxyExpired)) {
           ignoredSlope = nativeSlope
           ignoredPower = nativePower
           ignoredSide = 'native'
@@ -136,7 +138,7 @@ export const useUserVote = (gauge: Gauge | undefined, submitted?: boolean, usePr
         }
         // when proxy slope will expire before current epochEnd
         // use native slope only
-        if (proxyWillExpire && !nativeWillExpire) {
+        if ((proxyWillExpire && !nativeWillExpire) || (proxyExpired && !nativeExpired)) {
           ignoredSlope = proxySlope
           ignoredPower = proxyPower
           ignoredSide = 'proxy'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useUserVote` hook in `GaugesVoting` view to consider expired slopes when determining which slope to use.

### Detailed summary
- Introduces `nativeExpired` and `proxyExpired` variables
- Considers expired slopes when determining which slope to use in `useUserVote` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->