### PR TITLE
fix: Toggle user farm

### DIFF
--- a/apps/web/src/state/user/hooks/index.tsx
+++ b/apps/web/src/state/user/hooks/index.tsx
@@ -76,16 +76,15 @@ export function useUserFarmStakedOnly(isActive: boolean): [boolean, (stakedOnly:
     [dispatch],
   )
 
+  const booleanUserFarmStakedOnly =
+    userFarmStakedOnly === FarmStakedOnly.ON_FINISHED ? !isActive : userFarmStakedOnly === FarmStakedOnly.TRUE
+
   const toggleUserFarmStakedOnly = useCallback(
-    () => setUserFarmStakedOnly(!userFarmStakedOnly),
-    [setUserFarmStakedOnly, userFarmStakedOnly],
+    () => setUserFarmStakedOnly(!booleanUserFarmStakedOnly),
+    [setUserFarmStakedOnly, booleanUserFarmStakedOnly],
   )
 
-  return [
-    userFarmStakedOnly === FarmStakedOnly.ON_FINISHED ? !isActive : userFarmStakedOnly === FarmStakedOnly.TRUE,
-    setUserFarmStakedOnly,
-    toggleUserFarmStakedOnly,
-  ]
+  return [booleanUserFarmStakedOnly, setUserFarmStakedOnly, toggleUserFarmStakedOnly]
 }
 
 export function useUserPoolStakedOnly(): [boolean, (stakedOnly: boolean) => void] {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a boolean variable `booleanUserFarmStakedOnly` to simplify user farm staked only logic in the `useUserFarmStakedOnly` hook.

### Detailed summary
- Introduced `booleanUserFarmStakedOnly` variable to simplify user farm staked only logic
- Updated `toggleUserFarmStakedOnly` to use `booleanUserFarmStakedOnly` variable
- Updated return statement in `useUserFarmStakedOnly` to return `booleanUserFarmStakedOnly`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->