### PR TITLE
chore: list new pepe syrup pool

### DIFF
--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -70,9 +70,9 @@ const Predictions = () => {
     <>
       <Warnings />
       <RiskDisclaimer />
+      <InPageBanner />
       <SwiperProvider>
         <Container>
-          <InPageBanner />
           {isDesktop ? <Desktop /> : <Mobile />}
           <CollectWinningsPopup />
         </Container>

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -19,7 +19,7 @@ export const livePools: SerializedPool[] = [
     earningToken: bscTokens.pepe,
     contractAddress: '0xD85e40C414D04F63D991b3e1863Ff8eff1Dfd230',
     poolCategory: PoolCategory.CORE,
-    tokenPerBlock: '3282.76',
+    tokenPerBlock: '3282.760069632',
   },
   {
     sousId: 380,

--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,14 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 381,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.pepe,
+    contractAddress: '0xD85e40C414D04F63D991b3e1863Ff8eff1Dfd230',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '3282.76',
+  },
+  {
     sousId: 380,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.pepe,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new pool with `sousId: 381` and staking/earning tokens `cake` and `pepe`.

### Detailed summary
- Added a new pool with `sousId: 381`
- Staking token: `cake`, Earning token: `pepe`
- Contract address: `0xD85e40C414D04F63D991b3e1863Ff8eff1Dfd230`
- Pool category: `CORE`
- Token per block: `3282.760069632`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->