### PR TITLE
feat: Old price display on chart when tap in mobile and use default timezone

### DIFF
--- a/packages/uikit/src/components/Chart/PairPriceChart.tsx
+++ b/packages/uikit/src/components/Chart/PairPriceChart.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from "@pancakeswap/localization";
 import dayjs from "dayjs";
-import { createChart, IChartApi, LineStyle, UTCTimestamp } from "lightweight-charts";
+import { createChart, IChartApi, ISeriesApi, LineStyle, MouseEventParams, UTCTimestamp } from "lightweight-charts";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTheme } from "styled-components";
 import LineChartLoader from "./LineChartLoaderSVG";
+import { useMatchBreakpoints } from "../../contexts";
 
 export enum PairDataTimeWindowEnum {
   HOUR,
@@ -37,6 +38,41 @@ const dateFormattingByTimewindow: Record<PairDataTimeWindowEnum, string> = {
   [PairDataTimeWindowEnum.YEAR]: "MMM dd",
 };
 
+const getHandler = (
+  chart: IChartApi,
+  newSeries: ISeriesApi<"Area">,
+  locale: string,
+  setHoverValue: Dispatch<SetStateAction<number | undefined>> | undefined,
+  setHoverDate: Dispatch<SetStateAction<string | undefined>> | undefined,
+  isMobile: boolean
+) => {
+  return (param: MouseEventParams) => {
+    if (newSeries && param) {
+      const timestamp = param.time as number;
+      if (!timestamp) return;
+      const now = new Date(timestamp * 1000);
+      const time = `${now.toLocaleString(locale, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZone: "UTC",
+      })} (UTC)`;
+      // @ts-ignore
+      const parsed = (param.seriesData.get(newSeries)?.value ?? 0) as number | undefined;
+      if (parsed && param.time && isMobile) {
+        chart.setCrosshairPosition(parsed, param.time, newSeries);
+      }
+      if (setHoverValue) setHoverValue(parsed);
+      if (setHoverDate) setHoverDate(time);
+    } else {
+      if (setHoverValue) setHoverValue(undefined);
+      if (setHoverDate) setHoverDate(undefined);
+    }
+  };
+};
+
 export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
   data,
   setHoverValue,
@@ -48,6 +84,7 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
   ...rest
 }) => {
   const { isDark } = useTheme();
+  const { isMobile } = useMatchBreakpoints();
   const transformedData = useMemo(() => {
     return (
       data?.map(({ time, value }) => {
@@ -150,28 +187,11 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
 
     chart.timeScale().fitContent();
 
-    chart.subscribeCrosshairMove((param) => {
-      if (newSeries && param) {
-        const timestamp = param.time as number;
-        if (!timestamp) return;
-        const now = new Date(timestamp * 1000);
-        const time = `${now.toLocaleString(locale, {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-          hour: "numeric",
-          minute: "2-digit",
-          timeZone: "UTC",
-        })} (UTC)`;
-        // @ts-ignore
-        const parsed = (param.seriesData.get(newSeries)?.value ?? 0) as number | undefined;
-        if (setHoverValue) setHoverValue(parsed);
-        if (setHoverDate) setHoverDate(time);
-      } else {
-        if (setHoverValue) setHoverValue(undefined);
-        if (setHoverDate) setHoverDate(undefined);
-      }
-    });
+    if (isMobile) {
+      chart.subscribeClick(getHandler(chart, newSeries, locale, setHoverValue, setHoverDate, isMobile));
+    } else {
+      chart.subscribeCrosshairMove(getHandler(chart, newSeries, locale, setHoverValue, setHoverDate, isMobile));
+    }
 
     // eslint-disable-next-line consistent-return
     return () => {
@@ -181,6 +201,7 @@ export const SwapLineChart: React.FC<SwapLineChartNewProps> = ({
     transformedData,
     isDark,
     colors,
+    isMobile,
     isChartExpanded,
     locale,
     timeWindow,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the PairPriceChart component in the Chart module by adding interactive functionality for mobile devices.

### Detailed summary
- Added `useMatchBreakpoints` hook import
- Implemented conditional event handling based on device type
- Improved user interaction with chart on mobile devices

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->