### PR TITLE
fix: Unstake farms with vault

### DIFF
--- a/apps/web/src/state/user/hooks/index.tsx
+++ b/apps/web/src/state/user/hooks/index.tsx
@@ -76,10 +76,11 @@ export function useUserFarmStakedOnly(isActive: boolean): [boolean, (stakedOnly:
     [dispatch],
   )
 
-  const toggleUserFarmStakedOnly = useCallback(
-    () => setUserFarmStakedOnly(!userFarmStakedOnly),
-    [setUserFarmStakedOnly, userFarmStakedOnly],
-  )
+  const toggleUserFarmStakedOnly = useCallback(() => {
+    const booleanStakedOnly =
+      userFarmStakedOnly === FarmStakedOnly.ON_FINISHED ? !isActive : userFarmStakedOnly === FarmStakedOnly.TRUE
+    setUserFarmStakedOnly(!booleanStakedOnly)
+  }, [setUserFarmStakedOnly, userFarmStakedOnly, isActive])
 
   return [
     userFarmStakedOnly === FarmStakedOnly.ON_FINISHED ? !isActive : userFarmStakedOnly === FarmStakedOnly.TRUE,

--- a/apps/web/src/views/Farms/hooks/useStakeFarms.ts
+++ b/apps/web/src/views/Farms/hooks/useStakeFarms.ts
@@ -5,10 +5,12 @@ import { useCallback } from 'react'
 import { useFeeDataWithGasPrice } from 'state/user/hooks'
 import { bCakeStakeFarm, nonBscStakeFarm, stakeFarm } from 'utils/calls'
 import { useOraclePrice } from 'views/Farms/hooks/useFetchOraclePrice'
+import { ChainId } from '@pancakeswap/chains'
 
 const useStakeFarms = (pid: number, vaultPid?: number) => {
   const { account, chainId } = useAccountActiveChain()
   const { gasPrice } = useFeeDataWithGasPrice()
+  const { gasPrice: bnbGasPrice } = useFeeDataWithGasPrice(ChainId.BSC)
 
   const oraclePrice = useOraclePrice(chainId ?? 0)
   const masterChefContract = useMasterchef()
@@ -23,9 +25,9 @@ const useStakeFarms = (pid: number, vaultPid?: number) => {
 
   const handleStakeNonBsc = useCallback(
     async (amount: string) => {
-      return nonBscStakeFarm(nonBscVaultContract, vaultPid, amount, gasPrice, account, oraclePrice, chainId)
+      return nonBscStakeFarm(nonBscVaultContract, vaultPid, amount, bnbGasPrice, account, oraclePrice, chainId)
     },
-    [nonBscVaultContract, vaultPid, gasPrice, account, oraclePrice, chainId],
+    [nonBscVaultContract, vaultPid, bnbGasPrice, account, oraclePrice, chainId],
   )
 
   return { onStake: vaultPid ? handleStakeNonBsc : handleStake }

--- a/apps/web/src/views/Farms/hooks/useUnstakeFarms.ts
+++ b/apps/web/src/views/Farms/hooks/useUnstakeFarms.ts
@@ -5,10 +5,12 @@ import { useCallback } from 'react'
 import { useFeeDataWithGasPrice } from 'state/user/hooks'
 import { bCakeUnStakeFarm, nonBscUnstakeFarm, unstakeFarm } from 'utils/calls'
 import { useOraclePrice } from 'views/Farms/hooks/useFetchOraclePrice'
+import { ChainId } from '@pancakeswap/chains'
 
 const useUnstakeFarms = (pid?: number, vaultPid?: number) => {
   const { account, chainId } = useAccountActiveChain()
   const { gasPrice } = useFeeDataWithGasPrice()
+  const { gasPrice: bnbGasPrice } = useFeeDataWithGasPrice(ChainId.BSC)
   const oraclePrice = useOraclePrice(chainId ?? 0)
   const masterChefContract = useMasterchef()
   const nonBscVaultContract = useNonBscVault()
@@ -22,9 +24,9 @@ const useUnstakeFarms = (pid?: number, vaultPid?: number) => {
 
   const handleUnstakeNonBsc = useCallback(
     async (amount: string) => {
-      return nonBscUnstakeFarm(nonBscVaultContract, vaultPid, amount, gasPrice, account, oraclePrice, chainId)
+      return nonBscUnstakeFarm(nonBscVaultContract, vaultPid, amount, bnbGasPrice, account, oraclePrice, chainId)
     },
-    [nonBscVaultContract, vaultPid, gasPrice, account, oraclePrice, chainId],
+    [nonBscVaultContract, vaultPid, bnbGasPrice, account, oraclePrice, chainId],
   )
 
   return { onUnstake: vaultPid ? handleUnstakeNonBsc : handleUnstake }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update stake and unstake functions in the Farms feature to use gas prices specific to the Binance Smart Chain.

### Detailed summary
- Updated stake and unstake functions to use BNB gas prices for non-BSC vaults
- Added logic to handle BNB gas prices in stake and unstake functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->