### PR TITLE
chore: faster prediction prices

### DIFF
--- a/apps/web/src/components/PhishingWarningBanner/AIPredictionStripe.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/AIPredictionStripe.tsx
@@ -48,13 +48,13 @@ export const AIPrediction = ({
             </Text>
           </Box>
           <Link
-            external
-            fontSize={['12px', '12px', '14px']}
-            style={{ display: 'inline-flex', alignItems: 'center', whiteSpace: 'nowrap' }}
-            href={learnMoreLink}
+            color="primary"
+            fontSize={['12px', '12px', '12px']}
+            style={{ display: 'flex', alignItems: 'center', whiteSpace: 'nowrap' }}
+            href={ctaLink}
           >
-            {t('Learn More')}
-            <ArrowForwardIcon width="14px" mt="2px" color="primary" />
+            {t('Participate Now')}
+            <ArrowForwardIcon width="12px" color="primary" style={{ marginRight: '-8px' }} />
           </Link>
         </Column>
       </Flex>

--- a/apps/web/src/pages/api/prediction/price/index.ts
+++ b/apps/web/src/pages/api/prediction/price/index.ts
@@ -27,9 +27,9 @@ const handler: NextApiHandler = async (req, res) => {
       price: string
     } = await response.json()
 
-    res.setHeader('Cache-Control', 's-maxage=10, stale-while-revalidate=10')
-    res.setHeader('Vercel-CDN-Cache-Control', 'max-age=10')
-    res.setHeader('CDN-Cache-Control', 'max-age=10')
+    res.setHeader('Cache-Control', 's-maxage=5, stale-while-revalidate=5')
+    res.setHeader('Vercel-CDN-Cache-Control', 'max-age=5')
+    res.setHeader('CDN-Cache-Control', 'max-age=5')
 
     return res.status(response.status).json({
       currencyA,

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -9,7 +9,7 @@ import { useGetBufferSeconds } from 'state/predictions/hooks'
 import { NodeLedger, NodeRound } from 'state/types'
 import styled from 'styled-components'
 import { getNowInSeconds } from 'utils/getNowInSeconds'
-import { usePredictionPrice, usePredictionPriceMutation } from 'views/Predictions/hooks/usePredictionPrice'
+import { usePredictionPrice, usePredictionPriceUpdate } from 'views/Predictions/hooks/usePredictionPrice'
 import { useConfig } from '../../../context/ConfigProvider'
 import PositionTag from '../../PositionTag'
 import { LockPriceRow, PrizePoolRow, RoundResultBox } from '../../RoundResult'
@@ -60,7 +60,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
   } = usePredictionPrice({
     currencyA: config?.token.symbol,
   })
-  const { mutateAsync } = usePredictionPriceMutation()
+  const { updatePriceFromSource } = usePredictionPriceUpdate()
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
@@ -111,7 +111,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
     const secondsToClose = closeTimestamp ? closeTimestamp - getNowInSeconds() : 0
     if (secondsToClose > 0) {
       const refreshPriceTimeout = setTimeout(() => {
-        mutateAsync({
+        updatePriceFromSource({
           currencyA: config?.token.symbol,
         })
       }, (secondsToClose - REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE) * 1000)
@@ -126,7 +126,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
       }
     }
     return undefined
-  }, [closeTimestamp, config?.token.symbol, mutateAsync])
+  }, [closeTimestamp, config?.token.symbol, updatePriceFromSource])
 
   if (hasRoundFailed) {
     return <CanceledRoundCard round={round} />

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -9,7 +9,7 @@ import { useGetBufferSeconds } from 'state/predictions/hooks'
 import { NodeLedger, NodeRound } from 'state/types'
 import styled from 'styled-components'
 import { getNowInSeconds } from 'utils/getNowInSeconds'
-import { usePredictionPrice } from 'views/Predictions/hooks/usePredictionPrice'
+import { usePredictionPrice, usePredictionPriceMutation } from 'views/Predictions/hooks/usePredictionPrice'
 import { useConfig } from '../../../context/ConfigProvider'
 import PositionTag from '../../PositionTag'
 import { LockPriceRow, PrizePoolRow, RoundResultBox } from '../../RoundResult'
@@ -57,10 +57,10 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
   // Fetch Live Price for AI Predictions Open and Live Round Cards
   const {
     data: { price },
-    refetch,
   } = usePredictionPrice({
     currencyA: config?.token.symbol,
   })
+  const { mutateAsync } = usePredictionPriceMutation()
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
 
@@ -111,7 +111,9 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
     const secondsToClose = closeTimestamp ? closeTimestamp - getNowInSeconds() : 0
     if (secondsToClose > 0) {
       const refreshPriceTimeout = setTimeout(() => {
-        refetch()
+        mutateAsync({
+          currencyA: config?.token.symbol,
+        })
       }, (secondsToClose - REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE) * 1000)
 
       const calculatingPhaseTimeout = setTimeout(() => {
@@ -124,7 +126,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
       }
     }
     return undefined
-  }, [refetch, closeTimestamp])
+  }, [closeTimestamp, config?.token.symbol, mutateAsync])
 
   if (hasRoundFailed) {
     return <CanceledRoundCard round={round} />

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -114,7 +114,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
     setFetchAlternate(true)
     setTimeout(() => {
       setFetchAlternate(false)
-    }, REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE * 1000)
+    }, REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE * 2 * 1000)
   }, [])
 
   useEffect(() => {
@@ -134,7 +134,7 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
       }
     }
     return undefined
