### PR TITLE
feat: increase decimal precision in collect winnings modal

### DIFF
--- a/apps/web/src/views/Predictions/components/CollectRoundWinningsModal.tsx
+++ b/apps/web/src/views/Predictions/components/CollectRoundWinningsModal.tsx
@@ -160,7 +160,7 @@ const CollectRoundWinningsModal: React.FC<React.PropsWithChildren<CollectRoundWi
         <Flex alignItems="start" justifyContent="space-between" mb="8px">
           <Text>{t('Collecting')}</Text>
           <Box style={{ textAlign: 'right' }}>
-            <Text>{`${formatNumber(total, 0, 4)} ${token?.symbol}`}</Text>
+            <Text>{`${formatNumber(total, 0, 6)} ${token?.symbol}`}</Text>
             <Text fontSize="12px" color="textSubtle">
               {`~$${totalToken.toFixed(2)}`}
             </Text>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the number formatting in the `CollectRoundWinningsModal` component to display more decimal places for the total amount.

### Detailed summary
- Increased decimal places displayed for the total amount in the modal
- Adjusted formatting from 4 decimal places to 6
- Updated corresponding text display for total amount

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->