### PR TITLE
revert: "feat: v2 tvl chart explorer"

### DIFF
--- a/apps/web/src/state/info/api/hooks.ts
+++ b/apps/web/src/state/info/api/hooks.ts
@@ -2,8 +2,8 @@ import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 import type { components } from './schema'
 
-export const useExplorerChainNameByQuery = (): components['schemas']['ChainName'] | undefined => {
-  const { query, isReady } = useRouter()
+export const useExplorerChainNameByQuery = (): components['schemas']['ChainName'] => {
+  const { query } = useRouter()
   const chainName = useMemo(() => {
     switch (query?.chainName) {
       case 'eth':
@@ -25,5 +25,5 @@ export const useExplorerChainNameByQuery = (): components['schemas']['ChainName'
     }
   }, [query])
 
-  return isReady ? chainName : undefined
+  return chainName
 }

--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -15,7 +15,7 @@ import fetchPoolsForToken from 'state/info/queries/tokens/poolsForToken'
 import fetchTokenPriceData from 'state/info/queries/tokens/priceData'
 import { fetchAllTokenData, fetchAllTokenDataByAddresses } from 'state/info/queries/tokens/tokenData'
 import fetchTokenTransactions from 'state/info/queries/tokens/transactions'
-import { Block, Transaction, TransactionType, TvlChartEntry, VolumeChartEntry } from 'state/info/types'
+import { Block, Transaction, TransactionType } from 'state/info/types'
 import { getAprsForStableFarm } from 'utils/getAprsForStableFarm'
 import { getDeltaTimestamps } from 'utils/getDeltaTimestamps'
 import { getLpFeesAndApr } from 'utils/getLpFeesAndApr'
@@ -47,7 +47,7 @@ const QUERY_SETTINGS_INTERVAL_REFETCH = {
   ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
 }
 
-export const useProtocolDataQueryOld = (): ProtocolData | undefined => {
+export const useProtocolDataQuery = (): ProtocolData | undefined => {
   const chainName = useChainNameByQuery()
   const [t24, t48] = getDeltaTimestamps()
   const { blocks } = useBlockFromTimeStampQuery([t24, t48])
@@ -61,122 +61,6 @@ export const useProtocolDataQueryOld = (): ProtocolData | undefined => {
     ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
   })
   return protocolData ?? undefined
-}
-
-export const useProtocolDataQuery = (): ProtocolData | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data: protocolData } = useQuery({
-    queryKey: [`info/protocol/updateProtocolData2/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/protocol/{protocol}/{chainName}/stats', {
-          signal,
-          params: {
-            path: {
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-          },
-        })
-        .then((res) => {
-          if (res.data) {
-            return {
-              volumeUSD: res.data.totalVolumeUSD ? +res.data.totalVolumeUSD : 0,
-              volumeUSDChange: 0,
-              liquidityUSD: +res.data.tvlUSD,
-              liquidityUSDChange: 0,
-              txCount: res.data.totalTxCount ? +res.data.totalTxCount : 0,
-              txCountChange: 0,
-            }
-          }
-          throw new Error('No data')
-        })
-    },
-    enabled: Boolean(chainName),
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return protocolData ?? undefined
-}
-
-export const useProtocolChartDataTvlQuery = (): TvlChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data: chartData } = useQuery({
-    queryKey: [`info/protocol/chart/tvl/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/protocol/chart/{protocol}/{chainName}/tvl', {
-          signal,
-          params: {
-            path: {
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              groupBy: '1D',
-            },
-          },
-        })
-        .then(
-          (res) =>
-            res.data?.map((d) => {
-              return {
-                date: dayjs(d.bucket as string).unix(),
-                liquidityUSD: d.tvlUSD ? +d.tvlUSD : 0,
-              }
-            }) ?? [],
-        )
-    },
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return chartData ?? undefined
-}
-
-export const useProtocolChartDataVolumeQuery = (): VolumeChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data: chartData } = useQuery({
-    queryKey: [`info/protocol/chart/volume/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/protocol/chart/{protocol}/{chainName}/volume', {
-          signal,
-          params: {
-            path: {
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              groupBy: '1D',
-            },
-          },
-        })
-        .then(
-          (res) =>
-            res.data?.map((d) => {
-              return {
-                date: dayjs(d.bucket as string).unix(),
-                volumeUSD: d.volumeUSD ? +d.volumeUSD : 0,
-              }
-            }) ?? [],
-        )
-    },
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return chartData ?? undefined
 }
 
 export const useProtocolChartDataQuery = (): ChartEntry[] | undefined => {
@@ -211,9 +95,6 @@ export const useProtocolTransactionsQuery = (): Transaction[] | undefined => {
   const { data: transactions } = useQuery({
     queryKey: [`info/protocol/updateProtocolTransactionsData2/${type}`, chainName],
     queryFn: ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       if ((type === 'stableSwap' && chainName === 'bsc') || chainName === 'arbitrum') {
         return explorerApiClient
           .GET('/cached/tx/stable/{chainName}/recent', {
@@ -289,9 +170,6 @@ export const useAllPoolDataQuery = () => {
   const { data } = useQuery({
     queryKey: [`info/pools2/data/${type}`, chainName],
     queryFn: () => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       if (type === 'stableSwap' && (chainName === 'bsc' || chainName === 'arbitrum')) {
         return explorerApiClient
           .GET('/cached/pools/stable/{chainName}/list/top', {
@@ -409,79 +287,6 @@ export const usePoolChartDataQuery = (address: string): ChartEntry[] | undefined
   return data?.data ?? undefined
 }
 
-export const usePoolChartTvlDataQuery = (address: string): TvlChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data } = useQuery({
-    queryKey: [`info/pool/chartData/tvl/${address}/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/pools/chart/{protocol}/{chainName}/{address}/tvl', {
-          signal,
-          params: {
-            path: {
-              address,
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              period: '1Y',
-            },
-          },
-        })
-        .then((res) =>
-          res?.data?.map((d) => ({
-            date: dayjs(d.bucket as string).unix(),
-            liquidityUSD: d.tvlUSD ? +d.tvlUSD : 0,
-          })),
-        )
-    },
-    enabled: Boolean(chainName),
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return data ?? undefined
-}
-export const usePoolChartVolumeDataQuery = (address: string): VolumeChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data } = useQuery({
-    queryKey: [`info/pool/chartData/volume/${address}/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/pools/chart/{protocol}/{chainName}/{address}/volume', {
-          signal,
-          params: {
-            path: {
-              address,
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              period: '1Y',
-            },
-          },
-        })
-        .then((res) =>
-          res.data?.map((d) => ({
-            date: dayjs(d.bucket as string).unix(),
-            volumeUSD: d.volumeUSD ? +d.volumeUSD : 0,
-          })),
-        )
-    },
-    enabled: Boolean(chainName),
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return data ?? undefined
-}
-
 export const usePoolTransactionsQueryOld = (address: string): Transaction[] | undefined => {
   const chainName = useChainNameByQuery()
   const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
@@ -500,9 +305,6 @@ export const usePoolTransactionsQuery = (address: string): Transaction[] | undef
   const { data } = useQuery({
     queryKey: [`info/pool/transactionsData2/${address}/${type}`, chainName],
     queryFn: ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       if (type === 'stableSwap' && (chainName === 'bsc' || chainName === 'arbitrum')) {
         return explorerApiClient
           .GET('/cached/tx/stable/{chainName}/recent', {
@@ -622,9 +424,6 @@ export const useAllTokenDataQuery = (): {
   const { data } = useQuery({
     queryKey: [`info/token/data2/${type}`, chainName],
     queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       const final: { [address: string]: { data?: TokenData } } = {}
       let data_
 
@@ -760,79 +559,6 @@ export const useTokenChartDataQuery = (address: string): ChartEntry[] | undefine
   return data?.data ?? undefined
 }
 
-export const useTokenChartTvlDataQuery = (address: string): TvlChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data } = useQuery({
-    queryKey: [`info/token/chartData/tvl/${address}/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/tvl', {
-          signal,
-          params: {
-            path: {
-              address,
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              period: '1Y',
-            },
-          },
-        })
-        .then((res) =>
-          res?.data?.map((d) => ({
-            date: dayjs(d.bucket as string).unix(),
-            liquidityUSD: d.tvlUSD ? +d.tvlUSD : 0,
-          })),
-        )
-    },
-    enabled: Boolean(chainName),
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return data ?? undefined
-}
-export const useTokenChartVolumeDataQuery = (address: string): VolumeChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
-  const type = checkIsStableSwap() ? 'stableSwap' : 'swap'
-  const { data } = useQuery({
-    queryKey: [`info/token/chartData/volume/${address}/${type}`, chainName],
-    queryFn: async ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
-      return explorerApiClient
-        .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/volume', {
-          signal,
-          params: {
-            path: {
-              address,
-              chainName,
-              protocol: type === 'stableSwap' ? 'stable' : 'v2',
-            },
-            query: {
-              period: '1Y',
-            },
-          },
-        })
-        .then((res) =>
-          res.data?.map((d) => ({
-            date: dayjs(d.bucket as string).unix(),
-            volumeUSD: d.volumeUSD ? +d.volumeUSD : 0,
-          })),
-        )
-    },
-    enabled: Boolean(chainName),
-    ...QUERY_SETTINGS_IMMUTABLE,
-    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-  })
-  return data ?? undefined
-}
-
 export const useTokenPriceDataQueryOld = (
   address: string,
   interval: number,
@@ -860,9 +586,6 @@ export const useTokenPriceDataQuery = (
   const { data } = useQuery({
     queryKey: [`info/token/priceData2/${address}/${type}`, chainName],
     queryFn: ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       return explorerApiClient
         .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/price', {
           signal,
@@ -913,9 +636,6 @@ export const useTokenTransactionsQuery = (address: string): Transaction[] | unde
   const { data } = useQuery({
     queryKey: [`info/token/transactionsData/${address}/${type}`, chainName],
     queryFn: ({ signal }) => {
-      if (!chainName) {
-        throw new Error('No chain name')
-      }
       if (type === 'stableSwap' && (chainName === 'bsc' || chainName === 'arbitrum')) {
         return explorerApiClient
           .GET('/cached/tx/stable/{chainName}/recent', {

--- a/apps/web/src/state/info/types.ts
+++ b/apps/web/src/state/info/types.ts
@@ -11,16 +11,6 @@ export interface ChartEntry {
   liquidityUSD: number
 }
 
-export interface TvlChartEntry {
-  date: number
-  liquidityUSD: number
-}
-
-export interface VolumeChartEntry {
-  date: number
-  volumeUSD: number
-}
-
 /**
  * Formatted type for Candlestick charts
  */

--- a/apps/web/src/views/Info/Overview/index.tsx
+++ b/apps/web/src/views/Info/Overview/index.tsx
@@ -4,8 +4,7 @@ import Page from 'components/Layout/Page'
 import { useMemo } from 'react'
 import {
   useAllTokenDataQuery,
-  useProtocolChartDataTvlQuery,
-  useProtocolChartDataVolumeQuery,
+  useProtocolChartDataQuery,
   useProtocolDataQuery,
   useProtocolTransactionsQuery,
 } from 'state/info/hooks'
@@ -42,8 +41,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
   } = useTranslation()
 
   const protocolData = useProtocolDataQuery()
-  const volumeChartData = useProtocolChartDataVolumeQuery()
-  const tvlChartData = useProtocolChartDataTvlQuery()
+  const chartData = useProtocolChartDataQuery()
   const transactions = useProtocolTransactionsQuery()
 
   const currentDate = useMemo(
@@ -73,8 +71,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
       <ChartCardsContainer>
         <Card>
           <HoverableChart
-            volumeChartData={volumeChartData}
-            tvlChartData={tvlChartData}
+            chartData={chartData}
             protocolData={protocolData}
             currentDate={currentDate}
             valueProperty="liquidityUSD"
@@ -84,8 +81,7 @@ const Overview: React.FC<React.PropsWithChildren> = () => {
         </Card>
         <Card>
           <HoverableChart
-            volumeChartData={volumeChartData}
-            tvlChartData={tvlChartData}
+            chartData={chartData}
             protocolData={protocolData}
             currentDate={currentDate}
             valueProperty="volumeUSD"

--- a/apps/web/src/views/Info/Pools/PoolPage.tsx
+++ b/apps/web/src/views/Info/Pools/PoolPage.tsx
@@ -33,8 +33,7 @@ import {
   useChainIdByQuery,
   useChainNameByQuery,
   useMultiChainPath,
-  usePoolChartTvlDataQuery,
-  usePoolChartVolumeDataQuery,
+  usePoolChartDataQuery,
   usePoolDatasQuery,
   usePoolTransactionsQuery,
   useStableSwapPath,
@@ -98,10 +97,7 @@ const PoolPage: React.FC<React.PropsWithChildren<{ address: string }>> = ({ addr
   const address = routeAddress.toLowerCase()
 
   const poolData = usePoolDatasQuery(useMemo(() => [address], [address]))[0]
-  // const chartData = usePoolChartDataQuery(address)
-  const tvlChartData = usePoolChartTvlDataQuery(address)
-  const volumeChartData = usePoolChartVolumeDataQuery(address)
-
+  const chartData = usePoolChartDataQuery(address)
   const transactions = usePoolTransactionsQuery(address)
   const chainId = useChainIdByQuery()
   const [poolSymbol, symbol0, symbol1] = useMemo(() => {
@@ -327,7 +323,7 @@ const PoolPage: React.FC<React.PropsWithChildren<{ address: string }>> = ({ addr
                 </Flex>
               </Card>
             </Box>
-            <ChartCard variant="pool" volumeChartData={volumeChartData} tvlChartData={tvlChartData} />
+            <ChartCard variant="pool" chartData={chartData || []} />
           </ContentLayout>
           <Heading mb="16px" mt="40px" scale="lg">
             {t('Transactions')}

--- a/apps/web/src/views/Info/Tokens/TokenPage.tsx
+++ b/apps/web/src/views/Info/Tokens/TokenPage.tsx
@@ -35,8 +35,7 @@ import {
   usePoolDatasQuery,
   usePoolsForTokenQuery,
   useStableSwapPath,
-  useTokenChartTvlDataQuery,
-  useTokenChartVolumeDataQuery,
+  useTokenChartDataQuery,
   useTokenDataQuery,
   useTokenPriceDataQuery,
   useTokenTransactionsQuery,
@@ -92,9 +91,7 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
   const poolsForToken = usePoolsForTokenQuery(address)
   const poolDatas = usePoolDatasQuery(useMemo(() => poolsForToken ?? [], [poolsForToken]))
   const transactions = useTokenTransactionsQuery(address)
-  // const chartData = useTokenChartDataQuery(address)
-  const volumeChartData = useTokenChartVolumeDataQuery(address)
-  const tvlChartData = useTokenChartTvlDataQuery(address)
+  const chartData = useTokenChartDataQuery(address)
 
   // pricing data
   const priceData = useTokenPriceDataQuery(address, ONE_HOUR_SECONDS, DEFAULT_TIME_WINDOW)
@@ -247,13 +244,7 @@ const TokenPage: React.FC<React.PropsWithChildren<{ routeAddress: string }>> = (
                 </Box>
               </Card>
               {/* charts card */}
-              <ChartCard
-                variant="token"
-                volumeChartData={volumeChartData}
-                tvlChartData={tvlChartData}
-                tokenData={tokenData}
-                tokenPriceData={priceData}
-              />
+              <ChartCard variant="token" chartData={chartData} tokenData={tokenData} tokenPriceData={priceData} />
             </ContentLayout>
 
             {/* pools and transaction tables */}

--- a/apps/web/src/views/Info/components/InfoCharts/ChartCard/index.tsx
+++ b/apps/web/src/views/Info/components/InfoCharts/ChartCard/index.tsx
@@ -4,7 +4,7 @@ import { TabToggle, TabToggleGroup } from 'components/TabToggle'
 import dayjs from 'dayjs'
 import dynamic from 'next/dynamic'
 import { useMemo, useState } from 'react'
-import { PriceChartEntry, TokenData, TvlChartEntry, VolumeChartEntry } from 'state/info/types'
+import { ChartEntry, PriceChartEntry, TokenData } from 'state/info/types'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import BarChart from 'views/Info/components/InfoCharts/BarChart'
 import LineChart from 'views/Info/components/InfoCharts/LineChart'
@@ -21,16 +21,14 @@ enum ChartView {
 
 interface ChartCardProps {
   variant: 'pool' | 'token'
-  volumeChartData: VolumeChartEntry[] | undefined
-  tvlChartData: TvlChartEntry[] | undefined
+  chartData: ChartEntry[] | undefined
   tokenData?: TokenData
   tokenPriceData?: PriceChartEntry[]
 }
 
 const ChartCard: React.FC<React.PropsWithChildren<ChartCardProps>> = ({
   variant,
-  volumeChartData,
-  tvlChartData,
+  chartData,
   tokenData,
   tokenPriceData,
 }) => {
@@ -45,8 +43,8 @@ const ChartCard: React.FC<React.PropsWithChildren<ChartCardProps>> = ({
   const currentDate = new Date().toLocaleString(locale, { month: 'short', year: 'numeric', day: 'numeric' })
 
   const formattedTvlData = useMemo(() => {
-    if (tvlChartData) {
-      return tvlChartData.map((day) => {
+    if (chartData) {
+      return chartData.map((day) => {
         return {
           time: dayjs.unix(day.date).toDate(),
           value: day.liquidityUSD,
@@ -54,10 +52,10 @@ const ChartCard: React.FC<React.PropsWithChildren<ChartCardProps>> = ({
       })
     }
     return []
-  }, [tvlChartData])
+  }, [chartData])
   const formattedVolumeData = useMemo(() => {
-    if (volumeChartData) {
-      return volumeChartData.map((day) => {
+    if (chartData) {
+      return chartData.map((day) => {
         return {
           time: dayjs.unix(day.date).toDate(),
           value: day.volumeUSD,
@@ -65,7 +63,7 @@ const ChartCard: React.FC<React.PropsWithChildren<ChartCardProps>> = ({
       })
     }
     return []
-  }, [volumeChartData])
+  }, [chartData])
 
   const getLatestValueDisplay = () => {
     let valueToDisplay: string | undefined = ''

--- a/apps/web/src/views/Info/components/InfoCharts/HoverableChart.tsx
+++ b/apps/web/src/views/Info/components/InfoCharts/HoverableChart.tsx
@@ -1,14 +1,13 @@
-import { Box, Skeleton, Text } from '@pancakeswap/uikit'
+import { Box, Text, Skeleton } from '@pancakeswap/uikit'
 import dayjs from 'dayjs'
-import { memo, useEffect, useMemo, useState } from 'react'
-import { ProtocolData, TvlChartEntry, VolumeChartEntry } from 'state/info/types'
+import { useState, useMemo, memo, useEffect } from 'react'
+import { ChartEntry, ProtocolData } from 'state/info/types'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import BarChart from './BarChart'
 import LineChart from './LineChart'
 
 interface HoverableChartProps {
-  volumeChartData: VolumeChartEntry[] | undefined
-  tvlChartData: TvlChartEntry[] | undefined
+  chartData: ChartEntry[] | undefined
   protocolData: ProtocolData | undefined
   currentDate: string
   valueProperty: string
@@ -17,8 +16,7 @@ interface HoverableChartProps {
 }
 
 const HoverableChart = ({
-  volumeChartData,
-  tvlChartData,
+  chartData,
   protocolData,
   currentDate,
   valueProperty,
@@ -40,9 +38,8 @@ const HoverableChart = ({
   }, [protocolData, hover, valueProperty])
 
   const formattedData = useMemo(() => {
-    const data = valueProperty === 'volumeUSD' ? volumeChartData : tvlChartData
-    if (data) {
-      return data.map((day) => {
+    if (chartData) {
+      return chartData.map((day) => {
         return {
           time: dayjs.unix(day.date).toDate(),
           value: day[valueProperty],
@@ -50,7 +47,7 @@ const HoverableChart = ({
       })
     }
     return []
-  }, [tvlChartData, valueProperty, volumeChartData])
+  }, [chartData, valueProperty])
 
   return (
     <Box p={['16px', '16px', '24px']}>


### PR DESCRIPTION
Reverts pancakeswap/pancake-frontend#9927

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates chart data handling in various components by replacing separate TVL and volume chart entries with a unified `chartData` entry.

### Detailed summary
- Replaced `TvlChartEntry` and `VolumeChartEntry` with `ChartEntry` in multiple files.
- Updated functions to handle `chartData` instead of separate TVL and volume data entries.

> The following files were skipped due to too many changes: `apps/web/src/state/info/hooks.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->