-  }, [closeTimestamp, config?.token.symbol, refreshLivePrice])
+  }, [closeTimestamp, refreshLivePrice])
 
   if (hasRoundFailed) {
     return <CanceledRoundCard round={round} />

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -39,7 +39,7 @@ interface AILiveRoundCardProps {
   formattedBearMultiplier: string
 }
 
-const REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE = 3
+const REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE = 2
 
 export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardProps>> = ({
   round,

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -112,9 +112,6 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
     // Fetch live price before round ends
     currentUseAlternateSource.current = true
     refetch()
-    setTimeout(() => {
-      currentUseAlternateSource.current = false
-    }, REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE * 2 * 1000)
   }, [currentUseAlternateSource, refetch])
 
   useEffect(() => {

--- a/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/AIPredictions/AILiveRoundCard.tsx
@@ -54,14 +54,13 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
   const bufferSeconds = useGetBufferSeconds()
   const config = useConfig()
 
-  const [fetchAlternate, setFetchAlternate] = useState(false)
-
   // Fetch Live Price for AI Predictions Open and Live Round Cards
   const {
     data: { price },
+    refetch,
+    currentUseAlternateSource,
   } = usePredictionPrice({
     currencyA: config?.token.symbol,
-    useAlternateSource: fetchAlternate,
   })
 
   const [isCalculatingPhase, setIsCalculatingPhase] = useState(false)
@@ -111,11 +110,12 @@ export const AILiveRoundCard: React.FC<React.PropsWithChildren<AILiveRoundCardPr
 
   const refreshLivePrice = useCallback(() => {
     // Fetch live price before round ends
-    setFetchAlternate(true)
+    currentUseAlternateSource.current = true
+    refetch()
     setTimeout(() => {
-      setFetchAlternate(false)
+      currentUseAlternateSource.current = false
     }, REFRESH_PRICE_BEFORE_SECONDS_TO_CLOSE * 2 * 1000)
-  }, [])
+  }, [currentUseAlternateSource, refetch])
 
   useEffect(() => {
     const secondsToClose = closeTimestamp ? closeTimestamp - getNowInSeconds() : 0

--- a/apps/web/src/views/Predictions/context/PredictionConfigProviders.tsx
+++ b/apps/web/src/views/Predictions/context/PredictionConfigProviders.tsx
@@ -5,7 +5,7 @@ import makeStore from 'contexts/LocalRedux/makeStore'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import _toUpper from 'lodash/toUpper'
 import { useRouter } from 'next/router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import reducers, { initialState } from 'state/predictions'
 import { usePredictionConfigs } from 'views/Predictions/hooks/usePredictionConfigs'
 import { usePredictionToken } from 'views/Predictions/hooks/usePredictionToken'
@@ -17,6 +17,7 @@ const PredictionConfigProviders = ({ children }) => {
   const predictionConfigs = usePredictionConfigs()
   const [selectedPickedToken, setSelectedPickedToken] = useState('')
   const [prevSelectedToken, setPrevSelectedToken] = usePredictionToken()
+  const useAlternateSourceRef = useRef(false)
 
   const supportedSymbol = useMemo(() => (predictionConfigs ? Object.keys(predictionConfigs) : []), [predictionConfigs])
 
@@ -63,7 +64,16 @@ const PredictionConfigProviders = ({ children }) => {
     return selectedPickedToken || supportedSymbol?.[0]
   }, [chainId, prevSelectedToken, selectedPickedToken, supportedSymbol])
 
-  const config = useMemo(() => predictionConfigs?.[selectedToken], [predictionConfigs, selectedToken])
+  const config = useMemo(() => {
+    const selected = predictionConfigs?.[selectedToken]
+    if (selected?.ai) {
+      return {
+        ...selected,
+        ai: { ...selected.ai, useAlternateSource: useAlternateSourceRef },
+      }
+    }
+    return selected
+  }, [predictionConfigs, selectedToken])
 
   const store = useMemo(() => makeStore(reducers, initialState, config), [config])
 

--- a/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { BINANCE_DATA_API, PREDICTION_PRICE_API } from 'config/constants/endpoints'
 import { PriceApiWhitelistedCurrency } from 'config/constants/prediction/price'
+import { useCallback } from 'react'
 
 interface UsePredictionPriceParameters {
   /** Default: ETH */
@@ -33,21 +34,21 @@ const DEFAULT_POLLING_INTERVAL = 5_000
 export const usePredictionPriceUpdate = () => {
   const queryClient = useQueryClient()
 
-  const updatePriceFromSource = async ({
-    currencyA = DEFAULT_CURRENCY_A,
-    currencyB = DEFAULT_CURRENCY_B,
-  }: UsePredictionPriceParameters) =>
-    fetch(`${BINANCE_DATA_API}/v3/ticker/price?symbol=${currencyA}${currencyB}`)
-      .then((res) => res.json())
-      .then((result) => ({
-        price: parseFloat(result.price),
-        currencyA,
-        currencyB,
-      }))
-      .then((data) => {
-        queryClient.setQueryData(['price', currencyA, currencyB], data)
-        return data
-      })
+  const updatePriceFromSource = useCallback(
+    async ({ currencyA = DEFAULT_CURRENCY_A, currencyB = DEFAULT_CURRENCY_B }: UsePredictionPriceParameters) =>
+      fetch(`${BINANCE_DATA_API}/v3/ticker/price?symbol=${currencyA}${currencyB}`)
+        .then((res) => res.json())
+        .then((result) => ({
+          price: parseFloat(result.price),
+          currencyA,
+          currencyB,
+        }))
+        .then((data) => {
+          queryClient.setQueryData(['price', currencyA, currencyB], data)
+          return data
+        }),
+    [queryClient],
+  )
 
   return { updatePriceFromSource }
 }

--- a/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
-import { FAST_INTERVAL } from 'config/constants'
-import { PREDICTION_PRICE_API } from 'config/constants/endpoints'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { BINANCE_DATA_API, PREDICTION_PRICE_API } from 'config/constants/endpoints'
 import { PriceApiWhitelistedCurrency } from 'config/constants/prediction/price'
 
 interface UsePredictionPriceParameters {
@@ -10,7 +9,7 @@ interface UsePredictionPriceParameters {
   /** Default: USDT */
   currencyB?: PriceApiWhitelistedCurrency | (string & NonNullable<unknown>)
 
-  /** Default: 10,000 milliseconds */
+  /** Default: 5,000 milliseconds */
   pollingInterval?: number
 
   enabled?: boolean
@@ -23,10 +22,40 @@ interface PriceResponse {
   currencyB: PriceApiWhitelistedCurrency | (string & NonNullable<unknown>)
 }
 
+const DEFAULT_CURRENCY_A: PriceApiWhitelistedCurrency = 'ETH'
+const DEFAULT_CURRENCY_B: PriceApiWhitelistedCurrency = 'USDT'
+const DEFAULT_POLLING_INTERVAL = 5_000
+
+/**
+ * Mutate the price directly from the source API if
+ * Live Price is needed urgently
+ */
+export const usePredictionPriceMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      currencyA = DEFAULT_CURRENCY_A,
+      currencyB = DEFAULT_CURRENCY_B,
+    }: UsePredictionPriceParameters) => {
+      return fetch(`${BINANCE_DATA_API}/v3/ticker/price?symbol=${currencyA}${currencyB}`)
+        .then((res) => res.json())
+        .then((data) => ({
+          price: parseFloat(data.price),
+          currencyA,
+          currencyB,
+        }))
+    },
+    onSuccess: (data, { currencyA = DEFAULT_CURRENCY_A, currencyB = DEFAULT_CURRENCY_B }) => {
+      queryClient.setQueryData(['price', currencyA, currencyB], data)
+    },
+  })
+}
+
 export const usePredictionPrice = ({
-  currencyA = 'ETH',
-  currencyB = 'USDT',
-  pollingInterval = FAST_INTERVAL,
+  currencyA = DEFAULT_CURRENCY_A,
+  currencyB = DEFAULT_CURRENCY_B,
+  pollingInterval = DEFAULT_POLLING_INTERVAL,
   enabled = true,
 }: UsePredictionPriceParameters = {}) => {
   return useQuery<PriceResponse>({

--- a/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { BINANCE_DATA_API, PREDICTION_PRICE_API } from 'config/constants/endpoints'
 import { PriceApiWhitelistedCurrency } from 'config/constants/prediction/price'
 
@@ -27,29 +27,29 @@ const DEFAULT_CURRENCY_B: PriceApiWhitelistedCurrency = 'USDT'
 const DEFAULT_POLLING_INTERVAL = 5_000
 
 /**
- * Mutate the price directly from the source API if
+ * Fetch the price directly from the source API if
  * Live Price is needed urgently
  */
-export const usePredictionPriceMutation = () => {
+export const usePredictionPriceUpdate = () => {
   const queryClient = useQueryClient()
 
-  return useMutation({
-    mutationFn: async ({
-      currencyA = DEFAULT_CURRENCY_A,
-      currencyB = DEFAULT_CURRENCY_B,
-    }: UsePredictionPriceParameters) => {
-      return fetch(`${BINANCE_DATA_API}/v3/ticker/price?symbol=${currencyA}${currencyB}`)
-        .then((res) => res.json())
-        .then((data) => ({
-          price: parseFloat(data.price),
-          currencyA,
-          currencyB,
-        }))
-    },
-    onSuccess: (data, { currencyA = DEFAULT_CURRENCY_A, currencyB = DEFAULT_CURRENCY_B }) => {
-      queryClient.setQueryData(['price', currencyA, currencyB], data)
-    },
-  })
+  const updatePriceFromSource = async ({
+    currencyA = DEFAULT_CURRENCY_A,
+    currencyB = DEFAULT_CURRENCY_B,
+  }: UsePredictionPriceParameters) =>
+    fetch(`${BINANCE_DATA_API}/v3/ticker/price?symbol=${currencyA}${currencyB}`)
+      .then((res) => res.json())
+      .then((result) => ({
+        price: parseFloat(result.price),
+        currencyA,
+        currencyB,
+      }))
+      .then((data) => {
+        queryClient.setQueryData(['price', currencyA, currencyB], data)
+        return data
+      })
+
+  return { updatePriceFromSource }
 }
 
 export const usePredictionPrice = ({

--- a/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
@@ -47,10 +47,7 @@ export const usePredictionPrice = ({
               currencyB,
             }))
         : fetch(`${PREDICTION_PRICE_API}/?currencyA=${currencyA}&currencyB=${currencyB}`).then((res) => res.json()),
-    refetchInterval: () => {
-      if (useAlternateSource) return false
-      return pollingInterval
-    },
+    refetchInterval: () => (useAlternateSource ? false : pollingInterval),
     retry: 2,
     initialData: {
       price: 0,

--- a/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
+++ b/apps/web/src/views/Predictions/hooks/usePredictionPrice.ts
@@ -46,7 +46,7 @@ export const usePredictionPrice = ({
               currencyA,
               currencyB,
             }))
-        : fetch(`${PREDICTION_PRICE_API}/?currencyA=${currencyA}&currencyB=${currencyB}`).then((res) => res.json())
+        : fetch(`${PREDICTION_PRICE_API}?currencyA=${currencyA}&currencyB=${currencyB}`).then((res) => res.json())
     },
     refetchInterval: () => (config?.ai?.useAlternateSource?.current ? false : pollingInterval),
     retry: 2,

--- a/packages/prediction/src/type.ts
+++ b/packages/prediction/src/type.ts
@@ -29,8 +29,13 @@ export enum PredictionsChartView {
   Pyth = 'Pyth Oracle',
 }
 
+interface MutableRefObject<T> {
+  current: T
+}
+
 type AIPredictionConfig = {
   aiPriceDecimals?: number
+  useAlternateSource?: MutableRefObject<boolean>
 }
 
 export interface PredictionConfig {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `useAlternateSource` option in the AI prediction config to fetch price data from a different source. It also updates UI elements and refactors code for better performance.

### Detailed summary
- Added `MutableRefObject` interface for `useAlternateSource` in AI prediction config
- Updated cache control headers in the API response
- Modified UI elements in `PhishingWarningBanner` and `AILiveRoundCard`
- Refactored code in `PredictionConfigProviders` and `usePredictionPrice` to support alternate data source for price fetching

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->