### PR TITLE
fix: add skeleton for Positions loading

### DIFF
--- a/apps/web/src/views/universalFarms/PositionPage.tsx
+++ b/apps/web/src/views/universalFarms/PositionPage.tsx
@@ -49,6 +49,7 @@ import {
   useSelectedPoolTypes,
   V2PositionItem,
   V3PositionItem,
+  PositionItemSkeleton,
 } from './components'
 
 const ToggleWrapper = styled.div`
@@ -365,9 +366,12 @@ export const PositionPage = () => {
     }
     if (v3Loading && v2Loading && stableLoading) {
       return (
-        <Text color="textSubtle" textAlign="center">
-          <Dots>{t('Loading')}</Dots>
-        </Text>
+        <>
+          <PositionItemSkeleton />
+          <Text color="textSubtle" textAlign="center">
+            <Dots>{t('Loading')}</Dots>
+          </Text>
+        </>
       )
     }
 

--- a/packages/utils/formatFiatNumber.ts
+++ b/packages/utils/formatFiatNumber.ts
@@ -31,13 +31,13 @@ export function formatFiatNumber(
     const billion = 1e9
     const trillion = 1e12
     if (bnValue.isGreaterThanOrEqualTo(trillion)) {
-      return `>${valueWithSymbol('999b', fiatSymbol)}`
+      return `>${valueWithSymbol('999B', fiatSymbol)}`
     }
     if (bnValue.isGreaterThanOrEqualTo(billion)) {
-      return valueWithSymbol(`${bnValue.dividedBy(billion).toFixed(0, BigNumber.ROUND_DOWN)}b`, fiatSymbol)
+      return valueWithSymbol(`${bnValue.dividedBy(billion).toFixed(0, BigNumber.ROUND_DOWN)}B`, fiatSymbol)
     }
     if (bnValue.isGreaterThanOrEqualTo(million)) {
-      return valueWithSymbol(`${bnValue.dividedBy(million).toFixed(0, BigNumber.ROUND_DOWN)}m`, fiatSymbol)
+      return valueWithSymbol(`${bnValue.dividedBy(million).toFixed(0, BigNumber.ROUND_DOWN)}M`, fiatSymbol)
     }
   }
   // If less than 1, keep as many decimal digits as possible


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `PositionItemSkeleton` component in the `PositionPage` view and updates formatting in `formatFiatNumber` for better readability.

### Detailed summary
- Added `PositionItemSkeleton` component in `PositionPage`
- Updated formatting in `formatFiatNumber` for values greater than million to use 'B' or 'M' suffixes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->