### PR TITLE
fix: Provider exist check when window null

### DIFF
--- a/.changeset/old-cats-wink.md
+++ b/.changeset/old-cats-wink.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/wagmi': patch
+---
+
+fix: Injected provider check when window is null

--- a/packages/wagmi/connectors/trustWallet/trustWallet.ts
+++ b/packages/wagmi/connectors/trustWallet/trustWallet.ts
@@ -20,7 +20,11 @@ export function getTrustWalletProvider(): any | undefined {
     return trustWallet
   }
 
-  const injectedProviderExist = typeof window !== 'undefined' && typeof window.ethereum !== 'undefined'
+  const injectedProviderExist =
+    typeof window !== 'undefined' &&
+    window !== null &&
+    typeof window.ethereum !== 'undefined' &&
+    window.ethereum !== null
 
   // No injected providers exist.
   if (!injectedProviderExist) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue with injected provider check in the `trustWallet.ts` file of the `@pancakeswap/wagmi` package.

### Detailed summary
- Updated injected provider check to also verify if `window` is not null before checking `window.ethereum`
- Improved validation to ensure proper detection of injected providers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->