### PR TITLE
fix: block timestamp chainname

### DIFF
--- a/apps/web/src/state/info/constant.ts
+++ b/apps/web/src/state/info/constant.ts
@@ -104,15 +104,15 @@ export const multiChainQueryStableClient = {
 }
 
 export const infoChainNameToExplorerChainName = {
-  BSC: ChainId.BSC,
-  ETH: ChainId.ETHEREUM,
-  POLYGON_ZKEVM: ChainId.POLYGON_ZKEVM,
-  ZKSYNC: ChainId.ZKSYNC,
-  ARB: ChainId.ARBITRUM_ONE,
-  LINEA: ChainId.LINEA,
-  BASE: ChainId.BASE,
-  OPBNB: ChainId.OPBNB,
-}
+  BSC: 'bsc',
+  ETH: 'ethereum',
+  POLYGON_ZKEVM: 'polygon-zkevm',
+  ZKSYNC: 'zkync',
+  ARB: 'arbitrum',
+  LINEA: 'linea',
+  BASE: 'base',
+  OPBNB: 'opbnb',
+} as const
 
 export const STABLESWAP_SUBGRAPHS_START_BLOCK = {
   ARB: 169319653,

--- a/apps/web/src/utils/getBlocksFromTimestamps.ts
+++ b/apps/web/src/utils/getBlocksFromTimestamps.ts
@@ -22,6 +22,10 @@ export const getBlocksFromTimestamps = async (
 
   const explorerChainName = infoChainNameToExplorerChainName[chainName]
 
+  if (!explorerChainName) {
+    throw new Error('Invalid chain name')
+  }
+
   const blocks = await timestamps.reduce(async (accumP, timestamp) => {
     const acc = await accumP
     try {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the chain name mappings in `infoChainNameToExplorerChainName` and add error handling in `getBlocksFromTimestamps.ts`.

### Detailed summary
- Updated chain name mappings to use string values instead of enum values
- Added error handling in `getBlocksFromTimestamps.ts` to throw an error for invalid chain names

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->