### PR TITLE
chore: remove code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @chef-jojo @ChefMomota @Chef-Yogi @chefjackson @ChefJerry @ChefBingbong @thechefpenguin @chef-eric
+*       @ChefMomota @Chef-Yogi @chefjackson @ChefJerry @ChefBingbong @thechefpenguin @chef-eric


### PR DESCRIPTION
I have changed my username, as security concern to prevent any other register the chef-jojo after that, please remove it asap

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds multiple GitHub users as code owners in the `.github/CODEOWNERS` file.

### Detailed summary
- Added multiple GitHub users as code owners in the `.github/CODEOWNERS` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->