### PR TITLE
fix: recalculate the booster APR for PM v2 SS V3 bCake 

### DIFF
--- a/apps/web/src/state/farms/fetchFarmUser.ts
+++ b/apps/web/src/state/farms/fetchFarmUser.ts
@@ -177,10 +177,37 @@ export const fetchFarmUserBCakeWrapperConstants = async (farmsToFetch: Serialize
     allowFailure: false,
   })
 
+  const totalBoostedShare = await publicClient({ chainId }).multicall({
+    contracts: farmsToFetch.map((farm) => {
+      return {
+        abi: v2BCakeWrapperABI,
+        address: farm?.bCakeWrapperAddress ?? '0x',
+        functionName: 'totalBoostedShare',
+      } as const
+    }),
+    allowFailure: false,
+  })
+  const lpBalanceOf = await publicClient({ chainId }).multicall({
+    contracts: farmsToFetch.map((farm) => {
+      return {
+        abi: erc20Abi,
+        address: farm?.lpAddress ?? '0x',
+        functionName: 'balanceOf',
+        args: [farm?.bCakeWrapperAddress ?? '0x'],
+      } as const
+    }),
+    allowFailure: false,
+  })
+  const totalLiquidityX = totalBoostedShare.map((share, index) => {
+    if (!share || !lpBalanceOf[index]) return 1
+    return new BigNumber(share.toString()).div(lpBalanceOf[index].toString()).toNumber()
+  })
+
   return {
     boosterContractAddress,
     startTimestamp: startTimestamp.map((d) => Number(d)),
     endTimestamp: endTimestamp.map((d) => Number(d)),
+    totalLiquidityX,
   }
 }
 

