### PR TITLE
chore: fix quests button menu allignment

### DIFF
--- a/apps/gamification/views/Quests/components/Quests.tsx
+++ b/apps/gamification/views/Quests/components/Quests.tsx
@@ -77,6 +77,7 @@ export const Quests = () => {
           <ButtonMenu
             scale="sm"
             variant="subtle"
+            padding="2px"
             m={['16px 0 0 0', '16px 0 0 0', '0']}
             activeIndex={statusButtonIndex}
             onItemClick={onStatusButtonChange}

--- a/packages/uikit/src/__tests__/components/buttonmenu.test.tsx
+++ b/packages/uikit/src/__tests__/components/buttonmenu.test.tsx
@@ -20,6 +20,7 @@ it("renders correctly", () => {
       display: inline-flex;
       border: 1px solid var(--colors-disabled);
       width: auto;
+      align-items: center;
     }
 
     .c0>button,

--- a/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -1,5 +1,5 @@
-import React, { cloneElement, Children, ReactElement } from "react";
-import { styled, DefaultTheme } from "styled-components";
+import React, { Children, ReactElement, cloneElement } from "react";
+import { DefaultTheme, styled } from "styled-components";
 import { space } from "styled-system";
 import { scales, variants } from "../Button/types";
 import { ButtonMenuProps } from "./types";
@@ -24,7 +24,7 @@ const StyledButtonMenu = styled.div.withConfig({
   display: ${({ fullWidth }) => (fullWidth ? "flex" : "inline-flex")};
   border: 1px solid ${getBorderColor};
   width: ${({ fullWidth }) => (fullWidth ? "100%" : "auto")};
-
+  align-items: center;
   & > button,
   & > a {
     flex: ${({ fullWidth }) => (fullWidth ? 1 : "auto")};

--- a/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
+++ b/packages/uikit/src/components/ButtonMenu/ButtonMenu.tsx
@@ -1,5 +1,5 @@
-import React, { Children, ReactElement, cloneElement } from "react";
-import { DefaultTheme, styled } from "styled-components";
+import React, { cloneElement, Children, ReactElement } from "react";
+import { styled, DefaultTheme } from "styled-components";
 import { space } from "styled-system";
 import { scales, variants } from "../Button/types";
 import { ButtonMenuProps } from "./types";


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `align-items: center;` to button menus and quests for improved layout alignment.

### Detailed summary
- Added `align-items: center;` to button menus for centered content alignment.
- Added `padding="2px"` to Quests component for spacing adjustment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->