### PR TITLE
fix: add v2/ss fee24h

### DIFF
--- a/apps/web/src/state/farmsV4/state/type.ts
+++ b/apps/web/src/state/farmsV4/state/type.ts
@@ -25,6 +25,7 @@ export type BasePoolInfo = {
   tvlUsd24h?: `${number}`
   vol24hUsd?: `${number}`
   vol48hUsd?: `${number}`
+  vol7dUsd?: `${number}`
   fee24hUsd?: `${number}`
   liquidity?: bigint
   feeTier: number

--- a/apps/web/src/state/farmsV4/state/utils.ts
+++ b/apps/web/src/state/farmsV4/state/utils.ts
@@ -1,7 +1,7 @@
 import { Protocol, UNIVERSAL_FARMS } from '@pancakeswap/farms'
 import { LegacyRouter } from '@pancakeswap/smart-router/legacy-router'
-import { getTokenByAddress } from '@pancakeswap/tokens'
 import { Token } from '@pancakeswap/swap-sdk-core'
+import { getTokenByAddress } from '@pancakeswap/tokens'
 import { paths } from 'state/info/api/schema'
 import { safeGetAddress } from 'utils'
 import { Address, isAddressEqual } from 'viem'
@@ -61,6 +61,7 @@ export const parseFarmPools = (
       tvlUsd24h: pool.tvlUSD24h as `${number}`,
       vol24hUsd: pool.volumeUSD24h as `${number}`,
       vol48hUsd: pool.volumeUSD48h as `${number}`,
+      vol7dUsd: pool.volumeUSD7d as `${number}`,
       totalFeeUSD: pool.totalFeeUSD as `${number}`,
       fee24hUsd: pool.feeUSD24h as `${number}`,
       liquidity: pool.liquidity,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a new field `vol7dUsd` to farm state and optimize fee calculation in the PoolStatus component.

### Detailed summary
- Added `vol7dUsd` field to farm state
- Optimized fee calculation in PoolStatus component
- Imported `BigNumber` and `getLpFeesAndApr` functions
- Updated fee display logic in PoolStatus component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->