### PR TITLE
feat: add in-page banner in prediction page

### DIFF
--- a/apps/web/src/components/PhishingWarningBanner/AIPredictionStripe.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/AIPredictionStripe.tsx
@@ -3,7 +3,6 @@ import { ArrowForwardIcon, Box, Column, Flex, FlexGap, Link, Text, useMatchBreak
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import styled from 'styled-components'
-import { ICampaignBanner } from './ICampaignBanner'
 
 const MobileImage = styled.img`
   height: auto;
@@ -15,12 +14,20 @@ const MobileImage = styled.img`
 const stripeImage = `${ASSET_CDN}/web/banners/ai-prediction/info-strip-logo.png`
 const stripeImageAlt = 'AI Predictions'
 
-const ctaLink =
+const defaultCtaLink =
   '/prediction?token=ETH&chain=arb&utm_source=infostripe&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch'
-const learnMoreLink =
+const defaultLearnMoreLink =
   'https://blog.pancakeswap.finance/articles/pancake-swap-introduces-ai-powered-prediction-market-on-arbitrum-up-to-100-fund-protection-and-launching-60-000-arb-campaign?utm_source=infostripe&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch'
 
-export const AIPrediction: ICampaignBanner = () => {
+interface AIPredictionStripeProps {
+  ctaLink?: string
+  learnMoreLink?: string
+}
+
+export const AIPrediction = ({
+  ctaLink = defaultCtaLink,
+  learnMoreLink = defaultLearnMoreLink,
+}: AIPredictionStripeProps) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
 

--- a/apps/web/src/views/Predictions/components/InPageBanner.tsx
+++ b/apps/web/src/views/Predictions/components/InPageBanner.tsx
@@ -1,0 +1,106 @@
+import { ChainId } from '@pancakeswap/chains'
+import { SUPPORTED_CHAIN_IDS } from '@pancakeswap/prediction'
+import { Flex, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { usePhishingBanner } from '@pancakeswap/utils/user'
+import { AIPrediction } from 'components/PhishingWarningBanner/AIPredictionStripe'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useMemo } from 'react'
+import styled from 'styled-components'
+
+const Container = styled(Flex).withConfig({ shouldForwardProp: (prop) => !['$background'].includes(prop) })<{
+  $background?: string
+}>`
+  overflow: hidden;
+  padding: 12px;
+  align-items: center;
+  justify-content: center;
+  background: #280d5f;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    padding: 0px;
+    background: #7a6eaa;
+    ${({ $background }) => $background && `background: ${$background};`}
+  }
+`
+
+const InnerContainer = styled(Flex)`
+  width: 100%;
+  height: 100%;
+  align-items: center;
+`
+
+const SpeechBubble = styled(Flex)`
+  position: relative;
+  border-radius: 16px;
+  width: 100%;
+  height: 80%;
+  align-items: center;
+  justify-content: space-between;
+
+  & ${Text} {
+    flex-shrink: 0;
+    margin-right: 4px;
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    width: 800px;
+    padding: 8px;
+    margin-left: 8px;
+    background: #280d5f;
+
+    &:before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: -7px;
+      transform: translateY(-50%);
+      width: 0;
+      height: 0;
+      border-top: 8px solid transparent;
+      border-bottom: 8px solid transparent;
+      border-right: 8px solid #280d5f;
+    }
+  }
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    width: 900px;
+  }
+`
+
+export const InPageBanner = () => {
+  const { chainId } = useActiveChainId()
+  const { isDesktop, isLg } = useMatchBreakpoints()
+  const showInBigDevice = isDesktop || isLg
+
+  const [isInfoStripeActive] = usePhishingBanner()
+  const showBanner = useMemo(
+    () => !isInfoStripeActive && chainId !== ChainId.ARBITRUM_ONE && SUPPORTED_CHAIN_IDS.includes(chainId),
+    [isInfoStripeActive, chainId],
+  )
+
+  if (!showBanner) return <></>
+
+  return (
+    <>
+      <Container className="warning-banner" $background={AIPrediction.background}>
+        <Flex justifyContent="center" alignItems="center">
+          {showInBigDevice && (
+            <img
+              width={AIPrediction.stripeImageWidth}
+              alt={AIPrediction.stripeImageAlt}
+              src={AIPrediction.stripeImage}
+            />
+          )}
+          <SpeechBubble>
+            <InnerContainer>
+              <AIPrediction
+                ctaLink="/prediction?token=ETH&chain=arb&utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
+                learnMoreLink="https://blog.pancakeswap.finance/articles/pancake-swap-introduces-ai-powered-prediction-market-on-arbitrum-up-to-100-fund-protection-and-launching-60-000-arb-campaign?utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
+              />
+            </InnerContainer>
+          </SpeechBubble>
+        </Flex>
+      </Container>
+    </>
+  )
+}

--- a/apps/web/src/views/Predictions/components/InPageBanner.tsx
+++ b/apps/web/src/views/Predictions/components/InPageBanner.tsx
@@ -81,26 +81,20 @@ export const InPageBanner = () => {
   if (!showBanner) return <></>
 
   return (
-    <>
-      <Container className="warning-banner" $background={AIPrediction.background}>
-        <Flex justifyContent="center" alignItems="center">
-          {showInBigDevice && (
-            <img
-              width={AIPrediction.stripeImageWidth}
-              alt={AIPrediction.stripeImageAlt}
-              src={AIPrediction.stripeImage}
+    <Container className="warning-banner" $background={AIPrediction.background}>
+      <Flex justifyContent="center" alignItems="center">
+        {showInBigDevice && (
+          <img width={AIPrediction.stripeImageWidth} alt={AIPrediction.stripeImageAlt} src={AIPrediction.stripeImage} />
+        )}
+        <SpeechBubble>
+          <InnerContainer>
+            <AIPrediction
+              ctaLink="/prediction?token=ETH&chain=arb&utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
+              learnMoreLink="https://blog.pancakeswap.finance/articles/pancake-swap-introduces-ai-powered-prediction-market-on-arbitrum-up-to-100-fund-protection-and-launching-60-000-arb-campaign?utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
             />
-          )}
-          <SpeechBubble>
-            <InnerContainer>
-              <AIPrediction
-                ctaLink="/prediction?token=ETH&chain=arb&utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
-                learnMoreLink="https://blog.pancakeswap.finance/articles/pancake-swap-introduces-ai-powered-prediction-market-on-arbitrum-up-to-100-fund-protection-and-launching-60-000-arb-campaign?utm_source=PredictionPage&utm_medium=website&utm_campaign=Arbitrum&utm_id=PredictionLaunch"
-              />
-            </InnerContainer>
-          </SpeechBubble>
-        </Flex>
-      </Container>
-    </>
+          </InnerContainer>
+        </SpeechBubble>
+      </Flex>
+    </Container>
   )
 }

--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -11,6 +11,7 @@ import ChainlinkChartDisclaimer from './components/ChainlinkChartDisclaimer'
 import ChartDisclaimer from './components/ChartDisclaimer'
 import CollectWinningsPopup from './components/CollectWinningsPopup'
 import Container from './components/Container'
+import { InPageBanner } from './components/InPageBanner'
 import RiskDisclaimer from './components/RiskDisclaimer'
 import { useConfig } from './context/ConfigProvider'
 import SwiperProvider from './context/SwiperProvider'
@@ -71,6 +72,7 @@ const Predictions = () => {
       <RiskDisclaimer />
       <SwiperProvider>
         <Container>
+          <InPageBanner />
           {isDesktop ? <Desktop /> : <Mobile />}
           <CollectWinningsPopup />
         </Container>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an `InPageBanner` component to the Predictions view, displaying AI prediction information.

### Detailed summary
- Added `InPageBanner` component to display AI prediction information in Predictions view
- Updated `AIPrediction` component with default links and props
- Introduced new styled components for the `InPageBanner` component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->