### PR TITLE
fix: harvest all button should disabled when no earning

### DIFF
--- a/apps/web/src/views/PoolDetail/components/MyPositions.tsx
+++ b/apps/web/src/views/PoolDetail/components/MyPositions.tsx
@@ -41,6 +41,7 @@ import {
   V3PositionItem,
 } from 'views/universalFarms/components'
 import { useCheckShouldSwitchNetwork } from 'views/universalFarms/hooks'
+import { useV2CakeEarning, useV3CakeEarningsByPool } from 'views/universalFarms/hooks/useCakeEarning'
 import { useV2FarmActions } from 'views/universalFarms/hooks/useV2FarmActions'
 import { displayApr } from 'views/universalFarms/utils/displayApr'
 import { formatDollarAmount } from 'views/V3Info/utils/numbers'
@@ -145,6 +146,9 @@ const MyPositionsInner: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
     }
   }, [_handleHarvestAll, loading, setLoading, poolInfo.chainId, switchNetworkIfNecessary])
 
+  const { earningsBusd: v2EarningsBusd } = useV2CakeEarning(poolInfo)
+  const { earningsBusd: v3EarningsBusd } = useV3CakeEarningsByPool(poolInfo)
+
   return (
     <AutoColumn gap="lg">
       <Text as="h3" bold fontSize={24}>
@@ -187,7 +191,7 @@ const MyPositionsInner: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
                   onClick={handleHarvestAll}
                   endIcon={loading ? <AutoRenewIcon spin color="currentColor" /> : null}
                   isLoading={loading}
-                  disabled={loading}
+                  disabled={loading || (poolInfo.protocol === Protocol.V3 ? !v3EarningsBusd : !v2EarningsBusd)}
                 >
                   {loading ? t('Harvesting') : t('Harvest')}
                 </Button>

--- a/apps/web/src/views/PoolDetail/components/PoolEarnings.tsx
+++ b/apps/web/src/views/PoolDetail/components/PoolEarnings.tsx
@@ -1,13 +1,8 @@
-import { Protocol } from '@pancakeswap/farms'
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoColumn, Skeleton, Text } from '@pancakeswap/uikit'
 import { formatNumber } from '@pancakeswap/utils/formatBalance'
-import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import { useMemo } from 'react'
-import { useAccountPositionDetailByPool } from 'state/farmsV4/hooks'
 import { PoolInfo } from 'state/farmsV4/state/type'
-import { useChainIdByQuery } from 'state/info/hooks'
-import { useV2CakeEarning, useV3CakeEarning } from 'views/universalFarms/hooks/useCakeEarning'
+import { useV2CakeEarning, useV3CakeEarningsByPool } from 'views/universalFarms/hooks/useCakeEarning'
 
 type PoolEarningsProps = {
   earningsBusd: number
@@ -47,18 +42,6 @@ export const V2PoolEarnings: React.FC<{ pool: PoolInfo | null | undefined }> = (
 }
 
 export const V3PoolEarnings: React.FC<{ pool: PoolInfo | null | undefined }> = ({ pool }) => {
-  const chainId = useChainIdByQuery()
-  const { account } = useAccountActiveChain()
-  const { data, isLoading } = useAccountPositionDetailByPool<Protocol.V3>(
-    pool?.chainId ?? chainId,
-    account,
-    pool ?? undefined,
-  )
-  const tokenIds = useMemo(() => {
-    if (!data) return []
-    return data.filter((item) => item.isStaked).map((item) => item.tokenId)
-  }, [data])
-  const { earningsBusd, earningsAmount } = useV3CakeEarning(tokenIds, pool?.chainId ?? chainId)
-
+  const { earningsBusd, earningsAmount, isLoading } = useV3CakeEarningsByPool(pool)
   return <PoolEarnings earningsAmount={earningsAmount} earningsBusd={earningsBusd} loading={isLoading} />
 }

--- a/packages/uikit/src/components/MultiSelect/SearchBox.tsx
+++ b/packages/uikit/src/components/MultiSelect/SearchBox.tsx
@@ -30,6 +30,7 @@ const LabelsContainer = styled(Flex)`
   flex-wrap: wrap;
   gap: 4px;
   height: 100%;
+  max-width: calc(100% - 32px);
 `;
 const RemoveIconContainer = styled(Flex)`
   justify-content: center;
@@ -48,7 +49,7 @@ const StyledHiddenInput = styled.input`
   color: inherit;
   height: 100%;
   min-width: 4px;
-  max-width: 100%;
+  max-width: calc(100% - 32px);
 `;
 
 interface IAdaptiveInputProps {


### PR DESCRIPTION
- **fix: resolved token search overflow**
- **fix: harvest all button should disabled when no earning**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the calculation of earnings in the `MyPositions` and `PoolEarnings` components by introducing new hooks for V2 and V3 cake earnings.

### Detailed summary
- Added `max-width` styles to `SearchBox.tsx`
- Updated imports and added new hooks for V2 and V3 cake earnings in various files
- Improved handling of earnings calculations in `MyPositions` and `PoolEarnings` components

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->