### PR TITLE
chore: remove infostripe condition for inpage banner

### DIFF
--- a/apps/web/src/views/Predictions/components/InPageBanner.tsx
+++ b/apps/web/src/views/Predictions/components/InPageBanner.tsx
@@ -1,7 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { SUPPORTED_CHAIN_IDS } from '@pancakeswap/prediction'
 import { Flex, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { usePhishingBanner } from '@pancakeswap/utils/user'
 import { AIPrediction } from 'components/PhishingWarningBanner/AIPredictionStripe'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useMemo } from 'react'
@@ -72,11 +71,7 @@ export const InPageBanner = () => {
   const { isDesktop, isLg } = useMatchBreakpoints()
   const showInBigDevice = isDesktop || isLg
 
-  const [isInfoStripeActive] = usePhishingBanner()
-  const showBanner = useMemo(
-    () => !isInfoStripeActive && chainId !== ChainId.ARBITRUM_ONE && SUPPORTED_CHAIN_IDS.includes(chainId),
-    [isInfoStripeActive, chainId],
-  )
+  const showBanner = useMemo(() => chainId !== ChainId.ARBITRUM_ONE && SUPPORTED_CHAIN_IDS.includes(chainId), [chainId])
 
   if (!showBanner) return <></>
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to simplify the logic for displaying an in-page banner in the Predictions component.

### Detailed summary
- Removed `usePhishingBanner` hook
- Simplified logic for displaying the in-page banner based on chainId

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->