### PR TITLE
fix: Buy crypto url query not applied to output currency

### DIFF
--- a/apps/web/src/hooks/useCanBuyCrypto.ts
+++ b/apps/web/src/hooks/useCanBuyCrypto.ts
@@ -1,7 +1,7 @@
 import type { ChainId } from '@pancakeswap/chains'
 import { useMemo } from 'react'
 
-const SUPPORTED_ONRAMP_TOKENS = ['ETH', 'DAI', 'USDT', 'USDC', 'BUSD', 'BNB', 'WBTC']
+const SUPPORTED_ONRAMP_TOKENS = ['ETH', 'DAI', 'USDT', 'USDC', 'BNB', 'WBTC']
 
 interface Params {
   currencySymbol?: string

--- a/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
+++ b/apps/web/src/views/BuyCrypto/components/OnRampCurrencySelect/index.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from '@pancakeswap/localization'
+import { useMemo } from 'react'
 import { Currency, Token } from '@pancakeswap/sdk'
 import { ArrowDropDownIcon, Box, BoxProps, Flex, SkeletonText, Text, useModal } from '@pancakeswap/uikit'
 import { NumberDisplay, NumericalInput } from '@pancakeswap/widgets-internal'
 import OnRampCurrencySearchModal, { CurrencySearchModalProps } from 'components/SearchModal/OnRampCurrencyModal'
-import { fiatCurrencyMap, getNetworkDisplay, onRampCurrencies } from 'views/BuyCrypto/constants'
+import { fiatCurrencyMap, getNetworkDisplay, onRampCurrenciesMap } from 'views/BuyCrypto/constants'
 import { DropDownContainer, OptionSelectButton } from 'views/BuyCrypto/styles'
 import { OnRampUnit } from 'views/BuyCrypto/types'
 import { OnRampCurrencyLogo } from '../OnRampProviderLogo/OnRampProviderLogo'
@@ -73,7 +74,10 @@ export const BuyCryptoSelector = ({
   unit,
   ...props
 }: BuyCryptoSelectorProps) => {
-  const tokensToShow = id === 'onramp-fiat' ? Object.values(fiatCurrencyMap) : onRampCurrencies
+  const tokensToShow = useMemo(() => {
+    return id === 'onramp-fiat' ? Object.values(fiatCurrencyMap) : Object.values(onRampCurrenciesMap)
+  }, [id])
+
   const [onPresentCurrencyModal] = useModal(
     <OnRampCurrencySearchModal
       onCurrencySelect={onCurrencySelect}

--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -229,26 +229,6 @@ export const fiatCurrencyMap: Record<string, { symbol: string; name: string }> =
 }
 
 export type OnRampCurrency = Currency | NativeBtc
-export const onRampCurrencies: OnRampCurrency[] = [
-  NativeBtc.onChain(),
-  Native.onChain(OnRampChainId.ETHEREUM),
-  Native.onChain(OnRampChainId.BSC),
-  Native.onChain(OnRampChainId.ARBITRUM_ONE),
-  Native.onChain(OnRampChainId.POLYGON_ZKEVM),
-  Native.onChain(OnRampChainId.ZKSYNC),
-  Native.onChain(OnRampChainId.LINEA),
-  Native.onChain(OnRampChainId.BASE),
-  ethereumTokens.usdt,
-  bscTokens.usdt,
-  bscTokens.usdc,
-  ethereumTokens.usdc,
-  arbitrumTokens.usdc,
-  lineaTokens.usdc,
-  baseTokens.usdc,
-  ethereumTokens.dai,
-  ethereumTokens.wbtc,
-  // arbitrumTokens.usdce,
-]
 
 export const onRampCurrenciesMap: { [tokenSymbol: string]: Currency } = {
   BTC_0: NativeBtc.onChain(),

--- a/apps/web/src/views/Swap/V3Swap/containers/BuyCryptoLink.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/BuyCryptoLink.tsx
@@ -24,7 +24,7 @@ export const BuyCryptoLink = memo(function BuyCryptoInstruction({ currency }: Pr
     <Row alignItems="center" justifyContent="center" mb="4px">
       <Text fontSize="14px">
         {t('Insufficient Funds?')}{' '}
-        <InternalLink href={`/buy-crypto?inputCurrency=${currency.symbol}`}>{t('Buy Crypto here.')}</InternalLink>
+        <InternalLink href={`/buy-crypto?outputCurrency=${currency.symbol}`}>{t('Buy Crypto here.')}</InternalLink>
       </Text>
     </Row>
   )

--- a/apps/web/src/views/Swap/V3Swap/containers/BuyCryptoLink.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/BuyCryptoLink.tsx
@@ -24,7 +24,9 @@ export const BuyCryptoLink = memo(function BuyCryptoInstruction({ currency }: Pr
     <Row alignItems="center" justifyContent="center" mb="4px">
       <Text fontSize="14px">
         {t('Insufficient Funds?')}{' '}
-        <InternalLink href={`/buy-crypto?outputCurrency=${currency.symbol}`}>{t('Buy Crypto here.')}</InternalLink>
+        <InternalLink href={`/buy-crypto?outputCurrency=${currency.symbol}_${chainId}`}>
+          {t('Buy Crypto here.')}
+        </InternalLink>
       </Text>
     </Row>
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the supported onramp tokens and improve the buy crypto functionality.

### Detailed summary
- Removed tokens from `SUPPORTED_ONRAMP_TOKENS` array
- Updated link parameters in `BuyCryptoLink.tsx`
- Updated `onRampCurrenciesMap` and related imports
- Updated token selection logic in `OnRampCurrencySelect/index.tsx`
- Updated imports and types in `hooks.ts`
- Updated default fiat currency and output currency logic in `hooks.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->