### PR TITLE
fix: Use explorer chain name hook

### DIFF
--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -49,36 +49,36 @@ const QUERY_SETTINGS_IMMUTABLE = {
 }
 
 export const useProtocolChartData = (): ChartDayData[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data: chartData } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
-    queryFn: ({ signal }) => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    queryKey: [`v3/info/protocol/ProtocolChartData/${chainName}`, chainName],
+    queryFn: ({ signal }) => fetchChartData('v3', chainName!, signal),
+    enabled: Boolean(chainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => chartData?.data ?? [], [chartData])
 }
 
 export const useProtocolData = (): ProtocolData | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
-    queryFn: ({ signal }) => fetchProtocolData(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    queryKey: [`v3/info/protocol/ProtocolData/${chainName}`, chainName],
+    queryFn: ({ signal }) => fetchProtocolData(chainName!, signal),
+    enabled: Boolean(chainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
 }
 
 export const useProtocolTransactionData = (): Transaction[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
-    queryFn: ({ signal }) => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainName}`, chainName],
+    queryFn: ({ signal }) => fetchTopTransactions(chainName!, signal),
+    enabled: Boolean(chainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
@@ -91,8 +91,8 @@ export const usePairPriceChartTokenData = (
   targetChainId?: ChainId,
   enabled = true,
 ): { data: PriceChartEntry[] | undefined; maxPrice?: number; minPrice?: number; averagePrice?: number } => {
-  const chainName = useChainNameByQuery()
-  const chainId = targetChainId || multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+  const chainId = targetChainId ?? (chainName ? multiChainId[chainName] : undefined)
 
   const { data } = useQuery({
     queryKey: [`v3/info/token/pairPriceChartToken/${address}/${duration}`, targetChainId ?? chainId],
@@ -104,7 +104,9 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(
+      enabled && chainId && chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined',
+    ),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -178,14 +180,13 @@ export const useTopTokensData = ():
       [address: string]: TokenData
     }
   | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/TopTokensData/${chainId}`, chainId],
+    queryKey: [`v3/info/token/TopTokensData/${chainName}`, chainName],
 
-    queryFn: ({ signal }) => fetchTopTokens(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    queryFn: ({ signal }) => fetchTopTokens(chainName!, signal),
+    enabled: Boolean(chainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -237,15 +238,14 @@ export const useTokensData = (addresses: string[], targetChainId?: ChainId): Tok
 }
 
 export const useTokenData = (address: string): TokenData | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenData/${chainId}/${address}`, chainId],
+    queryKey: [`v3/info/token/tokenData/${chainName}/${address}`, chainName],
 
-    queryFn: ({ signal }) => fetchedTokenData(chainIdToExplorerInfoChainName[chainId], address, signal),
+    queryFn: ({ signal }) => fetchedTokenData(chainName!, address, signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
 
@@ -253,13 +253,12 @@ export const useTokenData = (address: string): TokenData | undefined => {
 }
 
 export const useTokenChartData = (address: string): TokenChartEntry[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
-    queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    queryKey: [`v3/info/token/tokenChartData/${chainName}/${address}`, chainName],
+    queryFn: ({ signal }) => fetchTokenChartData('v3', chainName!, address, signal),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -269,28 +268,26 @@ export const useTokenPriceData = (
   address: string,
   duration: 'day' | 'week' | 'month' | 'year',
 ): PriceChartEntry[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenPriceData/${chainId}/${address}/${duration}`, chainId],
+    queryKey: [`v3/info/token/tokenPriceData/${chainName}/${address}/${duration}`, chainName],
 
-    queryFn: ({ signal }) =>
-      fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
+    queryFn: ({ signal }) => fetchTokenPriceData(address, 'v3', duration, chainName!, signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const useTokenTransactions = (address: string): Transaction[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
-    queryFn: ({ signal }) => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    queryKey: [`v3/info/token/tokenTransaction/${chainName}/${address}`, chainName],
+    queryFn: ({ signal }) => fetchTokenTransactions(address, chainName!, signal),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
@@ -359,24 +356,23 @@ export const useTopPoolsData = ():
       [address: string]: PoolData
     }
   | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/TopPoolsData/${chainId}`, chainId],
+    queryKey: [`v3/info/pool/TopPoolsData/${chainName}`, chainName],
 
     queryFn: async ({ signal }) => {
-      return fetchTopPools(chainIdToExplorerInfoChainName[chainId], signal)
+      return fetchTopPools(chainName!, signal)
     },
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
 
@@ -384,62 +380,59 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       if (!chainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchPoolsForToken(address, chainIdToExplorerInfoChainName[chainId])
+      return fetchPoolsForToken(address, chainName)
     },
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolData = (address: string): PoolData | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolData/${chainId}/${address}`, chainId],
+    queryKey: [`v3/info/pool/poolData/${chainName}/${address}`, chainName],
 
