### PR TITLE
chore: add GA in prediction

### DIFF
--- a/apps/web/src/utils/customGTMEventTracking.ts
+++ b/apps/web/src/utils/customGTMEventTracking.ts
@@ -1,3 +1,5 @@
+import { BetPosition } from '@pancakeswap/prediction'
+
 export enum GTMEvent {
   EventTracking = 'eventTracking',
   Swap = 'swap',
@@ -19,6 +21,8 @@ export enum GTMEvent {
   LockCake = 'lockCake',
   BuyLotteryTickets = 'buyLotteryTickets',
   FiatOnRampModalOpened = 'fiatOnRampModalOpened',
+  PredictionBet = 'predictionBet',
+  PredictionBetPlaced = 'predictionBetPlaced',
 }
 
 export enum GTMCategory {
@@ -35,6 +39,7 @@ export enum GTMCategory {
   CakeStaking = 'CakeStaking',
   Lottery = 'Lottery',
   FiatOnRamp = 'FiatOnRamp',
+  Prediction = 'Prediction',
 }
 
 export enum GTMAction {
@@ -59,6 +64,9 @@ export enum GTMAction {
   ClickLockCakeButton = 'Click Lock CAKE Button',
   ClickBuyLotteryTicketsButton = 'Click Buy Lottery Tickets Button',
   ClickFiatOnRampModalButton = 'Click Fiat On-Ramp Modal Button',
+  ClickBetUpButton = 'Click Bet Up Button',
+  ClickBetDownButton = 'Click Bet Down Button',
+  PredictionBetPlaced = 'Prediction Bet Placed',
 }
 
 interface CustomGTMDataLayer {
@@ -278,5 +286,24 @@ export const logGTMFiatOnRampModalEvent = (provider: string | undefined) => {
     action: GTMAction.ClickFiatOnRampModalButton,
     category: GTMCategory.FiatOnRamp,
     label: `Provider: ${provider || 'Unknown'}`,
+  })
+}
+
+export const logGTMPredictionBetEvent = (position: BetPosition) => {
+  console.info(`---PredictionBet${position}---`)
+  window?.dataLayer?.push({
+    event: GTMEvent.PredictionBet,
+    action: position === BetPosition.BULL ? GTMAction.ClickBetUpButton : GTMAction.ClickBetDownButton,
+    category: GTMCategory.Prediction,
+  })
+}
+
+export const logGTMPredictionBetPlacedEvent = (position: string) => {
+  console.info('---PredictionBetPlaced---')
+  window?.dataLayer?.push({
+    event: GTMEvent.PredictionBetPlaced,
+    action: GTMAction.PredictionBetPlaced,
+    category: GTMCategory.Prediction,
+    label: `Position: ${position}`,
   })
 }

--- a/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
+++ b/apps/web/src/views/Predictions/components/RoundCard/OpenRoundCard.tsx
@@ -20,6 +20,7 @@ import { NodeLedger, NodeRound } from 'state/types'
 import { getNowInSeconds } from 'utils/getNowInSeconds'
 import { useConfig } from 'views/Predictions/context/ConfigProvider'
 import { useAccount } from 'wagmi'
+import { logGTMPredictionBetEvent, logGTMPredictionBetPlacedEvent } from 'utils/customGTMEventTracking'
 import { AVERAGE_CHAIN_BLOCK_TIMES } from '@pancakeswap/chains'
 import { formatTokenv2 } from '../../helpers'
 import CardFlip from '../CardFlip'
@@ -124,6 +125,8 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
   }, [])
 
   const handleSetPosition = useCallback((newPosition: BetPosition) => {
+    logGTMPredictionBetEvent(newPosition)
+
     setState((prevState) => ({
       ...prevState,
       isSettingPosition: true,
@@ -142,6 +145,8 @@ const OpenRoundCard: React.FC<React.PropsWithChildren<OpenRoundCardProps>> = ({
     async (hash: string) => {
       if (account && chainId) {
         await dispatch(fetchLedgerData({ account, chainId, epochs: [round.epoch] }))
+
+        logGTMPredictionBetPlacedEvent(positionDisplay)
 
         handleBack()
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Google Tag Manager event tracking for prediction bets in the Predictions feature.

### Detailed summary
- Added GTM events for prediction bets
- Implemented event tracking for bet placement and position selection

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->