### PR TITLE
fix: change url of perp to hardcode

### DIFF
--- a/apps/web/src/components/PhishingWarningBanner/PerpetualSeason.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/PerpetualSeason.tsx
@@ -3,8 +3,6 @@ import { ArrowForwardIcon, Box, Column, Flex, FlexGap, Link, Text, useMatchBreak
 import { ASSET_CDN } from 'config/constants/endpoints'
 import styled from 'styled-components'
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
-import { getPerpetualUrl } from 'utils/getPerpetualUrl'
-import { useTheme } from '@pancakeswap/hooks'
 import { ICampaignBanner } from './ICampaignBanner'
 
 const MobileImage = styled.img`
@@ -17,8 +15,6 @@ const MobileImage = styled.img`
 export const PerpetualSeason: ICampaignBanner = () => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
-  const { isDark } = useTheme()
-  const { currentLanguage } = useTranslation()
 
   const content = (
     <Box>
@@ -65,11 +61,7 @@ export const PerpetualSeason: ICampaignBanner = () => {
           color="primary"
           fontSize={['12px', '12px', '14px']}
           style={{ display: 'flex', alignItems: 'center', whiteSpace: 'nowrap' }}
-          href={`${getPerpetualUrl({
-            chainId: 42161,
-            languageCode: currentLanguage.code,
-            isDark,
-          })}&utm_source=infostripe&utm_medium=website&utm_campaign=PerpARBIncentives&utm_id=ARBincentives`}
+          href="https://perp.pancakeswap.finance/en/futures/v2/BTCUSD?chain=Arbitrum&utm_source=infostripe&utm_medium=website&utm_campaign=PerpARBIncentives&utm_id=ARBincentives"
         >
           {t('Start Trading')}
           <ArrowForwardIcon width="14px" color="primary" style={{ marginRight: '-8px' }} />

--- a/apps/web/src/views/Home/components/Banners/PerpetualSeasonalBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualSeasonalBanner.tsx
@@ -17,9 +17,6 @@ import {
 } from '@pancakeswap/widgets-internal'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import styled from 'styled-components'
-import { useTheme } from '@pancakeswap/hooks'
-import { getPerpetualUrl } from 'utils/getPerpetualUrl'
-import { useMemo } from 'react'
 
 const bgMobile = `${ASSET_CDN}/web/banners/perpetual-season-banner/bunny-bg-mobile.png`
 const bgDesktop = `${ASSET_CDN}/web/banners/perpetual-season-banner/bunny-bg.png`
@@ -39,6 +36,8 @@ const bgXsVariant: GraphicDetail = {
   height: 182,
 }
 
+const startTradingLink =
+  'https://perp.pancakeswap.finance/en/futures/v2/BTCUSD?chain=Arbitrum&utm_source=homepagebanner&utm_medium=website&utm_campaign=PerpARBIncentives&utm_id=ARBincentives'
 const learnMoreLink =
   'https://blog.pancakeswap.finance/articles/trade-on-arbitrum-pancake-swap-perpetual-v2-to-win-300-000-arb?utm_source=homepagebanner&utm_medium=website&utm_campaign=PerpARBIncentives&utm_id=ARBincentives'
 
@@ -56,18 +55,6 @@ const StyledFlexContainer = styled(FlexGap)`
 export const PerpetualSeasonalBanner = () => {
   const { t } = useTranslation()
   const { isMobile, isTablet, isMd } = useMatchBreakpoints()
-  const { isDark } = useTheme()
-  const { currentLanguage } = useTranslation()
-
-  const startTradingLink = useMemo(
-    () =>
-      `${getPerpetualUrl({
-        chainId: 42161,
-        languageCode: currentLanguage.code,
-        isDark,
-      })}&utm_source=homepagebanner&utm_medium=website&utm_campaign=PerpARBIncentives&utm_id=ARBincentives`,
-    [currentLanguage, isDark],
-  )
 
   return (
     <BannerContainer>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the trading links in the `PerpetualSeason.tsx` and `PerpetualSeasonalBanner.tsx` components to point to the new Perpetual trading URL.

### Detailed summary
- Updated trading links to `https://perp.pancakeswap.finance/en/futures/v2/BTCUSD?chain=Arbitrum`
- Removed unused imports and variables related to theme and language in both components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->