### PR TITLE
chore: add btcb-kbtc farm

### DIFF
--- a/packages/farms/constants/bsc.ts
+++ b/packages/farms/constants/bsc.ts
@@ -76,6 +76,13 @@ export const farmsV3 = defineFarmV3Configs([
   // new lps should follow after the top fixed lps
   // latest first
   {
+    pid: 180,
+    lpAddress: '0x7b0240618CfE1cf4c576a905CA2557f287F97911',
+    token0: bscTokens.btcb,
+    token1: bscTokens.kbtc,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 179,
     lpAddress: '0xc9002d23CEBF00b40f7CDB5B1E63d96eebB50031',
     token0: bscTokens.wstETH,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -5049,4 +5049,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token0Address: bscTokens.wstETH.address,
     token1Address: bscTokens.wbnb.address,
   },
+  {
+    gid: 510,
+    pairName: 'kBTC-BTCB',
+    address: '0x7b0240618CfE1cf4c576a905CA2557f287F97911',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    feeTier: FeeAmount.LOW,
+    token0Address: bscTokens.btcb.address,
+    token1Address: bscTokens.kbtc.address,
+  },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3269,4 +3269,12 @@ export const bscTokens = {
     'Wrapped liquid staked Ether 2.0',
     'https://lido.fi/',
   ),
+  kbtc: new ERC20Token(
+    ChainId.BSC,
+    '0x9356f6d95b8E109F4b7Ce3E49D672967d3B48383',
+    18,
+    'kBTC',
+    'Kinza Babylon Staked BTC',
+    'https://kinza.finance/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `kBTC` token on the BSC network. It includes the addition of `kBTC` token constants, a new farm configuration for `kbtc`, and a new gauge configuration for `kBTC-BTCB` pair.

### Detailed summary
- Added `kBTC` token constants in `bsc.ts`
- Configured a new farm for `kbtc` in `bsc.ts`
- Added a new gauge configuration for `kBTC-BTCB` pair in `prod.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->