### PR TITLE
fix: add switch network before do tx action

### DIFF
--- a/apps/web/src/views/PoolDetail/components/MyPositions.tsx
+++ b/apps/web/src/views/PoolDetail/components/MyPositions.tsx
@@ -41,6 +41,7 @@ import {
 } from 'views/universalFarms/components'
 import { useV2FarmActions } from 'views/universalFarms/hooks/useV2FarmActions'
 import { formatDollarAmount } from 'views/V3Info/utils/numbers'
+import { useCheckShouldSwitchNetwork } from 'views/universalFarms/hooks'
 import { useV3Positions } from '../hooks/useV3Positions'
 import { V2PoolEarnings, V3PoolEarnings } from './PoolEarnings'
 
@@ -77,8 +78,6 @@ export const MyPositions: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
   const { t } = useTranslation()
   const [count, setCount] = useState(0)
   const [totalLiquidityUSD, setTotalLiquidityUSD] = useState('0')
-  const [totalAPR, setTotalAPR] = useState(0)
-  const [totalEarning, setTotalEarning] = useState(0)
   const [filter, setFilter] = useState(PositionFilter.All)
   const addLiquidityLink = useMemo(() => {
     const token0Token1 = `${poolInfo.token0.wrapped.address}/${poolInfo.token1.wrapped.address}`
@@ -102,9 +101,14 @@ export const MyPositions: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
   ])
   const [_handleHarvestAll, setHandleHarvestAll] = useState(() => () => Promise.resolve())
   const [loading, setLoading] = useState(false)
+  const { switchNetworkIfNecessary } = useCheckShouldSwitchNetwork()
 
   const handleHarvestAll = useCallback(async () => {
     if (loading) return
+    const shouldSwitch = await switchNetworkIfNecessary(poolInfo.chainId)
+    if (shouldSwitch) {
+      return
+    }
     try {
       setLoading(true)
       await _handleHarvestAll()
@@ -113,7 +117,7 @@ export const MyPositions: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
       console.error(error)
       setLoading(false)
     }
-  }, [_handleHarvestAll, loading, setLoading])
+  }, [_handleHarvestAll, loading, setLoading, poolInfo.chainId, switchNetworkIfNecessary])
 
   return (
     <AutoColumn gap="lg">

--- a/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
@@ -56,25 +56,33 @@ export const V3PositionActions = ({
     if (outOfRange && !isStaked) {
       stakeModal.onOpen()
     } else {
-      await switchNetworkIfNecessary(currency0.chainId)
-      await onStake()
+      const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
+      if (!shouldSwitch) {
+        await onStake()
+      }
     }
   }, [isStaked, onStake, outOfRange, stakeModal, switchNetworkIfNecessary, currency0.chainId])
 
   const handleStake = useCallback(async () => {
     logGTMClickStakeFarmEvent()
-    await switchNetworkIfNecessary(currency0.chainId)
-    await onStake()
+    const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
+    if (!shouldSwitch) {
+      await onStake()
+    }
   }, [onStake, switchNetworkIfNecessary, currency0.chainId])
 
   const handleUnStake = useCallback(async () => {
-    await switchNetworkIfNecessary(currency0.chainId)
-    await onUnstake()
+    const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
+    if (!shouldSwitch) {
+      await onUnstake()
+    }
   }, [onUnstake, switchNetworkIfNecessary, currency0.chainId])
 
   const handleHarvest = useCallback(async () => {
-    await switchNetworkIfNecessary(currency0.chainId)
-    await onHarvest()
+    const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
+    if (!shouldSwitch) {
+      await onHarvest()
+    }
   }, [onHarvest, switchNetworkIfNecessary, currency0.chainId])
 
   const stakeButton = useMemo(

--- a/apps/web/src/views/universalFarms/hooks/useCheckShouldSwitchNetwork.ts
+++ b/apps/web/src/views/universalFarms/hooks/useCheckShouldSwitchNetwork.ts
@@ -10,9 +10,10 @@ export const useCheckShouldSwitchNetwork = () => {
     switchNetworkIfNecessary: useCallback(
       async (chainId: number) => {
         if (canSwitch && currentChainId !== chainId) {
-          return switchNetworkAsync(chainId)
+          await switchNetworkAsync(chainId)
+          return true
         }
-        return Promise.resolve()
+        return false
       },
       [canSwitch, currentChainId, switchNetworkAsync],
     ),

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3522,5 +3522,6 @@
   "Legacy Liquidity Page": "Legacy Liquidity Page",
   "Legacy Farm Page": "Legacy Farm Page",
   "Total Value Locked (TVL) in the pool.": "Total Value Locked (TVL) in the pool.",
-  "%t% LP": "%t% LP"
+  "%t% LP": "%t% LP",
+  "Pool": "Pool"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to implement network switching checks before executing actions in the universal farms feature.

### Detailed summary
- Added network switching checks before stake, unstake, and harvest actions in universal farms
- Updated components in V2 and V3 position actions to handle network switching
- Introduced `useCheckShouldSwitchNetwork` hook for network switching logic

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->