### PR TITLE
chore: add uni btc farm

### DIFF
--- a/packages/farms/src/farms/bsc.ts
+++ b/packages/farms/src/farms/bsc.ts
@@ -94,6 +94,15 @@ const pinnedFarmConfig: UniversalFarmConfig[] = [
 export const bscFarmConfig: UniversalFarmConfig[] = [
   ...pinnedFarmConfig,
   {
+    pid: 184,
+    chainId: ChainId.BSC,
+    protocol: Protocol.V3,
+    lpAddress: Pool.getAddress(bscTokens.uniBtc, bscTokens.btcb, FeeAmount.LOW),
+    token0: bscTokens.uniBtc,
+    token1: bscTokens.btcb,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 183,
     chainId: ChainId.BSC,
     protocol: Protocol.V3,

--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -5257,4 +5257,14 @@ export const CONFIG_PROD: GaugeConfig[] = [
     token1Address: polygonZkEvmTokens.matic.address,
     feeTier: FeeAmount.LOWEST,
   },
+  {
+    gid: 531,
+    address: '0x24853895C8864135E77f3b13CF735966f7636f39',
+    pairName: 'uniBTC-BTCB',
+    chainId: ChainId.BSC,
+    type: GaugeType.V3,
+    token0Address: bscTokens.uniBtc.address,
+    token1Address: bscTokens.btcb.address,
+    feeTier: FeeAmount.LOW,
+  },
 ]

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3301,12 +3301,12 @@ export const bscTokens = {
     'Liquid Staked BTC',
     'https://www.babylon.magpiexyz.io',
   ),
-  poolx: new ERC20Token(
+  uniBtc: new ERC20Token(
     ChainId.BSC,
-    '0xbAeA9aBA1454DF334943951d51116aE342eAB255',
-    18,
-    'POOLX',
-    'Poolz Finance',
-    'https://www.poolz.finance',
+    '0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a',
+    8,
+    'uniBTC',
+    'uniBTC',
+    'https://www.bedrock.technology/',
   ),
 }

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3301,6 +3301,14 @@ export const bscTokens = {
     'Liquid Staked BTC',
     'https://www.babylon.magpiexyz.io',
   ),
+  poolx: new ERC20Token(
+    ChainId.BSC,
+    '0xbAeA9aBA1454DF334943951d51116aE342eAB255',
+    18,
+    'POOLX',
+    'Poolz Finance',
+    'https://www.poolz.finance',
+  ),
   uniBtc: new ERC20Token(
     ChainId.BSC,
     '0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add support for a new token `uniBTC` on the BSC network and integrate it into various configurations such as gauges and farms.

### Detailed summary
- Added `uniBTC` token with address and metadata
- Added `uniBTC-BTCB` pair configuration for a gauge
- Integrated `uniBTC` into BSC farm configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->