### PR TITLE
feat(NFT): Hide lowestPrice text when is zero 

### DIFF
--- a/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ManageNFTsCard.tsx
+++ b/apps/web/src/views/Nft/market/Collection/IndividualNFTPage/shared/ManageNFTsCard.tsx
@@ -76,7 +76,7 @@ const CollectibleRow: React.FC<React.PropsWithChildren<CollectibleRowProps>> = (
         <Text fontSize="12px" color="textSubtle" textAlign="right">
           {nft?.collectionName}
         </Text>
-        {lowestPrice && (
+        {lowestPrice && Number(lowestPrice) > 0 && (
           <>
             <Text small color="textSubtle">
               {t('Lowest price')}

--- a/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/EditStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/EditStage.tsx
@@ -37,7 +37,7 @@ const EditStage: React.FC<React.PropsWithChildren<EditStageProps>> = ({
           <Text fontSize="12px" color="textSubtle" textAlign="right">
             {nftToSell?.collectionName}
           </Text>
-          {lowestPrice && (
+          {lowestPrice && lowestPrice > 0 && (
             <>
               <Text small color="textSubtle">
                 {t('Lowest price')}

--- a/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/SellStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/SellStage.tsx
@@ -41,7 +41,7 @@ const SellStage: React.FC<React.PropsWithChildren<SellStageProps>> = ({
           <Text fontSize="12px" color="textSubtle" textAlign="right">
             {nftToSell?.collectionName}
           </Text>
-          {lowestPrice && (
+          {lowestPrice > 0 && (
             <>
               <Text small color="textSubtle">
                 {t('Lowest price')}

--- a/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/TransferStage.tsx
+++ b/apps/web/src/views/Nft/market/components/BuySellModals/SellModal/TransferStage.tsx
@@ -47,7 +47,7 @@ const TransferStage: React.FC<React.PropsWithChildren<TransferStageProps>> = ({
           <Text fontSize="12px" color="textSubtle" textAlign="right">
             {nftToSell?.collectionName}
           </Text>
-          {lowestPrice && (
+          {lowestPrice && lowestPrice > 0 && (
             <>
               <Text small color="textSubtle">
                 {t('Lowest price')}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the conditional rendering logic to display the "Lowest price" only when the price is greater than 0 in multiple SellModal and ManageNFTsCard components.

### Detailed summary
- Updated conditional check to display "Lowest price" only when the price is greater than 0 in SellStage, EditStage, TransferStage, and ManageNFTsCard components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

Before
![Screenshot 2024-08-01 at 11 05 32 AM](https://github.com/user-attachments/assets/2100bc4f-d8d2-4bc8-8962-c513ceb3a2aa)


After
![Screenshot 2024-08-01 at 11 05 16 AM](https://github.com/user-attachments/assets/70ebbc2c-df57-428a-b167-dd277d036bbd)