### PR TITLE
fix: Perp seasonal banner height in mobile

### DIFF
--- a/apps/web/src/views/Home/components/Banners/PerpetualSeasonalBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/PerpetualSeasonalBanner.tsx
@@ -57,7 +57,7 @@ export const PerpetualSeasonalBanner = () => {
   const { isMobile, isTablet, isMd } = useMatchBreakpoints()
 
   return (
-    <BannerContainer>
+    <BannerContainer background="linear-gradient(140deg, #7645d9 0%, #452a7a 100%)">
       <BannerMain
         badges={
           <StyledFlexContainer gap="8px">


### PR DESCRIPTION

<img width="408" alt="image" src="https://github.com/pancakeswap/pancake-frontend/assets/2213635/5e579dbd-c0c4-4b31-96a6-acff876c6adf">

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the background color of the `PerpetualSeasonalBanner` component in the Home view.

### Detailed summary
- Updated the background color of the `BannerContainer` in `PerpetualSeasonalBanner.tsx` to a linear gradient.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->