### PR TITLE
chore: add SEED farm on arbitrum

### DIFF
--- a/packages/farms/constants/arb.ts
+++ b/packages/farms/constants/arb.ts
@@ -38,6 +38,13 @@ const v3TopFixedLps: FarmConfigV3[] = [
 export const farmsV3 = defineFarmV3Configs([
   ...v3TopFixedLps,
   {
+    pid: 89,
+    lpAddress: '0x87Fe0e807E3E92A7558303FB51F201dcBfb07cC1',
+    token0: arbitrumTokens.weth,
+    token1: arbitrumTokens.seed,
+    feeAmount: FeeAmount.MEDIUM,
+  },
+  {
     pid: 88,
     lpAddress: '0x1CAF100CD74792D4be6C64621C2E21c7830868c4',
     token0: arbitrumTokens.usde,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -4909,4 +4909,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: arbitrumTokens.usde.address,
     token1Address: arbitrumTokens.usdc.address,
   },
+  {
+    gid: 496,
+    pairName: 'ETH-SEED',
+    address: '0x87Fe0e807E3E92A7558303FB51F201dcBfb07cC1',
+    chainId: ChainId.ARBITRUM_ONE,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.MEDIUM,
+    token0Address: arbitrumTokens.weth.address,
+    token1Address: arbitrumTokens.seed.address,
+  },
 ]

--- a/packages/tokens/src/constants/arb.ts
+++ b/packages/tokens/src/constants/arb.ts
@@ -423,4 +423,12 @@ export const arbitrumTokens = {
     'Solv BTC',
     'https://solv.finance/',
   ),
+  seed: new ERC20Token(
+    ChainId.ARBITRUM_ONE,
+    '0x86f65121804D2Cdbef79F9f072D4e0c2eEbABC08',
+    18,
+    'SEED',
+    'SEED',
+    'https://garden.finance/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for the `SEED` token on Arbitrum One, including farms and gauges.

### Detailed summary
- Added `SEED` token on Arbitrum One with its ERC20 details
- Defined a new farm with `SEED` and WETH LP
- Added a new gauge for `ETH-SEED` LP pair on Arbitrum One

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->