### PR TITLE
chore: log swap Tx sent event

### DIFF
--- a/apps/web/src/utils/customGTMEventTracking.ts
+++ b/apps/web/src/utils/customGTMEventTracking.ts
@@ -2,6 +2,7 @@ export enum GTMEvent {
   EventTracking = 'eventTracking',
   Swap = 'swap',
   SwapTxSent = 'swapTxSent',
+  SwapConfirmed = 'SwapConfirmed',
   AddLiquidity = 'addLiquidity',
   RemoveLiquidity = 'removeLiquidity',
   Farm = 'stakeFarm',
@@ -25,6 +26,7 @@ export enum GTMCategory {
 export enum GTMAction {
   ClickTradeButton = 'Click Trade Button',
   ClickSwapButton = 'Click Swap Button',
+  ClickSwapConfirmButton = 'Click Swap Confirm Button',
   SwapTransactionSent = 'Swap Transaction Sent',
   ClickAddLiquidityButton = 'Click Add Liquidity Button',
   ClickRemoveLiquidityButton = 'Click Remove Liquidity Button',
@@ -74,6 +76,15 @@ export const logGTMSwapTxSentEvent = () => {
   window?.dataLayer?.push({
     event: GTMEvent.SwapTxSent,
     action: GTMAction.SwapTransactionSent,
+    category: GTMCategory.Swap,
+  })
+}
+
+export const logGTMClickSwapConfirmEvent = () => {
+  console.info('---SwapClickConfirm---')
+  window?.dataLayer?.push({
+    event: GTMEvent.SwapConfirmed,
+    action: GTMAction.ClickSwapConfirmButton,
     category: GTMCategory.Swap,
   })
 }

--- a/apps/web/src/utils/customGTMEventTracking.ts
+++ b/apps/web/src/utils/customGTMEventTracking.ts
@@ -1,6 +1,7 @@
 export enum GTMEvent {
   EventTracking = 'eventTracking',
   Swap = 'swap',
+  SwapTxSent = 'swapTxSent',
   AddLiquidity = 'addLiquidity',
   RemoveLiquidity = 'removeLiquidity',
   Farm = 'stakeFarm',
@@ -24,6 +25,7 @@ export enum GTMCategory {
 export enum GTMAction {
   ClickTradeButton = 'Click Trade Button',
   ClickSwapButton = 'Click Swap Button',
+  SwapTransactionSent = 'Swap Transaction Sent',
   ClickAddLiquidityButton = 'Click Add Liquidity Button',
   ClickRemoveLiquidityButton = 'Click Remove Liquidity Button',
   ClickStakeButton = 'Click Stake Button',
@@ -63,6 +65,15 @@ export const logGTMClickSwapEvent = () => {
   window?.dataLayer?.push({
     event: GTMEvent.Swap,
     action: GTMAction.ClickSwapButton,
+    category: GTMCategory.Swap,
+  })
+}
+
+export const logGTMSwapTxSentEvent = () => {
+  console.info('---SwapTxSent---')
+  window?.dataLayer?.push({
+    event: GTMEvent.SwapTxSent,
+    action: GTMAction.SwapTransactionSent,
     category: GTMCategory.Swap,
   })
 }

--- a/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
@@ -10,7 +10,7 @@ import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 import { WrapType } from 'hooks/useWrapCallback'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Field } from 'state/swap/actions'
-import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapConfirmEvent, logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
 import { Address } from 'viem'
 import { parseMMError } from 'views/Swap/MMLinkPools/utils/exchange'
 import { ConfirmSwapModal } from 'views/Swap/V3Swap/containers/ConfirmSwapModal'
@@ -113,7 +113,7 @@ SwapCommitButtonPropsType & CommitButtonProps) {
 
   const onConfirm = useCallback(() => {
     beforeCommit?.()
-
+    logGTMClickSwapConfirmEvent()
     callToAction()
   }, [beforeCommit, callToAction])
 

--- a/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
@@ -97,6 +97,7 @@ SwapCommitButtonPropsType & CommitButtonProps) {
     resetState()
     // if there was a tx hash, we want to clear the input
     if (txHash) {
+      logGTMSwapTxSentEvent()
       onUserInput(Field.INPUT, '')
     }
   }, [afterCommit, resetState, txHash, onUserInput])
@@ -115,7 +116,6 @@ SwapCommitButtonPropsType & CommitButtonProps) {
     beforeCommit?.()
 
     callToAction()
-    logGTMSwapTxSentEvent()
   }, [beforeCommit, callToAction])
 
   const [onPresentConfirmModal] = useModal(

--- a/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
@@ -10,7 +10,7 @@ import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 import { WrapType } from 'hooks/useWrapCallback'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Field } from 'state/swap/actions'
-import { logGTMClickSwapEvent, logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
 import { Address } from 'viem'
 import { parseMMError } from 'views/Swap/MMLinkPools/utils/exchange'
 import { ConfirmSwapModal } from 'views/Swap/V3Swap/containers/ConfirmSwapModal'
@@ -97,7 +97,6 @@ SwapCommitButtonPropsType & CommitButtonProps) {
     resetState()
     // if there was a tx hash, we want to clear the input
     if (txHash) {
-      logGTMSwapTxSentEvent()
       onUserInput(Field.INPUT, '')
     }
   }, [afterCommit, resetState, txHash, onUserInput])

