### PR TITLE
fix: unify ss fee

### DIFF
--- a/packages/smart-router/legacy-router/getStableSwapPairs.ts
+++ b/packages/smart-router/legacy-router/getStableSwapPairs.ts
@@ -1,11 +1,11 @@
-import { CurrencyAmount } from '@pancakeswap/sdk'
 import { ChainId } from '@pancakeswap/chains'
-import { deserializeToken } from '@pancakeswap/token-lists'
+import { CurrencyAmount } from '@pancakeswap/sdk'
 import { getStableSwapPools, STABLE_SUPPORTED_CHAIN_IDS } from '@pancakeswap/stable-swap-sdk'
+import { deserializeToken } from '@pancakeswap/token-lists'
 import fromPairs_ from 'lodash/fromPairs.js'
 
-import { StableSwapPair } from './types'
 import { createStableSwapPair } from './stableSwap'
+import { StableSwapPair } from './types'
 
 export function getStableSwapPairs(chainId: ChainId): StableSwapPair[] {
   const pools = getStableSwapPools(chainId)
@@ -17,6 +17,7 @@ export function getStableSwapPairs(chainId: ChainId): StableSwapPair[] {
       lpAddress,
       infoStableSwapAddress,
       stableLpFee,
+      stableTotalFee,
       stableLpFeeRateOfTotalFee,
     }) => {
       const token = deserializeToken(serializedToken)
@@ -33,6 +34,7 @@ export function getStableSwapPairs(chainId: ChainId): StableSwapPair[] {
         lpAddress,
         infoStableSwapAddress,
         stableLpFee,
+        stableTotalFee,
         stableLpFeeRateOfTotalFee,
       )
     },

--- a/packages/smart-router/legacy-router/stableSwap.ts
+++ b/packages/smart-router/legacy-router/stableSwap.ts
@@ -1,8 +1,8 @@
-import { Currency, CurrencyAmount, Pair, Percent, Price, Trade, TradeType, ERC20Token } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, ERC20Token, Pair, Percent, Price, Trade, TradeType } from '@pancakeswap/sdk'
 import invariant from 'tiny-invariant'
 import { Address } from 'viem'
 
-import { RouteType, RouteWithStableSwap, StableSwapFeeRaw, StableSwapPair, StableSwapFeePercent } from './types'
+import { RouteType, RouteWithStableSwap, StableSwapFeePercent, StableSwapFeeRaw, StableSwapPair } from './types'
 import { BasePair } from './types/pair'
 import { getOutputToken } from './utils/pair'
 
@@ -12,6 +12,7 @@ export function createStableSwapPair(
   lpAddress: Address = '0x',
   infoStableSwapAddress: Address = '0x',
   stableLpFee = 0,
+  stableTotalFee = 0,
   stableLpFeeRateOfTotalFee = 0,
 ): StableSwapPair {
   return {
@@ -26,6 +27,7 @@ export function createStableSwapPair(
     adminFee: new Percent(0),
     involvesToken: (token) => token.equals(pair.token0) || token.equals(pair.token1),
     stableLpFee,
+    stableTotalFee,
     stableLpFeeRateOfTotalFee,
   }
 }

--- a/packages/smart-router/legacy-router/types/stableSwap.ts
+++ b/packages/smart-router/legacy-router/types/stableSwap.ts
@@ -1,4 +1,4 @@
-import { Currency, CurrencyAmount, ERC20Token, Pair as V2Pair, Percent, Price, TradeType } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, ERC20Token, Percent, Price, TradeType, Pair as V2Pair } from '@pancakeswap/sdk'
 import { Address } from 'viem'
 
 import { RouteType } from './bestTrade'
@@ -14,6 +14,7 @@ export interface StableSwapPair extends BasePair {
   adminFee: Percent
   liquidityToken: ERC20Token
   stableLpFee: number
+  stableTotalFee: number
   stableLpFeeRateOfTotalFee: number
 }
 

