### PR TITLE
chore: usdce-usdc farm on arbitrum

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -38,6 +38,13 @@ const v3TopFixedLps: FarmConfigV3[] = [
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
   {
+    pid: 88,
+    lpAddress: '0x1CAF100CD74792D4be6C64621C2E21c7830868c4',
+    token0: arbitrumTokens.usde,
+    token1: arbitrumTokens.usdc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 87,
     lpAddress: '0xfb5076B8649022E9057FB6Eb7cbaC686CAcC2448',
     token0: arbitrumTokens.solvbtcbbn,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4899,4 +4899,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: bscTokens.btcb.address,
     token1Address: bscTokens.stbtc.address,
   },
+  {
+    gid: 495,
+    pairName: 'USDe-USDC',
+    address: '0x1CAF100CD74792D4be6C64621C2E21c7830868c4',
+    chainId: ChainId.ARBITRUM_ONE,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.LOWEST,
+    token0Address: arbitrumTokens.usde.address,
+    token1Address: arbitrumTokens.usdc.address,
+  },
 ]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new farm and gauge configuration for the USDe-USDC pair on Arbitrum.

### Detailed summary
- Added a new farm configuration for pid 88 with USDe-USDC pair on Arbitrum
- Added a new gauge configuration for gid 495 with USDe-USDC pair on Arbitrum

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->