### PR TITLE
fix: Is trustwallet check in ethereum object providers crash

### DIFF
--- a/.changeset/ten-dogs-leave.md
+++ b/.changeset/ten-dogs-leave.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/wagmi': patch
+---
+
+fix: Is trustwallet check in ethereum object providers crash

--- a/packages/wagmi/connectors/trustWallet/trustWallet.ts
+++ b/packages/wagmi/connectors/trustWallet/trustWallet.ts
@@ -36,17 +36,23 @@ export function getTrustWalletProvider(): any | undefined {
     return window.ethereum
   }
 
-  // Trust Wallet provider might be replaced by another
-  // injected provider, check the providers array.
-  if (window.ethereum?.providers) {
-    return window.ethereum.providers.find(isTrustWallet)
+  let trustWalletProvider
+
+  if (window.ethereum?.providers?.length) {
+    // Trust Wallet provider might be replaced by another
+    // injected provider, check the providers array.
+    trustWalletProvider = window.ethereum.providers.find((provider: any) => provider && isTrustWallet(provider))
   }
 
-  // In some cases injected providers can replace window.ethereum
-  // without updating the providers array. In those instances the Trust Wallet
-  // can be installed and its provider instance can be retrieved by
-  // looking at the global `trustwallet` object.
-  return window.trustwallet
+  if (!trustWalletProvider) {
+    // In some cases injected providers can replace window.ethereum
+    // without updating the providers array. In those instances the Trust Wallet
+    // can be installed and its provider instance can be retrieved by
+    // looking at the global `trustwallet` object.
+    trustWalletProvider = window.trustwallet
+  }
+
+  return trustWalletProvider
 }
 
 trustWalletConnect.type = 'trustWalletConnect' as const


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a crash related to the `Trust Wallet` check in the `ethereum` object providers by improving the logic used to identify the `Trust Wallet` provider.

### Detailed summary
- Updated the logic for finding the `Trust Wallet` provider in `window.ethereum.providers`.
- Introduced a fallback to retrieve the `Trust Wallet` provider from the global `trustwallet` object if not found in the providers array.
- Simplified the return statement to directly return the identified `trustWalletProvider`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->