### PR TITLE
chore: list new solvbtc.ena/solvbtc farms & gauges

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -40,8 +40,8 @@ export const farmsV3 = defineFarmV3Configs([
   {
     pid: 73,
     lpAddress: '0x04a35D7920f2f2fF9fAA447fF8cFaD47fc7cED2b',
-    token0: arbitrumTokens.solvBTCena,
-    token1: arbitrumTokens.solvBTC,
+    token0: arbitrumTokens.solvBTC,
+    token1: arbitrumTokens.solvBTCena,
     feeAmount: FeeAmount.LOW,
   },
   {

--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -38,6 +38,13 @@ const v3TopFixedLps: FarmConfigV3[] = [
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
   {
+    pid: 73,
+    lpAddress: '0x04a35D7920f2f2fF9fAA447fF8cFaD47fc7cED2b',
+    token0: arbitrumTokens.solvBTCena,
+    token1: arbitrumTokens.solvBTC,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 72,
     lpAddress: '0x152703894d31e54437d01b03BDD21c03583E9709',
     token0: arbitrumTokens.zro,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 172,
+    lpAddress: '0x7C6CC4D67C920e4b86d46EA125f69b410afdaF61',
+    token0: bscTokens.solvBTCena,
+    token1: bscTokens.solvbtc,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 171,
     lpAddress: '0x2C533e2C2B4fd1172b5A0a0178805Be1526a15a7',
     token0: bscTokens.usdt,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -78,8 +78,8 @@ export const farmsV3 = defineFarmV3Configs([
   {
     pid: 172,
     lpAddress: '0x7C6CC4D67C920e4b86d46EA125f69b410afdaF61',
-    token0: bscTokens.solvBTCena,
-    token1: bscTokens.solvbtc,
+    token0: bscTokens.solvbtc,
+    token1: bscTokens.solvBTCena,
     feeAmount: FeeAmount.LOW,
   },
   {

--- a/packages/farms/constants/common/index.ts
+++ b/packages/farms/constants/common/index.ts
@@ -27,7 +27,7 @@ export const priceHelperTokens = {
     list: [ethereumTokens.weth, ethereumTokens.usdc, ethereumTokens.usdt],
   },
   [ChainId.BSC]: {
-    list: [bscTokens.wbnb, bscTokens.usdt, bscTokens.busd, bscTokens.eth],
+    list: [bscTokens.wbnb, bscTokens.usdt, bscTokens.busd, bscTokens.eth, bscTokens.solvbtc, bscTokens.solvBTCena],
   },
   [ChainId.POLYGON_ZKEVM]: {
     list: [polygonZkEvmTokens.weth, polygonZkEvmTokens.usdc, polygonZkEvmTokens.usdt, polygonZkEvmTokens.matic],
@@ -36,7 +36,15 @@ export const priceHelperTokens = {
     list: [zksyncTokens.weth, zksyncTokens.usdc, zksyncTokens.usdt],
   },
   [ChainId.ARBITRUM_ONE]: {
-    list: [arbitrumTokens.weth, arbitrumTokens.usdc, arbitrumTokens.usdt, arbitrumTokens.arb, arbitrumTokens.usdplus],
+    list: [
+      arbitrumTokens.weth,
+      arbitrumTokens.usdc,
+      arbitrumTokens.usdt,
+      arbitrumTokens.arb,
+      arbitrumTokens.usdplus,
+      arbitrumTokens.solvBTC,
+      arbitrumTokens.solvBTCena,
+    ],
   },
   [ChainId.LINEA]: {
     list: [lineaTokens.weth, lineaTokens.usdc, lineaTokens.usdt, lineaTokens.wbtc, lineaTokens.dai],

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4532,4 +4532,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: ethereumTokens.blb.address,
     token1Address: ethereumTokens.weth.address,
   },
+  {
+    gid: 458,
+    pairName: 'SolvBTC.ena-SolvBTC',
+    address: '0x7C6CC4D67C920e4b86d46EA125f69b410afdaF61',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.LOW,
+    token0Address: bscTokens.solvBTCena.address,
+    token1Address: bscTokens.solvbtc.address,
+  },
 ]

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4539,7 +4539,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
     chainId: ChainId.BSC,
     type: GaugeType.V3,
     feeTier: FeeAmount.LOW,
-    token0Address: bscTokens.solvBTCena.address,
-    token1Address: bscTokens.solvbtc.address,
+    token0Address: bscTokens.solvbtc.address,
+    token1Address: bscTokens.solvBTCena.address,
   },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3197,4 +3197,12 @@ export const bscTokens = {
     'LayerZero',
     'https://www.layerzero.foundation/',
   ),
+  solvBTCena: new ERC20Token(
+    ChainId.BSC,
+    '0x53E63a31fD1077f949204b94F431bCaB98F72BCE',
+    18,
+    'SolvBTC.ENA',
+    'SolvBTC Ethena',
+    'https://solv.finance/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for `SolvBTCena` tokens in various farms and gauges configurations across different chains.

### Detailed summary
- Added `SolvBTCena` token with its details for BSC and Arbitrum chains
- Updated farms configurations to include `SolvBTCena` token pairs
- Added a new gauge for `SolvBTCena` token on BSC chain
- Expanded token lists to include `SolvBTCena` on BSC and Arbitrum chains

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->