### PR TITLE
feat: default sorted logic for farm page

### DIFF
--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -109,7 +109,7 @@ export const fetchFarmPools = async (
   return finalPools
 }
 
-export const fetchV3PoolsStatusByChainId = async (chainId: number, pools: PoolInfo[]) => {
+export const fetchV3PoolsStatusByChainId = async (chainId: number, pools: { pid?: number }[]) => {
   const masterChefAddress = masterChefV3Addresses[chainId]
   const client = publicClient({ chainId })
   const poolInfoCalls = pools.map(
@@ -129,7 +129,7 @@ export const fetchV3PoolsStatusByChainId = async (chainId: number, pools: PoolIn
   return resp
 }
 
-export const fetchPoolsLifecyle = async (bCakeAddresses: Address[], chainId: number) => {
+export const fetchPoolsTimeFrame = async (bCakeAddresses: Address[], chainId: number) => {
   if (!bCakeAddresses.length) {
     return []
   }
@@ -155,7 +155,7 @@ export const fetchPoolsLifecyle = async (bCakeAddresses: Address[], chainId: num
     allowFailure: false,
   })
 
-  const poolLifecyle = resp.reduce<bigint[][]>((acc, item, index) => {
+  const poolTimeFrame = resp.reduce<bigint[][]>((acc, item, index) => {
     const chunkIndex = Math.floor(index / 2)
     if (!acc[chunkIndex]) {
       // eslint-disable-next-line no-param-reassign
@@ -166,7 +166,7 @@ export const fetchPoolsLifecyle = async (bCakeAddresses: Address[], chainId: num
   }, [])
 
   return bCakeAddresses.map((_, index) => {
-    const [startTimestamp, endTimestamp] = poolLifecyle[index]
+    const [startTimestamp, endTimestamp] = poolTimeFrame[index]
     return {
       startTimestamp: Number(startTimestamp),
       endTimestamp: Number(endTimestamp),

--- a/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
@@ -1,10 +1,13 @@
+import dayjs from 'dayjs'
+import groupBy from 'lodash/groupBy'
+import keyBy from 'lodash/keyBy'
 import { useAtom } from 'jotai'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { QUERY_SETTINGS_IMMUTABLE, SLOW_INTERVAL } from 'config/constants'
 import { UseQueryResult, useQueries, useQuery } from '@tanstack/react-query'
 import { publicClient } from 'utils/viem'
 import { masterChefV3ABI } from '@pancakeswap/v3-sdk'
-import { masterChefV3Addresses } from '@pancakeswap/farms'
+import { Protocol, UNIVERSAL_FARMS, UniversalFarmConfig, masterChefV3Addresses } from '@pancakeswap/farms'
 import { masterChefAddresses } from '@pancakeswap/farms/src/const'
 import { masterChefV2ABI } from 'config/abi/masterchefV2'
 import { ChainId } from '@pancakeswap/chains'
@@ -12,8 +15,12 @@ import { Address } from 'viem/accounts'
 import { zeroAddress } from 'viem'
 
 import { farmPoolsAtom } from './atom'
-import { fetchFarmPools, fetchPoolsLifecyle, fetchV3PoolsStatusByChainId } from './fetcher'
+import { fetchFarmPools, fetchPoolsTimeFrame, fetchV3PoolsStatusByChainId } from './fetcher'
 import { PoolInfo } from '../type'
+import { getUniversalBCakeWrapperForPool } from '../poolApr/fetcher'
+
+type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
+type ArrayItemType<T> = T extends Array<infer U> ? U : T
 
 export const useFarmPools = () => {
   const [loaded, setLoaded] = useState(false)
@@ -29,7 +36,32 @@ export const useFarmPools = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return { loaded, data: pools }
+  const { data: poolsStatus, pending: isPoolStatusPending } = useMultiChainV3PoolsStatus(UNIVERSAL_FARMS)
+  const { data: poolsTimeFrame, pending: isPoolsTimeFramePending } = useMultiChainPoolsTimeFrame(UNIVERSAL_FARMS)
+
+  const poolsWithStatus: ((PoolInfo | UniversalFarmConfig) & { isActiveFarm?: boolean })[] = useMemo(() => {
+    const farms = pools.length ? pools : UNIVERSAL_FARMS
+    return farms.map((f: PoolInfo | UniversalFarmConfig) => {
+      if (f.protocol === Protocol.V3) {
+        return {
+          ...f,
+          isActiveFarm: isPoolStatusPending ? true : poolsStatus[f.chainId][f.lpAddress][0] > 0,
+        }
+      }
+      if (f.protocol === Protocol.V2 || f.protocol === Protocol.STABLE) {
+        return {
+          ...f,
+          isActiveFarm: isPoolsTimeFramePending
+            ? true
+            : poolsTimeFrame[f.chainId][f.lpAddress].startTimestamp <= dayjs().unix() &&
+              poolsTimeFrame[f.chainId][f.lpAddress].endTimestamp > dayjs().unix(),
+        }
+      }
+      return f
+    })
+  }, [pools, poolsStatus, isPoolStatusPending, poolsTimeFrame, isPoolsTimeFramePending])
+
+  return { loaded, data: poolsWithStatus }
 }
 
 export const useV3PoolsLength = (chainIds: number[]) => {
@@ -116,6 +148,47 @@ export const useV2PoolsLength = (chainIds: number[]) => {
   })
 }
 
+type IPoolsStatusType = {
+  [chainId: number]: {
+    [lpAddress: Address]: ArrayItemType<UnwrapPromise<ReturnType<typeof fetchV3PoolsStatusByChainId>>>
+  }
+}
+
+export const useMultiChainV3PoolsStatus = (pools: UniversalFarmConfig[]) => {
+  const v3Pools = useMemo(() => pools.filter((p) => p.protocol === Protocol.V3), [pools])
+  const poolsGourpByChains = useMemo(() => groupBy(v3Pools, 'chainId'), [v3Pools])
+  const poolsEntries = useMemo(() => Object.entries(poolsGourpByChains), [poolsGourpByChains])
+
+  const queries = poolsEntries.map(([chainId, poolList]) => ({
+    queryKey: ['useMultiChainV3PoolsStatus', chainId, ...poolList.map((p) => p.lpAddress)],
+    queryFn: () => {
+      return fetchV3PoolsStatusByChainId(Number(chainId), poolList)
+    },
+    enabled: !!chainId && !!poolList.length,
+    ...QUERY_SETTINGS_IMMUTABLE,
+    refetchInterval: SLOW_INTERVAL,
+    staleTime: SLOW_INTERVAL,
+  }))
+  const combine = useCallback(
+    (results: UseQueryResult<UnwrapPromise<ReturnType<typeof fetchV3PoolsStatusByChainId>>, Error>[]) => {
+      return {
+        data: results.reduce((acc, result, idx) => {
+          return {
+            ...acc,
+            [poolsEntries[idx][0]]: keyBy(result.data ?? [], ([, lpAddress]) => lpAddress),
+          }
+        }, {} as IPoolsStatusType),
+        pending: results.some((result) => result.isPending),
+      }
+    },
+    [poolsEntries],
+  )
+  return useQueries({
+    queries,
+    combine,
+  })
+}
+
 export const useV3PoolStatus = (pool?: PoolInfo | null) => {
   const { data } = useQuery({
     queryKey: ['usePoolStatus', pool?.chainId, pool?.pid, pool?.protocol],
@@ -130,11 +203,11 @@ export const useV3PoolStatus = (pool?: PoolInfo | null) => {
   return useMemo(() => (data ? data[0] : []), [data])
 }
 
-export const usePoolLifecyle = (bCakeWrapperAddress?: Address, chainId?: number) => {
+export const usePoolTimeFrame = (bCakeWrapperAddress?: Address, chainId?: number) => {
   const { data } = useQuery({
-    queryKey: ['usePoolLifecyle', bCakeWrapperAddress, chainId],
+    queryKey: ['usePoolTimeFrame', bCakeWrapperAddress, chainId],
     queryFn: () => {
-      return fetchPoolsLifecyle([bCakeWrapperAddress!], chainId!)
+      return fetchPoolsTimeFrame([bCakeWrapperAddress!], chainId!)
     },
     enabled: !!chainId && !!bCakeWrapperAddress && bCakeWrapperAddress !== zeroAddress,
     ...QUERY_SETTINGS_IMMUTABLE,
@@ -151,4 +224,56 @@ export const usePoolLifecyle = (bCakeWrapperAddress?: Address, chainId?: number)
           },
     [data],
   )
+}
+
+type IPoolsTimeFrameType = {
+  [chainId: number]: { [lpAddress: Address]: ArrayItemType<UnwrapPromise<ReturnType<typeof fetchPoolsTimeFrame>>> }
+}
+
+export const useMultiChainPoolsTimeFrame = (pools: UniversalFarmConfig[]) => {
+  const v2Pools = useMemo(
+    () => pools.filter((p) => p.protocol === Protocol.V2 || p.protocol === Protocol.STABLE),
+    [pools],
+  )
+  const poolsGourpByChains = useMemo(() => groupBy(v2Pools, 'chainId'), [v2Pools])
+  const poolsEntries = useMemo(() => Object.entries(poolsGourpByChains), [poolsGourpByChains])
+
+  const queries = poolsEntries.map(([chainId_, poolList]) => {
+    const chainId = Number(chainId_)
+    return {
+      queryKey: ['useMultiChainPoolTimeFrame', chainId, ...poolList.map((p) => p.lpAddress)],
+      queryFn: () => {
+        const bCakeAddresses = poolList.map(
+          ({ lpAddress, protocol }) =>
+            getUniversalBCakeWrapperForPool({ lpAddress, chainId, protocol })?.bCakeWrapperAddress ?? zeroAddress,
+        )
+        return fetchPoolsTimeFrame(bCakeAddresses, chainId)
+      },
+      enabled: !!chainId && !!poolList.length,
+      ...QUERY_SETTINGS_IMMUTABLE,
+      refetchInterval: SLOW_INTERVAL,
+      staleTime: SLOW_INTERVAL,
+    }
+  })
+  const combine = useCallback(
+    (results: UseQueryResult<UnwrapPromise<ReturnType<typeof fetchPoolsTimeFrame>>, Error>[]) => {
+      return {
+        data: results.reduce((acc, result, idx) => {
+          let dataIdx = 0
+          return {
+            ...acc,
+            [poolsEntries[idx][0]]: keyBy(result.data ?? [], () => {
+              return poolsEntries[idx][1][dataIdx++].lpAddress
+            }),
+          }
+        }, {} as IPoolsTimeFrameType),
+        pending: results.some((result) => result.isPending),
+      }
+    },
+    [poolsEntries],
+  )
+  return useQueries({
+    queries,
+    combine,
+  })
 }

--- a/apps/web/src/views/universalFarms/components/PositionItem/StablePositionItem.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/StablePositionItem.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react'
-import { usePoolInfo, usePoolLifecyle } from 'state/farmsV4/hooks'
+import { usePoolInfo, usePoolTimeFrame } from 'state/farmsV4/hooks'
 import { StableLPDetail } from 'state/farmsV4/state/accountPositions/type'
 import { useTotalPriceUSD } from 'views/universalFarms/hooks'
 import { useBCakeWrapperAddress } from 'views/universalFarms/hooks/useBCakeWrapperAddress'
@@ -45,7 +45,7 @@ export const StablePositionItem = memo(
       chainId,
       protocol: Protocol.STABLE,
     })
-    const { startTimestamp, endTimestamp } = usePoolLifecyle(bCakeWrapperAddress, chainId)
+    const { startTimestamp, endTimestamp } = usePoolTimeFrame(bCakeWrapperAddress, chainId)
 
     const isFarmLive = useMemo(
       () =>

--- a/apps/web/src/views/universalFarms/components/PositionItem/V2PositionItem.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/V2PositionItem.tsx
@@ -1,6 +1,6 @@
 import { unwrappedToken } from '@pancakeswap/tokens'
 import { memo, useMemo } from 'react'
-import { usePoolInfo, usePoolLifecyle } from 'state/farmsV4/hooks'
+import { usePoolInfo, usePoolTimeFrame } from 'state/farmsV4/hooks'
 import { V2LPDetail } from 'state/farmsV4/state/accountPositions/type'
 import currencyId from 'utils/currencyId'
 import { v2Fee } from 'views/PoolDetail/hooks/useStablePoolFee'
@@ -49,7 +49,7 @@ export const V2PositionItem = memo(
       chainId,
       protocol: Protocol.V2,
     })
-    const { startTimestamp, endTimestamp } = usePoolLifecyle(bCakeWrapperAddress, chainId)
+    const { startTimestamp, endTimestamp } = usePoolTimeFrame(bCakeWrapperAddress, chainId)
 
     const isFarmLive = useMemo(
       () =>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates pool lifecycle functions to pool time frame functions and refactors pool sorting logic in the PoolsPage view.

### Detailed summary
- Replaced `usePoolLifecyle` with `usePoolTimeFrame` in `V2PositionItem` and `StablePositionItem`
- Updated `fetchPoolsLifecyle` to `fetchPoolsTimeFrame` in `fetcher.ts`
- Added new functions and logic for sorting pools based on time frame in `PoolsPage`

> The following files were skipped due to too many changes: `apps/web/src/state/farmsV4/state/farmPools/hooks.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->