### PR TITLE
fix: lp fee in modal

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useExtraV3PositionInfo.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useExtraV3PositionInfo.ts
@@ -3,6 +3,7 @@ import { Position } from '@pancakeswap/v3-sdk'
 import { useTokenByChainId } from 'hooks/Tokens'
 import useIsTickAtLimit from 'hooks/v3/useIsTickAtLimit'
 import { usePoolByChainId } from 'hooks/v3/usePools'
+import getPriceOrderingFromPositionForUI from 'hooks/v3/utils/getPriceOrderingFromPositionForUI'
 import { useMemo } from 'react'
 import { PositionDetail } from '../type'
 
@@ -49,13 +50,14 @@ export const useExtraV3PositionInfo = (positionDetail?: PositionDetail) => {
   }, [pool, token0])
 
   const { priceLower, priceUpper, quote, base } = useMemo(() => {
-    return {
-      priceLower: position ? position.token0PriceLower : undefined,
-      priceUpper: position ? position.token0PriceUpper : undefined,
-      quote: token1,
-      base: token0,
-    }
-  }, [position, token0, token1])
+    // return {
+    //   priceLower: position ? position.token0PriceLower : undefined,
+    //   priceUpper: position ? position.token0PriceUpper : undefined,
+    //   quote: token1,
+    //   base: token0,
+    // }
+    return getPriceOrderingFromPositionForUI(position)
+  }, [position])
 
   return {
     pool,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the `useExtraV3PositionInfo` hook in the `farmsV4` state by replacing manual calculation with a utility function.

### Detailed summary
- Added import for `getPriceOrderingFromPositionForUI`
- Replaced manual calculation with `getPriceOrderingFromPositionForUI` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->