### PR TITLE
chore: add lorenzo btc farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -78,9 +78,9 @@ export const farmsV3 = defineFarmV3Configs([
   {
     pid: 176,
     lpAddress: '0xfc18301B94a77D91015bb90D5249827c506846Ae',
-    token0: bscTokens.stbtc,
-    token1: bscTokens.btcb,
-    feeAmount: FeeAmount.LOW,
+    token0: bscTokens.btcb,
+    token1: bscTokens.stbtc,
+    feeAmount: FeeAmount.LOWEST,
   },
   {
     pid: 175,

--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 176,
+    lpAddress: '0xfc18301B94a77D91015bb90D5249827c506846Ae',
+    token0: bscTokens.stbtc,
+    token1: bscTokens.btcb,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 175,
     lpAddress: '0x5a5ca75147550079411F6F543B729A4bEAb4dfEb',
     token0: bscTokens.solvbtcbbn,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4895,8 +4895,8 @@ export const CONFIG_PROD: GaugeConfig[] = [
     address: '0xfc18301B94a77D91015bb90D5249827c506846Ae',
     chainId: ChainId.BSC,
     type: GaugeType.V3,
-    feeTier: FeeAmount.LOW,
-    token0Address: bscTokens.stbtc.address,
-    token1Address: bscTokens.btcb.address,
+    feeTier: FeeAmount.LOWEST,
+    token0Address: bscTokens.btcb.address,
+    token1Address: bscTokens.stbtc.address,
   },
 ]

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4889,4 +4889,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: bscTokens.solvbtcbbn.address,
     token1Address: bscTokens.solvbtc.address,
   },
+  {
+    gid: 494,
+    pairName: 'stBTC-BTCB',
+    address: '0xfc18301B94a77D91015bb90D5249827c506846Ae',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.LOW,
+    token0Address: bscTokens.stbtc.address,
+    token1Address: bscTokens.btcb.address,
+  },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3245,4 +3245,12 @@ export const bscTokens = {
     'SolvBTC Babylon',
     'https://solv.finance/',
   ),
+  stbtc: new ERC20Token(
+    ChainId.BSC,
+    '0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3',
+    18,
+    'stBTC',
+    'Lorenzo stBTC',
+    'https://www.lorenzo-protocol.xyz',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for the `stBTC` token on the BSC network and integrate it into farming and gauges.

### Detailed summary
- Added `stBTC` token with details to BSC constants
- Included `stBTC` in a new LP pair in BSC farms
- Added `stBTC-BTCB` gauge configuration for BSC network

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->