### PR TITLE
chore: Make roi calculator chart default to day

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -1,6 +1,15 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency, CurrencyAmount, Price, Token, ZERO } from '@pancakeswap/sdk'
-import { CalculateIcon, Flex, IconButton, QuestionHelper, RocketIcon, Text, TooltipText } from '@pancakeswap/uikit'
+import {
+  CalculateIcon,
+  Flex,
+  IconButton,
+  PairDataTimeWindowEnum,
+  QuestionHelper,
+  RocketIcon,
+  Text,
+  TooltipText,
+} from '@pancakeswap/uikit'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { formatPrice } from '@pancakeswap/utils/formatFractions'
 import { FeeCalculator, Pool, encodeSqrtRatioX96, isPoolTickInRange, parseProtocolFees } from '@pancakeswap/v3-sdk'
@@ -72,7 +81,7 @@ export function AprCalculator({
 }: Props) {
   const { t } = useTranslation()
   const [isOpen, setOpen] = useState(false)
-  const [priceSpan, setPriceSpan] = useState(0)
+  const [priceSpan, setPriceSpan] = useState(PairDataTimeWindowEnum.DAY)
   const { data: farm } = useFarm({ currencyA: baseCurrency, currencyB: quoteCurrency, feeAmount })
   const cakePrice = useCakePrice()
 

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -5,6 +5,7 @@ import {
   CalculateIcon,
   Flex,
   IconButton,
+  PairDataTimeWindowEnum,
   RocketIcon,
   Skeleton,
   Text,
@@ -66,7 +67,7 @@ function FarmV3ApyButton_({ farm, existingPosition, isPositionStaked, tokenId }:
   const { t } = useTranslation()
   const roiModal = useModalV2()
 
-  const [priceTimeWindow, setPriceTimeWindow] = useState(0)
+  const [priceTimeWindow, setPriceTimeWindow] = useState(PairDataTimeWindowEnum.DAY)
   const prices = usePairTokensPrice(lpAddress, priceTimeWindow, baseCurrency?.chainId, roiModal.isOpen)
 
   const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount, roiModal.isOpen)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the default time window values in two components to `PairDataTimeWindowEnum.DAY`.

### Detailed summary
- Updated default time window value to `PairDataTimeWindowEnum.DAY` in `FarmV3ApyButton.tsx`
- Updated default time window value to `PairDataTimeWindowEnum.DAY` in `AprCalculator.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->