### PR TITLE
feat: list lista farm & gauge

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 169,
+    token0: bscTokens.wbnb,
+    token1: bscTokens.lista,
+    lpAddress: '0x976241c208CC07505a620d768ee7251d47AcB2a0',
+    feeAmount: FeeAmount.HIGH,
+  },
+  {
     pid: 168,
     token0: bscTokens.usdt,
     token1: bscTokens.axlSTARS,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4482,4 +4482,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: zksyncTokens.zk.address,
     token1Address: zksyncTokens.usdcNative.address,
   },
+  {
+    gid: 453,
+    pairName: 'LISTA-BNB',
+    address: '0x976241c208CC07505a620d768ee7251d47AcB2a0',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.HIGH,
+    token0Address: bscTokens.wbnb.address,
+    token1Address: bscTokens.lista.address,
+  },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new liquidity pool and gauge configurations for BSC network.

### Detailed summary
- Added a new liquidity pool with PID 169 for WBNB-LISTA pair
- Added a new gauge with GID 453 for LISTA-BNB pair on BSC network

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->