-    queryFn: ({ signal }) => fetchedPoolData(chainIdToExplorerInfoChainName[chainId], address, signal),
+    queryFn: ({ signal }) => fetchedPoolData(chainName!, address, signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 export const usePoolTransactions = (address: string): Transaction[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
-    queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    queryKey: [`v3/info/pool/poolTransaction/${chainName}/${address}`, chainName],
+    queryFn: ({ signal }) => fetchPoolTransactions(address, chainName!, signal),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
 }
 
 export const usePoolChartData = (address: string): PoolChartEntry[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
+
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
-    queryFn: ({ signal }) => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    queryKey: [`v3/info/pool/poolChartData/${chainName}/${address}`, chainName],
+    queryFn: ({ signal }) => fetchPoolChartData('v3', chainName!, address, signal),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolTickData = (address: string): PoolTickData | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
+    queryKey: [`v3/info/pool/poolTickData/${chainName}/${address}`, chainName],
     queryFn: ({ signal }) =>
-      fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+      fetchTicksSurroundingPrice(address, chainName!, multiChainId[chainName!], undefined, signal),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -104,7 +104,7 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainId && address),
+    enabled: Boolean(enabled && chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -259,7 +259,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -278,7 +278,7 @@ export const useTokenPriceData = (
     queryFn: ({ signal }) =>
       fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -290,7 +290,7 @@ export const useTokenTransactions = (address: string): Transaction[] | undefined
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
@@ -385,7 +385,7 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       }
       return fetchPoolsForToken(address, chainName)
     },
-    enabled: Boolean(chainName && address),
+    enabled: Boolean(chainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -412,7 +412,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
@@ -438,7 +438,7 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
     queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) =>
       fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainId && address),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -49,36 +49,42 @@ const QUERY_SETTINGS_IMMUTABLE = {
 }
 
 export const useProtocolChartData = (): ChartDayData[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data: chartData } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolChartData/${chainName}`, chainName],
-    queryFn: ({ signal }) => fetchChartData('v3', chainName!, signal),
-    enabled: Boolean(chainName),
+    queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
+    queryFn: ({ signal }) => fetchChartData('v3', explorerChainName!, signal),
+    enabled: Boolean(explorerChainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => chartData?.data ?? [], [chartData])
 }
 
 export const useProtocolData = (): ProtocolData | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolData/${chainName}`, chainName],
-    queryFn: ({ signal }) => fetchProtocolData(chainName!, signal),
-    enabled: Boolean(chainName),
+    queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
+    queryFn: ({ signal }) => fetchProtocolData(explorerChainName!, signal),
+    enabled: Boolean(explorerChainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
 }
 
 export const useProtocolTransactionData = (): Transaction[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainName}`, chainName],
-    queryFn: ({ signal }) => fetchTopTransactions(chainName!, signal),
-    enabled: Boolean(chainName),
+    queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
+    queryFn: ({ signal }) => fetchTopTransactions(explorerChainName!, signal),
+    enabled: Boolean(explorerChainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
@@ -91,7 +97,7 @@ export const usePairPriceChartTokenData = (
   targetChainId?: ChainId,
   enabled = true,
 ): { data: PriceChartEntry[] | undefined; maxPrice?: number; minPrice?: number; averagePrice?: number } => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
   const chainId = targetChainId ?? (chainName ? multiChainId[chainName] : undefined)
 
   const { data } = useQuery({
@@ -101,7 +107,7 @@ export const usePairPriceChartTokenData = (
       if (!address) {
         throw new Error('Address is not defined')
       }
-      return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
+      return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId!], duration ?? 'day', signal)
     },
 
     enabled: Boolean(
@@ -180,13 +186,15 @@ export const useTopTokensData = ():
       [address: string]: TokenData
     }
   | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/TopTokensData/${chainName}`, chainName],
+    queryKey: [`v3/info/token/TopTokensData/${chainId}`, chainId],
 
