### PR TITLE
fix: No quote for exact output

### DIFF
--- a/.changeset/slow-cougars-sparkle.md
+++ b/.changeset/slow-cougars-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/routing-sdk': patch
+---
+
+Fix an issue where there's no quote for exact output


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in `@pancakeswap/routing-sdk` where there was no quote for exact output.

### Detailed summary
- Replaced `Promise.all` with `Promise.allSettled` for better error handling
- Improved error handling for rejected trades
- Updated debug logs and removed unnecessary console logs
- Enhanced validation for finding the best route

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->