### PR TITLE
fix: v3 farm staked liquidity display issue

### DIFF
--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -117,7 +117,7 @@ export const useFarmsV3 = ({ mockApr = false, boosterLiquidityX = {} }: UseFarms
   const cakePrice = useCakePrice()
 
   const { data } = useQuery({
-    queryKey: [chainId, 'cake-apr-tvl', Object.keys(boosterLiquidityX).join('-')],
+    queryKey: [chainId, 'cake-apr-tvl', boosterLiquidityX],
 
     queryFn: async ({ signal }) => {
       if (chainId !== farmV3?.data.chainId) {

--- a/apps/web/src/state/farmsV3/hooks.ts
+++ b/apps/web/src/state/farmsV3/hooks.ts
@@ -117,7 +117,7 @@ export const useFarmsV3 = ({ mockApr = false, boosterLiquidityX = {} }: UseFarms
   const cakePrice = useCakePrice()
 
   const { data } = useQuery({
-    queryKey: [chainId, 'cake-apr-tvl'],
+    queryKey: [chainId, 'cake-apr-tvl', Object.keys(boosterLiquidityX).join('-')],
 
     queryFn: async ({ signal }) => {
       if (chainId !== farmV3?.data.chainId) {
@@ -180,7 +180,7 @@ export const useFarmsV3 = ({ mockApr = false, boosterLiquidityX = {} }: UseFarms
       }
     },
 
-    enabled: Boolean(farmV3.data.farmsWithPrice.length > 0) && Object.keys(boosterLiquidityX ?? {}).length > 0,
+    enabled: Boolean(farmV3.data.farmsWithPrice.length > 0),
     refetchInterval: FAST_INTERVAL * 3,
     staleTime: FAST_INTERVAL,
   })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the `useFarmsV3` hook in the `hooks.ts` file by removing `boosterLiquidityX` dependency from the queryKey and enabling condition.

### Detailed summary
- Removed `boosterLiquidityX` from the `queryKey`
- Updated the `enabled` condition to depend solely on `farmV3.data.farmsWithPrice.length`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->