### PR TITLE
fix: Update schema.ts for evm in packages 

### DIFF
--- a/packages/smart-router/evm/v3-router/schema.ts
+++ b/packages/smart-router/evm/v3-router/schema.ts
@@ -69,6 +69,7 @@ export const zRouterGetParams = z
     maxSplits: z.number().optional(),
     blockNumber: zBigNumber.optional(),
     poolTypes: zPoolTypes.optional(),
+    candidatePools: zPools.optional(),
   })
   .required({
     chainId: true,


### PR DESCRIPTION
I added a candidatePools type because the branch throws build errors otherwise when tryign to build as the candidatePools type wasn't defined and defaulted to never.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new field `candidatePools` to the schema in `packages/smart-router/evm/v3-router/schema.ts`.

### Detailed summary
- Added `candidatePools` field to the schema in `smart-router/evm/v3-router/schema.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->