### PR TITLE
fix: reduce the pool list api fetch

### DIFF
--- a/apps/web/src/pages/liquidity/pool/[chainName]/[id].tsx
+++ b/apps/web/src/pages/liquidity/pool/[chainName]/[id].tsx
@@ -1,0 +1,3 @@
+import { PoolDetail } from 'views/PoolDetail'
+
+export default PoolDetail

--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -2,7 +2,6 @@ import { getChainNameInKebabCase } from '@pancakeswap/chains'
 import { FarmV4SupportedChainId, Protocol, supportedChainIdV4, UNIVERSAL_FARMS } from '@pancakeswap/farms'
 import { FeeAmount } from '@pancakeswap/v3-sdk'
 import { explorerApiClient } from 'state/info/api/client'
-import { isAddressEqual } from 'viem'
 import { PoolInfo } from '../type'
 import { parseFarmPools } from '../utils'
 
@@ -36,7 +35,7 @@ export const fetchExplorerFarmPools = async (
     return []
   }
 
-  return parseFarmPools(resp.data)
+  return parseFarmPools(resp.data, { isFarming: true })
 }
 
 export const fetchFarmPools = async (
@@ -91,6 +90,7 @@ export const fetchFarmPools = async (
         farm.protocol === Protocol.V3 ? Number(farm.feeAmount) : farm.protocol === Protocol.V2 ? FeeAmount.MEDIUM : 100, // @todo @ChefJerry add stable fee
       // @todo @ChefJerry get by protocols
       feeTierBase: 1_000_000,
+      isFarming: true,
     } satisfies PoolInfo
   })
 

--- a/apps/web/src/state/farmsV4/state/poolApr/hooks.ts
+++ b/apps/web/src/state/farmsV4/state/poolApr/hooks.ts
@@ -5,11 +5,10 @@ import { useCallback } from 'react'
 import { extendPoolsAtom } from '../extendPools/atom'
 import { fetchExplorerPoolInfo } from '../extendPools/fetcher'
 import { ChainIdAddressKey, PoolInfo } from '../type'
-import { cakeAprSetterAtom, emptyCakeAprPoolsAtom, merklAprAtom, poolAprAtom, poolsAtom } from './atom'
+import { cakeAprSetterAtom, emptyCakeAprPoolsAtom, merklAprAtom, poolAprAtom } from './atom'
 import { getAllNetworkMerklApr, getCakeApr, getLpApr } from './fetcher'
 