--- a/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
+++ b/apps/web/src/views/Swap/MMLinkPools/components/MMCommitButton.tsx
@@ -10,7 +10,7 @@ import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 import { WrapType } from 'hooks/useWrapCallback'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Field } from 'state/swap/actions'
-import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapEvent, logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
 import { Address } from 'viem'
 import { parseMMError } from 'views/Swap/MMLinkPools/utils/exchange'
 import { ConfirmSwapModal } from 'views/Swap/V3Swap/containers/ConfirmSwapModal'
@@ -115,6 +115,7 @@ SwapCommitButtonPropsType & CommitButtonProps) {
     beforeCommit?.()
 
     callToAction()
+    logGTMSwapTxSentEvent()
   }, [beforeCommit, callToAction])
 
   const [onPresentConfirmModal] = useModal(

--- a/apps/web/src/views/Swap/MMLinkPools/hooks/useMMConfirmModalState.ts
+++ b/apps/web/src/views/Swap/MMLinkPools/hooks/useMMConfirmModalState.ts
@@ -6,6 +6,7 @@ import { ConfirmModalState } from '@pancakeswap/widgets-internal'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { RetryableError, retry } from 'state/multicall/retry'
+import { logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
 import { UserUnexpectedTxError } from 'utils/errors'
 import { publicClient } from 'utils/wagmi'
 import { Address, Hex, TransactionNotFoundError, TransactionReceipt, TransactionReceiptNotFoundError } from 'viem'
@@ -204,6 +205,7 @@ const useConfirmActions = (
       try {
         const result = await swap()
         if (result?.hash) {
+          logGTMSwapTxSentEvent()
           setTxHash(result.hash)
           const receipt = await retryWaitForTransaction({ hash: result.hash })
           if (receipt && receipt.status === 'reverted') {

--- a/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
@@ -22,7 +22,7 @@ import { useSwapState } from 'state/swap/hooks'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useRoutingSettingChanged } from 'state/user/smartRouter'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapConfirmEvent, logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
 import { warningSeverity } from 'utils/exchange'
 import { useAccount, useChainId } from 'wagmi'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../hooks'
@@ -190,6 +190,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
 
   const onConfirm = useCallback(() => {
     beforeCommit?.()
+    logGTMClickSwapConfirmEvent()
     callToAction()
   }, [beforeCommit, callToAction])
 

--- a/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
@@ -168,6 +168,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const reset = useCallback(() => {
     afterCommit?.()
     if (confirmState === ConfirmModalState.COMPLETED) {
+      logGTMSwapTxSentEvent()
       onUserInput(Field.INPUT, '')
     }
     resetState()
@@ -191,7 +192,6 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const onConfirm = useCallback(() => {
     beforeCommit?.()
     callToAction()
-    logGTMSwapTxSentEvent()
   }, [beforeCommit, callToAction])
 
   // modals

--- a/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
@@ -22,7 +22,7 @@ import { useSwapState } from 'state/swap/hooks'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useRoutingSettingChanged } from 'state/user/smartRouter'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapEvent, logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
 import { warningSeverity } from 'utils/exchange'
 import { useAccount, useChainId } from 'wagmi'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../hooks'
@@ -191,6 +191,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const onConfirm = useCallback(() => {
     beforeCommit?.()
     callToAction()
+    logGTMSwapTxSentEvent()
   }, [beforeCommit, callToAction])
 
   // modals

--- a/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
@@ -22,7 +22,7 @@ import { useSwapState } from 'state/swap/hooks'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useRoutingSettingChanged } from 'state/user/smartRouter'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { logGTMClickSwapEvent, logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
+import { logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
 import { warningSeverity } from 'utils/exchange'
 import { useAccount, useChainId } from 'wagmi'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../hooks'
@@ -168,7 +168,6 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const reset = useCallback(() => {
     afterCommit?.()
     if (confirmState === ConfirmModalState.COMPLETED) {
-      logGTMSwapTxSentEvent()
       onUserInput(Field.INPUT, '')
     }
     resetState()

--- a/apps/web/src/views/Swap/V3Swap/hooks/useConfirmModalState.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useConfirmModalState.ts
@@ -14,6 +14,7 @@ import { useSafeTxHashTransformer } from 'hooks/useSafeTxHashTransformer'
 import { useTransactionDeadline } from 'hooks/useTransactionDeadline'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { RetryableError, retry } from 'state/multicall/retry'
+import { logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
 import { UserUnexpectedTxError } from 'utils/errors'
 import { publicClient } from 'utils/wagmi'
 import {
@@ -319,6 +320,7 @@ const useConfirmActions = (
           const result = await swap()
           if (result?.hash) {
             const hash = await safeTxHashTransformer(result.hash)
+            logGTMSwapTxSentEvent()
             setTxHash(hash)
 
             await retryWaitForTransaction({ hash })


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add event tracking for swap transactions confirmation in the Swap feature.

### Detailed summary
- Added event tracking for swap transaction sent and swap confirmation button clicks
- Modified functions in `customGTMEventTracking.ts` to log these events
- Updated multiple files to call the new event tracking functions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->