### PR TITLE
fix: Token address null on buy crypto

### DIFF
--- a/apps/web/src/components/TokenImage/index.tsx
+++ b/apps/web/src/components/TokenImage/index.tsx
@@ -25,11 +25,13 @@ export const tokenImageChainNameMapping = {
 }
 
 export const getImageUrlFromToken = (token: Token) => {
-  const address = token?.isNative ? token.wrapped.address : token.address
+  const address = token?.isNative ? token.wrapped.address : token?.address
 
-  return token?.isNative && token.chainId !== ChainId.BSC
-    ? `${ASSET_CDN}/web/native/${token.chainId}.png`
-    : `https://tokens.pancakeswap.finance/images/${tokenImageChainNameMapping[token.chainId]}${address}.png`
+  return token
+    ? token?.isNative && token.chainId !== ChainId.BSC
+      ? `${ASSET_CDN}/web/native/${token.chainId}.png`
+      : `https://tokens.pancakeswap.finance/images/${tokenImageChainNameMapping[token.chainId]}${address}.png`
+    : ''
 }
 
 export const TokenPairImage: React.FC<React.PropsWithChildren<TokenPairImageProps>> = ({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to handle cases where `token` is null in the `getImageUrlFromToken` function by returning an empty string.

### Detailed summary
- Added a check for `token` existence before accessing properties
- Returned an empty string if `token` is null

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->