### PR TITLE
fix: missed v2/ss bCakeWrapperAddr

### DIFF
--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -82,12 +82,16 @@ export const fetchFarmPools = async (
       )
     })
 
-    if (pool)
+    if (pool) {
       return {
         ...pool,
         pid: farm.pid,
         feeTierBase: 1_000_000,
+        ...(farm.protocol === 'v2' || farm.protocol === 'stable'
+          ? { bCakeWrapperAddress: farm.bCakeWrapperAddress }
+          : {}),
       } satisfies PoolInfo
+    }
 
     remoteMissedPoolsIndex.push(index)
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `fetcher.ts` file in the `farmPools` state to include additional fields based on the farm's protocol.

### Detailed summary
- Added `bCakeWrapperAddress` field based on farm's protocol (`v2` or `stable`)
- Updated `feeTierBase` to `1_000_000` if `pool` exists
- Pushed `index` to `remoteMissedPoolsIndex` array when applicable

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->