### PR TITLE
fix: Add workaround for zksync smart wallets when withdraw

### DIFF
--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -13,6 +13,7 @@ import { getViemClients, viemClients } from 'utils/viem'
 import { Address, hexToBigInt } from 'viem'
 import { useAccount, useSendTransaction, useWalletClient } from 'wagmi'
 import { useIsSmartContract } from 'hooks/useIsSmartContract'
+import { BOOSTED_FARM_V3_GAS_LIMIT } from 'config'
 
 interface FarmV3ActionContainerChildrenProps {
   attemptingTxn: boolean
@@ -61,7 +62,7 @@ const useFarmV3Actions = ({
       if (isSC && chainId === ChainId.ZKSYNC) {
         const newTxn = {
           ...txn,
-          gas: 500000n,
+          gas: BOOSTED_FARM_V3_GAS_LIMIT,
         }
         return sendTransactionAsync(newTxn)
       }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement a workaround for zksync smart wallets in the `useFarmV3Actions` hook.

### Detailed summary
- Added `useIsSmartContract` import
- Added `BOOSTED_FARM_V3_GAS_LIMIT` import
- Implemented a workaround for zksync smart wallets in transaction error handling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->