-    queryFn: ({ signal }) => fetchTopTokens(chainName!, signal),
-    enabled: Boolean(chainName),
+    queryFn: ({ signal }) => fetchTopTokens(explorerChainName!, signal),
+    enabled: Boolean(explorerChainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -238,14 +246,16 @@ export const useTokensData = (addresses: string[], targetChainId?: ChainId): Tok
 }
 
 export const useTokenData = (address: string): TokenData | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenData/${chainName}/${address}`, chainName],
+    queryKey: [`v3/info/token/tokenData/${chainId}/${address}`, chainId],
 
-    queryFn: ({ signal }) => fetchedTokenData(chainName!, address, signal),
+    queryFn: ({ signal }) => fetchedTokenData(explorerChainName!, address, signal),
 
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
 
@@ -253,12 +263,14 @@ export const useTokenData = (address: string): TokenData | undefined => {
 }
 
 export const useTokenChartData = (address: string): TokenChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenChartData/${chainName}/${address}`, chainName],
-    queryFn: ({ signal }) => fetchTokenChartData('v3', chainName!, address, signal),
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
+    queryFn: ({ signal }) => fetchTokenChartData('v3', explorerChainName!, address, signal),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -268,26 +280,30 @@ export const useTokenPriceData = (
   address: string,
   duration: 'day' | 'week' | 'month' | 'year',
 ): PriceChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenPriceData/${chainName}/${address}/${duration}`, chainName],
+    queryKey: [`v3/info/token/tokenPriceData/${chainId}/${address}/${duration}`, chainId],
 
-    queryFn: ({ signal }) => fetchTokenPriceData(address, 'v3', duration, chainName!, signal),
+    queryFn: ({ signal }) => fetchTokenPriceData(address, 'v3', duration, explorerChainName!, signal),
 
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const useTokenTransactions = (address: string): Transaction[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/token/tokenTransaction/${chainName}/${address}`, chainName],
-    queryFn: ({ signal }) => fetchTokenTransactions(address, chainName!, signal),
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
+    queryFn: ({ signal }) => fetchTokenTransactions(address, explorerChainName!, signal),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
@@ -356,101 +372,112 @@ export const useTopPoolsData = ():
       [address: string]: PoolData
     }
   | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/TopPoolsData/${chainName}`, chainName],
+    queryKey: [`v3/info/pool/TopPoolsData/${chainId}`, chainId],
 
     queryFn: async ({ signal }) => {
-      return fetchTopPools(chainName!, signal)
+      return fetchTopPools(explorerChainName!, signal)
     },
-    enabled: Boolean(chainName),
+    enabled: Boolean(explorerChainName),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
+    queryKey: [`v3/info/pool/poolsDataForToken/${chainId}/${address}`],
 
     queryFn: () => {
       if (!chainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchPoolsForToken(address, chainName)
+      return fetchPoolsForToken(address, explorerChainName!)
     },
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolData = (address: string): PoolData | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolData/${chainName}/${address}`, chainName],
+    queryKey: [`v3/info/pool/poolData/${chainId}/${address}`, chainId],
 
-    queryFn: ({ signal }) => fetchedPoolData(chainName!, address, signal),
+    queryFn: ({ signal }) => fetchedPoolData(explorerChainName!, address, signal),
 
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 export const usePoolTransactions = (address: string): Transaction[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolTransaction/${chainName}/${address}`, chainName],
-    queryFn: ({ signal }) => fetchPoolTransactions(address, chainName!, signal),
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
+    queryFn: ({ signal }) => fetchPoolTransactions(address, explorerChainName!, signal),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
 }
 
 export const usePoolChartData = (address: string): PoolChartEntry[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolChartData/${chainName}/${address}`, chainName],
