### PR TITLE
fix: Chain param in query after switching network to bsc

### DIFF
--- a/apps/web/src/components/NetworkModal/WrongNetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/WrongNetworkModal.tsx
@@ -46,7 +46,7 @@ export function WrongNetworkModal({ currentChain, onDismiss }: { currentChain: C
           pathname: router.pathname,
           query: {
             ...router.query,
-            chain: chainId === ChainId.BSC ? null : CHAIN_QUERY_NAME[chainId],
+            chain: CHAIN_QUERY_NAME[chainId],
           },
         },
         undefined,

--- a/apps/web/src/hooks/useSwitchNetwork.ts
+++ b/apps/web/src/hooks/useSwitchNetwork.ts
@@ -28,7 +28,7 @@ export function useSwitchNetworkLocal() {
           pathname: router.pathname,
           query: {
             ...router.query,
-            chain: chainId === ChainId.BSC ? null : CHAIN_QUERY_NAME[chainId],
+            chain: CHAIN_QUERY_NAME[chainId],
           },
         },
         undefined,


### PR DESCRIPTION


![image](https://github.com/user-attachments/assets/ad9addc7-6776-4808-ad2e-943adc4bf833)

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useSwitchNetwork` hook and `WrongNetworkModal` component to remove conditional setting of the `chain` query parameter based on `chainId`.

### Detailed summary
- Removed conditional setting of `chain` query parameter based on `chainId` in `useSwitchNetwork` hook.
- Removed conditional setting of `chain` query parameter based on `chainId` in `WrongNetworkModal` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->