### PR TITLE
chore: Add bsc v2 exchange proxy endpoint

### DIFF
--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -58,7 +58,7 @@ export const V2_SUBGRAPH_URLS = {
   [ChainId.POLYGON_ZKEVM]: `${THE_GRAPH_PROXY_API}/exchange-v2-polygon-zkevm`,
   [ChainId.BASE]: `${THE_GRAPH_PROXY_API}/exchange-v2-base`,
   [ChainId.ETHEREUM]: `${THE_GRAPH_PROXY_API}/exchange-v2-eth`,
-  // [ChainId.BSC]: `${INFO_GATEWAY_OLD_API}/subgraphs/v2/bsc/graphql`,
+  [ChainId.BSC]: `${THE_GRAPH_PROXY_API}/exchange-v2-bsc`,
   [ChainId.ARBITRUM_ONE]: `${THE_GRAPH_PROXY_API}/exchange-v2-arb`,
   [ChainId.ZKSYNC]: `${THE_GRAPH_PROXY_API}/exchange-v2-zksync`,
   [ChainId.LINEA]: `${THE_GRAPH_PROXY_API}/exchange-v2-linea`,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates endpoint URLs in `endpoints.ts` for different chains to use `THE_GRAPH_PROXY_API`.

### Detailed summary
- Updated endpoint URLs for `ChainId.BASE`, `ChainId.ETHEREUM`, `ChainId.BSC`, `ChainId.ARBITRUM_ONE`, `ChainId.ZKSYNC`, and `ChainId.LINEA` to use `THE_GRAPH_PROXY_API`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->