### PR TITLE
fix: add pancakefee to onramp fee breakdown

### DIFF
--- a/apps/web/src/views/BuyCrypto/components/TransactionFeeDetails/TransactionFeeDetails.tsx
+++ b/apps/web/src/views/BuyCrypto/components/TransactionFeeDetails/TransactionFeeDetails.tsx
@@ -27,7 +27,7 @@ import { FeeTypes, getNetworkFullName, providerFeeTypes } from '../../constants'
 import { BtcLogo } from '../OnRampProviderLogo/OnRampProviderLogo'
 import BuyCryptoTooltip from '../Tooltip/Tooltip'
 
-type FeeComponents = { providerFee: number; networkFee: number; price: number }
+type FeeComponents = { providerFee: number; networkFee: number; pancakeFee: number }
 interface TransactionFeeDetailsProps {
   selectedQuote?: OnRampProviderQuote
   currency: Currency
@@ -93,7 +93,7 @@ export const TransactionFeeDetails = ({
                   {t('%fees%', {
                     fees: formatLocaleNumber({
                       number: selectedQuote
-                        ? Number((selectedQuote?.providerFee + selectedQuote?.networkFee).toFixed(2))
+                        ? selectedQuote?.providerFee + selectedQuote?.networkFee + selectedQuote.pancakeFee
                         : 0,
                       locale,
                       options: { currency: selectedQuote?.fiatCurrency ?? 'USD', style: 'currency' },
@@ -159,16 +159,15 @@ const FeeItem = ({ feeTitle, quote }: { feeTitle: FeeTypes; quote: OnRampProvide
   } = {
     [FeeTypes.NetworkingFees]: (q) => q.networkFee,
     [FeeTypes.ProviderFees]: (q) => q.providerFee,
-    [FeeTypes.ProviderRate]: (q) => q.price,
+    [FeeTypes.PancakeFees]: (q) => q.pancakeFee,
   }
 
-  const title = feeTitle === FeeTypes.ProviderRate ? `${quote.cryptoCurrency} ${feeTitle}` : feeTitle
   return (
     <RowBetween py="4px">
       <Flex justifyContent="space-evenly" width="100%">
         <Box width="max-content">
           <Text width="max-content" fontSize="14px" color="textSubtle">
-            {title}
+            {feeTitle}
           </Text>
         </Box>
 

--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -43,15 +43,15 @@ export enum ONRAMP_PROVIDERS {
 export enum FeeTypes {
   NetworkingFees = 'Networking Fees',
   ProviderFees = 'Provider Fees',
-  ProviderRate = 'Rate',
+  PancakeFees = 'PancakeFees',
 }
 
 export enum WidgetTheme {
   Dark = 'dark',
   Light = 'light',
 }
-const MOONPAY_FEE_TYPES = [FeeTypes.NetworkingFees, FeeTypes.ProviderFees, FeeTypes.ProviderRate]
-const MERCURYO_FEE_TYPES = [FeeTypes.ProviderFees, FeeTypes.ProviderRate]
+const DEFAULT_FEE_TYPES = [FeeTypes.NetworkingFees, FeeTypes.ProviderFees, FeeTypes.PancakeFees]
+const MERCURYO_FEE_TYPES = [FeeTypes.ProviderFees, FeeTypes.PancakeFees]
 
 export const getIsNetworkEnabled = (network: OnRampChainId | undefined) => {
   if (typeof network === 'undefined') return false
@@ -67,10 +67,10 @@ export const PROVIDER_ICONS = {
 } satisfies Record<keyof typeof ONRAMP_PROVIDERS, string>
 
 export const providerFeeTypes: { [provider in ONRAMP_PROVIDERS]: FeeTypes[] } = {
-  [ONRAMP_PROVIDERS.MoonPay]: MOONPAY_FEE_TYPES,
+  [ONRAMP_PROVIDERS.MoonPay]: DEFAULT_FEE_TYPES,
   [ONRAMP_PROVIDERS.Mercuryo]: MERCURYO_FEE_TYPES,
-  [ONRAMP_PROVIDERS.Transak]: MOONPAY_FEE_TYPES,
-  [ONRAMP_PROVIDERS.Topper]: MOONPAY_FEE_TYPES,
+  [ONRAMP_PROVIDERS.Transak]: DEFAULT_FEE_TYPES,
+  [ONRAMP_PROVIDERS.Topper]: DEFAULT_FEE_TYPES,
 }
 
 export const getNetworkDisplay = (chainId: number | undefined): string => {

--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -43,7 +43,7 @@ export enum ONRAMP_PROVIDERS {
 export enum FeeTypes {
   NetworkingFees = 'Networking Fees',
   ProviderFees = 'Provider Fees',
-  PancakeFees = 'PancakeFees',
+  PancakeFees = 'Pancake Fees',
 }
 
 export enum WidgetTheme {

--- a/apps/web/src/views/BuyCrypto/types.ts
+++ b/apps/web/src/views/BuyCrypto/types.ts
@@ -79,6 +79,7 @@ export type UseMutationReturnType<data = unknown, error = Error, variables = voi
 export type ProviderQuote = {
   providerFee: number
   networkFee: number
+  pancakeFee
   quote: number
   amount: number
   fiatCurrency: string
@@ -106,6 +107,7 @@ export type FiatCurrency = {
 export type OnRampProviderQuote = {
   providerFee: number
   networkFee: number
+  pancakeFee: number
   amount: number
   quote: number
   fiatCurrency: string

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3561,6 +3561,5 @@
   "%t% LP": "%t% LP",
   "Pool Detail": "Pool Detail",
   "of %quote% per %base%": "of %quote% per %base%",
-  "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.": "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.",
-  "Pancake Fees": "Pancake Fees"
+  "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.": "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range."
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3561,5 +3561,6 @@
   "%t% LP": "%t% LP",
   "Pool Detail": "Pool Detail",
   "of %quote% per %base%": "of %quote% per %base%",
-  "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.": "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range."
+  "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.": "Calculated using the total liquidity in the pool versus the total reward amount. Actual APR may be higher as some liquidity is not staked or not in-range.",
+  "Pancake Fees": "Pancake Fees"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `pancakeFee` property and updates fee types related to Pancake fees in the BuyCrypto feature.

### Detailed summary
- Added `pancakeFee` property to `OnRampProviderQuote` type
- Renamed `ProviderRate` to `PancakeFees` in `constants.ts`
- Updated fee types arrays in `constants.ts`
- Updated `FeeComponents` type in `TransactionFeeDetails.tsx`
- Adjusted fee calculations in `TransactionFeeDetails.tsx`
- Updated `FeeItem` component to handle Pancake fees

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->