### PR TITLE
feat: add unstaked farm apr

### DIFF
--- a/apps/web/src/views/universalFarms/hooks/useMasterChefV3FarmBoosterAddress.ts
+++ b/apps/web/src/views/universalFarms/hooks/useMasterChefV3FarmBoosterAddress.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { getMasterChefV3Contract } from 'utils/contractHelpers'
+
+export const useMasterChefV3FarmBoosterAddress = (chainId: number) => {
+  const masterChefV3 = getMasterChefV3Contract(undefined, chainId)
+  return useQuery({
+    queryKey: ['masterChefV3', 'farmBooster', chainId],
+    queryFn: async () => {
+      if (!masterChefV3) return 0
+      return masterChefV3.read.FARM_BOOSTER()
+    },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
+    staleTime: Infinity,
+  })
+}

--- a/apps/web/src/views/universalFarms/hooks/useUserMultiplier.ts
+++ b/apps/web/src/views/universalFarms/hooks/useUserMultiplier.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { getUserMultiplier } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/multiplierAPI'
+import { useMasterChefV3FarmBoosterAddress } from './useMasterChefV3FarmBoosterAddress'
+
+export const useUserMultiplier = (chainId: number, tokenId?: bigint) => {
+  const { data: farmBoosterAddress } = useMasterChefV3FarmBoosterAddress(chainId)
+  return useQuery({
+    queryKey: ['userMultiplier', farmBoosterAddress, chainId, tokenId?.toString()],
+    queryFn: async () => {
+      return getUserMultiplier({ address: farmBoosterAddress, tokenId, chainId })
+    },
+    enabled: !!farmBoosterAddress && !!tokenId && !!chainId,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
+    staleTime: Infinity,
+  })
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new hooks for fetching user multiplier and farm booster addresses, and updates position APR calculations in universal farms view.

### Detailed summary
- Added `useMasterChefV3FarmBoosterAddress` hook
- Added `useUserMultiplier` hook
- Updated position APR calculations in `useV3PositionApr`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->