### PR TITLE
fix: add V2 and SS positions in active filter

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
@@ -7,6 +7,7 @@ import { PoolInfo } from '../../type'
 import { getAccountV2LpDetails, getStablePairDetails } from '../fetcher'
 import { getAccountV3Positions } from '../fetcher/v3'
 import { PositionDetail, StableLPDetail, V2LPDetail } from '../type'
+import { useLatestTxReceipt } from './useLatestTxReceipt'
 
 type PoolPositionDetail = {
   [Protocol.STABLE]: StableLPDetail
@@ -67,8 +68,9 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
     },
     [poolInfo, protocol],
   )
+  const [latestTxReceipt] = useLatestTxReceipt()
   return useQuery({
-    queryKey: ['accountPosition', account, chainId, poolInfo?.lpAddress],
+    queryKey: ['accountPosition', account, chainId, poolInfo?.lpAddress, latestTxReceipt?.blockHash],
     queryFn,
     enabled: !!account && !!poolInfo?.lpAddress,
     select,

--- a/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
+++ b/apps/web/src/views/Farms/hooks/v3/useFarmV3Actions.tsx
@@ -167,6 +167,7 @@ const useFarmV3Actions = ({
     )
 
     if (resp?.status) {
+      onDone?.(resp)
       toastSuccess(
         `${t('Harvested')}!`,
         <ToastDescriptionWithTx txHash={resp.transactionHash}>
@@ -176,6 +177,7 @@ const useFarmV3Actions = ({
       queryClient.invalidateQueries({ queryKey: ['mcv3-harvest'] })
     }
   }, [
+    onDone,
     account,
     fetchWithCatchTxError,
     masterChefV3Address,

--- a/apps/web/src/views/universalFarms/PositionPage.tsx
+++ b/apps/web/src/views/universalFarms/PositionPage.tsx
@@ -237,7 +237,7 @@ const useV2Positions = ({
             selectedTokens.some(
               (token) => token === toTokenValue(pos.pair.token0) || token === toTokenValue(pos.pair.token1),
             )) &&
-          positionStatus === 0 &&
+          [V3_STATUS.ALL, V3_STATUS.ACTIVE].includes(positionStatus) &&
           (!farmsOnly || pos.isStaked),
       ),
     [farmsOnly, selectedNetwork, selectedTokens, v2Positions, positionStatus],
@@ -284,7 +284,7 @@ const useStablePositions = ({
               (token) =>
                 token === toTokenValueByCurrency(pos.pair.token0) || token === toTokenValueByCurrency(pos.pair.token1),
             )) &&
-          positionStatus === 0 &&
+          [V3_STATUS.ALL, V3_STATUS.ACTIVE].includes(positionStatus) &&
           (!farmsOnly || pos.isStaked),
       ),
     [farmsOnly, selectedNetwork, selectedTokens, stablePositions, positionStatus],

--- a/apps/web/src/views/universalFarms/components/Modals/V3StakeModal.tsx
+++ b/apps/web/src/views/universalFarms/components/Modals/V3StakeModal.tsx
@@ -28,9 +28,11 @@ interface IStakeModalProps {
   onUnStake?: (e: React.MouseEvent) => void
   onDismiss: () => void
   isOpen: boolean
+  disabled?: boolean
 }
 
 export const V3StakeModal: React.FC<React.PropsWithChildren<IStakeModalProps>> = ({
+  disabled,
   staking,
   onStake,
   onUnStake,
@@ -93,7 +95,12 @@ export const V3StakeModal: React.FC<React.PropsWithChildren<IStakeModalProps>> =
             </AtomBox>
           </AtomBox>
           <LightCard style={{ position: 'relative' }}>{children}</LightCard>
-          <Button variant={staking ? 'subtle' : 'primary'} onClick={staking ? onStake : onUnStake} width="100%">
+          <Button
+            variant={staking ? 'subtle' : 'primary'}
+            onClick={staking ? onStake : onUnStake}
+            width="100%"
+            disabled={disabled}
+          >
             {staking ? t('Continue Staking') : t('Unstake')}
           </Button>
           {staking ? null : (

--- a/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
@@ -1,3 +1,4 @@
+import styled from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 import { useLatestTxReceipt } from 'state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt'
 import { AutoRow, useModal, useToast } from '@pancakeswap/uikit'
@@ -32,13 +33,23 @@ type V2PositionActionsProps = {
   tvlUsd?: `${number}` | number | undefined
   poolInfo: PoolInfo
 }
+
+const StyledAutoRow = styled(AutoRow)`
+  flex-direction: row;
+  gap: 8px;
+  height: 48px;
+
+  & button {
+    flex: 1;
+  }
+`
 export const V2PositionActions: React.FC<V2PositionActionsProps> = ({ isStaked, ...props }) => {
   if (isStaked) {
     return (
-      <AutoRow gap="sm">
+      <StyledAutoRow gap="sm">
         <V2FarmingAction {...props} />
         <V2HarvestAction {...props} />
-      </AutoRow>
+      </StyledAutoRow>
     )
   }
   return <V2NativeAction {...props} />

--- a/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
@@ -77,8 +77,9 @@ export const V3PositionActions = ({
     const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
     if (!shouldSwitch) {
       await onUnstake()
+      stakeModal.onDismiss()
     }
-  }, [onUnstake, switchNetworkIfNecessary, currency0.chainId])
+  }, [onUnstake, switchNetworkIfNecessary, currency0.chainId, stakeModal])
 
   const handleHarvest = useCallback(async () => {
     const shouldSwitch = await switchNetworkIfNecessary(currency0.chainId)
@@ -136,6 +137,7 @@ export const V3PositionActions = ({
           {t('Unstake')}
         </Button>
         <V3StakeModal
+          disabled={attemptingTxn || isSwitchingNetwork}
           isOpen={stakeModal.isOpen}
           staking={outOfRange && !isStaked}
           onUnStake={handleUnStake}

--- a/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
@@ -89,7 +89,7 @@ export const V3PositionActions = ({
 
   const stakeButton = useMemo(
     () => (
-      <StopPropagation>
+      <>
         <Button
           scale="md"
           width={['100px']}
@@ -107,7 +107,7 @@ export const V3PositionActions = ({
         >
           {modalContent}
         </V3StakeModal>
-      </StopPropagation>
+      </>
     ),
     [
       isSwitchingNetwork,
@@ -124,7 +124,7 @@ export const V3PositionActions = ({
 
   const unstakeButton = useMemo(
     () => (
-      <StopPropagation>
+      <>
         <Button
           scale="md"
           width={['100px']}
@@ -143,7 +143,7 @@ export const V3PositionActions = ({
         >
           {modalContent}
         </V3StakeModal>
-      </StopPropagation>
+      </>
     ),
     [isSwitchingNetwork, handleUnStake, isStaked, modalContent, t, outOfRange, stakeModal, attemptingTxn],
   )


### PR DESCRIPTION
- **fix: position action UI in mobile**
- **fix: add V2 and SS positions in active filter**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the functionality of V3 farm actions and stake modals.

### Detailed summary
- Added `onDone` callback in `useFarmV3Actions.tsx`
- Updated conditionals in `useFarmV3Actions.tsx` and `useStablePositions`
- Added `disabled` prop in `V3StakeModal.tsx`
- Imported `useLatestTxReceipt` in `useAccountPositionDetailByPool`
- Styled button layout in `V2PositionActions.tsx`
- Modified logic in `V3PositionActions.tsx` for unstaking and harvesting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->