### PR TITLE
feat: Implement partners docs tooltip component in buy crypto

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/FAQ.tsx
+++ b/apps/web/src/views/BuyCrypto/components/FAQ.tsx
@@ -1,7 +1,42 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Card, CardBody, CardHeader, Heading, LinkExternal, Text } from '@pancakeswap/uikit'
+import { Box, Card, CardBody, CardHeader, Heading, LinkExternal, Text, useTooltip } from '@pancakeswap/uikit'
 
 import FoldableText from 'components/FoldableSection/FoldableText'
+import { ONRAMP_PROVIDERS } from '../constants'
+
+type LinkDataMap = {
+  [key in ONRAMP_PROVIDERS]: string
+}
+
+const linkData: LinkDataMap = {
+  [ONRAMP_PROVIDERS.Mercuryo]:
+    'https://help.mercuryo.io/hc/en-gb/articles/14495507502749-Which-fiat-currencies-are-supported',
+  [ONRAMP_PROVIDERS.MoonPay]: 'https://support.moonpay.com/customers/docs/moonpays-supported-currencies',
+  [ONRAMP_PROVIDERS.Transak]: 'https://transak.com/global-coverage',
+  [ONRAMP_PROVIDERS.Topper]:
+    'https://support.topperpay.com/hc/en-us/articles/8926553047708-What-fiat-currencies-does-Topper-support',
+}
+
+const PartnersDocumentation = ({ t }) => {
+  const { tooltip, tooltipVisible, targetRef } = useTooltip(
+    <Box>
+      {Object.entries(linkData).map(([provider, href]) => (
+        <LinkExternal key={provider} href={href}>
+          {provider}
+        </LinkExternal>
+      ))}
+    </Box>,
+  )
+
+  return (
+    <>
+      {tooltipVisible && tooltip}
+      <Text ref={targetRef} style={{ display: 'inline-flex', textDecoration: 'underline dotted' }}>
+        {t('partners documentation')}
+      </Text>
+    </>
+  )
+}
 
 const config = (t) => [
   {
@@ -28,14 +63,7 @@ const config = (t) => [
         >
           {t('documentation')}
         </LinkExternal>{' '}
-        {t('or')}{' '}
-        <LinkExternal
-          style={{ display: 'inline-flex' }}
-          href="https://help.mercuryo.io/en/articles/6122838-on-and-off-ramps"
-        >
-          {t('partners documentation')}
-        </LinkExternal>{' '}
-        {t('for more info.')}
+        {t('or')} <PartnersDocumentation t={t} /> {t('for more info.')}
       </>
     ),
   },


### PR DESCRIPTION

<img width="346" alt="Screenshot 2024-08-16 at 19 44 36" src="https://github.com/user-attachments/assets/91e256cc-b6fe-4c77-91b7-ac66a0912787">


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the PartnersDocumentation component in the FAQ view by adding dynamic links for onramp providers.

### Detailed summary
- Added ONRAMP_PROVIDERS constant and LinkDataMap type
- Created linkData object with provider links
- Implemented PartnersDocumentation component with dynamic links
- Updated config to use PartnersDocumentation component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->