### PR TITLE
fix: resovled token search input width

### DIFF
--- a/packages/uikit/src/components/MultiSelect/SearchBox.tsx
+++ b/packages/uikit/src/components/MultiSelect/SearchBox.tsx
@@ -49,7 +49,7 @@ const StyledHiddenInput = styled.input`
   color: inherit;
   height: 100%;
   min-width: 4px;
-  max-width: calc(100% - 32px);
+  max-width: 100%;
 `;
 
 interface IAdaptiveInputProps {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR increases the `max-width` property of the `SearchBox` component in the MultiSelect component to 100%.

### Detailed summary
- Increased `max-width` of the `SearchBox` component to 100% from `calc(100% - 32px)`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->