### PR TITLE
fix: farm apr 0 in mobile

### DIFF
--- a/apps/web/src/state/farmsV4/state/poolApr/hooks.ts
+++ b/apps/web/src/state/farmsV4/state/poolApr/hooks.ts
@@ -66,7 +66,10 @@ export const usePoolApr = (
   useQuery({
     queryKey: ['apr', key],
     queryFn: updateCallback,
-    enabled: !!pool && !poolApr?.lpApr && !!key,
+    // calcV3PoolApr depend on pool's TvlUsd
+    // so if there are local pool without tvlUsd, don't to fetch queryFn
+    // issue: PAN-3698
+    enabled: typeof pool?.tvlUsd !== 'undefined' && !poolApr?.lpApr && !!key,
     refetchInterval: 0,
     refetchOnMount: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `enabled` condition in `hooks.ts` to prevent unnecessary fetching based on the presence of `pool`'s `tvlUsd`.

### Detailed summary
- Updated `enabled` condition to check for `pool`'s `tvlUsd` before fetching
- Added comment explaining the rationale behind the change
- Issue reference: PAN-3698

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->