### PR TITLE
fix: Refetch block data immediate after trx receipt in updater

### DIFF
--- a/apps/web/src/state/transactions/updater.tsx
+++ b/apps/web/src/state/transactions/updater.tsx
@@ -53,8 +53,6 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
   useEffect(() => {
     if (!chainId || !provider) return
 
-    let toRefetchBlockData = false
-
     forEach(
       pickBy(transactions, (transaction) => shouldCheck(fetchedTransactions.current, transaction)),
       (transaction) => {
@@ -79,8 +77,8 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
               }),
             )
             const toast = receipt.status === 'success' ? toastSuccess : toastError
-            if (!toRefetchBlockData && receipt.status === 'success') {
-              toRefetchBlockData = true
+            if (receipt.status === 'success') {
+              refetchBlockData()
             }
             toast(
               t('Transaction receipt'),
@@ -109,9 +107,6 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
         })
       },
     )
-    if (toRefetchBlockData) {
-      refetchBlockData()
-    }
   }, [chainId, provider, transactions, dispatch, toastSuccess, toastError, t, refetchBlockData])
 
   const crossChainFarmPendingTxns = useMemo(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to simplify the logic for triggering a block data refetch upon successful transaction receipt.

### Detailed summary
- Removed unnecessary `toRefetchBlockData` variable
- Refactored logic to trigger `refetchBlockData` directly upon successful transaction receipt

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->