### PR TITLE
fix: Invalid variable assignment in maxLiquidityForAmounts

### DIFF
--- a/.changeset/weak-flowers-decide.md
+++ b/.changeset/weak-flowers-decide.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/v3-sdk': patch
+---
+
+Fix invalid assignment in max liquidity for amounts

--- a/packages/v3-sdk/src/utils/maxLiquidityForAmounts.ts
+++ b/packages/v3-sdk/src/utils/maxLiquidityForAmounts.ts
@@ -14,8 +14,7 @@ import { Q96 } from '../internalConstants'
  */
 function maxLiquidityForAmount0Imprecise(sqrtRatioAX96: bigint, sqrtRatioBX96: bigint, amount0: BigintIsh): bigint {
   if (sqrtRatioAX96 > sqrtRatioBX96) {
-    sqrtRatioAX96 = sqrtRatioBX96
-    sqrtRatioBX96 = sqrtRatioAX96
+    ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
   const intermediate = (sqrtRatioAX96 * sqrtRatioBX96) / Q96
   return (BigInt(amount0) * intermediate) / (sqrtRatioBX96 - sqrtRatioAX96)
@@ -31,8 +30,7 @@ function maxLiquidityForAmount0Imprecise(sqrtRatioAX96: bigint, sqrtRatioBX96: b
  */
 function maxLiquidityForAmount0Precise(sqrtRatioAX96: bigint, sqrtRatioBX96: bigint, amount0: BigintIsh): bigint {
   if (sqrtRatioAX96 > sqrtRatioBX96) {
-    sqrtRatioAX96 = sqrtRatioBX96
-    sqrtRatioBX96 = sqrtRatioAX96
+    ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
 
   const numerator = BigInt(amount0) * sqrtRatioAX96 * sqrtRatioBX96
@@ -50,8 +48,7 @@ function maxLiquidityForAmount0Precise(sqrtRatioAX96: bigint, sqrtRatioBX96: big
  */
 function maxLiquidityForAmount1(sqrtRatioAX96: bigint, sqrtRatioBX96: bigint, amount1: BigintIsh): bigint {
   if (sqrtRatioAX96 > sqrtRatioBX96) {
-    sqrtRatioAX96 = sqrtRatioBX96
-    sqrtRatioBX96 = sqrtRatioAX96
+    ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
   return (BigInt(amount1) * Q96) / (sqrtRatioBX96 - sqrtRatioAX96)
 }
@@ -76,8 +73,7 @@ export function maxLiquidityForAmounts(
   useFullPrecision: boolean
 ): bigint {
   if (sqrtRatioAX96 > sqrtRatioBX96) {
-    sqrtRatioAX96 = sqrtRatioBX96
-    sqrtRatioBX96 = sqrtRatioAX96
+    ;[sqrtRatioAX96, sqrtRatioBX96] = [sqrtRatioBX96, sqrtRatioAX96]
   }
 
   const maxLiquidityForAmount0 = useFullPrecision ? maxLiquidityForAmount0Precise : maxLiquidityForAmount0Imprecise


### PR DESCRIPTION
The same issue as with `sqrtPriceMath` https://github.com/pancakeswap/pancake-frontend/issues/10192#issuecomment-2228607467.

Implementation reference: https://github.com/Uniswap/v3-sdk/blob/main/src/utils/maxLiquidityForAmounts.ts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes an invalid assignment in max liquidity calculations for amounts.

### Detailed summary
- Fixed invalid assignment in max liquidity calculations for amounts in `maxLiquidityForAmounts.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->