### PR TITLE
fix: sorting by apr with boosted

### DIFF
--- a/apps/web/src/state/farmsV4/state/poolApr/utils.ts
+++ b/apps/web/src/state/farmsV4/state/poolApr/utils.ts
@@ -1,7 +1,8 @@
+import { sumApr } from 'views/universalFarms/utils/sumApr'
 import type { Address } from 'viem/accounts'
 import type { PoolApr } from './atom'
 
 export const getCombinedApr = (aprMap: PoolApr, chainId: number, address: Address) => {
-  const apr = aprMap[`${chainId}:${address}`] ?? { lpApr: '0', cakeApr: { value: '0' }, merklApr: '0' }
-  return Number(apr.lpApr ?? 0) + Number(apr.cakeApr?.value ?? 0) + Number(apr.merklApr ?? 0)
+  const apr = aprMap[`${chainId}:${address}`] ?? { lpApr: '0', cakeApr: { value: '0', boost: '0' }, merklApr: '0' }
+  return sumApr(apr.lpApr, apr.cakeApr?.boost ?? apr.cakeApr?.value, apr.merklApr)
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `getCombinedApr` function in `utils.ts` to include a new parameter `boost` for cakeApr.

### Detailed summary
- Added a `boost` parameter to `cakeApr`
- Refactored calculation using `sumApr` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->