### PR TITLE
chore: Add menu ga click tracking

### DIFF
--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -3,7 +3,7 @@ import { useTheme } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
 import { DropdownMenuItems, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import React, { useMemo } from 'react'
+import React, { MouseEventHandler, useMemo } from 'react'
 import { multiChainPaths } from 'state/info/constant'
 import { logMenuClick } from 'utils/customGTMEventTracking'
 
@@ -72,7 +72,11 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
 
           return innerItem
         })
-        return { ...item, items: innerItems }
+        const onItemClick: MouseEventHandler = (e) => {
+          logMenuClick(item.href || '')
+          item.onClick?.(e)
+        }
+        return { ...item, items: innerItems, onClick: onItemClick }
       })
     }
     return menuItems

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -35,7 +35,7 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
           const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
-            logMenuClick(item.label)
+            logMenuClick(currentItem.label)
             currentItem.onClick?.(e)
             onClick?.(e, currentItem)
           }

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -35,7 +35,9 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
           const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
-            logMenuClick(currentItem.href || '')
+            if (currentItem.href) {
+              logMenuClick(currentItem.href)
+            }
             currentItem.onClick?.(e)
             onClick?.(e, currentItem)
           }
@@ -73,7 +75,9 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
           return innerItem
         })
         const onItemClick: MouseEventHandler = (e) => {
-          logMenuClick(item.href || '')
+          if (item.href) {
+            logMenuClick(item.href)
+          }
           item.onClick?.(e)
         }
         return { ...item, items: innerItems, onClick: onItemClick }

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -35,7 +35,7 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
           const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
-            logMenuClick(currentItem.label)
+            logMenuClick(currentItem.href)
             currentItem.onClick?.(e)
             onClick?.(e, currentItem)
           }

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -35,7 +35,7 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
           const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
-            logMenuClick(currentItem.href)
+            logMenuClick(currentItem.href || '')
             currentItem.onClick?.(e)
             onClick?.(e, currentItem)
           }

--- a/apps/web/src/components/Menu/hooks/useMenuItems.ts
+++ b/apps/web/src/components/Menu/hooks/useMenuItems.ts
@@ -5,6 +5,8 @@ import { DropdownMenuItems, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import React, { useMemo } from 'react'
 import { multiChainPaths } from 'state/info/constant'
+import { logMenuClick } from 'utils/customGTMEventTracking'
+
 import config, { ConfigMenuDropDownItemsType, ConfigMenuItemsType } from '../config/config'
 import { useMenuItemsStatus } from './useMenuItemsStatus'
 
@@ -33,6 +35,7 @@ export const useMenuItems = ({ onClick }: UseMenuItemsParams = {}): ConfigMenuIt
       return menuItems.map((item) => {
         const innerItems = item?.items?.map((currentItem) => {
           const onClickEvent = (e: React.MouseEvent<HTMLButtonElement>) => {
+            logMenuClick(item.label)
             currentItem.onClick?.(e)
             onClick?.(e, currentItem)
           }

--- a/apps/web/src/utils/customGTMEventTracking.ts
+++ b/apps/web/src/utils/customGTMEventTracking.ts
@@ -7,6 +7,7 @@ export enum GTMEvent {
   UnStakeFarm = 'unStakeFarm',
   WalletConnect = 'walletConnect',
   Web3WalletView = 'Web3WalletView',
+  MenuClick = 'menuClick',
 }
 
 export enum GTMCategory {
@@ -33,8 +34,8 @@ export enum GTMAction {
 
 interface CustomGTMDataLayer {
   event: GTMEvent
-  category: GTMCategory
-  action: GTMAction
+  category?: GTMCategory
+  action?: GTMAction
   label?: string
 }
 
@@ -118,5 +119,12 @@ export const logWeb3WalletViews = () => {
     event: GTMEvent.Web3WalletView,
     action: GTMAction.Web3WalletView,
     category: GTMCategory.Web3WalletView,
+  })
+}
+
+export const logMenuClick = (path: string) => {
+  window?.dataLayer?.push({
+    event: GTMEvent.MenuClick,
+    label: path,
   })
 }

--- a/packages/uikit/src/components/MenuItem/types.ts
+++ b/packages/uikit/src/components/MenuItem/types.ts
@@ -1,3 +1,5 @@
+import { MouseEventHandler } from "react";
+
 import { Colors } from "../../theme";
 
 export type MenuItemVariant = "default" | "subMenu";
@@ -9,6 +11,7 @@ export interface MenuItemProps {
   variant?: MenuItemVariant;
   statusColor?: keyof Colors;
   scrollLayerRef?: React.RefObject<HTMLDivElement>;
+  onClick?: MouseEventHandler;
 }
 
 export type StyledMenuItemProps = {

--- a/packages/uikit/src/components/MenuItems/MenuItems.tsx
+++ b/packages/uikit/src/components/MenuItems/MenuItems.tsx
@@ -14,7 +14,7 @@ const MenuItems: React.FC<React.PropsWithChildren<MenuItemsProps>> = ({
 }) => {
   return (
     <Flex {...props}>
-      {items.map(({ label, items: menuItems = [], href, icon, disabled }) => {
+      {items.map(({ label, items: menuItems = [], href, icon, disabled, onClick }) => {
         const statusColor = menuItems?.find((menuItem) => menuItem.status !== undefined)?.status?.color;
         const isActive = activeItem === href;
         const linkProps = isTouchDevice() && menuItems && menuItems.length > 0 ? {} : { href };
@@ -27,7 +27,13 @@ const MenuItems: React.FC<React.PropsWithChildren<MenuItemsProps>> = ({
             activeItem={activeSubItem}
             isDisabled={disabled}
           >
-            <MenuItem {...linkProps} isActive={isActive} statusColor={statusColor} isDisabled={disabled}>
+            <MenuItem
+              {...linkProps}
+              isActive={isActive}
+              statusColor={statusColor}
+              isDisabled={disabled}
+              onClick={onClick}
+            >
               {label || (icon && createElement(Icon as any, { color: isActive ? "secondary" : "textSubtle" }))}
             </MenuItem>
           </DropdownMenu>

--- a/packages/uikit/src/components/MenuItems/types.ts
+++ b/packages/uikit/src/components/MenuItems/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ElementType } from "react";
+import { ElementType, MouseEventHandler } from "react";
 import { BoxProps } from "../Box";
 import { DropdownMenuItems } from "../DropdownMenu/types";
 
@@ -12,6 +12,7 @@ export type MenuItemsType = {
   disabled?: boolean;
   showOnMobile?: boolean;
   showItemsOnMobile?: boolean;
+  onClick?: MouseEventHandler;
 };
 
 export interface MenuItemsProps extends BoxProps {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `onClick` functionality to various components and track menu clicks for analytics.

### Detailed summary
- Added `onClick` prop to `MenuItemProps` in `MenuItem/types.ts`
- Added `onClick` prop to `MenuItemsType` in `MenuItems/types.ts`
- Added `MenuClick` enum in `customGTMEventTracking.ts`
- Updated `CustomGTMDataLayer` interface in `customGTMEventTracking.ts`
- Added `logMenuClick` function in `customGTMEventTracking.ts`
- Updated `MenuItems` component in `MenuItems.tsx` to handle `onClick`
- Updated `useMenuItems` hook in `useMenuItems.ts` to handle `onClick` and track menu clicks

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->