### PR TITLE
fix: gas token logo source, token decimals

### DIFF
--- a/.changeset/slow-shrimps-admire.md
+++ b/.changeset/slow-shrimps-admire.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/tokens': patch
+---
+
+fix zkSync USDT+ decimals

--- a/apps/web/src/components/Paymaster/GasTokenSelector.tsx
+++ b/apps/web/src/components/Paymaster/GasTokenSelector.tsx
@@ -238,7 +238,7 @@ export const GasTokenSelector = ({ trade }: GasTokenSelectorProps) => {
       <FixedHeightRow style={style} onClick={() => !disabled && onTokenSelected(item)} $disabled={disabled}>
         <Flex alignItems="center" justifyContent="space-between" width="100%">
           <Flex alignItems="center">
-            <CurrencyLogo currency={item} />
+            <CurrencyLogo currency={item} useTrustWalletUrl={false} />
             <Column marginLeft="12px">
               <Text bold>
                 {item.symbol} &nbsp;

--- a/packages/tokens/src/constants/zkSync.ts
+++ b/packages/tokens/src/constants/zkSync.ts
@@ -90,7 +90,7 @@ export const zksyncTokens = {
   usdtPlus: new ERC20Token(
     ChainId.ZKSYNC,
     '0xBb8D60008A08b1828E02120F1a952D295036eF3d',
-    7,
+    6,
     'USDT+',
     'USDT+',
     'https://overnight.fi/',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the decimals for zkSync USDT+ and updating the CurrencyLogo component in GasTokenSelector.

### Detailed summary
- Fixed zkSync USDT+ decimals
- Updated CurrencyLogo component in GasTokenSelector to not use TrustWallet URL

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->