### PR TITLE
feat: Add default rpc gas price to settings and fix returning default gasprice when it is in wrong network

### DIFF
--- a/apps/web/src/components/Menu/GlobalSettings/GasSettings.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/GasSettings.tsx
@@ -1,11 +1,13 @@
 import { Flex, Button, Text, QuestionHelper } from '@pancakeswap/uikit'
 import { useTranslation } from '@pancakeswap/localization'
-import { useGasPriceManager } from 'state/user/hooks'
+import { useDefaultGasPrice, useGasPriceManager } from 'state/user/hooks'
 import { GAS_PRICE_GWEI, GAS_PRICE } from 'state/types'
+import { formatGwei } from 'viem'
 
 const GasSettings = () => {
   const { t } = useTranslation()
   const [gasPrice, setGasPrice] = useGasPriceManager()
+  const defaultGasPrice = useDefaultGasPrice()
 
   return (
     <Flex flexDirection="column">
@@ -37,6 +39,7 @@ const GasSettings = () => {
           variant={gasPrice === GAS_PRICE_GWEI.rpcDefault ? 'primary' : 'tertiary'}
         >
           {t('Default')}
+          {defaultGasPrice ? ` (${formatGwei(defaultGasPrice)})` : null}
         </Button>
         <Button
           mt="4px"


### PR DESCRIPTION
Before: 

<img width="468" alt="Screenshot 2024-08-04 at 13 10 22" src="https://github.com/user-attachments/assets/69bb2aec-b5a0-40ec-a117-7b00edb4f938">

After:
<img width="490" alt="Screenshot 2024-08-04 at 13 09 49" src="https://github.com/user-attachments/assets/93910d9d-b537-4a8a-ab7f-d90d86c7d7da">


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance gas price management in the application by introducing a new default gas price feature.

### Detailed summary
- Added `useDefaultGasPrice` hook for managing default gas price
- Updated `GasSettings` component to display default gas price
- Refactored `useGasPrice` hook to use `useDefaultGasPrice` for BSC chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->