### PR TITLE
fix: Keep previous data on chainlink chart to not show loading on each fetch

### DIFF
--- a/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
+++ b/apps/web/src/views/Predictions/components/ChainlinkChart.tsx
@@ -10,7 +10,7 @@ import {
   lightColors,
 } from '@pancakeswap/uikit'
 import { formatBigIntToFixed } from '@pancakeswap/utils/formatBalance'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query'
 import { LineChartLoader } from 'components/ChartLoaders'
 import PairPriceDisplay from 'components/PairPriceDisplay'
 import { chainlinkOracleABI } from 'config/abi/chainlinkOracle'
@@ -73,6 +73,7 @@ function useChainlinkRoundDataSet() {
       }),
     query: {
       enabled: !!lastRound,
+      placeholderData: keepPreviousData,
     },
   })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance data consistency by using the `keepPreviousData` option in the `useQuery` hook for fetching Chainlink round data.

### Detailed summary
- Added `keepPreviousData` option to `useQuery` hook for Chainlink round data fetching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->