### PR TITLE
feat: add page loading for pool detail page

### DIFF
--- a/apps/web/src/views/PoolDetail/components/BreadcrumbNav.tsx
+++ b/apps/web/src/views/PoolDetail/components/BreadcrumbNav.tsx
@@ -13,6 +13,8 @@ export const BreadcrumbNav: React.FC = () => {
   const chainName = useChainNameByQuery()
   const { poolSymbol } = usePoolSymbol()
 
+  if (!poolSymbol || poolSymbol === ' / ') return null
+
   return (
     <Flex justifyContent="space-between">
       <Breadcrumbs mb="32px">

--- a/apps/web/src/views/PoolDetail/components/PoolInfo.tsx
+++ b/apps/web/src/views/PoolDetail/components/PoolInfo.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { AutoColumn, AutoRow, Column, Flex, FlexGap, Grid, Row, Text } from '@pancakeswap/uikit'
+import { AutoColumn, AutoRow, Column, Flex, FlexGap, Grid, Row, Spinner, Text } from '@pancakeswap/uikit'
 import { ChainLogo, DoubleCurrencyLogo, FeatureStack, FeeTierTooltip } from '@pancakeswap/widgets-internal'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useMemo } from 'react'
@@ -23,6 +23,13 @@ export const PoolInfo = () => {
   }, [poolInfo])
   const { fee } = usePoolFee(poolInfo?.lpAddress, poolInfo?.protocol)
   const { account } = useAccountActiveChain()
+
+  if (!poolInfo)
+    return (
+      <Flex mt="80px" justifyContent="center">
+        <Spinner />
+      </Flex>
+    )
 
   return (
     <Column gap="24px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the PoolDetail view by adding a loading spinner when pool info is not available and by handling a specific case where the pool symbol is empty or equal to '/'. 

### Detailed summary
- Added a loading spinner when pool info is not available in `PoolInfo.tsx`
- Handled case where pool symbol is empty or equal to '/' in `BreadcrumbNav.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->