### PR TITLE
feat: Port trigger block data after trx to gamifications

### DIFF
--- a/apps/gamification/hooks/usePublicNodeWaitForTransaction.ts
+++ b/apps/gamification/hooks/usePublicNodeWaitForTransaction.ts
@@ -17,6 +17,7 @@ import {
   http,
 } from 'viem'
 import { usePublicClient } from 'wagmi'
+import { useFetchBlockData } from '@pancakeswap/wagmi'
 import { useActiveChainId } from './useActiveChainId'
 
 export const viemClientsPublicNodes = CHAINS.reduce((prev, cur) => {
@@ -45,6 +46,7 @@ export type PublicNodeWaitForTransactionParams = GetTransactionReceiptParameters
 export function usePublicNodeWaitForTransaction() {
   const { chainId } = useActiveChainId()
   const provider = usePublicClient({ chainId })
+  const refetchBlockData = useFetchBlockData(chainId)
 
   const waitForTransaction_ = useCallback(
     async (opts: PublicNodeWaitForTransactionParams): Promise<TransactionReceipt> => {
@@ -53,12 +55,19 @@ export function usePublicNodeWaitForTransaction() {
           const selectedChain: ChainId = opts?.chainId ?? chainId
           // our custom node might be late to sync up
           if (selectedChain && viemClientsPublicNodes[selectedChain]) {
-            return await viemClientsPublicNodes[selectedChain].getTransactionReceipt({ hash: opts.hash })
+            const receipt = await viemClientsPublicNodes[selectedChain].getTransactionReceipt({ hash: opts.hash })
+            if (receipt.status === 'success') {
+              refetchBlockData()
+            }
           }
 
           if (!provider) return undefined
 
-          return await provider.getTransactionReceipt({ hash: opts.hash })
+          const receipt = await provider.getTransactionReceipt({ hash: opts.hash })
+          if (receipt.status === 'success') {
+            refetchBlockData()
+          }
+          return receipt
         } catch (error) {
           if (error instanceof TransactionNotFoundError) {
             throw new RetryableError(`Transaction not found: ${opts.hash}`)
@@ -79,7 +88,7 @@ export function usePublicNodeWaitForTransaction() {
         delay: (chainId ? AVERAGE_CHAIN_BLOCK_TIMES[chainId as ChainId] : BSC_BLOCK_TIME) * 1000 + 1000,
       }).promise as Promise<TransactionReceipt>
     },
-    [chainId, provider],
+    [chainId, provider, refetchBlockData],
   )
 
   return {

--- a/apps/gamification/state/transactions/updater.tsx
+++ b/apps/gamification/state/transactions/updater.tsx
@@ -17,6 +17,7 @@ import {
   WaitForTransactionReceiptTimeoutError,
 } from 'viem'
 import { usePublicClient } from 'wagmi'
+import { useFetchBlockData } from '@pancakeswap/wagmi'
 import { finalizeTransaction } from './actions'
 import { useAllChainTransactions } from './hooks'
 import { TransactionDetails } from './reducer'
@@ -35,6 +36,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
 
   const dispatch = useAppDispatch()
   const transactions = useAllChainTransactions(chainId)
+  const refetchBlockData = useFetchBlockData(chainId)
 
   const { toastError, toastSuccess } = useToast()
 
@@ -67,6 +69,9 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
               }),
             )
             const toast = receipt.status === 'success' ? toastSuccess : toastError
+            if (receipt.status === 'success') {
+              refetchBlockData()
+            }
             toast(
               t('Transaction receipt'),
               <ToastDescriptionWithTx txHash={receipt.transactionHash} txChainId={chainId} />,
@@ -94,7 +99,7 @@ export const Updater: React.FC<{ chainId: number }> = ({ chainId }) => {
         })
       },
     )
-  }, [chainId, provider, transactions, dispatch, toastSuccess, toastError, t])
+  }, [chainId, provider, transactions, dispatch, toastSuccess, toastError, t, refetchBlockData])
 
   return null
 }

--- a/apps/gamification/views/DashboardQuestEdit/hooks/useQuestRewardApprovalStatus.ts
+++ b/apps/gamification/views/DashboardQuestEdit/hooks/useQuestRewardApprovalStatus.ts
@@ -1,9 +1,10 @@
 import { ChainId } from '@pancakeswap/sdk'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
+import { useReadContract } from '@pancakeswap/wagmi'
 import BigNumber from 'bignumber.js'
 import { getQuestRewardAddress } from 'utils/addressHelpers'
 import { Address, erc20Abi } from 'viem'
-import { useAccount, useReadContract } from 'wagmi'
+import { useAccount } from 'wagmi'
 
 export const useQuestRewardApprovalStatus = (tokenAddress: Address, chainId: ChainId) => {
   const { address: account } = useAccount()


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new function `useFetchBlockData` and updates existing functions to refetch block data upon successful transactions.

### Detailed summary
- Added `useFetchBlockData` function
- Updated `useQuestRewardApprovalStatus` to use `useAccount` instead of `useReadContract`
- Updated `Updater` and `usePublicNodeWaitForTransaction` to refetch block data on successful transactions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->