-    queryFn: ({ signal }) => fetchPoolChartData('v3', chainName!, address, signal),
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
+    queryFn: ({ signal }) => fetchPoolChartData('v3', explorerChainName!, address, signal),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolTickData = (address: string): PoolTickData | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
+  const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolTickData/${chainName}/${address}`, chainName],
-    queryFn: ({ signal }) =>
-      fetchTicksSurroundingPrice(address, chainName!, multiChainId[chainName!], undefined, signal),
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
+    queryFn: ({ signal }) => fetchTicksSurroundingPrice(address, explorerChainName!, chainId, undefined, signal),
+    enabled: Boolean(explorerChainName && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
 }
 
 export const useSearchData = (searchValue: string, enabled = true) => {
-  const chainName = useExplorerChainNameByQuery()
+  const explorerChainName = useExplorerChainNameByQuery()
   const { data, status, error } = useQuery({
-    queryKey: [`v3/info/pool/searchData/${chainName}/${searchValue}`, chainName],
+    queryKey: [`v3/info/pool/searchData/${explorerChainName}/${searchValue}`, explorerChainName],
 
     queryFn: () => {
-      if (!chainName) {
+      if (!explorerChainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchSearchResults(chainName, searchValue)
+      return fetchSearchResults(explorerChainName, searchValue)
     },
 
-    enabled: Boolean(chainName && searchValue && enabled),
+    enabled: Boolean(explorerChainName && searchValue && enabled),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   const searchResult = useMemo(() => {

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -54,7 +54,7 @@ export const useProtocolChartData = (): ChartDayData[] | undefined => {
   const { data: chartData } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => chartData?.data ?? [], [chartData])
@@ -66,7 +66,7 @@ export const useProtocolData = (): ProtocolData | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchProtocolData(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
@@ -78,7 +78,7 @@ export const useProtocolTransactionData = (): Transaction[] | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
@@ -104,7 +104,7 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainId && address && address !== 'undefined'),
+    enabled: Boolean(enabled && chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -185,7 +185,7 @@ export const useTopTokensData = ():
     queryKey: [`v3/info/token/TopTokensData/${chainId}`, chainId],
 
     queryFn: ({ signal }) => fetchTopTokens(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -245,7 +245,7 @@ export const useTokenData = (address: string): TokenData | undefined => {
 
     queryFn: ({ signal }) => fetchedTokenData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
 
@@ -259,7 +259,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -278,7 +278,7 @@ export const useTokenPriceData = (
     queryFn: ({ signal }) =>
       fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -368,14 +368,15 @@ export const useTopPoolsData = ():
     queryFn: async ({ signal }) => {
       return fetchTopPools(chainIdToExplorerInfoChainName[chainId], signal)
     },
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
-  const chainName = useExplorerChainNameByQuery()
+  const chainName = useChainNameByQuery()
+  const chainId = multiChainId[chainName]
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
 
@@ -383,9 +384,9 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       if (!chainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchPoolsForToken(address, chainName)
+      return fetchPoolsForToken(address, chainIdToExplorerInfoChainName[chainId])
     },
-    enabled: Boolean(chainName && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -400,7 +401,7 @@ export const usePoolData = (address: string): PoolData | undefined => {
 
     queryFn: ({ signal }) => fetchedPoolData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -412,7 +413,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
@@ -424,7 +425,7 @@ export const usePoolChartData = (address: string): PoolChartEntry[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -438,7 +439,7 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
     queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) =>
       fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -104,10 +104,7 @@ export const usePairPriceChartTokenData = (
     queryKey: [`v3/info/token/pairPriceChartToken/${address}/${duration}`, targetChainId ?? chainId],
 
     queryFn: async ({ signal }) => {
-      if (!address) {
-        throw new Error('Address is not defined')
-      }
-      return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId!], duration ?? 'day', signal)
+      return fetchPairPriceChartTokenData(address!, chainIdToExplorerInfoChainName[chainId!], duration ?? 'day', signal)
     },
 
     enabled: Boolean(
@@ -390,16 +387,12 @@ export const useTopPoolsData = ():
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
   const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
   const explorerChainName = useExplorerChainNameByQuery()
 
   const { data } = useQuery({
-    queryKey: [`v3/info/pool/poolsDataForToken/${chainId}/${address}`],
+    queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
 
     queryFn: () => {
-      if (!chainName) {
-        throw new Error('Chain name is not defined')
-      }
       return fetchPoolsForToken(address, explorerChainName!)
     },
     enabled: Boolean(explorerChainName && address && address !== 'undefined'),
@@ -466,15 +459,14 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
 }
 
 export const useSearchData = (searchValue: string, enabled = true) => {
+  const chainName = useChainNameByQuery()
   const explorerChainName = useExplorerChainNameByQuery()
+
   const { data, status, error } = useQuery({
-    queryKey: [`v3/info/pool/searchData/${explorerChainName}/${searchValue}`, explorerChainName],
+    queryKey: [`v3/info/pool/searchData/${chainName}/${searchValue}`, chainName],
 
     queryFn: () => {
-      if (!explorerChainName) {
-        throw new Error('Chain name is not defined')
-      }
-      return fetchSearchResults(explorerChainName, searchValue)
+      return fetchSearchResults(explorerChainName!, searchValue)
     },
 
     enabled: Boolean(explorerChainName && searchValue && enabled),

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -54,7 +54,7 @@ export const useProtocolChartData = (): ChartDayData[] | undefined => {
   const { data: chartData } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolChartData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchChartData('v3', chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => chartData?.data ?? [], [chartData])
@@ -66,7 +66,7 @@ export const useProtocolData = (): ProtocolData | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchProtocolData(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined
@@ -78,7 +78,7 @@ export const useProtocolTransactionData = (): Transaction[] | undefined => {
   const { data } = useQuery({
     queryKey: [`v3/info/protocol/ProtocolTransactionData/${chainId}`, chainId],
     queryFn: ({ signal }) => fetchTopTransactions(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.filter((d) => d.amountUSD > 0) ?? [], [data])
@@ -104,7 +104,7 @@ export const usePairPriceChartTokenData = (
       return fetchPairPriceChartTokenData(address, chainIdToExplorerInfoChainName[chainId], duration ?? 'day', signal)
     },
 
-    enabled: Boolean(enabled && chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(enabled && chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(
@@ -185,7 +185,7 @@ export const useTopTokensData = ():
     queryKey: [`v3/info/token/TopTokensData/${chainId}`, chainId],
 
     queryFn: ({ signal }) => fetchTopTokens(chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -245,7 +245,7 @@ export const useTokenData = (address: string): TokenData | undefined => {
 
     queryFn: ({ signal }) => fetchedTokenData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
 
@@ -259,7 +259,7 @@ export const useTokenChartData = (address: string): TokenChartEntry[] | undefine
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -278,7 +278,7 @@ export const useTokenPriceData = (
     queryFn: ({ signal }) =>
       fetchTokenPriceData(address, 'v3', duration, chainIdToExplorerInfoChainName[chainId], signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -290,7 +290,7 @@ export const useTokenTransactions = (address: string): Transaction[] | undefined
   const { data } = useQuery({
     queryKey: [`v3/info/token/tokenTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchTokenTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainId && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0), [data])