--- a/packages/stable-swap-sdk/src/constants/pools/arb.ts
+++ b/packages/stable-swap-sdk/src/constants/pools/arb.ts
@@ -10,7 +10,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: arbitrumTokens.mpendle,
     stableSwapAddress: '0x73ed25e04Aa673ddf7411441098fC5ae19976CE0',
     infoStableSwapAddress: '0x58B2F00f74a1877510Ec37b22f116Bf5D63Ab1b0',
-    stableLpFee: 0.0025,
+    stableTotalFee: 0.0025,
+    stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -20,7 +21,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: arbitrumTokens.mdlp,
     stableSwapAddress: '0xd0f0be815a76eFE677c92b07b39a5e972BAf22bD',
     infoStableSwapAddress: '0x58B2F00f74a1877510Ec37b22f116Bf5D63Ab1b0',
-    stableLpFee: 0.0025,
+    stableTotalFee: 0.0025,
+    stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
   },
 ]

--- a/packages/stable-swap-sdk/src/constants/pools/bsc.ts
+++ b/packages/stable-swap-sdk/src/constants/pools/bsc.ts
@@ -2,7 +2,6 @@ import { bscTokens } from '@pancakeswap/tokens'
 
 import { StableSwapPool } from '../../types'
 
-// @todo @ChefJerry why there are two stable swap config apart from packages/farms
 export const pools: StableSwapPool[] = [
   {
     lpSymbol: 'lisUSD-BUSD LP',
@@ -11,6 +10,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.busd,
     stableSwapAddress: '0x49079D07ef47449aF808A4f36c2a8dEC975594eC',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
+    stableTotalFee: 0.0004,
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -21,6 +21,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.busd,
     stableSwapAddress: '0x169F653A54ACD441aB34B73dA9946e2C451787EF',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
+    stableTotalFee: 0.0001,
     stableLpFee: 0.00005,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -31,6 +32,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.busd,
     stableSwapAddress: '0xc2F5B9a3d9138ab2B74d581fC11346219eBf43Fe',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
+    stableTotalFee: 0.0001,
     stableLpFee: 0.00005,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -41,6 +43,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.usdc,
     stableSwapAddress: '0x3EFebC418efB585248A0D2140cfb87aFcc2C63DD',
     infoStableSwapAddress: '0xa680d27f63Fa5E213C502d1B3Ca1EB6a3C1b31D6',
+    stableTotalFee: 0.0001,
     stableLpFee: 0.00005,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -51,6 +54,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.usdt,
     stableSwapAddress: '0x6D8fba276ec6F1EDa2344DA48565AdbCA7e4FFa5',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
+    stableTotalFee: 0.0004,
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -61,6 +65,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.stkbnb,
     stableSwapAddress: '0x0b03e3d6Ec0c5e5bBf993dED8D947C6fb6eEc18D',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
+    stableTotalFee: 0.0004,
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -71,6 +76,7 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.wbnb,
     stableSwapAddress: '0x9c138bE1D76ee4C5162E0fe9D4eEA5542a23D1bD',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
+    stableTotalFee: 0.0004,
     stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
@@ -81,7 +87,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.usdt,
     stableSwapAddress: '0xb1Da7D2C257c5700612BdE35C8d7187dc80d79f1',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.0004,
+    stableTotalFee: 0.0004,
+    stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -91,7 +98,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.sdcake,
     stableSwapAddress: '0xb8204D31379A9B317CD61C833406C972F58ecCbC',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.001,
+    stableTotalFee: 0.001,
+    stableLpFee: 0.0005,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -101,7 +109,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.mcake,
     stableSwapAddress: '0xc54d35a8Cfd9f6dAe50945Df27A91C9911A03ab1',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.005,
+    stableTotalFee: 0.005,
+    stableLpFee: 0.0025,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -111,7 +120,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.pendle,
     stableSwapAddress: '0xD8CB82059da7215b1a9604E845d49D3e78d0f95A',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.0025,
+    stableTotalFee: 0.0025,
+    stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -121,7 +131,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.dlp,
     stableSwapAddress: '0x25d0eD3b1cE5aF0F3Ac7da4b39B46FC409bF67e2',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.0025,
+    stableTotalFee: 0.0025,
+    stableLpFee: 0.00125,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -131,7 +142,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTokens.wbeth,
     stableSwapAddress: '0xfF5Ce4846A3708EA9befa6c3Ab145e63f65DC045',
     infoStableSwapAddress: '0x150c8AbEB487137acCC541925408e73b92F39A50',
-    stableLpFee: 0.0002,
+    stableTotalFee: 0.0002,
+    stableLpFee: 0.0001,
     stableLpFeeRateOfTotalFee: 0.5,
   },
 ]

