### PR TITLE
feat: new syrup pool

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,14 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 387,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.csix,
+    contractAddress: '0xC5275FFD108F9Df6ce7dE987686803605018a692',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.4351',
+  },
+  {
     sousId: 386,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.pepe,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool with `sousId` 387, staking `cake` and earning `csix` tokens on BSC. 

### Detailed summary
- Added a new pool with `sousId` 387
- Staking token: `cake`
- Earning token: `csix`
- Contract address: '0xC5275FFD108F9Df6ce7dE987686803605018a692'
- Pool category: `CORE`
- Token per block: '0.4351'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->