### PR TITLE
fix: unknown chain name when query fee

### DIFF
--- a/apps/web/src/hooks/v3/useFeeTierDistributionQuery.ts
+++ b/apps/web/src/hooks/v3/useFeeTierDistributionQuery.ts
@@ -11,12 +11,16 @@ export function useFeeTierDistributionQuery(token0: string | undefined, token1: 
 
     queryFn: async ({ signal }) => {
       if (!chainId || !t0 || !t1) return undefined
+      const chainName = chainIdToExplorerInfoChainName[chainId]
+
+      if (!chainName) throw new Error(`Unknown chainId: ${chainId}`)
+
       return explorerApiClient
         .GET('/cached/pools/v3/{chainName}/list/simple', {
           signal,
           params: {
             path: {
-              chainName: chainIdToExplorerInfoChainName[chainId],
+              chainName,
             },
             query: {
               token0: t0,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `useFeeTierDistributionQuery` hook by introducing a `chainName` variable and using it in the query parameters.

### Detailed summary
- Introduces a `chainName` variable based on `chainId`
- Uses `chainName` in the query parameters instead of `chainIdToExplorerInfoChainName[chainId]`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->