### PR TITLE
fix: Network multi select not fully visible on mobile in gamification

### DIFF
--- a/apps/gamification/components/NetworkMultiSelector.tsx
+++ b/apps/gamification/components/NetworkMultiSelector.tsx
@@ -2,7 +2,7 @@ import { ChainId } from '@pancakeswap/chains'
 import { Box, BoxProps, MultiSelect } from '@pancakeswap/uikit'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import { targetChains } from 'config/supportedChain'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTheme } from 'styled-components'
 import { chainNameConverter } from 'utils/chainNameConverter'
 
@@ -19,15 +19,22 @@ const options = targetChains.map((chain) => ({
 
 export const defaultValueChains = options.map((i) => Number(i.value) as ChainId)
 
-export const NetworkMultiSelector: React.FC<NetworkMultiSelectorProps> = (props) => {
+export const NetworkMultiSelector: React.FC<NetworkMultiSelectorProps> = ({
+  pickMultiSelect,
+  setPickMultiSelect,
+  ...props
+}) => {
   const theme = useTheme()
 
-  const convertValueToString = useMemo(() => props.pickMultiSelect.map((i) => i.toString()), [props])
+  const convertValueToString = useMemo(() => pickMultiSelect.map((i) => i.toString()), [pickMultiSelect])
 
-  const onChange = (e) => {
-    const chains = e.value.map((chain) => Number(chain) as ChainId)
-    props.setPickMultiSelect(chains)
-  }
+  const onChange = useCallback(
+    (e) => {
+      const chains = e.value.map((chain) => Number(chain) as ChainId)
+      setPickMultiSelect(chains)
+    },
+    [setPickMultiSelect],
+  )
 
   return (
     <Box {...props}>

--- a/apps/gamification/views/Quests/components/Quests.tsx
+++ b/apps/gamification/views/Quests/components/Quests.tsx
@@ -2,7 +2,7 @@ import { ChainId } from '@pancakeswap/chains'
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, ButtonMenu, ButtonMenuItem, Flex, FlexGap, Spinner } from '@pancakeswap/uikit'
 import { NetworkMultiSelector, defaultValueChains } from 'components/NetworkMultiSelector'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import useInfiniteScroll from 'react-infinite-scroll-hook'
 import { styled } from 'styled-components'
 import { EmptyQuest } from 'views/Quests/components/EmptyQuest'
@@ -45,9 +45,9 @@ export const Quests = () => {
   const [statusButtonIndex, setStatusButtonIndex] = useState(0)
   const [pickMultiSelect, setPickMultiSelect] = useState<Array<ChainId>>(defaultValueChains)
 
-  const onStatusButtonChange = (newIndex: number) => {
+  const onStatusButtonChange = useCallback((newIndex: number) => {
     setStatusButtonIndex(newIndex)
-  }
+  }, [])
 
   const { quests, loadMore, isFetching, hasNextPage } = usePublicQuests({
     chainIdList: pickMultiSelect,

--- a/apps/gamification/views/Quests/index.tsx
+++ b/apps/gamification/views/Quests/index.tsx
@@ -8,7 +8,7 @@ export const QuestsView = () => {
   const { t } = useTranslation()
 
   return (
-    <Box pb={['100px', '100px', '100px', '200px']}>
+    <Box pb={['160px', '160px', '160px', '200px']}>
       <Banner
         title={t('Explore Quests')}
         subTitle={t('Join Quests and Build Your Profile')}

--- a/packages/uikit/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/uikit/src/components/MultiSelect/MultiSelect.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { MultiSelect as PrimereactSelect, MultiSelectChangeEvent } from "primereact/multiselect";
 import { styled } from "styled-components";
 import { useTheme } from "@pancakeswap/hooks";
+import noop from "lodash/noop";
 import { ArrowDropDownIcon, SearchIcon } from "../Svg";
 import { Box, Flex } from "../Box";
 import { Checkbox } from "../Checkbox";
@@ -454,7 +455,7 @@ export const MultiSelect = <T extends string | number>(props: IMultiSelectProps<
           onChange={handleChange}
           onShow={handleShow}
           onHide={handleHide}
-          onKeyDown={() => {}}
+          onKeyDown={noop}
         />
       </PrimereactSelectContainer>
     </SelectContainer>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor and optimize code in the `Quests` feature of the gamification app.

### Detailed summary
- Updated padding in `index.tsx`
- Replaced empty arrow function with `noop`
- Added `useCallback` in `Quests.tsx` for function optimization
- Added `useCallback` and `useMemo` in `NetworkMultiSelector.tsx` for performance improvements

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->