### PR TITLE
chore: remove predictions in-page banner

### DIFF
--- a/apps/web/src/views/Predictions/index.tsx
+++ b/apps/web/src/views/Predictions/index.tsx
@@ -11,7 +11,6 @@ import ChainlinkChartDisclaimer from './components/ChainlinkChartDisclaimer'
 import ChartDisclaimer from './components/ChartDisclaimer'
 import CollectWinningsPopup from './components/CollectWinningsPopup'
 import Container from './components/Container'
-import { InPageBanner } from './components/InPageBanner'
 import RiskDisclaimer from './components/RiskDisclaimer'
 import { useConfig } from './context/ConfigProvider'
 import SwiperProvider from './context/SwiperProvider'
@@ -68,7 +67,6 @@ const Predictions = () => {
 
   return (
     <SwiperProvider>
-      <InPageBanner />
       <Container>
         <Warnings />
         <RiskDisclaimer />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to remove the `InPageBanner` component from the `Predictions` view.

### Detailed summary
- Removed the `InPageBanner` component import and usage from the `Predictions` view.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->