### PR TITLE
perf: Dont create portal when tooltip not visible

### DIFF
--- a/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -202,7 +202,7 @@ const useTooltip = (content: React.ReactNode, options?: TooltipOptions): Tooltip
     e.stopPropagation();
   }, []);
 
-  const tooltip = (
+  const tooltip = visible ? (
     <StyledTooltip
       onClick={stopPropagation}
       data-theme={isDark ? "light" : "dark"}
@@ -216,16 +216,16 @@ const useTooltip = (content: React.ReactNode, options?: TooltipOptions): Tooltip
       {content}
       <Arrow ref={setArrowElement} style={styles.arrow} />
     </StyledTooltip>
-  );
+  ) : null;
 
-  const AnimatedTooltip = (
+  const AnimatedTooltip = visible ? (
     <LazyMotion features={domAnimation}>
-      <AnimatePresence>{visible && tooltip}</AnimatePresence>
+      <AnimatePresence>{tooltip}</AnimatePresence>
     </LazyMotion>
-  );
+  ) : null;
 
-  const portal = getPortalRoot();
-  const tooltipInPortal = portal && isInPortal ? createPortal(AnimatedTooltip, portal) : null;
+  const portal = visible && isInPortal && getPortalRoot();
+  const tooltipInPortal = visible && isInPortal && portal ? createPortal(AnimatedTooltip, portal) : null;
 
   return {
     targetRef: setTargetElement,

--- a/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -202,25 +202,23 @@ const useTooltip = (content: React.ReactNode, options?: TooltipOptions): Tooltip
     e.stopPropagation();
   }, []);
 
-  const tooltip = visible ? (
-    <StyledTooltip
-      onClick={stopPropagation}
-      data-theme={isDark ? "light" : "dark"}
-      {...animationMap}
-      variants={animationVariants}
-      transition={{ duration: 0.3 }}
-      ref={setTooltipElement}
-      style={styles.popper}
-      {...attributes.popper}
-    >
-      {content}
-      <Arrow ref={setArrowElement} style={styles.arrow} />
-    </StyledTooltip>
-  ) : null;
-
   const AnimatedTooltip = visible ? (
     <LazyMotion features={domAnimation}>
-      <AnimatePresence>{tooltip}</AnimatePresence>
+      <AnimatePresence>
+        <StyledTooltip
+          onClick={stopPropagation}
+          data-theme={isDark ? "light" : "dark"}
+          {...animationMap}
+          variants={animationVariants}
+          transition={{ duration: 0.3 }}
+          ref={setTooltipElement}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          {content}
+          <Arrow ref={setArrowElement} style={styles.arrow} />
+        </StyledTooltip>
+      </AnimatePresence>
     </LazyMotion>
   ) : null;
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to optimize the rendering of tooltips by conditionally showing the AnimatedTooltip component only when it is visible.

### Detailed summary
- Refactored tooltip rendering logic to conditionally show AnimatedTooltip based on visibility
- Updated the creation of portal element based on visibility of tooltip

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->