### PR TITLE
chore: Support subgraph healtch check after upgrade

### DIFF
--- a/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
@@ -2,10 +2,12 @@ import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
 import { ChainId } from '@pancakeswap/chains'
 
+import { GRAPH_API_NFTMARKET } from 'config/constants/endpoints'
+
 const SubgraphHealthIndicator = dynamic(() => import('components/SubgraphHealthIndicator'), { ssr: false })
 
 export const FixedSubgraphHealthIndicator = () => {
   const { pathname } = useRouter()
   const isOnNftPages = pathname.includes('nfts')
-  return isOnNftPages ? <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="pancakeswap/nft-market" /> : null
+  return isOnNftPages ? <SubgraphHealthIndicator chainId={ChainId.BSC} subgraph={GRAPH_API_NFTMARKET} /> : null
 }

--- a/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
@@ -4,47 +4,47 @@ import { createPortal } from 'react-dom'
 
 import { GRAPH_API_PREDICTION_BNB } from '@pancakeswap/prediction'
 import { getPortalRoot } from '@pancakeswap/uikit'
-import { GRAPH_API_LOTTERY, THE_GRAPH_PROXY_API } from 'config/constants/endpoints'
+import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { SubgraphHealthIndicator, SubgraphHealthIndicatorProps } from './SubgraphHealthIndicator'
 
 interface FactoryParams {
-  getSubgraphName: (chainId: ChainId) => string
+  getSubgraph: (chainId: ChainId) => string
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
-export function subgraphHealthIndicatorFactory({ getSubgraphName }: FactoryParams) {
-  return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraphName' | 'chainId'>) {
+export function subgraphHealthIndicatorFactory({ getSubgraph }: FactoryParams) {
+  return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraph' | 'chainId'>) {
     const { chainId } = useActiveChainId()
 
-    const subgraphName = useMemo(() => {
+    const subgraph = useMemo(() => {
       if (props.chainId) {
-        return getSubgraphName(props.chainId)
+        return getSubgraph(props.chainId)
       }
       if (chainId) {
-        return getSubgraphName(chainId)
+        return getSubgraph(chainId)
       }
       return undefined
     }, [chainId, props?.chainId])
 
-    if (!subgraphName) {
+    if (!subgraph) {
       return null
     }
 
     const portalRoot = getPortalRoot()
 
     return portalRoot
-      ? createPortal(<SubgraphHealthIndicator chainId={chainId} subgraphName={subgraphName} {...props} />, portalRoot)
+      ? createPortal(<SubgraphHealthIndicator chainId={chainId} subgraph={subgraph} {...props} />, portalRoot)
       : null
   }
 }
 
 export const LotterySubgraphHealthIndicator = subgraphHealthIndicatorFactory({
-  getSubgraphName: () => GRAPH_API_LOTTERY.replace(`${THE_GRAPH_PROXY_API}/`, ''),
+  getSubgraph: () => GRAPH_API_LOTTERY,
 })
 
 export const PredictionSubgraphHealthIndicator = subgraphHealthIndicatorFactory({
-  getSubgraphName: (chainId) => GRAPH_API_PREDICTION_BNB?.[chainId]?.replace(`${THE_GRAPH_PROXY_API}/`, ''),
+  getSubgraph: (chainId) => GRAPH_API_PREDICTION_BNB?.[chainId],
 })

--- a/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
@@ -95,7 +95,7 @@ export interface BlockResponse {
 
 export type SubgraphHealthIndicatorProps = React.PropsWithChildren<{
   chainId: ChainId
-  subgraphName: string
+  subgraph: string
   inline?: boolean
   customDescriptions?: CustomDescriptions
   obeyGlobalSetting?: boolean
@@ -103,13 +103,13 @@ export type SubgraphHealthIndicatorProps = React.PropsWithChildren<{
 
 export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = ({
   chainId,
-  subgraphName,
+  subgraph,
   inline,
   customDescriptions,
   obeyGlobalSetting = true,
 }) => {
   const { t } = useTranslation()
-  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth({ chainId, subgraphName })
+  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth({ chainId, subgraph })
   const [alwaysShowIndicator] = useSubgraphHealthIndicatorManager()
   const forceIndicatorDisplay =
     status === SubgraphStatus.WARNING || status === SubgraphStatus.NOT_OK || status === SubgraphStatus.DOWN

--- a/apps/web/src/hooks/useSubgraphHealth.ts
+++ b/apps/web/src/hooks/useSubgraphHealth.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { request, gql } from 'graphql-request'
 import { GRAPH_HEALTH } from 'config/constants/endpoints'
 import { publicClient } from 'utils/wagmi'
@@ -24,7 +24,7 @@ export type SubgraphHealthState = {
 const NOT_OK_BLOCK_DIFFERENCE = 200 // ~15 minutes delay
 const WARNING_BLOCK_DIFFERENCE = 50 // ~2.5 minute delay
 
-const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgraphName?: string }) => {
+const useSubgraphHealth = ({ chainId, subgraph }: { chainId: ChainId; subgraph?: string }) => {
   const [sgHealth, setSgHealth] = useState<SubgraphHealthState>({
     status: SubgraphStatus.UNKNOWN,
     currentBlock: 0,
@@ -32,20 +32,78 @@ const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgra
     latestBlock: 0,
     blockDifference: 0,
   })
+  const [deploymentId, setDeploymentId] = useState<string | undefined>()
+
+  useEffect(() => {
+    let unmounted = false
+    const unmount = () => {
+      unmounted = true
+    }
+    if (!subgraph) {
+      return unmount
+    }
+
+    const fetchDeploymentId = async () => {
+      const {
+        _meta: { deployment },
+      } = await request(
+        subgraph,
+        gql`
+          query MyQuery {
+            _meta {
+              deployment
+            }
+          }
+        `,
+      )
+
+      if (unmounted) {
+        return
+      }
+      setDeploymentId(deployment)
+    }
+
+    fetchDeploymentId()
+    return unmount
+  }, [subgraph])
 
   useSlowRefreshEffect(
     (currentBlockNumber) => {
+      if (!deploymentId) {
+        return
+      }
       const getSubgraphHealth = async () => {
         try {
-          const [{ indexingStatusForCurrentVersion }, currentBlock] = await Promise.all([
+          const [{ indexingStatuses }, currentBlock] = await Promise.all([
             request(
               GRAPH_HEALTH,
               gql`
             query getSubgraphHealth {
-              indexingStatusForCurrentVersion(subgraphName: "${subgraphName}") {
+              indexingStatuses(
+                subgraphs: ["${deploymentId}"]
+              ) {
+                subgraph
+                synced
                 health
+                entityCount
+                fatalError {
+                  handler
+                  message
+                  deterministic
+                  block {
+                    hash
+                    number
+                  }
+                }
+                nonFatalErrors{
+                  message
+                  block{number}
+                }
                 chains {
                   chainHeadBlock {
+                    number
+                  }
+                  earliestBlock {
                     number
                   }
                   latestBlock {
@@ -62,6 +120,8 @@ const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgra
                   ?.getBlockNumber()
                   .then((blockNumber) => Number(blockNumber)),
           ])
+
+          const [indexingStatusForCurrentVersion] = indexingStatuses
 
           const isHealthy = indexingStatusForCurrentVersion?.health === 'healthy'
           const chainHeadBlock = parseInt(indexingStatusForCurrentVersion?.chains[0]?.chainHeadBlock.number)
@@ -85,7 +145,7 @@ const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgra
             setSgHealth({ status: SubgraphStatus.OK, currentBlock, chainHeadBlock, latestBlock, blockDifference })
           }
         } catch (error) {
-          console.error(`Failed to perform health check for ${subgraphName} subgraph`, error)
+          console.error(`Failed to perform health check for ${subgraph}(deployment: ${deploymentId}) subgraph`, error)
           setSgHealth({
             status: SubgraphStatus.DOWN,
             currentBlock: -1,
@@ -95,11 +155,11 @@ const useSubgraphHealth = ({ chainId, subgraphName }: { chainId: ChainId; subgra
           })
         }
       }
-      if (subgraphName) {
+      if (deploymentId) {
         getSubgraphHealth()
       }
     },
-    [subgraphName, chainId],
+    [subgraph, deploymentId, chainId],
   )
 
   return sgHealth

--- a/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useShowWarningMessage.tsx
@@ -1,11 +1,11 @@
-import { THE_GRAPH_PROXY_API, V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
+import { V3_SUBGRAPH_URLS } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import useSubgraphHealth, { SubgraphStatus } from 'hooks/useSubgraphHealth'
 
 const useShowWarningMessage = () => {
   const { chainId } = useActiveChainId()
-  const subgraphName = chainId ? V3_SUBGRAPH_URLS[chainId]?.replace(`${THE_GRAPH_PROXY_API}/`, '') || '' : ''
-  const { status } = useSubgraphHealth({ chainId, subgraphName })
+  const subgraph = chainId ? V3_SUBGRAPH_URLS[chainId] || '' : ''
+  const { status } = useSubgraphHealth({ chainId, subgraph })
 
   return status === SubgraphStatus.DOWN
 }

--- a/apps/web/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
+++ b/apps/web/src/views/LimitOrders/components/LimitOrderTable/TableNavigation.tsx
@@ -2,8 +2,6 @@ import { useState, useMemo, useCallback, ReactElement, memo, useEffect } from 'r
 import { Text, Flex, Box, Grid, ArrowBackIcon, ArrowForwardIcon } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
-import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
-import { ChainId } from '@pancakeswap/chains'
 import NoOrdersMessage from './NoOrdersMessage'
 import { ORDER_CATEGORY } from '../../types'
 import LoadingTable from './LoadingTable'
@@ -85,9 +83,6 @@ const TableNavigation: React.FC<TableNavigationProps> = ({
           <Arrow onClick={onPageNext}>
             <ArrowForwardIcon color={currentPage === maxPage ? 'textDisabled' : 'primary'} />
           </Arrow>
-        </Flex>
-        <Flex width="100%" justifyContent={['center', null, null, null, 'flex-end']}>
-          <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="gelatodigital/limit-orders-bsc" inline />
         </Flex>
       </Grid>
     </>

--- a/apps/web/src/views/Pottery/components/Pot/Claim/index.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/Claim/index.tsx
@@ -8,6 +8,9 @@ import { BIG_ONE } from '@pancakeswap/utils/bigNumber'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
 import { useAccount } from 'wagmi'
 import { ChainId } from '@pancakeswap/chains'
+
+import { GRAPH_API_POTTERY } from 'config/constants/endpoints'
+
 import YourDeposit from '../YourDeposit'
 import WalletNotConnected from './WalletNotConnected'
 import AvailableWithdraw from './AvailableWithdraw'
@@ -41,7 +44,7 @@ const Claim: React.FC<React.PropsWithChildren> = () => {
       {account ? (
         <Container>
           <GreyCard>
-            <SubgraphHealthIndicator inline chainId={ChainId.BSC} subgraphName="pancakeswap/pottery" />
+            <SubgraphHealthIndicator inline chainId={ChainId.BSC} subgraph={GRAPH_API_POTTERY} />
             <Flex justifyContent="space-between" mb="20px">
               <YourDeposit depositBalance={allDeposit} />
             </Flex>

--- a/apps/web/src/views/Pottery/index.tsx
+++ b/apps/web/src/views/Pottery/index.tsx
@@ -7,6 +7,9 @@ import Pot from 'views/Pottery/components/Pot/index'
 import { useTranslation } from '@pancakeswap/localization'
 import SubgraphHealthIndicator from 'components/SubgraphHealthIndicator'
 import { ChainId } from '@pancakeswap/chains'
+
+import { GRAPH_API_POTTERY } from 'config/constants/endpoints'
+
 import FinishedRounds from './components/FinishedRounds'
 import HowToPlay from './components/HowToPlay'
 import PrizeFunds from './components/PrizeFunds'
@@ -53,7 +56,7 @@ const Pottery: React.FC<React.PropsWithChildren> = () => {
       <FAQ />
       {createPortal(
         <>
-          <SubgraphHealthIndicator chainId={ChainId.BSC} subgraphName="pancakeswap/pottery" />
+          <SubgraphHealthIndicator chainId={ChainId.BSC} subgraph={GRAPH_API_POTTERY} />
         </>,
         document.body,
       )}

--- a/apps/web/src/views/TradingCompetition/MoDCompetition.tsx
+++ b/apps/web/src/views/TradingCompetition/MoDCompetition.tsx
@@ -239,7 +239,7 @@ const MoDCompetition = () => {
                 team3LeaderboardInformation={team3LeaderboardInformation as any}
                 globalLeaderboardInformation={globalLeaderboardInformation as any}
                 participantSubgraphAddress={TC_MOD_SUBGRAPH}
-                subgraphName="pancakeswap/trading-competition-v4"
+                subgraph={TC_MOD_SUBGRAPH}
               />
             </Box>
           </PageSection>

--- a/apps/web/src/views/TradingCompetition/MoboxCompetition.tsx
+++ b/apps/web/src/views/TradingCompetition/MoboxCompetition.tsx
@@ -248,7 +248,7 @@ const MoboxCompetition = () => {
                 team3LeaderboardInformation={team3LeaderboardInformation as any}
                 globalLeaderboardInformation={globalLeaderboardInformation as any}
                 participantSubgraphAddress={TC_MOBOX_SUBGRAPH}
-                subgraphName="pancakeswap/trading-competition-v3"
+                subgraph={TC_MOBOX_SUBGRAPH}
               />
             </Box>
           </PageSection>

--- a/apps/web/src/views/TradingCompetition/components/TeamRanks/TeamRanksWithParticipants.tsx
+++ b/apps/web/src/views/TradingCompetition/components/TeamRanks/TeamRanksWithParticipants.tsx
@@ -66,7 +66,7 @@ const TotalParticipantsCloud = styled(Flex)`
 interface TeamRanksWithParticipantsProps extends TeamRanksProps {
   image: StaticImageData
   participantSubgraphAddress: string
-  subgraphName: string
+  subgraph: string
 }
 
 const TeamRanksWithParticipants: React.FC<React.PropsWithChildren<TeamRanksWithParticipantsProps>> = ({
@@ -76,7 +76,7 @@ const TeamRanksWithParticipants: React.FC<React.PropsWithChildren<TeamRanksWithP
   team3LeaderboardInformation,
   globalLeaderboardInformation,
   participantSubgraphAddress,
-  subgraphName,
+  subgraph,
 }) => {
   const { t } = useTranslation()
   const participants = useGetParticipants(participantSubgraphAddress)
@@ -129,7 +129,7 @@ const TeamRanksWithParticipants: React.FC<React.PropsWithChildren<TeamRanksWithP
           team3LeaderboardInformation={team3LeaderboardInformation}
           globalLeaderboardInformation={globalLeaderboardInformation}
           isGlobalLeaderboardDataComplete={isGlobalLeaderboardDataComplete}
-          subgraphName={subgraphName}
+          subgraph={subgraph}
         />
       </StyledTopTradersWrapper>
     </Wrapper>

--- a/apps/web/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
+++ b/apps/web/src/views/TradingCompetition/components/TeamRanks/TopTradersCard/index.tsx
@@ -17,13 +17,13 @@ import { ChainId } from '@pancakeswap/chains'
 import { LeaderboardDataItem, TeamRanksProps } from '../../../types'
 import TopTradersGrid from './TopTradersGrid'
 
-const TopTradersCard: React.FC<React.PropsWithChildren<TeamRanksProps & { subgraphName?: string }>> = ({
+const TopTradersCard: React.FC<React.PropsWithChildren<TeamRanksProps & { subgraph?: string }>> = ({
   team1LeaderboardInformation,
   team2LeaderboardInformation,
   team3LeaderboardInformation,
   globalLeaderboardInformation,
   isGlobalLeaderboardDataComplete,
-  subgraphName,
+  subgraph,
 }) => {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState(0)
@@ -76,10 +76,10 @@ const TopTradersCard: React.FC<React.PropsWithChildren<TeamRanksProps & { subgra
                 {t('Since start of the competition')}
               </Text>
             </Flex>
-            {subgraphName && (
+            {subgraph && (
               <SubgraphHealthIndicator
                 chainId={ChainId.BSC}
-                subgraphName={subgraphName}
+                subgraph={subgraph}
                 inline
                 obeyGlobalSetting={false}
                 customDescriptions={{

--- a/apps/web/src/views/TradingCompetition/components/YourScore/ScoreCard.tsx
+++ b/apps/web/src/views/TradingCompetition/components/YourScore/ScoreCard.tsx
@@ -57,7 +57,7 @@ interface ScoreCardProps extends YourScoreProps {
   stormShareImage: StaticImageData
   cakersShareImage: StaticImageData
   extraUserRankBox?: ReactNode
-  subgraphName?: string
+  subgraph?: string
 }
 
 const ScoreCard: React.FC<React.PropsWithChildren<ScoreCardProps>> = ({
@@ -77,7 +77,7 @@ const ScoreCard: React.FC<React.PropsWithChildren<ScoreCardProps>> = ({
   finishedAndPrizesClaimed,
   finishedAndNothingToClaim,
   onClaimSuccess,
-  subgraphName,
+  subgraph,
 }) => {
   const { t } = useTranslation()
   const [onPresentClaimModal] = useModal(
@@ -149,11 +149,11 @@ const ScoreCard: React.FC<React.PropsWithChildren<ScoreCardProps>> = ({
           <LaurelRightIcon />
         </StyledCardFooter>
       )}
-      {subgraphName && hasRegistered && (
+      {subgraph && hasRegistered && (
         <Flex p="16px" justifyContent="flex-end">
           <SubgraphHealthIndicator
             chainId={ChainId.BSC}
-            subgraphName={subgraphName}
+            subgraph={subgraph}
             inline
             obeyGlobalSetting={false}
             customDescriptions={{

--- a/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxYourScore.tsx
+++ b/apps/web/src/views/TradingCompetition/mobox/components/YourScore/MoboxYourScore.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Heading, Skeleton, Text } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
+
+import { TC_MOBOX_SUBGRAPH } from 'config/constants/endpoints'
+
 import { LIVE } from '../../../../../config/constants/trading-competition/phases'
 import RibbonWithImage from '../../../components/RibbonWithImage'
 import ScoreCard from '../../../components/YourScore/ScoreCard'
@@ -47,7 +50,7 @@ const MoboxYourScore: React.FC<React.PropsWithChildren<YourScoreProps>> = ({
         </RibbonWithImage>
       )}
       <ScoreCard
-        subgraphName="pancakeswap/trading-competition-v3"
+        subgraph={TC_MOBOX_SUBGRAPH}
         userPrizeGrid={<MoboxUserPrizeGrid userTradingInformation={userTradingInformation} />}
         extraUserRankBox={
           <UserRankBox

--- a/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModYourScore.tsx
+++ b/apps/web/src/views/TradingCompetition/mod/components/YourScore/ModYourScore.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Heading, Skeleton, Text } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
+
+import { TC_MOD_SUBGRAPH } from 'config/constants/endpoints'
+
 import { LIVE } from '../../../../../config/constants/trading-competition/phases'
 import RibbonWithImage from '../../../components/RibbonWithImage'
 import ScoreCard from '../../../components/YourScore/ScoreCard'
@@ -55,7 +58,7 @@ const ModYourScore: React.FC<React.PropsWithChildren<MoDYourScoreProps>> = ({
         </RibbonWithImage>
       )}
       <ScoreCard
-        subgraphName="pancakeswap/trading-competition-v4"
+        subgraph={TC_MOD_SUBGRAPH}
         userPrizeGrid={<ModUserPrizeGrid userTradingInformation={userTradingInformation} />}
         extraUserRankBox={
           <UserRankBox


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates subgraph configurations in various components and hooks for Trading Competition, Pottery, NFT Market, and Limit Orders. 

### Detailed summary
- Updated subgraph configurations in Trading Competition components and hooks
- Refactored subgraph settings in Pottery and NFT Market components
- Adjusted subgraph configurations in Limit Orders components

> The following files were skipped due to too many changes: `apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx`, `apps/web/src/hooks/useSubgraphHealth.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->