### PR TITLE
chore: add user's nonce to paymaster txn

### DIFF
--- a/apps/web/src/hooks/usePaymaster.ts
+++ b/apps/web/src/hooks/usePaymaster.ts
@@ -66,8 +66,15 @@ export const usePaymaster = () => {
 
     const txResponse: ZyfiResponse = await response.json()
 
+    const zkPublicClient = publicClient({ chainId: ChainId.ZKSYNC })
+
+    const nonce = await zkPublicClient.getTransactionCount({
+      address: account,
+    })
+
     const newTx = {
       account,
+      nonce,
       to: txResponse.txData.to,
       value: txResponse.txData.value && !isZero(txResponse.txData.value) ? hexToBigInt(txResponse.txData.value) : 0n,
       chainId: ChainId.ZKSYNC,
@@ -84,7 +91,6 @@ export const usePaymaster = () => {
       throw new Error('Failed to execute paymaster transaction')
     }
 
-    const zkPublicClient = publicClient({ chainId: ChainId.ZKSYNC })
     const client: any = walletClient.extend(eip712WalletActions() as any)
 
     const txReq = await client.prepareTransactionRequest(newTx)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add functionality related to nonce generation for transactions in the `usePaymaster` hook.

### Detailed summary
- Added nonce generation using `zkPublicClient.getTransactionCount`
- Updated `newTx` object to include the generated nonce for transactions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->