### PR TITLE
chore: List usdt bitu stable pool

### DIFF
--- a/.changeset/angry-nails-perform.md
+++ b/.changeset/angry-nails-perform.md
@@ -1,0 +1,6 @@
+---
+'@pancakeswap/stable-swap-sdk': patch
+'@pancakeswap/tokens': patch
+---
+
+List USDT-BITU stable pool

--- a/packages/stable-swap-sdk/src/constants/pools/bsc.ts
+++ b/packages/stable-swap-sdk/src/constants/pools/bsc.ts
@@ -133,4 +133,14 @@ export const pools: StableSwapPool[] = [
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
+  {
+    lpSymbol: 'USDT-BITU LP',
+    lpAddress: '0x00020c0235677c9D66CE1E20A8FD4a2526d58CDb',
+    token: bscTokens.usdt,
+    quoteToken: bscTokens.bitu,
+    stableSwapAddress: '0x469F3B14FA289c960d272D4159eD005cFFC8D09D',
+    infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
+    stableLpFee: 0.0004,
+    stableLpFeeRateOfTotalFee: 0.5,
+  },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3253,4 +3253,12 @@ export const bscTokens = {
     'Lorenzo stBTC',
     'https://www.lorenzo-protocol.xyz',
   ),
+  bitu: new ERC20Token(
+    ChainId.BSC,
+    '0x654A32542A84bEA7D2c2C1A1Ed1AAAf26888E6bD',
+    18,
+    'BITU',
+    'BitU USD',
+    'https://www.bitu.io',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the USDT-BITU stable pool in PancakeSwap on BSC.

### Detailed summary
- Added `bitu` token to BSC constants
- Added USDT-BITU LP pool in BSC pools constants

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->