### PR TITLE
chore: fix zksync paymaster gas bug

### DIFF
--- a/apps/web/src/hooks/usePaymaster.ts
+++ b/apps/web/src/hooks/usePaymaster.ts
@@ -5,6 +5,7 @@ import { Address, Hex, hexToBigInt, isAddress, stringify } from 'viem'
 
 import { ChainId } from '@pancakeswap/chains'
 import { ZyfiResponse } from 'config/paymaster'
+import { calculateGasMargin } from 'utils'
 import { publicClient } from 'utils/viem'
 import { eip712WalletActions } from 'viem/zksync'
 import { useWalletClient } from 'wagmi'
@@ -71,7 +72,7 @@ export const usePaymaster = () => {
       to: txResponse.txData.to,
       value: txResponse.txData.value && !isZero(txResponse.txData.value) ? hexToBigInt(txResponse.txData.value) : 0n,
       chainId: ChainId.ZKSYNC,
-      gas: BigInt(txResponse.gasLimit),
+      gas: calculateGasMargin(BigInt(txResponse.gasLimit), 2000n), // allow margin to avoid gas esti. error
       maxFeePerGas: BigInt(txResponse.txData.maxFeePerGas),
       maxPriorityFeePerGas: BigInt(0),
       data: call.calldata,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to improve gas calculation in the `usePaymaster` hook by adding a margin to avoid gas estimation errors.

### Detailed summary
- Added import for `calculateGasMargin` from `utils`
- Updated gas calculation to include margin using `calculateGasMargin` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->