### PR TITLE
perf: reduce rerender of ItemAction

### DIFF
--- a/apps/web/src/views/Farms/v4/components/PoolListItemAction.tsx
+++ b/apps/web/src/views/Farms/v4/components/PoolListItemAction.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
 import { Button, MoreIcon, SubMenu } from '@pancakeswap/uikit'
+import { memo } from 'react'
 import styled from 'styled-components'
 
 export const StyledButton = styled(Button)`
@@ -11,7 +12,7 @@ export const StyledButton = styled(Button)`
   height: auto;
 `
 
-export const PoolListItemAction = () => {
+export const PoolListItemAction = memo(() => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   return (
@@ -37,4 +38,4 @@ export const PoolListItemAction = () => {
       </StyledButton>
     </SubMenu>
   )
-}
+})

--- a/apps/web/src/views/Farms/v4/components/useColumnConfig.tsx
+++ b/apps/web/src/views/Farms/v4/components/useColumnConfig.tsx
@@ -71,7 +71,7 @@ export const useColumnConfig = <T extends BasicDataType>(): ITableViewProps<T>['
       },
       {
         title: '',
-        render: PoolListItemAction,
+        render: () => <PoolListItemAction />,
         dataIndex: null,
         key: 'action',
       },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize rendering performance by using `memo` in the `PoolListItemAction` component.

### Detailed summary
- Updated `PoolListItemAction` component to use `memo` for performance optimization
- Updated rendering of `PoolListItemAction` in `useColumnConfig.tsx` to `<PoolListItemAction />`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->