@@ -368,15 +368,14 @@ export const useTopPoolsData = ():
     queryFn: async ({ signal }) => {
       return fetchTopPools(chainIdToExplorerInfoChainName[chainId], signal)
     },
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId]),
+    enabled: Boolean(chainId),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
 }
 
 export const usePoolsDataForToken = (address: string): PoolData[] | undefined => {
-  const chainName = useChainNameByQuery()
-  const chainId = multiChainId[chainName]
+  const chainName = useExplorerChainNameByQuery()
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolsDataForToken/${chainName}/${address}`],
 
@@ -384,9 +383,9 @@ export const usePoolsDataForToken = (address: string): PoolData[] | undefined =>
       if (!chainName) {
         throw new Error('Chain name is not defined')
       }
-      return fetchPoolsForToken(address, chainIdToExplorerInfoChainName[chainId])
+      return fetchPoolsForToken(address, chainName)
     },
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainName && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -401,7 +400,7 @@ export const usePoolData = (address: string): PoolData | undefined => {
 
     queryFn: ({ signal }) => fetchedPoolData(chainIdToExplorerInfoChainName[chainId], address, signal),
 
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -413,7 +412,7 @@ export const usePoolTransactions = (address: string): Transaction[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolTransaction/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolTransactions(address, chainIdToExplorerInfoChainName[chainId], signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return useMemo(() => data?.data?.filter((d) => d.amountUSD > 0) ?? undefined, [data])
@@ -425,7 +424,7 @@ export const usePoolChartData = (address: string): PoolChartEntry[] | undefined 
   const { data } = useQuery({
     queryKey: [`v3/info/pool/poolChartData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) => fetchPoolChartData('v3', chainIdToExplorerInfoChainName[chainId], address, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address && address !== 'undefined'),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data
@@ -439,7 +438,7 @@ export const usePoolTickData = (address: string): PoolTickData | undefined => {
     queryKey: [`v3/info/pool/poolTickData/${chainId}/${address}`, chainId],
     queryFn: ({ signal }) =>
       fetchTicksSurroundingPrice(address, chainIdToExplorerInfoChainName[chainId], chainId, undefined, signal),
-    enabled: Boolean(chainIdToExplorerInfoChainName[chainId] && address && address !== 'undefined'),
+    enabled: Boolean(chainId && address),
     ...QUERY_SETTINGS_IMMUTABLE,
   })
   return data?.data ?? undefined


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates hooks in `V3Info` to use `explorerChainName` instead of `chainIdToExplorerInfoChainName` for better flexibility and consistency.

### Detailed summary
- Replaced `chainIdToExplorerInfoChainName[chainId]` with `explorerChainName`
- Updated query functions to use `explorerChainName` parameter
- Enabled queries based on `explorerChainName` instead of `chainIdToExplorerInfoChainName[chainId]`

> The following files were skipped due to too many changes: `apps/web/src/views/V3Info/hooks/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->