### PR TITLE
feat: Add Tg prediction bot banner

### DIFF
--- a/apps/web/src/views/Home/components/Banners/TgPredictionBotBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/TgPredictionBotBanner.tsx
@@ -1,0 +1,133 @@
+import { useTranslation } from '@pancakeswap/localization'
+import { Box, Flex, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import {
+  BackgroundGraphic,
+  BannerActionContainer,
+  BannerContainer,
+  BannerGraphics,
+  BannerMain,
+  BannerTitle,
+  FloatingGraphic,
+  LinkExternalAction,
+  PancakeSwapBadge,
+  type GraphicDetail,
+} from '@pancakeswap/widgets-internal'
+import { ASSET_CDN } from 'config/constants/endpoints'
+import { useMemo } from 'react'
+import styled from 'styled-components'
+
+const StyledBackgroundGraphic = styled(BackgroundGraphic)`
+  left: calc(100% - 196px);
+
+  ${({ theme }) => theme.mediaQueries.sm} {
+    left: calc(100% - 272px);
+  }
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    left: 5%;
+  }
+
+  ${({ theme }) => theme.mediaQueries.lg} {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+`
+
+const StyledBannerDesc = styled(Text)`
+  color: white;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 11px;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    font-size: 16px;
+  }
+`
+
+const PATH = `${ASSET_CDN}/web/banners/tg-prediction-bot`
+const floatingAsset = `${PATH}/floating.png`
+
+const bgSmVariant: GraphicDetail = {
+  src: `${PATH}/bunny-md.png`,
+  width: 272,
+  height: 224,
+}
+
+const bgXsVariant: GraphicDetail = {
+  src: `${PATH}/bunny-md.png`,
+  width: 196,
+  height: 164,
+}
+
+const whiteVariant = {
+  color: '#3E04B0',
+  strokeColor: 'white',
+  strokeSize: 2,
+  fontSize: 28,
+  lineHeight: 30,
+  fontWeight: 800,
+}
+
+const Desc = () => {
+  const { t } = useTranslation()
+  const { isMobile } = useMatchBreakpoints()
+  const endTime = 1727049599 // 22nd Sep 23:59 UTC
+
+  const isCampaignEnded = useMemo(() => new Date().getTime() / 1000 >= endTime, [endTime])
+
+  if (isMobile) return <></>
+
+  return (
+    <StyledBannerDesc>
+      {isCampaignEnded
+        ? t('Predict BNB price every 5 minutes to win a share of the round’s prize pool')
+        : t('Predict BNB Price and Celebrate Our 4th Birthday with $4,444 rewards')}
+    </StyledBannerDesc>
+  )
+}
+
+export const TgPredictionBotBanner = () => {
+  const { t } = useTranslation()
+  const { isMobile, isSm } = useMatchBreakpoints()
+
+  const PlayNowAction = (
+    <LinkExternalAction href="https://t.me/pancakefi_bot" color="#280D5F" externalIcon="arrowForward">
+      <Flex color="#280D5F" alignItems="center" style={{ whiteSpace: 'nowrap' }}>
+        {t('Play Now on Telegram')}
+      </Flex>
+    </LinkExternalAction>
+  )
+
+  return (
+    <BannerContainer background="linear-gradient(64deg, rgba(214, 126, 10, 0.26) 44.37%, rgba(255, 235, 55, 0.00) 102.8%), radial-gradient(113.12% 140.14% at 26.47% 0%, #0AF 0%, #0BADFE 50%, #A2DAF5 100%)">
+      <BannerMain
+        badges={
+          <Flex>
+            <PancakeSwapBadge whiteText />
+          </Flex>
+        }
+        title={
+          <BannerTitle variant={whiteVariant} marginTop={isSm ? '-6px' : '0px'}>
+            {t('Introducing PancakeSwap Prediction Telegram Bot')}
+          </BannerTitle>
+        }
+        desc={isMobile ? null : <Desc />}
+        actions={<BannerActionContainer>{PlayNowAction}</BannerActionContainer>}
+      />
+
+      <BannerGraphics>
+        <StyledBackgroundGraphic
+          src={`${PATH}/bunny-lg.png`}
+          sm={bgSmVariant}
+          xs={bgXsVariant}
+          width={468}
+          height={224}
+          className=""
+        />
+        <Box position="absolute" width="100%" top={isMobile ? '10%' : '0'} left="3%">
+          <FloatingGraphic src={floatingAsset} width={isMobile ? 70 : 100} height={isMobile ? 70 : 100} />
+        </Box>
+      </BannerGraphics>
+    </BannerContainer>
+  )
+}

--- a/apps/web/src/views/Home/components/Banners/hooks/useIsRenderTgPredictionBotBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useIsRenderTgPredictionBotBanner.tsx
@@ -1,0 +1,7 @@
+import { useMemo } from 'react'
+
+export const useIsRenderTgPredictionBotBanner = () => {
+  const endTime = 1726059600 // 11 September 2024 13:00:00 GMT
+
+  return useMemo(() => new Date().getTime() / 1000 >= endTime, [endTime])
+}

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -8,6 +8,7 @@ import { OptionsBanner } from '../OptionsBanner'
 import { PaymasterBanner } from '../PaymasterBanner'
 import { PerpetualSeasonalBanner } from '../PerpetualSeasonalBanner'
 import { QuestBanner } from '../QuestBanner'
+import { TgPredictionBotBanner } from '../TgPredictionBotBanner'
 import { TopperCampaignBanner } from '../TopperCampaignBanner'
 import UserBanner from '../UserBanner'
 import { V4InfoBanner } from '../V4InfoBanner'
@@ -44,6 +45,10 @@ export const useMultipleBannerConfig = () => {
       {
         shouldRender: isRenderUserBanner.shouldRender && !isRenderUserBanner.isEarningsBusdZero,
         banner: <UserBanner />,
+      },
+      {
+        shouldRender: true,
+        banner: <TgPredictionBotBanner />,
       },
       {
         shouldRender: true,

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -16,6 +16,7 @@ import { VeCakeBanner } from '../VeCakeBanner'
 import WebNotificationBanner from '../WebNotificationBanner'
 import { ZksyncAirDropBanner } from '../ZksyncAirdropBanner'
 import useIsRenderCompetitionBanner from './useIsRenderCompetitionBanner'
+import { useIsRenderTgPredictionBotBanner } from './useIsRenderTgPredictionBotBanner'
 import useIsRenderUserBanner from './useIsRenderUserBanner'
 
 interface IBannerConfig {
@@ -39,6 +40,7 @@ interface IBannerConfig {
 export const useMultipleBannerConfig = () => {
   const isRenderCompetitionBanner = useIsRenderCompetitionBanner()
   const isRenderUserBanner = useIsRenderUserBanner()
+  const isRenderTgPredictionBotBanner = useIsRenderTgPredictionBotBanner()
 
   return useMemo(() => {
     const NO_SHUFFLE_BANNERS: IBannerConfig[] = [
@@ -47,7 +49,7 @@ export const useMultipleBannerConfig = () => {
         banner: <UserBanner />,
       },
       {
-        shouldRender: true,
+        shouldRender: isRenderTgPredictionBotBanner,
         banner: <TgPredictionBotBanner />,
       },
       {

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3496,5 +3496,9 @@
   "Please exercise due caution when trading / providing liquidity for the PNP token. The protocol recently encountered a": "Please exercise due caution when trading / providing liquidity for the PNP token. The protocol recently encountered a",
   "Only have one token? Try Zap to automatically balance and provide V3 liquidity in one click.": "Only have one token? Try Zap to automatically balance and provide V3 liquidity in one click.",
   "Click here to start": "Click here to start",
-  "Zap in for %lpSymbol%": "Zap in for %lpSymbol%"
+  "Zap in for %lpSymbol%": "Zap in for %lpSymbol%",
+  "Predict BNB price every 5 minutes to win a share of the round’s prize pool": "Predict BNB price every 5 minutes to win a share of the round’s prize pool",
+  "Predict BNB Price and Celebrate Our 4th Birthday with $4,444 rewards": "Predict BNB Price and Celebrate Our 4th Birthday with $4,444 rewards",
+  "Play Now on Telegram": "Play Now on Telegram",
+  "Introducing PancakeSwap Prediction Telegram Bot": "Introducing PancakeSwap Prediction Telegram Bot"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to introduce a new banner for the PancakeSwap Prediction Telegram Bot on the home page.

### Detailed summary
- Added a new banner component for the PancakeSwap Prediction Telegram Bot
- Updated translations in `translations.json`
- Created a hook to check if the Telegram Bot banner should be rendered

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->