### PR TITLE
chore: Remove skip count from block timestamps

### DIFF
--- a/apps/web/src/utils/getBlocksFromTimestamps.ts
+++ b/apps/web/src/utils/getBlocksFromTimestamps.ts
@@ -7,13 +7,11 @@ import { Block } from 'state/info/types'
  * @notice Fetches block objects for an array of timestamps.
  * @param {Array} timestamps
  * @param sortDirection The direction to sort the retrieved blocks. Defaults to 'desc'
- * @param skipCount How many subqueries to fire at a time
  * @param chainName The name of the blockchain to retrieve blocks from. Defaults to 'BSC'
  */
 export const getBlocksFromTimestamps = async (
   timestamps: number[],
   sortDirection: 'asc' | 'desc' | undefined = 'desc',
-  skipCount: number | undefined = 500,
   chainName: MultiChainNameExtend | undefined = 'BSC',
 ): Promise<Block[]> => {
   if (timestamps?.length === 0) {

--- a/apps/web/src/views/Info/hooks/useBlocksFromTimestamps.ts
+++ b/apps/web/src/views/Info/hooks/useBlocksFromTimestamps.ts
@@ -29,7 +29,7 @@ export const useBlocksFromTimestamps = (
   useEffect(() => {
     const fetchData = async () => {
       const timestampsArray = JSON.parse(timestampsString)
-      const result = await getBlocksFromTimestamps(timestampsArray, sortDirection, skipCount, chainName)
+      const result = await getBlocksFromTimestamps(timestampsArray, sortDirection, chainName)
       if (result.length === 0) {
         setError(true)
       } else {
@@ -61,7 +61,7 @@ export const useBlockFromTimeStampQuery = (
   const timestampsArray = JSON.parse(timestampsString)
   const { data } = useQuery({
     queryKey: [`info/blocks/${timestampsString}/${chainId}`, multiChainName[chainId] ?? chainName],
-    queryFn: () => getBlocksFromTimestamps(timestampsArray, sortDirection, skipCount, chainName),
+    queryFn: () => getBlocksFromTimestamps(timestampsArray, sortDirection, chainName),
     refetchOnReconnect: false,
     refetchOnMount: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `skipCount` parameter in `getBlocksFromTimestamps` function and updates its usage in `useBlocksFromTimestamps` and `useBlockFromTimeStampQuery`.

### Detailed summary
- Removed the `skipCount` parameter from `getBlocksFromTimestamps` function
- Updated `useBlocksFromTimestamps` to reflect the removal of `skipCount`
- Updated `useBlockFromTimeStampQuery` to reflect the removal of `skipCount`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->