### PR TITLE
fix: resolved apr missing include farm page

### DIFF
--- a/apps/web/src/state/farmsV4/state/extendPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/extendPools/fetcher.ts
@@ -1,4 +1,5 @@
 import { getChainNameInKebabCase } from '@pancakeswap/chains'
+import { UNIVERSAL_FARMS } from '@pancakeswap/farms'
 import { chainIdToExplorerInfoChainName, explorerApiClient } from 'state/info/api/client'
 import { PoolInfo } from '../type'
 import { parseFarmPools } from '../utils'
@@ -62,6 +63,7 @@ export const fetchExplorerPoolInfo = async (
   }
   // @ts-ignore
   resp.data.chainId = chainId
+  const isFarming = UNIVERSAL_FARMS.some((farm) => farm.lpAddress === poolAddress)
 
-  return parseFarmPools([resp.data])[0]
+  return parseFarmPools([resp.data], { isFarming })[0]
 }

--- a/apps/web/src/state/farmsV4/state/utils.ts
+++ b/apps/web/src/state/farmsV4/state/utils.ts
@@ -1,5 +1,4 @@
 import BN from 'bignumber.js'
-import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { Protocol, UNIVERSAL_FARMS } from '@pancakeswap/farms'
 import { LegacyRouter } from '@pancakeswap/smart-router/legacy-router'
 import { Token } from '@pancakeswap/swap-sdk-core'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `fetchExplorerPoolInfo` function in `utils.ts` to include a new parameter `isFarming` in the `parseFarmPools` function call.

### Detailed summary
- Added `isFarming` parameter in `parseFarmPools` function call in `fetchExplorerPoolInfo`
- Removed import of `BIG_ZERO` from `utils.ts`
- Updated import of `UNIVERSAL_FARMS` in `fetcher.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->