--- a/apps/web/src/state/farms/index.ts
+++ b/apps/web/src/state/farms/index.ts
@@ -10,13 +10,13 @@ import type {
 import { getFarmsPriceHelperLpFiles } from 'config/constants/priceHelperLps'
 import stringify from 'fast-json-stable-stringify'
 import keyBy from 'lodash/keyBy'
+import { fetchStableFarmsAvgInfo, fetchV2FarmsAvgInfo } from 'queries/farms'
 import type { AppState } from 'state'
 import { verifyBscNetwork } from 'utils/verifyBscNetwork'
 import { getViemClients } from 'utils/viem'
 import { chains } from 'utils/wagmi'
 import { Address } from 'viem'
 import splitProxyFarms from 'views/Farms/components/YieldBooster/helpers/splitProxyFarms'
-import { fetchStableFarmsAvgInfo, fetchV2FarmsAvgInfo } from 'queries/farms'
 import { resetUserState } from '../global/actions'
 import {
   fetchFarmBCakeWrapperUserAllowances,
@@ -233,10 +233,11 @@ async function getBCakeWrapperFarmsStakeValue(farms, account, chainId) {
 }
 
 async function getBCakeWrapperFarmsData(farms, chainId) {
-  const [{ boosterContractAddress, startTimestamp, endTimestamp }, { rewardPerSec }] = await Promise.all([
-    fetchFarmUserBCakeWrapperConstants(farms, chainId),
-    fetchFarmUserBCakeWrapperRewardPerSec(farms, chainId),
-  ])
+  const [{ boosterContractAddress, startTimestamp, endTimestamp, totalLiquidityX }, { rewardPerSec }] =
+    await Promise.all([
+      fetchFarmUserBCakeWrapperConstants(farms, chainId),
+      fetchFarmUserBCakeWrapperRewardPerSec(farms, chainId),
+    ])
 
   const normalFarmAllowances = farms.map((_, index) => {
     return {
@@ -245,6 +246,7 @@ async function getBCakeWrapperFarmsData(farms, chainId) {
       rewardPerSecond: rewardPerSec[index],
       startTimestamp: startTimestamp[index],
       endTimestamp: endTimestamp[index],
+      totalLiquidityX: totalLiquidityX[index],
     }
   })
 

--- a/apps/web/src/views/Farms/FarmsV3.tsx
+++ b/apps/web/src/views/Farms/FarmsV3.tsx
@@ -292,7 +292,7 @@ const Farms: React.FC<React.PropsWithChildren> = ({ children }) => {
                 chainId,
                 new BigNumber(farm?.poolWeight ?? 0),
                 cakePrice,
-                totalLiquidity,
+                totalLiquidity.times(farm.bCakePublicData?.totalLiquidityX ?? 1),
                 farm.lpAddress,
                 regularCakePerBlock,
                 farm.lpRewardsApr,

--- a/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
+++ b/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
@@ -70,6 +70,7 @@ interface Props {
   lpTokenDecimals?: number
   aprTimeWindow?: number
   bCakeWrapper?: Address
+  adapterAddress?: Address
   minDepositUSD?: number
   boosterMultiplier?: number
   isBooster?: boolean
@@ -127,6 +128,7 @@ export const AddLiquidity = memo(function AddLiquidity({
   boosterMultiplier,
   onStake,
   isTxLoading,
+  adapterAddress,
 }: Props) {
   const [valueA, setValueA] = useState('')
   const [valueB, setValueB] = useState('')
@@ -228,6 +230,8 @@ export const AddLiquidity = memo(function AddLiquidity({
     farmRewardAmount: aprDataInfo?.info?.rewardAmount ?? 0,
     rewardEndTime,
     rewardStartTime,
+    bCakeWrapperAddress: bCakeWrapper,
+    adapterAddress,
   })
 
   const displayBalanceText = useCallback(

--- a/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/components/DuoTokenVaultCard.tsx
@@ -86,6 +86,7 @@ interface Props {
   minDepositUSD?: number
   boosterMultiplier?: number
   boosterContractAddress?: Address
+  adapterAddress?: Address
 }
 
 export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
@@ -133,6 +134,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
   minDepositUSD,
   boosterMultiplier,
   boosterContractAddress,
+  adapterAddress,
 }: PropsWithChildren<Props>) {
   const apr = useApr({
     currencyA,
@@ -148,6 +150,8 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
     farmRewardAmount: aprDataInfo?.info?.rewardAmount ?? 0,
     rewardEndTime,
     rewardStartTime,
+    adapterAddress,
+    bCakeWrapperAddress: bCakeWrapper,
   })
 
   const vaultName = useMemo(() => getVaultName(idByManager, name), [name, idByManager])
@@ -239,6 +243,7 @@ export const DuoTokenVaultCard = memo(function DuoTokenVaultCard({
           minDepositUSD={minDepositUSD}
           isBooster={isBoosterWhiteList && apr?.isInCakeRewardDateRange}
           boosterContractAddress={boosterContractAddress}
+          adapterAddress={adapterAddress}
         />
         <ExpandableSection mt="1.5em">
           <VaultInfo

--- a/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
@@ -94,6 +94,7 @@ export interface LiquidityManagementProps {
   aprTimeWindow?: number
   isBooster?: boolean
   bCakeWrapper?: Address
+  adapterAddress?: Address
   minDepositUSD?: number
   boosterMultiplier?: number
   boosterContractAddress?: Address
@@ -140,6 +141,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
   boosterMultiplier,
   isBooster,
   boosterContractAddress,
+  adapterAddress,
 }: LiquidityManagementProps) {
   const { colors } = useTheme()
   const { t } = useTranslation()
@@ -314,6 +316,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
         isBooster={isBooster}
         onStake={onStake}
         isTxLoading={isTxLoading}
+        adapterAddress={adapterAddress}
       />
       <RemoveLiquidity
         isOpen={removeLiquidityModalOpen}

--- a/apps/web/src/views/PositionManagers/components/TableView/ActionPanel.tsx
+++ b/apps/web/src/views/PositionManagers/components/TableView/ActionPanel.tsx
@@ -58,6 +58,7 @@ export const ActionPanel: React.FC<
   minDepositUSD,
   isBooster,
   boosterContractAddress,
+  adapterAddress,
 }) => {
   const { colors } = useTheme()
   const { isMobile, isDesktop } = useMatchBreakpoints()
@@ -150,6 +151,7 @@ export const ActionPanel: React.FC<
             minDepositUSD={minDepositUSD}
             isBooster={isBooster && isInCakeRewardDateRange}
             boosterContractAddress={boosterContractAddress}
+            adapterAddress={adapterAddress}
           />
         </TableActionCard>
       </Flex>

--- a/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
@@ -83,6 +83,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
   boosterMultiplier,
   isBooster,
   boosterContractAddress,
+  adapterAddress,
 }: LiquidityManagementProps) {
   const { colors } = useTheme()
   const { t } = useTranslation()
@@ -283,6 +284,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
         isBooster={isBooster}
         onStake={onStake}
         isTxLoading={isTxLoading}
+        adapterAddress={adapterAddress}
       />
       <RemoveLiquidity
         isOpen={removeLiquidityModalOpen}

--- a/apps/web/src/views/PositionManagers/components/TableView/index.tsx
+++ b/apps/web/src/views/PositionManagers/components/TableView/index.tsx
@@ -194,6 +194,8 @@ export const TableRow: React.FC<Props> = ({ config, farmsV3, aprDataList, update
     rewardEndTime: info.endTimestamp,
     rewardStartTime: info.startTimestamp,
     farmRewardAmount: aprDataInfo?.info?.rewardAmount ?? 0,
+    adapterAddress,
+    bCakeWrapperAddress,
   })
 
   const staked0Amount = info?.userToken0Amounts
@@ -463,6 +465,7 @@ export const TableRow: React.FC<Props> = ({ config, farmsV3, aprDataList, update
               aprTimeWindow={aprDataInfo.timeWindow}
               bCakeWrapper={bCakeWrapperAddress}
               minDepositUSD={minDepositUSD}
+              adapterAddress={adapterAddress}
               isBooster={isBoosterWhiteList}
               boosterContractAddress={info?.boosterContractAddress}
             />

--- a/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
+++ b/apps/web/src/views/PositionManagers/containers/PCSVaultCard.tsx
@@ -147,6 +147,8 @@ export const ThirdPartyVaultCard = memo(function PCSVaultCard({
     rewardEndTime: info.endTimestamp,
     rewardStartTime: info.startTimestamp,
     farmRewardAmount: aprDataInfo?.info?.rewardAmount ?? 0,
+    adapterAddress,
+    bCakeWrapperAddress,
   })
 
   const staked0Amount = info?.userToken0Amounts
@@ -227,6 +229,7 @@ export const ThirdPartyVaultCard = memo(function PCSVaultCard({
       minDepositUSD={minDepositUSD}
       boosterMultiplier={info?.boosterMultiplier}
       boosterContractAddress={info?.boosterContractAddress}
+      adapterAddress={adapterAddress}
     >
       {id}
     </DuoTokenVaultCard>

--- a/apps/web/src/views/PositionManagers/hooks/useApr.ts
+++ b/apps/web/src/views/PositionManagers/hooks/useApr.ts
@@ -6,7 +6,9 @@ import { YEAR_IN_SECONDS } from '@pancakeswap/utils/getTimePeriods'
 import BigNumber from 'bignumber.js'
 import { useCurrencyUsdPrice } from 'hooks/useCurrencyUsdPrice'
 import { useMemo } from 'react'
+import { Address } from 'viem'
 import { useTotalStakedInUsd } from 'views/PositionManagers/hooks/useTotalStakedInUsd'
+import { useBoosterLiquidityX } from './useBoostedLiquidityX'
 
 interface AprProps {
   currencyA: Currency
@@ -22,6 +24,8 @@ interface AprProps {
   rewardEndTime: number
   rewardStartTime: number
   farmRewardAmount?: number
+  adapterAddress?: Address
+  bCakeWrapperAddress?: Address
 }
 
 export interface AprResult {
@@ -47,8 +51,11 @@ export const useApr = ({
   rewardEndTime,
   rewardStartTime,
   farmRewardAmount,
+  adapterAddress,
+  bCakeWrapperAddress,
 }: AprProps): AprResult => {
   const { data: rewardUsdPrice } = useCurrencyUsdPrice(earningToken ?? undefined)
+  const { boostedLiquidityX } = useBoosterLiquidityX(bCakeWrapperAddress, adapterAddress)
 
   const isInCakeRewardDateRange = useMemo(
     // () =>  true // mock cake in range to see the booster changes
@@ -63,6 +70,7 @@ export const useApr = ({
     poolToken1Amount,
     token0PriceUSD,
     token1PriceUSD,
+    boostedLiquidityX,
   })
 
   const totalLpApr = useMemo(() => {

--- a/apps/web/src/views/PositionManagers/hooks/useApr.ts
+++ b/apps/web/src/views/PositionManagers/hooks/useApr.ts
@@ -70,7 +70,6 @@ export const useApr = ({
     poolToken1Amount,
     token0PriceUSD,
     token1PriceUSD,
-    boostedLiquidityX,
   })
 
   const totalLpApr = useMemo(() => {
@@ -104,9 +103,9 @@ export const useApr = ({
     return getBalanceAmount(new BigNumber(rewardPerSecond), earningToken.decimals)
       .times(YEAR_IN_SECONDS)
       .times(rewardUsdPrice ?? 0)
-      .div(totalStakedInUsd)
+      .div(totalStakedInUsd * (boostedLiquidityX ?? 1))
       .times(100)
-  }, [isInCakeRewardDateRange, earningToken, rewardPerSecond, rewardUsdPrice, totalStakedInUsd])
+  }, [isInCakeRewardDateRange, earningToken, rewardPerSecond, rewardUsdPrice, totalStakedInUsd, boostedLiquidityX])
 
   const totalApr = useMemo(() => cakeYieldApr.plus(totalLpApr), [cakeYieldApr, totalLpApr])
 

--- a/apps/web/src/views/PositionManagers/hooks/useBoostedLiquidityX.tsx
+++ b/apps/web/src/views/PositionManagers/hooks/useBoostedLiquidityX.tsx
@@ -1,0 +1,50 @@
+import { positionManagerAdapterABI, positionManagerVeBCakeWrapperABI } from '@pancakeswap/position-managers'
+import { useQuery } from '@tanstack/react-query'
+import BN from 'bignumber.js'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { publicClient } from 'utils/wagmi'
+import { Address } from 'viem'
+
+export const useBoosterLiquidityX = (bCakeWrapperAddress?: Address, adapterAddress?: Address) => {
+  const { chainId } = useActiveChainId()
+  const enabled = Boolean(adapterAddress) && Boolean(bCakeWrapperAddress) && Boolean(chainId)
+
+  const { data } = useQuery({
+    queryKey: ['boostedLiquidityX', adapterAddress, bCakeWrapperAddress, chainId],
+    queryFn: async () => {
+      const boostedLiquidityX = await getBoosterLiquidityX({ bCakeWrapperAddress, adapterAddress, chainId })
+      return boostedLiquidityX
+    },
+    enabled,
+  })
+  return { boostedLiquidityX: data?.boostedLiquidityX ?? 1 }
+}
+
+export async function getBoosterLiquidityX({ bCakeWrapperAddress, adapterAddress, chainId }): Promise<{
+  boostedLiquidityX: number
+} | null> {
+  const [totalBoostedShareData, totalSupplyData] = await publicClient({
+    chainId,
+  }).multicall({
+    contracts: [
+      {
+        address: bCakeWrapperAddress,
+        functionName: 'totalBoostedShare',
+        abi: positionManagerVeBCakeWrapperABI,
+      },
+      {
+        address: adapterAddress,
+        functionName: 'totalSupply',
+        abi: positionManagerAdapterABI,
+      },
+    ],
+  })
+
+  if (!totalBoostedShareData.result || !totalSupplyData.result) return null
+
+  const [totalBoostedShare, totalSupply] = [totalBoostedShareData.result, totalSupplyData.result]
+
+  return {
+    boostedLiquidityX: new BN(totalBoostedShare.toString()).div(totalSupply.toString()).toNumber(),
+  }
+}

--- a/apps/web/src/views/PositionManagers/hooks/useTotalStakedInUsd.ts
+++ b/apps/web/src/views/PositionManagers/hooks/useTotalStakedInUsd.ts
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
-import BigNumber from 'bignumber.js'
 import { Currency, CurrencyAmount } from '@pancakeswap/sdk'
+import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
 
 interface TotalStakedInUsdProps {
   currencyA: Currency
@@ -9,6 +9,7 @@ interface TotalStakedInUsdProps {
   poolToken1Amount?: bigint
   token0PriceUSD?: number
   token1PriceUSD?: number
+  boostedLiquidityX?: number
 }
 
 export const useTotalStakedInUsd = ({
@@ -18,6 +19,7 @@ export const useTotalStakedInUsd = ({
   poolToken1Amount,
   token0PriceUSD,
   token1PriceUSD,
+  boostedLiquidityX = 1,
 }: TotalStakedInUsdProps): number => {
   const pool0Amount = poolToken0Amount ? CurrencyAmount.fromRawAmount(currencyA, poolToken0Amount) : undefined
   const pool1Amount = poolToken1Amount ? CurrencyAmount.fromRawAmount(currencyB, poolToken1Amount) : undefined
@@ -28,5 +30,5 @@ export const useTotalStakedInUsd = ({
     return totalPoolToken0Usd.plus(totalPoolToken1Usd).toNumber()
   }, [pool0Amount, pool1Amount, token0PriceUSD, token1PriceUSD])
 
-  return totalStakedInUsd ?? 0
+  return totalStakedInUsd * boostedLiquidityX ?? 0
 }

--- a/packages/farms/src/index.ts
+++ b/packages/farms/src/index.ts
@@ -119,13 +119,19 @@ export function createFarmFetcherV3(provider: ({ chainId }: { chainId: number })
     }
   }
 
-  const getCakeAprAndTVL = (farm: FarmV3DataWithPrice, lpTVL: LPTvl, cakePrice: string, cakePerSecond: string) => {
+  const getCakeAprAndTVL = (
+    farm: FarmV3DataWithPrice,
+    lpTVL: LPTvl,
+    cakePrice: string,
+    cakePerSecond: string,
+    boosterLiquidityX?: number,
+  ) => {
     const [token0Price, token1Price] = farm.token.sortsBefore(farm.quoteToken)
       ? [farm.tokenPriceBusd, farm.quoteTokenPriceBusd]
       : [farm.quoteTokenPriceBusd, farm.tokenPriceBusd]
     const tvl = new BigNumber(token0Price).times(lpTVL.token0).plus(new BigNumber(token1Price).times(lpTVL.token1))
 
-    const cakeApr = getCakeApr(farm.poolWeight, tvl, cakePrice, cakePerSecond)
+    const cakeApr = getCakeApr(farm.poolWeight, tvl.times(boosterLiquidityX ?? 1), cakePrice, cakePerSecond)
 
     return {
       activeTvlUSD: tvl.toString(),

--- a/packages/farms/src/types.ts
+++ b/packages/farms/src/types.ts
@@ -168,6 +168,7 @@ export interface SerializedBCakeUserData {
   rewardPerSecond?: number
   startTimestamp?: number
   endTimestamp?: number
+  totalLiquidityX?: number
 }
 
 export interface SerializedFarm extends SerializedFarmPublicData {
@@ -227,6 +228,7 @@ export interface DeserializedBCakeWrapperUserData {
   startTimestamp?: number
   endTimestamp?: number
   isRewardInRange?: boolean
+  totalLiquidityX?: number
 }
 
 export interface DeserializedFarm extends DeserializedFarmConfig {

--- a/packages/farms/src/v2/deserializeFarmUserData.ts
+++ b/packages/farms/src/v2/deserializeFarmUserData.ts
@@ -63,5 +63,6 @@ export const deserializeFarmBCakePublicData = (farm?: SerializedFarm): Deseriali
     startTimestamp: farm?.bCakePublicData?.startTimestamp,
     endTimestamp: farm?.bCakePublicData?.endTimestamp,
     isRewardInRange: Boolean(isRewardInRange),
+    totalLiquidityX: farm?.bCakePublicData?.totalLiquidityX ?? 1,
   }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce a new `adapterAddress` field and enhance calculations related to liquidity and rewards in various components.

### Detailed summary
- Added `adapterAddress` field to multiple components
- Introduced `totalLiquidityX` for boosted liquidity calculations
- Updated calculations for total staked USD with boosted liquidity factor

> The following files were skipped due to too many changes: `apps/web/src/views/PositionManagers/hooks/useBoostedLiquidityX.tsx`, `apps/web/src/state/farmsV3/hooks.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->