### PR TITLE
fix: Buy crypto shows old fee details while loading

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/TransactionFeeDetails/TransactionFeeDetails.tsx
+++ b/apps/web/src/views/BuyCrypto/components/TransactionFeeDetails/TransactionFeeDetails.tsx
@@ -25,6 +25,7 @@ interface TransactionFeeDetailsProps {
   independentField: Field
   inputError: string | undefined
   quotesError: string | undefined
+  loading: boolean | undefined
 }
 
 export const TransactionFeeDetails = ({
@@ -33,6 +34,7 @@ export const TransactionFeeDetails = ({
   independentField,
   inputError,
   quotesError,
+  loading,
 }: TransactionFeeDetailsProps) => {
   const [elementHeight, setElementHeight] = useState<number>(51)
   const [show, setShow] = useState<boolean>(false)
@@ -70,7 +72,11 @@ export const TransactionFeeDetails = ({
         </StyledFeesContainer3>
       </Flex>
 
-      <StyledFeesContainer width="100%" onClick={handleExpandClick} disabled={Boolean(quotesError || inputError)}>
+      <StyledFeesContainer
+        width="100%"
+        onClick={handleExpandClick}
+        disabled={Boolean(loading || quotesError || inputError)}
+      >
         <StyledArrowHead />
         <Flex justifyContent="space-between" alignItems="center">
           <Flex alignItems="center">
@@ -79,7 +85,7 @@ export const TransactionFeeDetails = ({
                 <Text fontWeight="600" fontSize="14px" px="2px">
                   {t('Est total fees:')}
                 </Text>
-                <SkeletonText loading={Boolean(inputError)} initialWidth={40} fontSize="14px">
+                <SkeletonText loading={Boolean(loading || inputError)} initialWidth={40} fontSize="14px">
                   {t('%fees%', {
                     fees: formatLocaleNumber({
                       number: Number((selectedQuote?.providerFee + selectedQuote?.networkFee).toFixed(2)),

--- a/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
@@ -194,6 +194,7 @@ export function BuyCryptoForm() {
           independentField={independentField}
           inputError={inputError}
           quotesError={quotesError}
+          loading={isLoading}
         />
 
         <Box>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `loading` prop to `TransactionFeeDetails` component for handling loading state.

### Detailed summary
- Added `loading` prop to `TransactionFeeDetails` component
- Updated component logic to handle loading state
- Modified `StyledFeesContainer` to consider loading state in onClick event

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->