### PR TITLE
fix: Error when drawing image on context

### DIFF
--- a/apps/web/src/views/Home/hooks/useDrawSequence.ts
+++ b/apps/web/src/views/Home/hooks/useDrawSequence.ts
@@ -24,7 +24,7 @@ export const useDrawSequenceImages = (
         clearInterval(intervalRef.current)
         onplayEnd()
       } else {
-        if (images.current[ImageDrawProgress.current]) {
+        if (images.current[ImageDrawProgress.current]?.complete) {
           context?.clearRect(0, 0, width, height)
           context?.drawImage(images.current[ImageDrawProgress.current], 0, 0, width, height)
         }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the `useDrawSequence` hook in the `Home` view by checking if the current image is complete before drawing it.

### Detailed summary
- Improved logic to check if the current image is complete before drawing it in the hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->