### PR TITLE
fix: Oort banner desc text not visible

### DIFF
--- a/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
@@ -58,11 +58,10 @@ const titleVariant = {
 }
 
 const Action = ({ href, icon, text, ...props }: IActions) => {
-  const { t } = useTranslation()
   return (
     <Box display={props.display}>
       <LinkExternalAction href={href} externalIcon={icon} color={props.color}>
-        {t(text)}
+        {text}
       </LinkExternalAction>
     </Box>
   )
@@ -102,7 +101,7 @@ export const OortTradingBanner = () => {
               display={isMobile ? 'none' : 'flex'}
               icon="arrowForward"
               alignItems="center"
-              text="Trade Now"
+              text={t('Trade Now')}
               color="#280D5F"
             />
             <Action
@@ -110,7 +109,7 @@ export const OortTradingBanner = () => {
               icon="openNew"
               display="flex"
               alignItems="center"
-              text="Learn More"
+              text={t('Learn More')}
               color="#280D5F"
             />
           </BannerActionContainer>

--- a/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
@@ -28,14 +28,6 @@ const StyledImage = styled.img<{ hidden?: boolean }>`
   width: 85px;
 `
 
-const GradientBlur = styled(BannerContainer)<{ width: number; left: number; top: number; blur: number }>`
-  width: ${({ width }) => width}%;
-  position: absolute;
-  left: ${({ left }) => left}%;
-  top: ${({ right }) => right}%;
-  background: #c6cbf2;
-  filter: blur(${({ blur }) => blur}px);
-`
 const OORT_PATH = `${ASSET_CDN}/web/banners/oort`
 const floatingAsset = `${ASSET_CDN}/web/banners/oort/oort-coin.png`
 

--- a/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/OortTradingBanner.tsx
@@ -65,17 +65,20 @@ const titleVariant = {
   fontWeight: 800,
 }
 
-export const OortTradingBanner = () => {
+const Action = ({ href, icon, text, ...props }: IActions) => {
   const { t } = useTranslation()
-  const { isMobile, isDesktop } = useMatchBreakpoints()
-
-  const Action = ({ href, icon, text, ...props }: IActions) => (
+  return (
     <Box display={props.display}>
       <LinkExternalAction href={href} externalIcon={icon} color={props.color}>
         {t(text)}
       </LinkExternalAction>
     </Box>
   )
+}
+
+export const OortTradingBanner = () => {
+  const { t } = useTranslation()
+  const { isMobile, isDesktop } = useMatchBreakpoints()
 
   return (
     <BannerContainer background={`url(${ASSET_CDN}/web/banners/oort/bg.png)`}>
@@ -93,7 +96,7 @@ export const OortTradingBanner = () => {
         }
         desc={
           isMobile ? null : (
-            <BannerDesc style={{ whiteSpace: 'break-spaces' }}>
+            <BannerDesc style={{ whiteSpace: 'break-spaces' }} color="secondary">
               {isDesktop
                 ? t('Win guaranteed prize, leaderboard prize, and daily lucky draws')
                 : t('Trade OORT to win guaranteed prizes!')}


### PR DESCRIPTION
<img width="529" alt="image" src="https://github.com/user-attachments/assets/47c954a5-952e-4458-92f0-fb10a333ddca">

<img width="505" alt="image" src="https://github.com/user-attachments/assets/a2f20100-1705-4b4d-81ba-5c8a8cc7500f">

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `OortTradingBanner` component in the Home view. 

### Detailed summary
- Removed `GradientBlur` styled component
- Refactored `Action` component to properly return JSX
- Updated text rendering in `Action` component
- Added color prop to `BannerDesc` component
- Updated text rendering in `BannerDesc` component
- Updated text rendering in `BannerActionContainer` components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->