### PR TITLE
chore: list new gauges on Arb

### DIFF
--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4601,4 +4601,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: bscTokens.weEth.address,
     token1Address: bscTokens.eth.address,
   },
+  {
+    gid: 465,
+    pairName: 'SQD-WETH',
+    address: '0xc24B560c7f8a1A50c2336cd8917Af61B5E14984F',
+    chainId: ChainId.ARBITRUM_ONE,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.HIGH,
+    token0Address: arbitrumTokens.sqd.address,
+    token1Address: arbitrumTokens.weth.address,
+  },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new gauge configuration for the pair SQD-WETH on Arbitrum One.

### Detailed summary
- Added a new gauge configuration for the pair SQD-WETH on Arbitrum One
- Pair name: 'SQD-WETH'
- Address: '0xc24B560c7f8a1A50c2336cd8917Af61B5E14984F'
- Chain ID: Arbitrum One
- Gauge type: V3
- Fee tier: High
- Token 0 address: arbitrumTokens.sqd.address
- Token 1 address: arbitrumTokens.weth.address

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->