### PR TITLE
fix: resolved UI cannot refresh after stake/unstake/harvest a position

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/atom.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/atom.ts
@@ -1,3 +1,4 @@
+import type { TransactionReceipt } from 'viem'
 import { PositionDetails } from '@pancakeswap/farms'
 import { atom } from 'jotai'
 import { ChainIdAddressKey } from '../type'
@@ -11,6 +12,8 @@ export const userPositionsAtom = atom<Record<ChainIdAddressKey, AccountPositionM
 export const cakePendingRewardsAtom = atom<Record<ChainIdAddressKey, number>>({})
 
 export const priceOfPositionsAtom = atom<Record<ChainIdAddressKey, { priceUSD: string }>>({})
+
+export const txReceiptAtom = atom<TransactionReceipt | null>(null)
 
 type PositionInfo = {
   chainId: number

--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
@@ -59,17 +59,7 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
       tokensOwed0,
       tokensOwed1,
     ] = position
-    const [
-      farmingLiquidity,
-      boostLiquidity,
-      tickLower_,
-      tickUpper_,
-      rewardGrowthInside,
-      reward,
-      user,
-      pid,
-      boostMultiplier,
-    ] = farmingPosition[index]
+    const [farmingLiquidity, boostMultiplier] = farmingPosition[index]
     return {
       tokenId: tokenIds[index],
       nonce,

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
@@ -5,13 +5,15 @@ import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
 import { getStablePairDetails } from '../fetcher'
 import { StableLPDetail } from '../type'
+import { useLatestTxReceipt } from './useLatestTxReceipt'
 
 export const useAccountStableLpDetails = (chainIds: number[], account?: Address | null) => {
+  const [latestTxReceipt] = useLatestTxReceipt()
   const queries = useMemo(() => {
     return chainIds.map((chainId) => {
       const stablePairs = LegacyRouter.stableSwapPairsByChainId[chainId]
       return {
-        queryKey: ['accountStableLpBalance', account, chainId],
+        queryKey: ['accountStableLpBalance', account, chainId, latestTxReceipt?.blockHash],
         // @todo @ChefJerry add signal
         queryFn: () => getStablePairDetails(chainId, account!, stablePairs),
         enabled: !!account && stablePairs && stablePairs.length > 0,
@@ -26,7 +28,7 @@ export const useAccountStableLpDetails = (chainIds: number[], account?: Address 
         staleTime: SLOW_INTERVAL,
       } satisfies UseQueryOptions<StableLPDetail[]>
     })
-  }, [account, chainIds])
+  }, [account, chainIds, latestTxReceipt?.blockHash])
 
   const combine = useCallback((results: UseQueryResult<StableLPDetail[], Error>[]) => {
     return {

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
@@ -4,12 +4,14 @@ import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
 import { getAccountV3Positions } from '../fetcher/v3'
 import { PositionDetail } from '../type'
+import { useLatestTxReceipt } from './useLatestTxReceipt'
 
 export const useAccountV3Positions = (chainIds: number[], account?: Address | null) => {
+  const [latestTxReceipt] = useLatestTxReceipt()
   const queries = useMemo(() => {
     return chainIds.map((chainId) => {
       return {
-        queryKey: ['accountV3Positions', account, chainId],
+        queryKey: ['accountV3Positions', account, chainId, latestTxReceipt?.blockHash],
         // @todo @ChefJerry add signal
         queryFn: () => getAccountV3Positions(chainId, account!),
         enabled: !!account && !!chainId,
@@ -21,7 +23,7 @@ export const useAccountV3Positions = (chainIds: number[], account?: Address | nu
         staleTime: SLOW_INTERVAL,
       } satisfies UseQueryOptions<PositionDetail[]>
     })
-  }, [account, chainIds])
+  }, [account, chainIds, latestTxReceipt?.blockHash])
 
   const combine = useCallback((results: UseQueryResult<PositionDetail[], Error>[]) => {
     return {

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt.ts
@@ -1,0 +1,4 @@
+import { useAtom } from 'jotai'
+import { txReceiptAtom } from '../atom'
+
+export const useLatestTxReceipt = () => useAtom(txReceiptAtom)

--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -1,3 +1,4 @@
+import type { TransactionReceipt } from 'viem'
 import { useTranslation } from '@pancakeswap/localization'
 import { useToast } from '@pancakeswap/uikit'
 import { MasterChefV3, NonfungiblePositionManager } from '@pancakeswap/v3-sdk'
@@ -24,7 +25,7 @@ const useFarmV3Actions = ({
   onDone,
 }: {
   tokenId: string
-  onDone?: () => void
+  onDone?: (resp: TransactionReceipt | null) => void
 }): FarmV3ActionContainerChildrenProps => {
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
@@ -64,7 +65,7 @@ const useFarmV3Actions = ({
       }),
     )
     if (resp?.status) {
-      onDone?.()
+      onDone?.(resp)
       toastSuccess(
         `${t('Unstaked')}!`,
         <ToastDescriptionWithTx txHash={resp.transactionHash}>
@@ -114,7 +115,7 @@ const useFarmV3Actions = ({
     )
 
     if (resp?.status) {
-      onDone?.()
+      onDone?.(resp)
       toastSuccess(
         `${t('Staked')}!`,
         <ToastDescriptionWithTx txHash={resp.transactionHash}>

--- a/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
+import { useLatestTxReceipt } from 'state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt'
 import { AutoRow, useModal, useToast } from '@pancakeswap/uikit'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { FarmWidget } from '@pancakeswap/widgets-internal'
@@ -81,12 +82,15 @@ const useDepositModal = (props: V2PositionActionsProps) => {
     return new BigNumber(tvlUsd ?? 0).dividedBy(data.totalSupply.toExact())
   }, [data.totalSupply, tvlUsd])
 
+  const [, setLatestTxReceipt] = useLatestTxReceipt()
+
   const handleStake = useCallback(
     async (amount: string) => {
       const receipt = await fetchWithCatchTxError(() => {
         return onStake(amount)
       })
       if (receipt?.status) {
+        setLatestTxReceipt(receipt)
         toastSuccess(
           `${t('Staked')}!`,
           <ToastDescriptionWithTx txHash={receipt.transactionHash}>
@@ -95,7 +99,7 @@ const useDepositModal = (props: V2PositionActionsProps) => {
         )
       }
     },
-    [fetchWithCatchTxError, onStake, t, toastSuccess],
+    [setLatestTxReceipt, fetchWithCatchTxError, onStake, t, toastSuccess],
   )
 
   const handleApprove = useCallback(async () => {
@@ -103,9 +107,10 @@ const useDepositModal = (props: V2PositionActionsProps) => {
       return onApprove()
     })
     if (receipt?.status) {
+      setLatestTxReceipt(receipt)
       toastSuccess(t('Contract Enabled'), <ToastDescriptionWithTx txHash={receipt.transactionHash} />)
     }
-  }, [fetchWithCatchTxError, onApprove, t, toastSuccess])
+  }, [setLatestTxReceipt, fetchWithCatchTxError, onApprove, t, toastSuccess])
 
   const [onPresentDeposit] = useModal(
     <FarmWidget.DepositModal
@@ -162,10 +167,12 @@ const useWithdrawModal = (
   }, [data.farmingBalance])
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError } = useCatchTxError()
+  const [, setLatestTxReceipt] = useLatestTxReceipt()
   const handleUnstake = useCallback(
     async (amount: string) => {
       const receipt = await fetchWithCatchTxError(() => onUnStake(amount))
       if (receipt?.status) {
+        setLatestTxReceipt(receipt)
         toastSuccess(
           `${t('Unstaked')}!`,
           <ToastDescriptionWithTx txHash={receipt.transactionHash}>
@@ -174,7 +181,7 @@ const useWithdrawModal = (
         )
       }
     },
-    [fetchWithCatchTxError, onUnStake, t, toastSuccess],
+    [setLatestTxReceipt, fetchWithCatchTxError, onUnStake, t, toastSuccess],
   )
   const [onPresentWithdraw] = useModal(
     <FarmWidget.WithdrawModal
@@ -249,6 +256,7 @@ const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress 
   const pendingReward = useMemo(() => {
     return new BigNumber(pendingReward_?.toString() ?? '0')
   }, [pendingReward_])
+  const [, setLatestTxReceipt] = useLatestTxReceipt()
   const handleHarvest = useCallback(async () => {
     const shouldSwitch = await switchNetworkIfNecessary(chainId)
     if (shouldSwitch) {
@@ -256,6 +264,7 @@ const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress 
     }
     const receipt = await fetchWithCatchTxError(() => onHarvest())
     if (receipt?.status) {
+      setLatestTxReceipt(receipt)
       toastSuccess(
         `${t('Harvested')}!`,
         <ToastDescriptionWithTx txHash={receipt.transactionHash}>
@@ -263,7 +272,7 @@ const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress 
         </ToastDescriptionWithTx>,
       )
     }
-  }, [chainId, switchNetworkIfNecessary, fetchWithCatchTxError, onHarvest, t, toastSuccess])
+  }, [setLatestTxReceipt, chainId, switchNetworkIfNecessary, fetchWithCatchTxError, onHarvest, t, toastSuccess])
 
   if (!pendingReward || pendingReward.isZero()) {
     return null

--- a/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
@@ -1,4 +1,5 @@
 import { Protocol } from '@pancakeswap/farms'
+import { useLatestTxReceipt } from 'state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt'
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency } from '@pancakeswap/swap-sdk-core'
 import { Button, Flex, useModalV2 } from '@pancakeswap/uikit'
@@ -37,9 +38,10 @@ export const V3PositionActions = ({
   fee,
 }: ActionPanelProps) => {
   const { t } = useTranslation()
+  const [, setLatestTxReceipt] = useLatestTxReceipt()
   const { onStake, onUnstake, onHarvest, attemptingTxn } = useFarmV3Actions({
     tokenId: tokenId?.toString() ?? '',
-    onDone: () => {},
+    onDone: (resp) => setLatestTxReceipt(resp),
   })
   const stakeModal = useModalV2()
   const { switchNetworkIfNecessary, isLoading: isSwitchingNetwork } = useCheckShouldSwitchNetwork()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the ability to track the latest transaction receipt for various actions in the farmsV4 state.

### Detailed summary
- Added `txReceiptAtom` to track transaction receipts
- Implemented `useLatestTxReceipt` hook to retrieve and update latest transaction receipt
- Updated components to use the latest transaction receipt for actions like stake, unstake, harvest

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->