### PR TITLE
fix: harvest button should disabled when no earning

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolsFilterPanel.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsFilterPanel.tsx
@@ -1,7 +1,6 @@
 import { getChainNameInKebabCase } from '@pancakeswap/chains'
 import { Protocol } from '@pancakeswap/farms'
 import { useTranslation } from '@pancakeswap/localization'
-import { ERC20Token } from '@pancakeswap/sdk'
 import { Flex } from '@pancakeswap/uikit'
 import {
   INetworkProps,
@@ -12,7 +11,6 @@ import {
   TokenFilter,
 } from '@pancakeswap/widgets-internal'
 import { ASSET_CDN } from 'config/constants/endpoints'
-import { useAllTokensByChainIds } from 'hooks/Tokens'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import isEmpty from 'lodash/isEmpty'
 import React, { useMemo } from 'react'

--- a/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
@@ -23,6 +23,7 @@ import { sumApr } from 'views/universalFarms/utils/sumApr'
 import getLiquidityUrlPathParts from 'utils/getLiquidityUrlPathParts'
 import { useBCakeWrapperAddress } from 'views/universalFarms/hooks/useBCakeWrapperAddress'
 import { Protocol } from '@pancakeswap/farms'
+import { useV2CakeEarning } from 'views/universalFarms/hooks/useCakeEarning'
 import { DepositStakeAction, HarvestAction, ModifyStakeActions } from './StakeActions'
 
 type V2PositionActionsProps = {
@@ -259,7 +260,7 @@ const V2NativeAction: React.FC<V2PositionActionsProps> = (props) => {
   return <DepositStakeAction onDeposit={handleDeposit} />
 }
 
-const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress }) => {
+const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress, poolInfo }) => {
   const { t } = useTranslation()
   const { onHarvest } = useV2FarmActions(lpAddress, chainId)
   const { toastSuccess } = useToast()
@@ -297,9 +298,11 @@ const V2HarvestAction: React.FC<V2PositionActionsProps> = ({ chainId, lpAddress 
     }
   }, [setLatestTxReceipt, chainId, switchNetworkIfNecessary, fetchWithCatchTxError, onHarvest, t, toastSuccess])
 
+  const { earningsBusd } = useV2CakeEarning(poolInfo)
+
   if (!pendingReward || pendingReward.isZero()) {
     return null
   }
 
-  return <HarvestAction onHarvest={handleHarvest} executing={pendingTx} disabled={pendingTx} />
+  return <HarvestAction onHarvest={handleHarvest} executing={pendingTx} disabled={pendingTx || !earningsBusd} />
 }

--- a/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V3PositionActions.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { logGTMClickStakeFarmEvent } from 'utils/customGTMEventTracking'
 import useFarmV3Actions from 'views/Farms/hooks/v3/useFarmV3Actions'
 import { useCheckShouldSwitchNetwork } from 'views/universalFarms/hooks'
+import { useV3CakeEarning } from 'views/universalFarms/hooks/useCakeEarning'
 import { V3StakeModal } from '../Modals/V3StakeModal'
 import { StopPropagation } from '../StopPropagation'
 
@@ -15,7 +16,6 @@ type ActionPanelProps = {
   tokenId?: bigint
   isStaked?: boolean
   isFarmLive?: boolean
-  detailMode?: boolean
   modalContent: React.ReactNode
   chainId: number
 }
@@ -28,7 +28,6 @@ export const V3PositionActions = ({
   outOfRange,
   tokenId,
   modalContent,
-  detailMode,
 }: ActionPanelProps) => {
   const { t } = useTranslation()
   const [, setLatestTxReceipt] = useLatestTxReceipt()
@@ -136,26 +135,19 @@ export const V3PositionActions = ({
     [isSwitchingNetwork, handleUnStake, isStaked, modalContent, t, outOfRange, stakeModal, attemptingTxn],
   )
 
-  if (detailMode) {
-    return (
-      <StopPropagation>
-        <ActionPanelContainer>
-          {isStaked ? unstakeButton : !removed && isFarmLive ? stakeButton : null}
-          {isStaked && !removed ? (
-            <Button width={['100px']} scale="md" disabled={attemptingTxn || isSwitchingNetwork} onClick={handleHarvest}>
-              {attemptingTxn ? t('Harvesting') : t('Harvest')}
-            </Button>
-          ) : null}
-        </ActionPanelContainer>
-      </StopPropagation>
-    )
-  }
+  const { earningsBusd } = useV3CakeEarning(tokenId ? [tokenId] : [], chainId)
+
   return (
     <StopPropagation>
       <ActionPanelContainer>
         {isStaked ? unstakeButton : !removed && isFarmLive ? stakeButton : null}
         {isStaked && !removed ? (
-          <Button width={['100px']} scale="md" disabled={attemptingTxn || isSwitchingNetwork} onClick={handleHarvest}>
+          <Button
+            width={['100px']}
+            scale="md"
+            disabled={attemptingTxn || isSwitchingNetwork || !earningsBusd}
+            onClick={handleHarvest}
+          >
             {attemptingTxn ? t('Harvesting') : t('Harvest')}
           </Button>
         ) : null}

--- a/apps/web/src/views/universalFarms/components/PositionItem/V3PositionItem.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/V3PositionItem.tsx
@@ -69,7 +69,6 @@ export const V3PositionItem = memo(({ data, detailMode, poolLength }: V3Position
           removed={removed}
           outOfRange={outOfRange}
           tokenId={data.tokenId}
-          detailMode={detailMode}
           modalContent={
             <V3UnstakeModalContent
               chainId={data.chainId}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the PositionItem and PositionActions components in the universalFarms view with new features and hooks.

### Detailed summary
- Added `useV2CakeEarning` and `useV3CakeEarning` hooks for earnings calculation
- Updated `V2HarvestAction` and `V3PositionActions` components with new earnings logic
- Removed `detailMode` prop from components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->