--- a/packages/stable-swap-sdk/src/constants/pools/bscTestnet.ts
+++ b/packages/stable-swap-sdk/src/constants/pools/bscTestnet.ts
@@ -1,5 +1,5 @@
-import { Token } from '@pancakeswap/swap-sdk-core'
 import { ChainId } from '@pancakeswap/chains'
+import { Token } from '@pancakeswap/swap-sdk-core'
 import { bscTestnetTokens } from '@pancakeswap/tokens'
 
 import { StableSwapPool } from '../../types'
@@ -22,7 +22,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTestnetTokens.wbnb, // coins[1]
     stableSwapAddress: '0xBcd585Ee8B8Ac8de6b0e45dA32Aa31703036b2a1',
     infoStableSwapAddress: '0x0A548d59D04096Bc01206D58C3D63c478e1e06dB',
-    stableLpFee: 0.0004,
+    stableTotalFee: 0.0004,
+    stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -32,7 +33,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTestnetTokens.busd, // coins[1]
     stableSwapAddress: '0xE25A1352477f3DB9B3008B31e9b7a07a18f8A9e6',
     infoStableSwapAddress: '0x0A548d59D04096Bc01206D58C3D63c478e1e06dB',
-    stableLpFee: 0.0004,
+    stableTotalFee: 0.0004,
+    stableLpFee: 0.0002,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -42,7 +44,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTestnetTokens.usdc, // coins[1]
     stableSwapAddress: '0xd5E56CD4c8111643a94Ee084df31F44055a1EC9F',
     infoStableSwapAddress: '0xaE6C14AAA753B3FCaB96149e1E10Bc4EDF39F546',
-    stableLpFee: 0.0002,
+    stableTotalFee: 0.0015,
+    stableLpFee: 0.00075,
     stableLpFeeRateOfTotalFee: 0.5,
   },
   {
@@ -52,7 +55,8 @@ export const pools: StableSwapPool[] = [
     quoteToken: bscTestnetTokens.mockBusd, // coins[1]
     stableSwapAddress: '0xc418d68751Cbe0407C8fdd90Cde73cE95b892f39',
     infoStableSwapAddress: '0xaE6C14AAA753B3FCaB96149e1E10Bc4EDF39F546',
-    stableLpFee: 0.0002,
+    stableTotalFee: 0.0015,
+    stableLpFee: 0.00075,
     stableLpFeeRateOfTotalFee: 0.5,
   },
 ]

--- a/packages/stable-swap-sdk/src/types.ts
+++ b/packages/stable-swap-sdk/src/types.ts
@@ -12,6 +12,7 @@ export interface BasePool {
 export interface StableSwapPool extends BasePool {
   stableSwapAddress: Address
   infoStableSwapAddress: Address
+  stableTotalFee: number
   stableLpFee: number
   stableLpFeeRateOfTotalFee: number
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update stable swap fees in various pools and add a new `stableTotalFee` field.

### Detailed summary
- Added `stableTotalFee` field in multiple stable swap pools
- Updated stable swap fees in BSC, BSC Testnet, and Arb pools
- Updated `types.ts` and `stableSwap.ts` with new fields and imports

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->