### PR TITLE
feat: pass position to v3 unstake modal

### DIFF
--- a/apps/web/src/views/universalFarms/components/PositionItem/V3PositionItem.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/V3PositionItem.tsx
@@ -72,6 +72,7 @@ export const V3PositionItem = memo(({ data, detailMode }: V3PositionItemProps) =
           modalContent={
             <V3UnstakeModalContent
               chainId={data.chainId}
+              userPosition={data}
               link={`/liquidity/${data.tokenId}`}
               pool={pool}
               totalPriceUSD={totalPriceUSD}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `V3PositionItem.tsx` to pass `data` directly to `V3UnstakeModalContent` and adds a `link` prop for navigation.

### Detailed summary
- Passes `data` directly to `V3UnstakeModalContent`
- Adds a `link` prop for navigation to `/liquidity/${data.tokenId}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->