### PR TITLE
chore: Add iso to unsupported list

### DIFF
--- a/apps/web/src/config/constants/tokenLists/pancake-unsupported.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-unsupported.tokenlist.json
@@ -16,6 +16,13 @@
       "address": "0xB1A1D06d42A43a8FCfDC7FDcd744f7eF03e8ad1a",
       "chainId": 56,
       "decimals": 18
+    },
+    {
+      "name": "invesco",
+      "symbol": "iso",
+      "address": "0xa7192e74A09Ccae2284a5FbD71c983948A6075a6",
+      "chainId": 56,
+      "decimals": 9
     }
   ]
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new token called `invesco` with symbol `iso` to the `pancake-unsupported.tokenlist.json`.

### Detailed summary
- Added a new token `invesco` with symbol `iso`
- Token address: `0xa7192e74A09Ccae2284a5FbD71c983948A6075a6`
- Chain ID: 56
- Decimals: 9

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->