### PR TITLE
chore: Switch to use subgraph proxies

### DIFF
--- a/apis/farms/src/lpApr.ts
+++ b/apis/farms/src/lpApr.ts
@@ -13,7 +13,7 @@ interface BlockResponse {
   }[]
 }
 
-const STABLESWAP_SUBGRAPH_ENDPOINT = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exchange-stableswap'
+const STABLESWAP_SUBGRAPH_ENDPOINT = 'https://thegraph.pancakeswap.com/exchange-stableswap-bsc'
 
 const LP_HOLDERS_FEE = 0.0017
 const WEEKS_IN_A_YEAR = 52.1429

--- a/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { createPortal } from 'react-dom'
 
 import { GRAPH_API_PREDICTION_BNB } from '@pancakeswap/prediction'
-import { GRAPH_API_LOTTERY, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
+import { GRAPH_API_LOTTERY, THE_GRAPH_PROXY_API, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { getPortalRoot } from '@pancakeswap/uikit'
 import { SubgraphHealthIndicator, SubgraphHealthIndicatorProps } from './SubgraphHealthIndicator'
@@ -43,18 +43,17 @@ export function subgraphHealthIndicatorFactory({ getSubgraphName }: FactoryParam
 
 export const V3SubgraphHealthIndicator = subgraphHealthIndicatorFactory({
   getSubgraphName: (chainId) => {
-    if (V3_SUBGRAPH_URLS[chainId]?.startsWith('https://api.thegraph.com/subgraphs/name/')) {
-      return V3_SUBGRAPH_URLS?.[chainId]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
+    if (V3_SUBGRAPH_URLS[chainId]?.startsWith(`${THE_GRAPH_PROXY_API}/`)) {
+      return V3_SUBGRAPH_URLS?.[chainId]?.replace(`${THE_GRAPH_PROXY_API}/`, '') || ''
     }
     return ''
   },
 })
 
 export const LotterySubgraphHealthIndicator = subgraphHealthIndicatorFactory({
-  getSubgraphName: () => GRAPH_API_LOTTERY.replace('https://api.thegraph.com/subgraphs/name/', ''),
+  getSubgraphName: () => GRAPH_API_LOTTERY.replace(`${THE_GRAPH_PROXY_API}/`, ''),
 })
 
 export const PredictionSubgraphHealthIndicator = subgraphHealthIndicatorFactory({
-  getSubgraphName: (chainId) =>
-    GRAPH_API_PREDICTION_BNB?.[chainId]?.replace('https://api.thegraph.com/subgraphs/name/', ''),
+  getSubgraphName: (chainId) => GRAPH_API_PREDICTION_BNB?.[chainId]?.replace(`${THE_GRAPH_PROXY_API}/`, ''),
 })

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -1,14 +1,16 @@
 import { BLOCKS_SUBGRAPHS, ChainId, STABLESWAP_SUBGRAPHS, V2_SUBGRAPHS, V3_SUBGRAPHS } from '@pancakeswap/chains'
 
-export const GRAPH_API_PROFILE = 'https://api.thegraph.com/subgraphs/name/pancakeswap/profile'
+export const THE_GRAPH_PROXY_API = 'https://thegraph.pancakeswap.com'
 
-export const GRAPH_API_LOTTERY = 'https://api.thegraph.com/subgraphs/name/pancakeswap/lottery'
+export const GRAPH_API_PROFILE = `${THE_GRAPH_PROXY_API}/profile`
+
+export const GRAPH_API_LOTTERY = `${THE_GRAPH_PROXY_API}/lottery-bsc`
 export const SNAPSHOT_BASE_URL = process.env.NEXT_PUBLIC_SNAPSHOT_BASE_URL
 export const API_PROFILE = 'https://profile.pancakeswap.com'
 export const API_NFT = 'https://nft.pancakeswap.com/api/v1'
 export const SNAPSHOT_API = `${SNAPSHOT_BASE_URL}/graphql`
 export const SNAPSHOT_HUB_API = `${SNAPSHOT_BASE_URL}/api/message`
-export const GRAPH_API_POTTERY = 'https://api.thegraph.com/subgraphs/name/pancakeswap/pottery'
+export const GRAPH_API_POTTERY = `${THE_GRAPH_PROXY_API}/pottery`
 // export const ONRAMP_API_BASE_URL = 'https://pcs-onramp-api.com'
 export const ONRAMP_API_BASE_URL = 'https://onramp2-api.pancakeswap.com'
 export const TRANSAK_API_BASE_URL = 'https://api-stg.transak.com/api/v1'
@@ -17,20 +19,17 @@ export const NOTIFICATION_HUB_BASE_URL = 'https://notification-hub.pancakeswap.c
 /**
  * V1 will be deprecated but is still used to claim old rounds
  */
-export const GRAPH_API_PREDICTION_V1 = 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction'
+export const GRAPH_API_PREDICTION_V1 = `${THE_GRAPH_PROXY_API}/prediction-v1-bsc`
 
 export const V3_BSC_INFO_CLIENT = `https://open-platform.nodereal.io/${
   process.env.NEXT_PUBLIC_NODE_REAL_API_INFO || process.env.NEXT_PUBLIC_NODE_REAL_API_ETH
 }/pancakeswap-v3/graphql`
-
-export const THE_GRAPH_PROXY_API = 'https://thegraph.pancakeswap.com'
 
 const BLOCKS_SUBGRAPH_URLS = {
   ...BLOCKS_SUBGRAPHS,
   [ChainId.OPBNB]: `${THE_GRAPH_PROXY_API}/blocks-opbnb`,
 }
 
-export const INFO_CLIENT_ETH = 'https://api.thegraph.com/subgraphs/name/pancakeswap/exhange-eth'
 export const BLOCKS_CLIENT = BLOCKS_SUBGRAPH_URLS[ChainId.BSC]
 export const BLOCKS_CLIENT_ETH = BLOCKS_SUBGRAPH_URLS[ChainId.ETHEREUM]
 export const BLOCKS_CLIENT_POLYGON_ZKEVM = BLOCKS_SUBGRAPH_URLS[ChainId.POLYGON_ZKEVM]
@@ -39,11 +38,11 @@ export const BLOCKS_CLIENT_LINEA = BLOCKS_SUBGRAPH_URLS[ChainId.LINEA]
 export const BLOCKS_CLIENT_BASE = BLOCKS_SUBGRAPH_URLS[ChainId.BASE]
 export const BLOCKS_CLIENT_OPBNB = BLOCKS_SUBGRAPH_URLS[ChainId.OPBNB]
 
-export const GRAPH_API_NFTMARKET = 'https://api.thegraph.com/subgraphs/name/pancakeswap/nft-market'
+export const GRAPH_API_NFTMARKET = `${THE_GRAPH_PROXY_API}/nft-marketplace-bsc`
 export const GRAPH_HEALTH = 'https://api.thegraph.com/index-node/graphql'
 
-export const TC_MOBOX_SUBGRAPH = 'https://api.thegraph.com/subgraphs/name/pancakeswap/trading-competition-v3'
-export const TC_MOD_SUBGRAPH = 'https://api.thegraph.com/subgraphs/name/pancakeswap/trading-competition-v4'
+export const TC_MOBOX_SUBGRAPH = `${THE_GRAPH_PROXY_API}/trading-competition-v3`
+export const TC_MOD_SUBGRAPH = `${THE_GRAPH_PROXY_API}/trading-competition-v4`
 
 export const BIT_QUERY = 'https://graphql.bitquery.io'
 
@@ -64,6 +63,7 @@ export const V2_SUBGRAPH_URLS = {
   [ChainId.LINEA]: `${THE_GRAPH_PROXY_API}/exchange-v2-linea`,
   [ChainId.OPBNB]: `${THE_GRAPH_PROXY_API}/exchange-v2-opbnb`,
 }
+export const INFO_CLIENT_ETH = V2_SUBGRAPH_URLS[ChainId.ETHEREUM]
 
 export const BLOCKS_CLIENT_WITH_CHAIN = BLOCKS_SUBGRAPH_URLS
 

--- a/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
@@ -1,12 +1,10 @@
-import { V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
+import { THE_GRAPH_PROXY_API, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useSubgraphHealth, { SubgraphStatus } from 'hooks/useSubgraphHealth'
 
 const useShowWarningMessage = () => {
   const { chainId } = useActiveChainId()
-  const subgraphName = chainId
-    ? V3_SUBGRAPH_URLS[chainId]?.replace('https://api.thegraph.com/subgraphs/name/', '') || ''
-    : ''
+  const subgraphName = chainId ? V3_SUBGRAPH_URLS[chainId]?.replace(`${THE_GRAPH_PROXY_API}/`, '') || '' : ''
   const { status } = useSubgraphHealth({ chainId, subgraphName })
 
   return status === SubgraphStatus.DOWN

--- a/packages/prediction/src/endpoints.ts
+++ b/packages/prediction/src/endpoints.ts
@@ -3,13 +3,13 @@ import { SupportedChainId } from './constants/supportedChains'
 import { EndPointType } from './type'
 
 export const GRAPH_API_PREDICTION_BNB = {
-  [ChainId.BSC]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-v2',
+  [ChainId.BSC]: 'https://thegraph.pancakeswap.com/prediction-v2-bsc',
   [ChainId.ZKSYNC]: '',
   // [ChainId.ARBITRUM_ONE]: '',
 } as const satisfies EndPointType<SupportedChainId>
 
 export const GRAPH_API_PREDICTION_CAKE = {
-  [ChainId.BSC]: 'https://api.thegraph.com/subgraphs/name/pancakeswap/prediction-cake',
+  [ChainId.BSC]: 'https://thegraph.pancakeswap.com/prediction-cake-bsc',
   [ChainId.ZKSYNC]: '',
   // [ChainId.ARBITRUM_ONE]: '',
 } as const satisfies EndPointType<SupportedChainId>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates API endpoints to use `thegraph.pancakeswap.com` instead of `api.thegraph.com` for better performance and reliability.

### Detailed summary
- Updated various API endpoints to use `thegraph.pancakeswap.com` domain
- Refactored endpoint URLs in multiple files
- Improved subgraph health indicator logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->