### PR TITLE
fix: Slider function calls when still null

### DIFF
--- a/apps/web/src/views/Predictions/components/MobileMenu.tsx
+++ b/apps/web/src/views/Predictions/components/MobileMenu.tsx
@@ -79,7 +79,7 @@ const MobileMenu = () => {
   return (
     <StyledMobileMenu>
       <ButtonNav>
-        <IconButton variant="text" onClick={() => swiper.slidePrev()} disabled={status !== PredictionStatus.LIVE}>
+        <IconButton variant="text" onClick={() => swiper?.slidePrev()} disabled={status !== PredictionStatus.LIVE}>
           <ArrowBackIcon width="24px" color="primary" />
         </IconButton>
       </ButtonNav>
@@ -97,7 +97,7 @@ const MobileMenu = () => {
         </ButtonMenu>
       </TabNav>
       <ButtonNav>
-        <IconButton variant="text" onClick={() => swiper.slideNext()} disabled={status !== PredictionStatus.LIVE}>
+        <IconButton variant="text" onClick={() => swiper?.slideNext()} disabled={status !== PredictionStatus.LIVE}>
           <ArrowForwardIcon width="24px" color="primary" />
         </IconButton>
       </ButtonNav>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves error handling in `MobileMenu.tsx` by adding optional chaining to `swiper` calls.

### Detailed summary
- Added optional chaining to `swiper` calls in `MobileMenu.tsx`
- Improves error handling when `swiper` is undefined

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->