### PR TITLE
chore: update stake/unstake pool in Aptos

### DIFF
--- a/apps/aptos/components/Pools/components/PoolCard/StakeModalContainer.tsx
+++ b/apps/aptos/components/Pools/components/PoolCard/StakeModalContainer.tsx
@@ -1,14 +1,15 @@
 import { useToast } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/widgets-internal'
 
-import { useTranslation } from '@pancakeswap/localization'
-import { useCallback } from 'react'
-import { ToastDescriptionWithTx } from 'components/Toast'
-import useCatchTxError from 'hooks/useCatchTxError'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { Coin } from '@pancakeswap/aptos-swap-sdk'
 import { TransactionResponse } from '@pancakeswap/awgmi/dist/core'
+import { useTranslation } from '@pancakeswap/localization'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
+import { ToastDescriptionWithTx } from 'components/Toast'
+import useActiveWeb3React from 'hooks/useActiveWeb3React'
+import useCatchTxError from 'hooks/useCatchTxError'
+import { useCallback } from 'react'
+import { logGTMPoolStakeEvent } from 'utils/customGTMEventTracking'
 
 const StakeModalContainer = ({
   pool,
@@ -50,6 +51,8 @@ const StakeModalContainer = ({
 
       if (receipt?.status) {
         if (isRemovingStake) {
+          logGTMPoolStakeEvent('unstake', stakingToken?.symbol, stakeAmount)
+
           toastSuccess(
             `${t('Unstaked')}!`,
             <ToastDescriptionWithTx txHash={receipt.transactionHash}>
@@ -59,6 +62,8 @@ const StakeModalContainer = ({
             </ToastDescriptionWithTx>,
           )
         } else {
+          logGTMPoolStakeEvent('stake', stakingToken?.symbol, stakeAmount)
+
           toastSuccess(
             `${t('Staked')}!`,
             <ToastDescriptionWithTx txHash={receipt.transactionHash}>

--- a/apps/aptos/components/Swap/SwapModalFooter.tsx
+++ b/apps/aptos/components/Swap/SwapModalFooter.tsx
@@ -1,7 +1,7 @@
-import { Trade, Currency, CurrencyAmount, TradeType } from '@pancakeswap/aptos-swap-sdk'
+import { Currency, CurrencyAmount, Trade, TradeType } from '@pancakeswap/aptos-swap-sdk'
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoColumn, AutoRow, Button, QuestionHelper, RowBetween, RowFixed, Text } from '@pancakeswap/uikit'
-import { Swap as SwapUI, SwapCallbackError } from '@pancakeswap/widgets-internal'
+import { SwapCallbackError, Swap as SwapUI } from '@pancakeswap/widgets-internal'
 
 import { useMemo } from 'react'
 import { Field } from 'state/swap'

--- a/apps/aptos/utils/customGTMEventTracking.ts
+++ b/apps/aptos/utils/customGTMEventTracking.ts
@@ -6,6 +6,7 @@ export enum GTMEvent {
   Farm = 'stakeFarm',
   UnStakeFarm = 'unStakeFarm',
   WalletConnect = 'walletConnect',
+  PoolStake = 'poolStake',
 }
 
 export enum GTMCategory {
@@ -15,6 +16,7 @@ export enum GTMCategory {
   Farm = 'Farm',
   UnStakeFarm = 'UnStakeFarm',
   WalletConnect = 'WalletConnect',
+  Pool = 'Pool',
 }
 
 export enum GTMAction {
@@ -25,6 +27,8 @@ export enum GTMAction {
   ClickStakeButton = 'Click Stake Button',
   ClickUnStakeButton = 'Click UnStake Button',
   ClickWalletConnectButton = 'Click Wallet Connect and Connected',
+  StakePoolCompleted = 'Stake Pool Completed',
+  UnstakePoolCompleted = 'Unstake Pool Completed',
 }
 
 interface CustomGTMDataLayer {
@@ -93,5 +97,15 @@ export const logGTMWalletConnectEvent = (walletTitle?: string) => {
   window?.dataLayer?.push({
     event: GTMEvent.WalletConnect,
     label: walletTitle,
+  })
+}
+
+export const logGTMPoolStakeEvent = (action: 'stake' | 'unstake', tokenSymbol: string, amount: string) => {
+  console.info(`---Pool${action.charAt(0).toUpperCase() + action.slice(1)}---`)
+  window?.dataLayer?.push({
+    event: GTMEvent.PoolStake,
+    action: action === 'stake' ? GTMAction.StakePoolCompleted : GTMAction.UnstakePoolCompleted,
+    category: GTMCategory.Pool,
+    label: `${action} ${amount} ${tokenSymbol}`,
   })
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds pool stake events to custom GTM tracking in the Swap and PoolCard components.

### Detailed summary
- Added `PoolStake` event tracking for pool stakes in Swap and PoolCard components
- Updated GTM enums in `customGTMEventTracking.ts`
- Imported and used `logGTMPoolStakeEvent` in `StakeModalContainer.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->