### PR TITLE
fix: resolved the sort field value when there is no sorting

### DIFF
--- a/apps/web/src/views/universalFarms/PoolsPage.tsx
+++ b/apps/web/src/views/universalFarms/PoolsPage.tsx
@@ -123,12 +123,13 @@ export const PoolsPage = () => {
   }, [isPoolListExtended])
 
   const handleSort = useCallback(({ order, dataIndex }) => {
-    setSortField(dataIndex)
     // we don't need asc sort, so reset it to null
     if (order === SORT_ORDER.ASC) {
       setSortOrder(SORT_ORDER.NULL)
+      setSortField(null)
     } else {
       setSortOrder(order)
+      setSortField(dataIndex)
     }
   }, [])
 
@@ -186,7 +187,7 @@ export const PoolsPage = () => {
   }, [activeChainId, allChainIds, dataByChain])
 
   const sortedData = useMemo(() => {
-    if (sortField === null) {
+    if (sortField === null || sortOrder === SORT_ORDER.NULL) {
       return defaultSortedData
     }
     return [...filteredData].sort((a, b) => {
@@ -195,7 +196,7 @@ export const PoolsPage = () => {
         const aprOfB = getCombinedApr(poolsApr, b.chainId, b.lpAddress)
         return sortOrder * aprOfA + -1 * sortOrder * aprOfB
       }
-      return sortOrder * a[sortField] + -1 * sortOrder * b[sortField]
+      return sortOrder * Number(a[sortField]) + -1 * sortOrder * Number(b[sortField])
     })
   }, [defaultSortedData, sortOrder, sortField, filteredData, poolsApr]) as IDataType[]
 


### PR DESCRIPTION
- **feat: default sorted logic for farm page**
- **fix: resolved the sort field value when there is no sorting**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the sorting logic in `PoolsPage.tsx` to handle null values properly.

### Detailed summary
- Updated sorting logic to handle null values in `sortField`
- Ensured proper sorting when `sortOrder` is NULL
- Converted `sortField` values to numbers for accurate sorting

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->