### PR TITLE
chore: put gas ovverride in api call instead

### DIFF
--- a/apps/web/src/hooks/usePaymaster.ts
+++ b/apps/web/src/hooks/usePaymaster.ts
@@ -5,7 +5,6 @@ import { Address, Hex, hexToBigInt, isAddress, stringify } from 'viem'
 
 import { ChainId } from '@pancakeswap/chains'
 import { ZyfiResponse } from 'config/paymaster'
-import { calculateGasMargin } from 'utils'
 import { publicClient } from 'utils/viem'
 import { eip712WalletActions } from 'viem/zksync'
 import { useWalletClient } from 'wagmi'
@@ -72,7 +71,7 @@ export const usePaymaster = () => {
       to: txResponse.txData.to,
       value: txResponse.txData.value && !isZero(txResponse.txData.value) ? hexToBigInt(txResponse.txData.value) : 0n,
       chainId: ChainId.ZKSYNC,
-      gas: calculateGasMargin(BigInt(txResponse.gasLimit), 2000n), // allow margin to avoid gas esti. error
+      gas: BigInt(txResponse.gasLimit),
       maxFeePerGas: BigInt(txResponse.txData.maxFeePerGas),
       maxPriorityFeePerGas: BigInt(0),
       data: call.calldata,

--- a/apps/web/src/pages/api/paymaster/index.ts
+++ b/apps/web/src/pages/api/paymaster/index.ts
@@ -6,6 +6,7 @@ import {
 } from 'config/paymaster'
 import stringify from 'fast-json-stable-stringify'
 import { NextApiHandler } from 'next'
+import { calculateGasMargin } from 'utils'
 import { decodeFunctionData, erc20Abi } from 'viem'
 
 const handler: NextApiHandler = async (req, res) => {
@@ -36,6 +37,7 @@ const handler: NextApiHandler = async (req, res) => {
     const isSponsored = gasTokenInfo?.discount === 'FREE'
 
     const PAYMASTER_URL = isSponsored ? ZYFI_SPONSORED_PAYMASTER_URL : ZYFI_PAYMASTER_URL
+    const gas = calculateGasMargin(BigInt(call.gas), 2000n)
 
     const response = await fetch(PAYMASTER_URL, {
       method: 'POST',
@@ -45,7 +47,7 @@ const handler: NextApiHandler = async (req, res) => {
       },
       body: stringify({
         feeTokenAddress: gasTokenAddress,
-        gasLimit: call.gas,
+        gasLimit: Number(gas),
         txData: {
           from: account,
           to: call.address,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates gas handling in `usePaymaster` and `api/paymaster` for better accuracy and removes gas margin calculation.

### Detailed summary
- Removed `calculateGasMargin` function import
- Updated gas handling in `usePaymaster` to use exact gas limit
- Updated gas handling in `api/paymaster` to calculate gas margin with `calculateGasMargin`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->