-export const usePoolApr = (key: ChainIdAddressKey) => {
-  const pool = useAtomValue(poolsAtom)[key]
+export const usePoolApr = (key: ChainIdAddressKey, pool: PoolInfo) => {
   const updatePools = useSetAtom(extendPoolsAtom)
   const updateCallback = useCallback(async () => {
     if (!pool) {

--- a/apps/web/src/state/farmsV4/state/type.ts
+++ b/apps/web/src/state/farmsV4/state/type.ts
@@ -27,8 +27,7 @@ export type BasePoolInfo = {
   feeTier: number
   feeTierBase: number
   totalFeeUSD?: `${number}`
-  // @todo @ChefJerry add whitelist field
-  whitelist?: boolean
+  isFarming: boolean
 }
 
 export type V3PoolInfo = BasePoolInfo & {

--- a/apps/web/src/state/farmsV4/state/utils.ts
+++ b/apps/web/src/state/farmsV4/state/utils.ts
@@ -9,6 +9,7 @@ export const parseFarmPools = (
     | paths['/cached/pools/farming']['get']['responses']['200']['content']['application/json']
     | paths['/cached/pools/list']['get']['responses']['200']['content']['application/json']['rows']
     | paths['/cached/pools/{chainName}/{id}']['get']['responses']['200']['content']['application/json'][],
+  options: { isFarming?: boolean } = {},
 ): PoolInfo[] => {
   return data.map((pool) => {
     return {
@@ -42,8 +43,7 @@ export const parseFarmPools = (
       feeTier: Number(pool.feeTier),
       // @todo @ChefJerry get by protocols
       feeTierBase: 1_000_000,
-      // @todo @ChefJerry implement whitelist
-      whitelist: false,
+      isFarming: !!options?.isFarming,
     } satisfies PoolInfo
   })
 }

--- a/apps/web/src/views/universalFarms/PoolsPage.tsx
+++ b/apps/web/src/views/universalFarms/PoolsPage.tsx
@@ -1,19 +1,16 @@
 import styled from 'styled-components'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect, useMemo, useState, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '@pancakeswap/localization'
 import { toTokenValueByCurrency } from '@pancakeswap/widgets-internal'
-import { Protocol, UNIVERSAL_FARMS } from '@pancakeswap/farms'
+import { UNIVERSAL_FARMS } from '@pancakeswap/farms'
 import { useIntersectionObserver, useTheme } from '@pancakeswap/hooks'
-import { Button, Image, InfoIcon, ISortOrder, SORT_ORDER, TableView, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Button, InfoIcon, ISortOrder, SORT_ORDER, TableView, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useAllTokensByChainIds } from 'hooks/Tokens'
 import { PoolSortBy } from 'state/farmsV4/atom'
 import { useExtendPools, useFarmPools, usePoolsApr } from 'state/farmsV4/hooks'
 import { getCombinedApr } from 'state/farmsV4/state/poolApr/utils'
 import type { PoolInfo } from 'state/farmsV4/state/type'
-import { getChainName } from '@pancakeswap/chains'
-import { LegacyRouter } from '@pancakeswap/smart-router/legacy-router'
-import { isAddressEqual } from 'viem'
 
 import {
   Card,
@@ -24,6 +21,7 @@ import {
   ListView,
   MAINNET_CHAINS,
   PoolsFilterPanel,
+  getPoolDetailPageLink,
   useColumnConfig,
   useSelectedPoolTypes,
 } from './components'
@@ -42,7 +40,7 @@ export const PoolsPage = () => {
   const { theme } = useTheme()
   const { isMobile } = useMatchBreakpoints()
 
-  const columns = useColumnConfig<IDataType>()
+  const columns = useColumnConfig()
   const allChainIds = useMemo(() => MAINNET_CHAINS.map((chain) => chain.id), [])
   const [filters, setFilters] = useState<IPoolsFilterPanelProps['value']>({
     selectedTypeIndex: 0,
@@ -138,14 +136,7 @@ export const PoolsPage = () => {
 
   const handleRowClick = useCallback(
     (pool: PoolInfo) => {
-      let link = `/pools/${getChainName(pool.chainId)}/${pool.lpAddress}`
-      if (pool.protocol === Protocol.STABLE) {
-        const stablePair = LegacyRouter.stableSwapPairsByChainId[pool.chainId]?.find((pair) =>
-          isAddressEqual(pair.lpAddress, pool.lpAddress),
-        )
-        link = `/pools/${getChainName(pool.chainId)}/${stablePair?.stableSwapAddress}`
-      }
-      nextRouter.push(link)
+      nextRouter.push(getPoolDetailPageLink(pool))
     },
     [nextRouter],
   )

--- a/apps/web/src/views/universalFarms/PoolsPage.tsx
+++ b/apps/web/src/views/universalFarms/PoolsPage.tsx
@@ -34,11 +34,6 @@ const PoolsContent = styled.div`
   min-height: calc(100vh - 64px - 56px);
 `
 
-const StyledImage = styled(Image)`
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: 58px;
-`
 const NUMBER_OF_FARMS_VISIBLE = 20
 
 export const PoolsPage = () => {

--- a/apps/web/src/views/universalFarms/components/PoolApyButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolApyButton.tsx
@@ -44,7 +44,7 @@ const AprTooltip: React.FC<{
 }> = ({ hasBoost, pool, combinedBaseApr, combinedBoostedApr }) => {
   const { t } = useTranslation()
   const key = useMemo(() => `${pool.chainId}:${pool.lpAddress}` as const, [pool.chainId, pool.lpAddress])
-  const { lpApr, cakeApr, merklApr } = usePoolApr(key)
+  const { lpApr, cakeApr, merklApr } = usePoolApr(key, pool)
   const merklLink = useMemo(() => {
     return getMerklLink({ chainId: pool.chainId, lpAddress: pool.lpAddress })
   }, [pool.chainId, pool.lpAddress])
@@ -102,7 +102,7 @@ const AprTooltip: React.FC<{
 export const PoolApyButton: React.FC<{ pool: PoolInfo }> = ({ pool }) => {
   const { t } = useTranslation()
   const key = useMemo(() => `${pool.chainId}:${pool.lpAddress}` as const, [pool.chainId, pool.lpAddress])
-  const { lpApr, cakeApr, merklApr } = usePoolApr(key)
+  const { lpApr, cakeApr, merklApr } = usePoolApr(key, pool)
   const roiModal = useModalV2()
   // @todo @ChefJerry display user apr if staking
   const userIsStaking = false

--- a/apps/web/src/views/universalFarms/components/PoolListView.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolListView.tsx
@@ -135,7 +135,7 @@ export interface IListItemDetailsProps {
 }
 
 const ListItemDetails: React.FC<IListItemDetailsProps> = memo(({ data }) => {
-  const columns = useColumnMobileConfig<PoolInfo>()
+  const columns = useColumnMobileConfig()
 
   if (!data) {
     return null

--- a/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, Button, Column, LinkExternal, PageHeader, Row, Text } from '@pancakeswap/uikit'
 import { NextLinkFromReactRouter, VerticalDivider } from '@pancakeswap/widgets-internal'
@@ -6,6 +7,7 @@ import { FarmFlexWrapper, FarmH1, FarmH2 } from 'views/Farms/styled'
 
 export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }) => {
   const { t } = useTranslation()
+  const { theme } = useTheme()
   return (
     <PageHeader>
       <Column>
@@ -26,7 +28,7 @@ export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }
                   </Text>
                 </Button>
               </LinkExternal>
-              <VerticalDivider />
+              <VerticalDivider bg={theme.colors.inputSecondary} />
               <NextLinkFromReactRouter to="/farms/auction" prefetch={false}>
                 <Button p="0" variant="text">
                   <Text color="primary" bold fontSize="16px" mr="4px">
@@ -36,7 +38,7 @@ export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }
               </NextLinkFromReactRouter>
               {!!additionLink && (
                 <>
-                  <VerticalDivider />
+                  <VerticalDivider bg={theme.colors.inputSecondary} />
                   {additionLink}
                 </>
               )}

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3523,5 +3523,6 @@
   "You have no position in this wallet.": "You have no position in this wallet.",
   "Legacy Liquidity Page": "Legacy Liquidity Page",
   "Legacy Farm Page": "Legacy Farm Page",
-  "Total Value Locked (TVL) in the pool.": "Total Value Locked (TVL) in the pool."
+  "Total Value Locked (TVL) in the pool.": "Total Value Locked (TVL) in the pool.",
+  "%t% LP": "%t% LP"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3522,5 +3522,6 @@
   "Please Connect Wallet to view positions.": "Please Connect Wallet to view positions.",
   "You have no position in this wallet.": "You have no position in this wallet.",
   "Legacy Liquidity Page": "Legacy Liquidity Page",
-  "Legacy Farm Page": "Legacy Farm Page"
+  "Legacy Farm Page": "Legacy Farm Page",
+  "Total Value Locked (TVL) in the pool.": "Total Value Locked (TVL) in the pool."
 }

--- a/packages/widgets-internal/components/FeeTierTooltip/index.tsx
+++ b/packages/widgets-internal/components/FeeTierTooltip/index.tsx
@@ -1,7 +1,7 @@
 import { Protocol } from "@pancakeswap/farms";
 import { useTranslation } from "@pancakeswap/localization";
 import { Percent } from "@pancakeswap/swap-sdk-core";
-import { FeeTier, LinkExternal, useTooltip } from "@pancakeswap/uikit";
+import { FeeTier, LinkExternal, Text, useTooltip } from "@pancakeswap/uikit";
 import { useMemo } from "react";
 
 export type FeeTierTooltipProps = {
@@ -16,23 +16,37 @@ const FeeTooltips: React.FC<FeeTierTooltipProps> = ({ type, dynamic, percent }) 
 
   switch (type) {
     case "stable":
-      return t("Fees are lower for Stable LP");
+      return (
+        <>
+          <Text bold>{t("%t% LP", { t: "StableSwap" })}</Text>
+          <div>{t("Fees are lower for Stable LP")}</div>
+        </>
+      );
     case "v4bin": {
-      if (dynamic) {
-        return (
-          <>
-            {t("Dynamic fee: ↕️ %p%% Fee may vary based on several conditions", { p })}
-            {/* @todo @ChefJerry */}
-            <LinkExternal href="https://pancakeswap.finance/#todo">{t("Learn more")}</LinkExternal>
-          </>
-        );
-      }
-      return t("Static Fee: %p%%", { p });
+      return (
+        <>
+          <Text bold>{t("%t% LP", { t: type.toUpperCase() })}</Text>
+          {dynamic ? (
+            <>
+              {t("Dynamic fee: ↕️ %p%% Fee may vary based on several conditions", { p })}
+              {/* @todo @ChefJerry */}
+              <LinkExternal href="https://pancakeswap.finance/#todo">{t("Learn more")}</LinkExternal>
+            </>
+          ) : (
+            t("Static Fee: %p%%", { p })
+          )}
+        </>
+      );
     }
     case "v3":
     case "v2":
     default:
-      return t("%p%% Fee Tier", { p });
+      return (
+        <>
+          <Text bold>{t("%t% LP", { t: type.toUpperCase() })}</Text>
+          {t("%p%% Fee Tier", { p })}
+        </>
+      );
   }
 };
 
@@ -41,12 +55,14 @@ export const FeeTierTooltip: React.FC<FeeTierTooltipProps> = ({ type, dynamic, p
     <FeeTooltips type={type} dynamic={dynamic} percent={percent} />
   );
 
+  const typeSymbol = useMemo(() => (type === "stable" ? "SS" : type), [type]);
+
   return (
     <>
       <FeeTier
         ref={targetRef}
         dynamic={dynamic}
-        type={type}
+        type={typeSymbol}
         fee={Number(percent.numerator)}
         denominator={Number(percent.denominator)}
       />

--- a/packages/widgets-internal/components/NumberDisplay/FiatNumberDisplay.tsx
+++ b/packages/widgets-internal/components/NumberDisplay/FiatNumberDisplay.tsx
@@ -12,6 +12,7 @@ export type FiatNumberDisplayProps = {
   value: string | number | BigNumber;
   maximumSignificantDigits?: number;
   showFullDigitsTooltip?: boolean;
+  tooltipText?: React.ReactNode;
   roundingMode?: BigNumber.RoundingMode;
   as?: ElementType;
   style?: CSSProperties;
@@ -24,6 +25,7 @@ export const FiatNumberDisplay = memo(function FiatNumberDisplay({
   maximumSignificantDigits = 8,
   roundingMode = BigNumber.ROUND_DOWN,
   showFullDigitsTooltip = true,
+  tooltipText,
   style,
   fiatSymbol = "$",
   ...props
@@ -48,7 +50,7 @@ export const FiatNumberDisplay = memo(function FiatNumberDisplay({
   );
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
-    t("Exact number: %numberWithFullDigits%", { numberWithFullDigits: valueDisplayInFullDigits }),
+    tooltipText ?? t("Exact number: %numberWithFullDigits%", { numberWithFullDigits: valueDisplayInFullDigits }),
     {
       placement: "top-end",
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating pool-related components and state in the web app. 

### Detailed summary
- Updated `PoolDetail` import in `pool/[chainName]/[id].tsx`
- Removed `whitelist` field and added `isFarming` in `type.ts`
- Updated translations in `translations.json`
- Added `isFarming` option in `parseFarmPools`
- Updated `usePoolApr` in `hooks.ts`
- Added `isFarming` option in `fetchExplorerFarmPools`
- Updated `FiatNumberDisplay` with `tooltipText` prop
- Updated `PoolApyButton` and `PoolsBanner` components
- Updated `FeeTierTooltip` component
- Updated `PoolsPage` and `PoolListItemAction` components

> The following files were skipped due to too many changes: `apps/web/src/views/universalFarms/components/PoolListItemAction.tsx`, `apps/web/src/views/universalFarms/components/useColumnConfig.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->