### PR TITLE
fix: hide stake button when farm finished

### DIFF
--- a/apps/web/src/views/universalFarms/components/PositionActions/StakeActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/StakeActions.tsx
@@ -6,6 +6,8 @@ import { StopPropagation } from 'views/universalFarms/components/StopPropagation
 type StakeActionsProps = {
   increaseDisabled?: boolean
   decreaseDisabled?: boolean
+  showIncreaseBtn?: boolean
+  showDecreaseBtn?: boolean
   onIncrease: () => void
   onDecrease?: () => void
 }
@@ -13,18 +15,24 @@ type StakeActionsProps = {
 export const ModifyStakeActions: React.FC<StakeActionsProps> = ({
   increaseDisabled = false,
   decreaseDisabled = false,
+  showIncreaseBtn = true,
+  showDecreaseBtn = true,
   onIncrease,
   onDecrease,
 }) => {
   return (
     <StopPropagation>
       <AutoRow gap="sm">
-        <IconButton variant="secondary" disabled={decreaseDisabled} onClick={onDecrease}>
-          <MinusIcon color="primary" width="24px" />
-        </IconButton>
-        <IconButton variant="secondary" disabled={increaseDisabled} onClick={onIncrease}>
-          <AddIcon color="primary" width="24px" />
-        </IconButton>
+        {showDecreaseBtn && (
+          <IconButton variant="secondary" disabled={decreaseDisabled} onClick={onDecrease}>
+            <MinusIcon color="primary" width="24px" />
+          </IconButton>
+        )}
+        {showIncreaseBtn && (
+          <IconButton variant="secondary" disabled={increaseDisabled} onClick={onIncrease}>
+            <AddIcon color="primary" width="24px" />
+          </IconButton>
+        )}
       </AutoRow>
     </StopPropagation>
   )

--- a/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
@@ -240,11 +240,11 @@ const V2FarmingAction: React.FC<V2PositionActionsProps> = (props) => {
     }
   }, [chainId, onPresentWithdraw, switchNetworkIfNecessary])
 
-  return <ModifyStakeActions increaseDisabled={!isFarmLive} onIncrease={handleIncrease} onDecrease={handleDecrease} />
+  return <ModifyStakeActions showIncreaseBtn={isFarmLive} onIncrease={handleIncrease} onDecrease={handleDecrease} />
 }
 
 const V2NativeAction: React.FC<V2PositionActionsProps> = (props) => {
-  const { chainId } = props
+  const { chainId, isFarmLive } = props
   const { switchNetworkIfNecessary } = useCheckShouldSwitchNetwork()
   const onPresentDeposit = useDepositModal(props)
   const handleDeposit = useCallback(async () => {
@@ -253,6 +253,9 @@ const V2NativeAction: React.FC<V2PositionActionsProps> = (props) => {
       onPresentDeposit()
     }
   }, [chainId, switchNetworkIfNecessary, onPresentDeposit])
+  if (!isFarmLive) {
+    return null
+  }
   return <DepositStakeAction onDeposit={handleDeposit} />
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to enhance the user experience by adding conditional visibility for increase and decrease buttons in stake actions.

### Detailed summary
- Added `showIncreaseBtn` and `showDecreaseBtn` props in `ModifyStakeActions` component
- Updated the rendering logic to show/hide increase and decrease buttons based on the new props

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->