### PR TITLE
feat: Add abort signal to explorer api calls

### DIFF
--- a/apps/web/src/views/V3Info/data/pool/chartData.ts
+++ b/apps/web/src/views/V3Info/data/pool/chartData.ts
@@ -12,13 +12,14 @@ export async function fetchPoolChartData(
   protocol: 'v2' | 'v3' | 'stable',
   chainName: components['schemas']['ChainName'],
   address: string,
+  signal?: AbortSignal,
 ) {
   let error = false
 
   try {
     const rawFeeResults = await explorerApiClient
       .GET('/cached/pools/chart/v3/{chainName}/{address}/fees', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,
@@ -30,7 +31,7 @@ export async function fetchPoolChartData(
 
     const rawTvlResults = await explorerApiClient
       .GET('/cached/pools/chart/{protocol}/{chainName}/{address}/tvl', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,
@@ -46,7 +47,7 @@ export async function fetchPoolChartData(
 
     const rawVolumeResults = await explorerApiClient
       .GET('/cached/pools/chart/{protocol}/{chainName}/{address}/volume', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,

--- a/apps/web/src/views/V3Info/data/pool/tickData.ts
+++ b/apps/web/src/views/V3Info/data/pool/tickData.ts
@@ -51,7 +51,7 @@ export const fetchTicksSurroundingPrice = async (
   try {
     const poolData = await explorerApiClient
       .GET('/cached/pools/v3/{chainName}/{address}', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/data/pool/transactions.ts
+++ b/apps/web/src/views/V3Info/data/pool/transactions.ts
@@ -6,11 +6,12 @@ import { Transaction, TransactionType } from '../../types'
 export async function fetchPoolTransactions(
   address: string,
   chainName: components['schemas']['ChainName'],
+  signal: AbortSignal,
 ): Promise<{ data: Transaction[] | undefined; error: boolean }> {
   try {
     const data = await explorerApiClient
       .GET('/cached/tx/v3/{chainName}/recent', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/data/protocol/chart.ts
+++ b/apps/web/src/views/V3Info/data/protocol/chart.ts
@@ -7,13 +7,17 @@ import { ChartDayData } from '../../types'
 // format dayjs with the libraries that we need
 dayjs.extend(utc)
 
-export async function fetchChartData(protocol: 'v2' | 'v3' | 'stable', chainName: components['schemas']['ChainName']) {
+export async function fetchChartData(
+  protocol: 'v2' | 'v3' | 'stable',
+  chainName: components['schemas']['ChainName'],
+  signal: AbortSignal,
+) {
   let error = false
 
   try {
     const rawTvlResults = await explorerApiClient
       .GET('/cached/protocol/chart/{protocol}/{chainName}/tvl', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,
@@ -28,7 +32,7 @@ export async function fetchChartData(protocol: 'v2' | 'v3' | 'stable', chainName
 
     const rawVolumeResults = await explorerApiClient
       .GET('/cached/protocol/chart/{protocol}/{chainName}/volume', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,

--- a/apps/web/src/views/V3Info/data/protocol/overview.ts
+++ b/apps/web/src/views/V3Info/data/protocol/overview.ts
@@ -4,14 +4,17 @@ import { explorerApiClient } from 'state/info/api/client'
 import { getPercentChange } from '../../utils/data'
 import { ProtocolData } from '../../types'
 
-export async function fetchProtocolData(chainName: components['schemas']['ChainName']): Promise<{
+export async function fetchProtocolData(
+  chainName: components['schemas']['ChainName'],
+  signal: AbortSignal,
+): Promise<{
   error: boolean
   data: ProtocolData | undefined
 }> {
   try {
     const data = await explorerApiClient
       .GET('/cached/protocol/{protocol}/{chainName}/stats', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/data/protocol/transactions.ts
+++ b/apps/web/src/views/V3Info/data/protocol/transactions.ts
@@ -5,11 +5,12 @@ import { Transaction, TransactionType } from '../../types'
 
 export async function fetchTopTransactions(
   chainName: components['schemas']['ChainName'],
+  signal: AbortSignal,
 ): Promise<Transaction[] | undefined> {
   try {
     const data = await explorerApiClient
       .GET('/cached/tx/v3/{chainName}/recent', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/data/token/chartData.ts
+++ b/apps/web/src/views/V3Info/data/token/chartData.ts
@@ -12,13 +12,14 @@ export async function fetchTokenChartData(
   protocol: 'v2' | 'v3' | 'stable',
   chainName: components['schemas']['ChainName'],
   address: string,
+  signal: AbortSignal,
 ) {
   let error = false
 
   try {
     const rawTvlResults = await explorerApiClient
       .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/tvl', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,
@@ -34,7 +35,7 @@ export async function fetchTokenChartData(
 
     const rawVolumeResults = await explorerApiClient
       .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/volume', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,

--- a/apps/web/src/views/V3Info/data/token/priceData.ts
+++ b/apps/web/src/views/V3Info/data/token/priceData.ts
@@ -12,14 +12,12 @@ export async function fetchTokenPriceData(
   protocol: 'v2' | 'v3' | 'stable',
   duration: 'day' | 'week' | 'month' | 'year',
   chainName: components['schemas']['ChainName'],
-): Promise<{
-  data: PriceChartEntry[]
-  error: boolean
-}> {
+  signal: AbortSignal,
+): Promise<{ data: PriceChartEntry[]; error: boolean }> {
   try {
     const data = await explorerApiClient
       .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/price', {
-        signal: null,
+        signal,
         params: {
           path: {
             protocol,
@@ -76,6 +74,7 @@ export async function fetchPairPriceChartTokenData(
   address: string,
   chainName: components['schemas']['ChainName'],
   duration: 'day' | 'week' | 'month' | 'year',
+  signal: AbortSignal,
 ): Promise<{
   data: PriceChartEntry[]
   maxPrice?: number
@@ -90,7 +89,7 @@ export async function fetchPairPriceChartTokenData(
   try {
     const data = await explorerApiClient
       .GET('/cached/pools/chart/v3/{chainName}/{address}/rate', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/data/token/transactions.ts
+++ b/apps/web/src/views/V3Info/data/token/transactions.ts
@@ -6,11 +6,12 @@ import { Transaction, TransactionType } from '../../types'
 export async function fetchTokenTransactions(
   address: string,
   chainName: components['schemas']['ChainName'],
+  signal: AbortSignal,
 ): Promise<{ data: Transaction[] | undefined; error: boolean; loading: boolean }> {
   try {
     const data = await explorerApiClient
       .GET('/cached/tx/v3/{chainName}/recent', {
-        signal: null,
+        signal,
         params: {
           path: {
             chainName,

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -104,7 +104,7 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainId && address),
+    enabled: Boolean(enabled && chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -259,7 +259,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -278,7 +278,7 @@ export const useTokenPriceData = (
     queryFn: ({ signal }) =>
       fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -290,7 +290,7 @@ export const useTokenTransactions = (address: string): Transaction[] | undefined
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
@@ -385,7 +385,7 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       }
       return fetchPoolsForToken(address, chainName)
     },
-    enabled: Boolean(chainName && address),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -412,7 +412,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
@@ -438,7 +438,7 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
     queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) =>
       fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -54,7 +54,7 @@ export const useProtocolChartData = (): ChartDayData[] | undefined => {
   const { data: chartData } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => chartData?.data ?? [], [chartData])
@@ -66,7 +66,7 @@ export const useProtocolData = (): ProtocolData | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchProtocolData(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
@@ -78,7 +78,7 @@ export const useProtocolTransactionData = (): Transaction[] | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
@@ -104,7 +104,7 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainId && address && address !== 'undefined'),
+    enabled: Boolean(enabled && chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -185,7 +185,7 @@ export const useTopTokensData = ():
     queryKey: [`v3/info/token/TopTokensData/${chainId}`, chainId],
 
     queryFn: ({ signal }) => fetchTopTokens(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -245,7 +245,7 @@ export const useTokenData = (address: string): TokenData | undefined => {
 
     queryFn: ({ signal }) => fetchedTokenData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
 
@@ -259,7 +259,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -278,7 +278,7 @@ export const useTokenPriceData = (
     queryFn: ({ signal }) =>
       fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -368,14 +368,15 @@ export const useTopPoolsData = ():
     queryFn: async ({ signal }) => {
       return fetchTopPools(chainIdToExplorerInfoChainName[chainId], signal)
     },
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
 
@@ -383,9 +384,9 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       if (!chainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchPoolsForToken(address, chainName)
+      return fetchPoolsForToken(address, chainIdToExplorerInfoChainName[chainId])
     },
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -400,7 +401,7 @@ export const usePoolData = (address: string): PoolData | undefined => {
 
     queryFn: ({ signal }) => fetchedPoolData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -412,7 +413,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
@@ -424,7 +425,7 @@ export const usePoolChartData = (address: string): PoolChartEntry[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -438,7 +439,7 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
     queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) =>
       fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -53,7 +53,7 @@ export const useProtocolChartData = (): ChartDayData[] | undefined => {
   const chainId = multiChainId[chainName]
   const { data: chartData } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
-    queryFn: () => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId], signal),
     enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -65,7 +65,7 @@ export const useProtocolData = (): ProtocolData | undefined => {
   const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
-    queryFn: () => fetchProtocolData(chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchProtocolData(chainIdToExplorerInfoChainName[chainId], signal),
     enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -77,7 +77,7 @@ export const useProtocolTransactionData = (): Transaction[] | undefined => {
   const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
-    queryFn: () => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId], signal),
     enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -97,11 +97,11 @@ export const usePairPriceChartTokenData = (
   const { data } = useQuery({
     queryKey: [`v3/info/token/pairPriceChartToken/${address}/${duration}`, targetChainId ?? chainId],
 
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       if (!address) {
         throw new Error('Address is not defined')
       }
-      return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day')
+      return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
     enabled: Boolean(enabled && chainId && address),
@@ -258,7 +258,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
 
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
-    queryFn: () => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address),
+    queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
     enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -275,7 +275,8 @@ export const useTokenPriceData = (
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenPriceData/${chainId}/${address}/${duration}`, chainId],
 
-    queryFn: () => fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) =>
+      fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
     enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
@@ -288,7 +289,7 @@ export const useTokenTransactions = (address: string): Transaction[] | undefined
   const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
-    queryFn: () => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
     enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -410,7 +411,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
-    queryFn: () => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
     enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
@@ -422,7 +423,7 @@ export const usePoolChartData = (address: string): PoolChartEntry[] | undefined 
   const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
-    queryFn: () => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address),
+    queryFn: ({ signal }) => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
     enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add the `AbortSignal` parameter to various API calls in the V3Info module.

### Detailed summary
- Added `AbortSignal` parameter to API calls in `tickData.ts`, `transactions.ts`, `overview.ts`, `chartData.ts`, `priceData.ts`, and more.
- Updated functions in `hooks/index.ts` and other files to include `AbortSignal`.
- Improved error handling and loading indicators in some functions.

> The following files were skipped due to too many changes: `apps/web/src/views/V3Info/hooks/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->