### PR TITLE
fix: missed v2 lp position

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
@@ -1,11 +1,11 @@
 import { ERC20Token } from '@pancakeswap/sdk'
 import { useQueries, UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
+import { SLOW_INTERVAL } from 'config/constants'
 import { useOfficialsAndUserAddedTokensByChainIds } from 'hooks/Tokens'
 import { useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { AppState } from 'state'
 import { Address } from 'viem'
-import { SLOW_INTERVAL } from 'config/constants'
 import { getAccountV2LpDetails, getTrackedV2LpTokens } from '../fetcher'
 import { V2LPDetail } from '../type'
 import { useLatestTxReceipt } from './useLatestTxReceipt'
@@ -27,7 +27,7 @@ export const useAccountV2LpDetails = (chainIds: number[], account?: Address | nu
   const queries = useMemo(() => {
     return Object.entries(lpTokensByChain).map(([chainId, lpTokens]) => {
       return {
-        queryKey: ['accountV2LpDetails', account, chainId, latestTxReceipt?.blockHash],
+        queryKey: ['accountV2LpDetails', account, chainId, lpTokens.length, latestTxReceipt?.blockHash],
         // @todo @ChefJerry add signal
         queryFn: () => getAccountV2LpDetails(Number(chainId), account!, lpTokens),
         enabled: !!account && lpTokens && lpTokens.length > 0,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useAccountV2LpDetails` hook by including the length of `lpTokens` in the query key to improve data fetching accuracy.

### Detailed summary
- Added `lpTokens.length` to the query key for better data fetching accuracy.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->