### PR TITLE
perf: Don't fetch cake price when currency is not and not enabled

### DIFF
--- a/apps/web/src/hooks/useCakePrice.ts
+++ b/apps/web/src/hooks/useCakePrice.ts
@@ -16,9 +16,6 @@ export const useCakePrice = ({ enabled = true } = {}) => {
     staleTime: FAST_INTERVAL,
     refetchInterval: FAST_INTERVAL,
     enabled,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
   })
   return data ?? BIG_ZERO
 }

--- a/apps/web/src/hooks/useCakePrice.ts
+++ b/apps/web/src/hooks/useCakePrice.ts
@@ -16,6 +16,9 @@ export const useCakePrice = ({ enabled = true } = {}) => {
     staleTime: FAST_INTERVAL,
     refetchInterval: FAST_INTERVAL,
     enabled,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
   })
   return data ?? BIG_ZERO
 }

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -29,9 +29,9 @@ export function useStablecoinPrice(
   const chainId = currency?.chainId
   const { enabled, hideIfPriceImpactTooHigh } = { ...DEFAULT_CONFIG, ...config }
 
-  const cakePrice = useCakePrice()
+  const isCake = Boolean(chainId && currency && CAKE[chainId] && currency.wrapped.equals(CAKE[chainId]))
+  const cakePrice = useCakePrice({ enabled: Boolean(isCake && enabled) })
   const stableCoin = chainId && chainId in ChainId ? STABLE_COIN[chainId as ChainId] : undefined
-  const isCake = chainId && currency && CAKE[chainId] && currency.wrapped.equals(CAKE[chainId])
 
   const isStableCoin = currency && stableCoin && currency.wrapped.equals(stableCoin)
 

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/CommissionInfo.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/CommissionInfo.tsx
@@ -88,19 +88,19 @@ const chartConfig: ChartInfo[] = [
 
 const CommissionInfo: React.FC<React.PropsWithChildren<CommissionInfoProps>> = ({ affiliate }) => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { totalUsers, totalEarnFeeUSD } = affiliate.metric
 
   const totalCakeEarned = useMemo(() => {
-    const cakeBalance = new BigNumber(totalEarnFeeUSD).div(cakePriceBusd).toNumber()
+    const cakeBalance = new BigNumber(totalEarnFeeUSD).div(cakePrice).toNumber()
     return formatNumber(cakeBalance)
-  }, [cakePriceBusd, totalEarnFeeUSD])
+  }, [cakePrice, totalEarnFeeUSD])
 
   const chartData = useMemo(() => {
     return chartConfig
       .map((chart) => {
         const usdValue: string = affiliate.metric[chart?.id] ?? '0'
-        const cakeBalance = new BigNumber(usdValue).div(cakePriceBusd).toNumber()
+        const cakeBalance = new BigNumber(usdValue).div(cakePrice).toNumber()
         const valuePercentage = new BigNumber(usdValue).div(totalEarnFeeUSD)
         const percentage = new BigNumber(valuePercentage.isNaN() ? '0' : valuePercentage).times(100).toNumber()
         return {
@@ -112,7 +112,7 @@ const CommissionInfo: React.FC<React.PropsWithChildren<CommissionInfoProps>> = (
         }
       })
       .sort((a, b) => b.cakeValueAsNumber - a.cakeValueAsNumber)
-  }, [affiliate?.metric, cakePriceBusd, totalEarnFeeUSD])
+  }, [affiliate?.metric, cakePrice, totalEarnFeeUSD])
 
   return (
     <Box width={['100%', '100%', '100%', '100%', '100%', '387px']}>

--- a/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/LatestReward.tsx
+++ b/apps/web/src/views/AffiliatesProgram/components/Dashboard/Reward/LatestReward.tsx
@@ -43,19 +43,19 @@ const LatestReward: React.FC<React.PropsWithChildren<LatestRewardProps>> = ({
   const { isUserExist } = useUserExist()
   const { toastSuccess, toastError } = useToast()
   const { signMessageAsync } = useSignMessage()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const [isAffiliateClaimLoading, setIsAffiliateClaimLoading] = useState(false)
   const [isUserClaimLoading, setIsUserClaimLoading] = useState(false)
   const contract = useAffiliateProgramContract({ chainId: ChainId.BSC })
 
   const affiliateTotalCakeEarned = useMemo(
-    () => new BigNumber(affiliateRewardFeeUSD).div(cakePriceBusd).toNumber(),
-    [cakePriceBusd, affiliateRewardFeeUSD],
+    () => new BigNumber(affiliateRewardFeeUSD).div(cakePrice).toNumber(),
+    [cakePrice, affiliateRewardFeeUSD],
   )
   const userTotalCakeEarned = useMemo(
-    () => new BigNumber(userRewardFeeUSD).div(cakePriceBusd).toNumber(),
-    [cakePriceBusd, userRewardFeeUSD],
+    () => new BigNumber(userRewardFeeUSD).div(cakePrice).toNumber(),
+    [cakePrice, userRewardFeeUSD],
   )
 
   const handleClaim = async (isAffiliateClaim: boolean) => {

--- a/apps/web/src/views/AffiliatesProgram/hooks/useLeaderboard.tsx
+++ b/apps/web/src/views/AffiliatesProgram/hooks/useLeaderboard.tsx
@@ -16,16 +16,16 @@ interface Leaderboard {
 }
 
 const useLeaderboard = (): Leaderboard => {
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const { data, isPending } = useQuery({
-    queryKey: ['affiliates-program', 'affiliate-program-leaderboard', cakePriceBusd],
+    queryKey: ['affiliates-program', 'affiliate-program-leaderboard', cakePrice],
 
     queryFn: async () => {
       const response = await fetch(`/api/affiliates-program/leader-board`)
       const result = await response.json()
       const list: ListType[] = result.affiliates.map((affiliate) => {
-        const cakeBalance = new BigNumber(affiliate.metric.totalEarnFeeUSD).div(cakePriceBusd)
+        const cakeBalance = new BigNumber(affiliate.metric.totalEarnFeeUSD).div(cakePrice)
         return {
           ...affiliate,
           cakeBalance: cakeBalance.isNaN() ? '0' : cakeBalance.toString(),
@@ -34,7 +34,7 @@ const useLeaderboard = (): Leaderboard => {
       return list
     },
 
-    enabled: cakePriceBusd.gt(0),
+    enabled: cakePrice.gt(0),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   })

--- a/apps/web/src/views/CakeStaking/components/CakeRewardsCard.tsx
+++ b/apps/web/src/views/CakeStaking/components/CakeRewardsCard.tsx
@@ -94,7 +94,7 @@ export const CakeRewardsCard = ({ onDismiss }) => {
     currentLanguage: { locale },
   } = useTranslation()
   const { isDesktop } = useMatchBreakpoints()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { cakeUnlockTime, cakeLockedAmount } = useCakeLockStatus()
   const { balanceOfAt, totalSupplyAt, nextDistributionTimestamp, lastTokenTimestamp, availableClaim } =
     useRevenueSharingVeCake()
@@ -112,8 +112,8 @@ export const CakeRewardsCard = ({ onDismiss }) => {
     [availableClaimFromCakePool],
   )
   const availableCakePoolCakeUsdValue = useMemo(
-    () => new BigNumber(availableCakePoolCake).times(cakePriceBusd).toNumber(),
-    [availableCakePoolCake, cakePriceBusd],
+    () => new BigNumber(availableCakePoolCake).times(cakePrice).toNumber(),
+    [availableCakePoolCake, cakePrice],
   )
 
   const availableRevenueSharingCake = useMemo(
@@ -121,8 +121,8 @@ export const CakeRewardsCard = ({ onDismiss }) => {
     [availableClaim],
   )
   const availableRevenueSharingCakeUsdValue = useMemo(
-    () => new BigNumber(availableRevenueSharingCake).times(cakePriceBusd).toNumber(),
-    [availableRevenueSharingCake, cakePriceBusd],
+    () => new BigNumber(availableRevenueSharingCake).times(cakePrice).toNumber(),
+    [availableRevenueSharingCake, cakePrice],
   )
 
   const totalAvailableClaim = useMemo(
@@ -130,8 +130,8 @@ export const CakeRewardsCard = ({ onDismiss }) => {
     [availableClaim, availableClaimFromCakePool],
   )
   const totalAvailableClaimUsdValue = useMemo(
-    () => new BigNumber(totalAvailableClaim).times(cakePriceBusd).toNumber(),
-    [totalAvailableClaim, cakePriceBusd],
+    () => new BigNumber(totalAvailableClaim).times(cakePrice).toNumber(),
+    [totalAvailableClaim, cakePrice],
   )
 
   const showExpireSoonWarning = useMemo(() => {

--- a/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
@@ -21,10 +21,10 @@ const CakeInput: React.FC<{
   disabled?: boolean
 }> = ({ value, onUserInput, disabled }) => {
   const { t } = useTranslation()
-  const cakeUsdPrice = useCakePrice()
+  const cakePrice = useCakePrice()
   const cakeUsdValue = useMemo(() => {
-    return cakeUsdPrice && value ? cakeUsdPrice.times(value).toNumber() : 0
-  }, [cakeUsdPrice, value])
+    return cakePrice && value ? cakePrice.times(value).toNumber() : 0
+  }, [cakePrice, value])
   const [percent, setPercent] = useState<number | null>(null)
   const _cakeBalance = useBSCCakeBalance()
   const cakeBalance = BigInt(_cakeBalance.toString())

--- a/apps/web/src/views/Home/components/Banners/LotteryBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/LotteryBanner.tsx
@@ -72,8 +72,8 @@ const LotteryPrice: React.FC<React.PropsWithChildren> = () => {
   const { data } = useQuery<LotteryResponse>({
     queryKey: ['currentLottery'],
   })
-  const cakePriceBusd = useCakePrice()
-  const prizeInBusd = new BigNumber(data?.amountCollectedInCake || Number.NaN).times(cakePriceBusd)
+  const cakePrice = useCakePrice()
+  const prizeInBusd = new BigNumber(data?.amountCollectedInCake || Number.NaN).times(cakePrice)
   const prizeTotal = getBalanceNumber(prizeInBusd)
   const { t } = useTranslation()
 

--- a/apps/web/src/views/Home/components/Banners/hooks/useIsRenderUserBanner.ts
+++ b/apps/web/src/views/Home/components/Banners/hooks/useIsRenderUserBanner.ts
@@ -11,8 +11,8 @@ const useIsRenderUserBanner = () => {
   const { account, chainId } = useActiveWeb3React()
 
   const { earningsSum: farmEarningsSum } = useFarmsWithBalance()
-  const cakePriceBusd = useCakePrice()
-  const isEarningsBusdZero = new BigNumber(farmEarningsSum).multipliedBy(cakePriceBusd).isZero()
+  const cakePrice = useCakePrice()
+  const isEarningsBusdZero = new BigNumber(farmEarningsSum).multipliedBy(cakePrice).isZero()
 
   const { data: shouldRenderUserBanner } = useQuery({
     queryKey: ['shouldRenderUserBanner', account],

--- a/apps/web/src/views/Home/components/CakeDataRow.tsx
+++ b/apps/web/src/views/Home/components/CakeDataRow.tsx
@@ -124,8 +124,8 @@ const CakeDataRow = () => {
     enabled: Boolean(loadData),
     refetchInterval: SLOW_INTERVAL,
   })
-  const cakePriceBusd = useCakePrice()
-  const mcap = cakePriceBusd.times(circulatingSupply)
+  const cakePrice = useCakePrice()
+  const mcap = cakePrice.times(circulatingSupply)
   const mcapString = formatLocalisedCompactNumber(mcap.toNumber(), isMobile)
 
   useEffect(() => {

--- a/apps/web/src/views/Home/components/CommunitySection/LotteryCardContent.tsx
+++ b/apps/web/src/views/Home/components/CommunitySection/LotteryCardContent.tsx
@@ -25,7 +25,7 @@ const LotteryCardContent = () => {
   const { t } = useTranslation()
   const { observerRef, isIntersecting } = useIntersectionObserver()
   const [loadData, setLoadData] = useState(false)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { data: currentLotteryId } = useQuery({
     queryKey: ['currentLotteryId'],
     queryFn: fetchCurrentLotteryId,
@@ -46,10 +46,10 @@ const LotteryCardContent = () => {
     refetchOnWindowFocus: false,
   })
 
-  const cakePrizesText = t('%cakePrizeInUsd% in CAKE prizes this round', { cakePrizeInUsd: cakePriceBusd.toString() })
-  const [pretext, prizesThisRound] = cakePrizesText.split(cakePriceBusd.toString())
+  const cakePrizesText = t('%cakePrizeInUsd% in CAKE prizes this round', { cakePrizeInUsd: cakePrice.toString() })
+  const [pretext, prizesThisRound] = cakePrizesText.split(cakePrice.toString())
   const amountCollectedInCake = currentLottery ? parseFloat(currentLottery.amountCollectedInCake) : null
-  const currentLotteryPrize = amountCollectedInCake ? cakePriceBusd.times(amountCollectedInCake) : null
+  const currentLotteryPrize = amountCollectedInCake ? cakePrice.times(amountCollectedInCake) : null
 
   useEffect(() => {
     if (isIntersecting) {

--- a/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
+++ b/apps/web/src/views/Home/components/UserBanner/HarvestCard.tsx
@@ -51,11 +51,11 @@ const HarvestCard: React.FC<React.PropsWithChildren<HarvestCardProps>> = ({ onHa
   const { fetchWithCatchTxError, loading: v2PendingTx } = useCatchTxError()
   const { farmsWithStakedBalance, earningsSum: farmEarningsSum } = useFarmsWithBalance()
 
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const masterChefAddress = useMasterchef()
   const { isMobile } = useMatchBreakpoints()
   const gasPrice = useGasPrice()
-  const earningsBusd = new BigNumber(farmEarningsSum).multipliedBy(cakePriceBusd)
+  const earningsBusd = new BigNumber(farmEarningsSum).multipliedBy(cakePrice)
   const numTotalToCollect = farmsWithStakedBalance.length
   const numFarmsToCollect = farmsWithStakedBalance.filter(
     (value) => (value && 'pid' in value && value.pid !== 0) || (value && 'sendTx' in value && value.sendTx !== null),

--- a/apps/web/src/views/Home/hooks/useGetTopFarmsByApr.tsx
+++ b/apps/web/src/views/Home/hooks/useGetTopFarmsByApr.tsx
@@ -23,7 +23,7 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
       version: 2 | 3
     } | null)[]
   >(() => [null, null, null, null, null])
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { chainId } = useActiveChainId()
 
   const { status: fetchStatus, isFetching } = useQuery({
@@ -77,7 +77,7 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
         const { cakeRewardsApr, lpRewardsApr } = getFarmApr(
           chainId,
           farm.poolWeight,
-          cakePriceBusd,
+          cakePrice,
           totalLiquidity,
           farm.lpAddress,
           regularCakePerBlock,
@@ -102,7 +102,7 @@ const useGetTopFarmsByApr = (isIntersecting: boolean) => {
       )
       setTopFarms(sortedByApr.slice(0, 5))
     }
-  }, [cakePriceBusd, chainId, farms, farmsV3.farmsWithPrice, fetchStatus, isLoading, regularCakePerBlock, farmsV3Aprs])
+  }, [cakePrice, chainId, farms, farmsV3.farmsWithPrice, fetchStatus, isLoading, regularCakePerBlock, farmsV3Aprs])
   return { topFarms, fetched: fetchStatus === 'success' && !isFetching, chainId }
 }
 

--- a/apps/web/src/views/Ifos/hooks/v2/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v2/useGetPublicIfoData.ts
@@ -31,9 +31,9 @@ const formatPool = (pool) => ({
  */
 const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
   const { address } = ifo
-  const cakePriceUsd = useCakePrice()
+  const cakePrice = useCakePrice()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
-  const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePriceUsd : lpTokenPriceInUsd
+  const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePrice : lpTokenPriceInUsd
 
   const [state, setState] = useState({
     isInitialized: false,

--- a/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v3/useGetPublicIfoData.ts
@@ -44,9 +44,9 @@ const ROUND_DIGIT = 3
  */
 const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
   const { address, plannedStartTime } = ifo
-  const cakePriceUsd = useCakePrice()
+  const cakePrice = useCakePrice()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
-  const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePriceUsd : lpTokenPriceInUsd
+  const currencyPriceInUSD = ifo.currency === bscTokens.cake ? cakePrice : lpTokenPriceInUsd
 
   const [state, setState] = useState({
     isInitialized: false,

--- a/apps/web/src/views/Ifos/hooks/v7/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v7/useGetPublicIfoData.ts
@@ -99,9 +99,9 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
   const { address: account } = useAccount()
   const { chainId } = ifo
   const { address, plannedStartTime } = ifo
-  const cakePriceUsd = useCakePrice()
+  const cakePrice = useCakePrice()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
-  const currencyPriceInUSD = ifo.currency === CAKE[ifo.chainId] ? cakePriceUsd : lpTokenPriceInUsd
+  const currencyPriceInUSD = ifo.currency === CAKE[ifo.chainId] ? cakePrice : lpTokenPriceInUsd
 
   const [state, setState] = useState(INITIAL_STATE)
 

--- a/apps/web/src/views/Ifos/hooks/v8/useGetPublicIfoData.ts
+++ b/apps/web/src/views/Ifos/hooks/v8/useGetPublicIfoData.ts
@@ -99,9 +99,9 @@ const useGetPublicIfoData = (ifo: Ifo): PublicIfoData => {
   const { address: account } = useAccount()
   const { chainId } = ifo
   const { address, plannedStartTime } = ifo
-  const cakePriceUsd = useCakePrice()
+  const cakePrice = useCakePrice()
   const lpTokenPriceInUsd = useLpTokenPrice(ifo.currency.symbol)
-  const currencyPriceInUSD = ifo.currency === CAKE[ifo.chainId] ? cakePriceUsd : lpTokenPriceInUsd
+  const currencyPriceInUSD = ifo.currency === CAKE[ifo.chainId] ? cakePrice : lpTokenPriceInUsd
 
   const [state, setState] = useState(INITIAL_STATE)
 

--- a/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
+++ b/apps/web/src/views/Lottery/components/BuyTicketsModal/BuyTicketsModal.tsx
@@ -86,7 +86,7 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
   const stringifiedUserCake = userCake.toJSON()
   const memoisedUserCake = useMemo(() => new BigNumber(stringifiedUserCake), [stringifiedUserCake])
 
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const dispatch = useAppDispatch()
   const hasFetchedBalance = fetchStatus === FetchStatus.Fetched
   const userCakeDisplayBalance = getFullDisplayBalance(userCake, 18, 3)
@@ -321,7 +321,7 @@ const BuyTicketsModal: React.FC<React.PropsWithChildren<BuyTicketsModalProps>> =
         value={ticketsToBuy}
         onUserInput={handleInputChange}
         currencyValue={
-          cakePriceBusd.gt(0) &&
+          cakePrice.gt(0) &&
           `~${ticketsToBuy ? getFullDisplayBalance(priceTicketInCake.times(new BigNumber(ticketsToBuy))) : '0.00'} CAKE`
         }
       />

--- a/apps/web/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
+++ b/apps/web/src/views/Lottery/components/ClaimPrizesModal/ClaimPrizesInner.tsx
@@ -37,9 +37,9 @@ const ClaimInnerContainer: React.FC<React.PropsWithChildren<ClaimInnerProps>> = 
   const lotteryContract = useLotteryV2Contract()
   const activeClaimData = roundsToClaim[activeClaimIndex]
 
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const cakeReward = activeClaimData.cakeTotal
-  const dollarReward = cakeReward.times(cakePriceBusd)
+  const dollarReward = cakeReward.times(cakePrice)
   const rewardAsBalance = getBalanceAmount(cakeReward).toNumber()
   const dollarRewardAsBalance = getBalanceAmount(dollarReward).toNumber()
 

--- a/apps/web/src/views/Lottery/components/Hero.tsx
+++ b/apps/web/src/views/Lottery/components/Hero.tsx
@@ -217,8 +217,8 @@ const Hero = () => {
     isTransitioning,
   } = useLottery()
 
-  const cakePriceBusd = useCakePrice()
-  const prizeInBusd = amountCollectedInCake.times(cakePriceBusd)
+  const cakePrice = useCakePrice()
+  const prizeInBusd = amountCollectedInCake.times(cakePrice)
   const prizeTotal = getBalanceNumber(prizeInBusd)
   const ticketBuyIsDisabled = status !== LotteryStatus.OPEN || isTransitioning
 

--- a/apps/web/src/views/Lottery/components/NextDrawCard.tsx
+++ b/apps/web/src/views/Lottery/components/NextDrawCard.tsx
@@ -66,8 +66,8 @@ const NextDrawCard = () => {
   const [isExpanded, setIsExpanded] = useState(false)
   const ticketBuyIsDisabled = status !== LotteryStatus.OPEN || isTransitioning
 
-  const cakePriceBusd = useCakePrice()
-  const prizeInBusd = amountCollectedInCake.times(cakePriceBusd)
+  const cakePrice = useCakePrice()
+  const prizeInBusd = amountCollectedInCake.times(cakePrice)
   const endTimeMs = parseInt(endTime, 10) * 1000
   const endDate = new Date(endTimeMs)
   const isLotteryOpen = status === LotteryStatus.OPEN

--- a/apps/web/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
+++ b/apps/web/src/views/Lottery/components/PreviousRoundCard/FooterExpanded.tsx
@@ -26,7 +26,7 @@ const PreviousRoundCardFooter: React.FC<
   const { t } = useTranslation()
   const [fetchedLotteryGraphData, setFetchedLotteryGraphData] = useState<LotteryRoundGraphEntity>()
   const lotteryGraphDataFromState = useGetLotteryGraphDataById(lotteryId)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   useEffect(() => {
     if (!lotteryId) return
@@ -43,7 +43,7 @@ const PreviousRoundCardFooter: React.FC<
   let prizeInBusd = new BigNumber(NaN)
   if (lotteryNodeData) {
     const { amountCollectedInCake } = lotteryNodeData
-    prizeInBusd = amountCollectedInCake.times(cakePriceBusd)
+    prizeInBusd = amountCollectedInCake.times(cakePrice)
   }
 
   const getTotalUsers = (): string | null => {

--- a/apps/web/src/views/Lottery/components/RewardBracketDetail.tsx
+++ b/apps/web/src/views/Lottery/components/RewardBracketDetail.tsx
@@ -22,7 +22,7 @@ const RewardBracketDetail: React.FC<React.PropsWithChildren<RewardBracketDetailP
   isLoading,
 }) => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const getRewardText = () => {
     const numberMatch = rewardBracket + 1
@@ -59,7 +59,7 @@ const RewardBracketDetail: React.FC<React.PropsWithChildren<RewardBracketDetailP
             fontSize="12px"
             color="textSubtle"
             prefix="~$"
-            value={getBalanceNumber(cakeAmount.times(cakePriceBusd))}
+            value={getBalanceNumber(cakeAmount.times(cakePrice))}
             decimals={0}
           />
         )}

--- a/apps/web/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/RecentCakeProfitRow.tsx
@@ -15,13 +15,13 @@ const RecentCakeProfitCountdownRow = ({ pool }: { pool: Pool.DeserializedPool<To
   const { t } = useTranslation()
   const { address: account } = useAccount()
   const { pricePerFullShare, userData } = useVaultPoolByKey(pool.vaultKey)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { hasAutoEarnings, autoCakeToDisplay } = getCakeVaultEarnings(
     account,
     userData?.cakeAtLastUserAction || BIG_ZERO,
     userData?.userShares || BIG_ZERO,
     pricePerFullShare || BIG_ZERO,
-    cakePriceBusd.toNumber(),
+    cakePrice.toNumber(),
     pool.vaultKey === VaultKey.CakeVault
       ? (userData as DeserializedLockedVaultUser).currentPerformanceFee.plus(
           (userData as DeserializedLockedVaultUser).currentOverdueFee,

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultCardActions/HasSharesActions.tsx
@@ -47,9 +47,9 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
 
   const { stakingToken } = pool
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
-  const stakedDollarValue = cakePriceBusd.gt(0)
-    ? getBalanceNumber(cakeAsBigNumber?.multipliedBy(cakePriceBusd), stakingToken.decimals)
+  const cakePrice = useCakePrice()
+  const stakedDollarValue = cakePrice.gt(0)
+    ? getBalanceNumber(cakeAsBigNumber?.multipliedBy(cakePrice), stakingToken.decimals)
     : 0
 
   const [onPresentTokenRequired] = useModal(<NotEnoughTokensModal tokenSymbol={stakingToken.symbol} />)
@@ -68,7 +68,7 @@ const HasSharesActions: React.FC<React.PropsWithChildren<HasStakeActionProps>> =
         <Flex flexDirection="column">
           <Balance fontSize="20px" bold value={cakeAsNumberBalance ?? 0} decimals={5} />
           <Text as={Flex} fontSize="12px" color="textSubtle" flexWrap="wrap">
-            {cakePriceBusd.gt(0) ? (
+            {cakePrice.gt(0) ? (
               <Balance
                 value={stakedDollarValue}
                 fontSize="12px"

--- a/apps/web/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
+++ b/apps/web/src/views/Pools/components/CakeVaultCard/VaultStakeModal.tsx
@@ -96,9 +96,9 @@ const VaultStakeModal: React.FC<React.PropsWithChildren<VaultStakeModalProps>> =
   const [percent, setPercent] = useState(0)
   const [showRoiCalculator, setShowRoiCalculator] = useState(false)
   const { hasUnstakingFee } = useWithdrawalFeeTimer(parseInt(lastDepositedTime || '0', 10), userShares || BIG_ZERO)
-  const cakePriceBusd = useCakePrice()
-  const usdValueStaked = new BigNumber(stakeAmount).times(cakePriceBusd)
-  const formattedUsdValueStaked = cakePriceBusd.gt(0) && stakeAmount ? formatNumber(usdValueStaked.toNumber()) : ''
+  const cakePrice = useCakePrice()
+  const usdValueStaked = new BigNumber(stakeAmount).times(cakePrice)
+  const formattedUsdValueStaked = cakePrice.gt(0) && stakeAmount ? formatNumber(usdValueStaked.toNumber()) : ''
   const { flexibleApy } = useVaultApy()
   const { allowance, setLastUpdated } = useCheckVaultApprovalStatus(vaultKey)
   const { handleApprove: handleCakeApprove, pendingTx: cakePendingTx } = useVaultApprove(vaultKey, setLastUpdated)
@@ -263,7 +263,7 @@ const VaultStakeModal: React.FC<React.PropsWithChildren<VaultStakeModalProps>> =
         value={stakeAmount}
         isWarning={needEnable}
         onUserInput={handleStakeInputChange}
-        currencyValue={cakePriceBusd.gt(0) && `~${formattedUsdValueStaked || 0} USD`}
+        currencyValue={cakePrice.gt(0) && `~${formattedUsdValueStaked || 0} USD`}
         decimals={stakingToken.decimals}
       />
       {needEnable && (

--- a/apps/web/src/views/Pools/components/RevenueSharing/BenefitsModal/RevenueSharing.tsx
+++ b/apps/web/src/views/Pools/components/RevenueSharing/BenefitsModal/RevenueSharing.tsx
@@ -21,15 +21,15 @@ const RevenueSharing: React.FunctionComponent<React.PropsWithChildren<RevenueSha
     t,
     currentLanguage: { locale },
   } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { userData } = useVaultPoolByKey(VaultKey.CakeVault) as DeserializedLockedCakeVault
 
   const { lastTokenTimestamp, availableClaim } = useRevenueSharingPool()
 
   const availableCake = useMemo(() => getBalanceAmount(new BigNumber(availableClaim)).toNumber(), [availableClaim])
   const availableCakeUsdValue = useMemo(
-    () => new BigNumber(availableCake).times(cakePriceBusd).toNumber(),
-    [availableCake, cakePriceBusd],
+    () => new BigNumber(availableCake).times(cakePrice).toNumber(),
+    [availableCake, cakePrice],
   )
 
   const showNoCakeAmountWarning = useMemo(

--- a/apps/web/src/views/Pottery/components/Banner/index.tsx
+++ b/apps/web/src/views/Pottery/components/Banner/index.tsx
@@ -70,11 +70,11 @@ interface BannerProps {
 
 const Banner: React.FC<React.PropsWithChildren<BannerProps>> = ({ handleScroll }) => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { publicData } = usePotteryData()
   const { getLockedApy } = useVaultApy()
 
-  const prizeInBusd = publicData.totalPrize.times(cakePriceBusd)
+  const prizeInBusd = publicData.totalPrize.times(cakePrice)
   const prizeTotal = getBalanceNumber(prizeInBusd)
 
   const apy = useMemo(() => Number(getLockedApy(weeksToSeconds(10))), [getLockedApy])

--- a/apps/web/src/views/Pottery/components/FinishedRounds/AllHistoryCard/PreviousRoundCardBody.tsx
+++ b/apps/web/src/views/Pottery/components/FinishedRounds/AllHistoryCard/PreviousRoundCardBody.tsx
@@ -58,11 +58,11 @@ const PreviousRoundCardBody: React.FC<React.PropsWithChildren<PreviousRoundCardB
     currentLanguage: { locale },
   } = useTranslation()
   const { isFetched, roundId, prizePot, totalPlayers, txid, winners, lockDate } = finishedRoundInfo
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const prizeAsBn = new BigNumber(prizePot)
   const prize = getBalanceNumber(prizeAsBn)
-  const prizeInBusd = new BigNumber(prize).times(cakePriceBusd).toNumber()
+  const prizeInBusd = new BigNumber(prize).times(cakePrice).toNumber()
 
   const isLatest = useMemo(
     () => latestRoundId && new BigNumber(latestRoundId).minus(1).eq(roundId),

--- a/apps/web/src/views/Pottery/components/Pot/Claim/AvailableWithdraw.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/Claim/AvailableWithdraw.tsx
@@ -19,7 +19,7 @@ const AvailableWithdraw: React.FC<React.PropsWithChildren<AvailableWithdrawProps
     t,
     currentLanguage: { locale },
   } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { previewRedeem, lockedDate, shares, status, potteryVaultAddress, totalSupply, totalLockCake, balanceOf } =
     withdrawData
 
@@ -33,7 +33,7 @@ const AvailableWithdraw: React.FC<React.PropsWithChildren<AvailableWithdrawProps
   })
 
   const amount = getBalanceNumber(amountAsBn)
-  const amountInBusd = new BigNumber(amount).times(cakePriceBusd).toNumber()
+  const amountInBusd = new BigNumber(amount).times(cakePrice).toNumber()
 
   const lockDate = useMemo(() => getDrawnDate(locale, lockedDate?.toString()), [lockedDate, locale])
   const withdrawableDate = dayjs.unix(parseInt(lockedDate, 10)).add(70, 'days').unix()

--- a/apps/web/src/views/Pottery/components/Pot/Claim/PrizeToBeClaimed.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/Claim/PrizeToBeClaimed.tsx
@@ -12,10 +12,10 @@ interface PrizeToBeClaimedProps {
 
 const PrizeToBeClaimed: React.FC<React.PropsWithChildren<PrizeToBeClaimedProps>> = ({ userData }) => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const rewardToken = getBalanceNumber(userData.rewards)
-  const rewardInBusd = new BigNumber(rewardToken).times(cakePriceBusd).toNumber()
+  const rewardInBusd = new BigNumber(rewardToken).times(cakePrice).toNumber()
 
   return (
     <Box mt="20px">

--- a/apps/web/src/views/Pottery/components/Pot/YourDeposit.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/YourDeposit.tsx
@@ -13,10 +13,10 @@ interface YourDepositProps {
 const YourDeposit: React.FC<React.PropsWithChildren<YourDepositProps>> = ({ depositBalance }) => {
   const { t } = useTranslation()
   const { address: account } = useAccount()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { userData } = usePotteryData()
   const totalDepositBalance = getBalanceAmount(depositBalance).toNumber()
-  const balanceInBusd = new BigNumber(totalDepositBalance).times(cakePriceBusd).toNumber()
+  const balanceInBusd = new BigNumber(totalDepositBalance).times(cakePrice).toNumber()
 
   return (
     <Box>

--- a/apps/web/src/views/Pottery/components/Pot/index.tsx
+++ b/apps/web/src/views/Pottery/components/Pot/index.tsx
@@ -66,14 +66,14 @@ const BalanceStyle = styled(Balance)`
 
 const Pot: React.FC<React.PropsWithChildren> = () => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { isMobile } = useMatchBreakpoints()
   const { publicData } = usePotteryData()
 
   const [activeTab, setIndex] = useState<POT_CATEGORY>(POT_CATEGORY.Deposit)
   const handleClick = useCallback((tabType: POT_CATEGORY) => setIndex(tabType), [])
 
-  const prizeInBusd = publicData.totalPrize.times(cakePriceBusd)
+  const prizeInBusd = publicData.totalPrize.times(cakePrice)
   const prizeTotal = getBalanceNumber(prizeInBusd)
 
   const tabMenuItems = useMemo(() => {

--- a/apps/web/src/views/TradingCompetition/helpers.ts
+++ b/apps/web/src/views/TradingCompetition/helpers.ts
@@ -13,10 +13,10 @@ export const localiseTradingVolume = (value?: number, decimals = 0) => {
 export const useCompetitionCakeRewards = (userCakeReward: string | number) => {
   const cakeAsBigNumber = new BigNumber(userCakeReward as string)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   return {
     cakeReward: cakeBalance,
-    dollarValueOfCakeReward: cakePriceBusd.multipliedBy(cakeBalance).toNumber(),
+    dollarValueOfCakeReward: cakePrice.multipliedBy(cakeBalance).toNumber(),
   }
 }
 
@@ -42,11 +42,11 @@ export const useFanTokenCompetitionRewards = ({
   const lazioBalance = getBalanceNumber(lazioAsBigNumber, 8)
   const portoBalance = getBalanceNumber(portoAsBigNumber, 8)
   const santosBalance = getBalanceNumber(santosAsBigNumber, 8)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const dollarValueOfTokensReward =
-    cakePriceBusd && lazioPriceBUSD && portoPriceBUSD && santosPriceBUSD
-      ? cakePriceBusd.multipliedBy(cakeBalance).toNumber() +
+    cakePrice && lazioPriceBUSD && portoPriceBUSD && santosPriceBUSD
+      ? cakePrice.multipliedBy(cakeBalance).toNumber() +
         multiplyPriceByAmount(lazioPriceBUSD, lazioBalance, 8) +
         multiplyPriceByAmount(portoPriceBUSD, portoBalance, 8) +
         multiplyPriceByAmount(santosPriceBUSD, santosBalance, 8)
@@ -73,11 +73,11 @@ export const useMoboxCompetitionRewards = ({
   const moboxAsBigNumber = userMoboxRewards ? new BigNumber(userMoboxRewards) : new BigNumber(0)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
   const moboxBalance = getBalanceNumber(moboxAsBigNumber)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const dollarValueOfTokensReward =
-    cakePriceBusd && moboxPriceBUSD
-      ? cakePriceBusd.multipliedBy(cakeBalance).toNumber() + multiplyPriceByAmount(moboxPriceBUSD, moboxBalance, 8)
+    cakePrice && moboxPriceBUSD
+      ? cakePrice.multipliedBy(cakeBalance).toNumber() + multiplyPriceByAmount(moboxPriceBUSD, moboxBalance, 8)
       : null
 
   return {
@@ -99,11 +99,11 @@ export const useModCompetitionRewards = ({
   const darAsBigNumber = userDarRewards ? new BigNumber(userDarRewards) : new BigNumber(0)
   const cakeBalance = getBalanceNumber(cakeAsBigNumber)
   const darBalance = getBalanceNumber(darAsBigNumber, bscTokens.dar.decimals)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const dollarValueOfTokensReward =
-    cakePriceBusd && darPriceBUSD
-      ? cakePriceBusd.multipliedBy(cakeBalance).toNumber() +
+    cakePrice && darPriceBUSD
+      ? cakePrice.multipliedBy(cakeBalance).toNumber() +
         multiplyPriceByAmount(darPriceBUSD, darBalance, bscTokens.dar.decimals)
       : null
 

--- a/apps/web/src/views/TradingReward/components/CurrentRewardPool.tsx
+++ b/apps/web/src/views/TradingReward/components/CurrentRewardPool.tsx
@@ -95,7 +95,7 @@ const CurrentRewardPool: React.FC<React.PropsWithChildren<CurrentRewardPoolProps
     currentLanguage: { locale },
   } = useTranslation()
   const { isDesktop } = useMatchBreakpoints()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { totalReward, campaignClaimTime } = incentives ?? { totalReward: '0', campaignClaimTime: 0 }
 
   const currentDate = Date.now() / 1000
@@ -108,7 +108,7 @@ const CurrentRewardPool: React.FC<React.PropsWithChildren<CurrentRewardPoolProps
     timeRemaining,
     totalEstimateRewardUSD: campaignInfoData?.totalEstimateRewardUSD ?? 0,
     totalReward,
-    cakePriceBusd,
+    cakePrice,
     rewardPrice: currentRewardInfo?.rewardPrice ?? '0',
     rewardTokenDecimal: currentRewardInfo?.rewardTokenDecimal ?? 0,
   })

--- a/apps/web/src/views/TradingReward/components/Leaderboard/DesktopResult.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/DesktopResult.tsx
@@ -13,13 +13,13 @@ interface DesktopResultProps {
 }
 
 const DesktopResult: React.FC<React.PropsWithChildren<DesktopResultProps>> = ({ rank }) => {
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { profile, isLoading: isProfileLoading } = useProfileForAddress(rank.origin)
   const { domainName, avatar } = useDomainNameForAddress(rank.origin, !profile && !isProfileLoading)
 
   const cakeAmount = useMemo(
-    () => new BigNumber(rank?.estimateRewardUSD).div(cakePriceBusd).toNumber(),
-    [cakePriceBusd, rank?.estimateRewardUSD],
+    () => new BigNumber(rank?.estimateRewardUSD).div(cakePrice).toNumber(),
+    [cakePrice, rank?.estimateRewardUSD],
   )
 
   return (

--- a/apps/web/src/views/TradingReward/components/Leaderboard/MobileResult.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/MobileResult.tsx
@@ -26,13 +26,13 @@ interface MobileResultProps {
 
 const MobileResult: React.FC<React.PropsWithChildren<MobileResultProps>> = ({ isMyRank, rank }) => {
   const { t } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { profile, isLoading: isProfileLoading } = useProfileForAddress(rank.origin)
   const { domainName, avatar } = useDomainNameForAddress(rank.origin, !profile && !isProfileLoading)
 
   const cakeAmount = useMemo(
-    () => new BigNumber(rank?.estimateRewardUSD).div(cakePriceBusd).toNumber(),
-    [cakePriceBusd, rank?.estimateRewardUSD],
+    () => new BigNumber(rank?.estimateRewardUSD).div(cakePrice).toNumber(),
+    [cakePrice, rank?.estimateRewardUSD],
   )
 
   return (

--- a/apps/web/src/views/TradingReward/components/Leaderboard/RankingCard.tsx
+++ b/apps/web/src/views/TradingReward/components/Leaderboard/RankingCard.tsx
@@ -51,13 +51,13 @@ const getRankingColor = (rank: number) => {
 const RankingCard: React.FC<React.PropsWithChildren<RankingCardProps>> = ({ rank, user }) => {
   const { t } = useTranslation()
   const rankColor = getRankingColor(rank)
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { profile, isLoading: isProfileLoading } = useProfileForAddress(user?.origin)
   const { domainName, avatar } = useDomainNameForAddress(user?.origin, !profile && !isProfileLoading)
 
   const cakeAmount = useMemo(
-    () => new BigNumber(user?.estimateRewardUSD).div(cakePriceBusd).toNumber() ?? 0,
-    [cakePriceBusd, user?.estimateRewardUSD],
+    () => new BigNumber(user?.estimateRewardUSD).div(cakePrice).toNumber() ?? 0,
+    [cakePrice, user?.estimateRewardUSD],
   )
 
   return (

--- a/apps/web/src/views/TradingReward/components/TopTraders/YourTradingReward/CurrentPeriod.tsx
+++ b/apps/web/src/views/TradingReward/components/TopTraders/YourTradingReward/CurrentPeriod.tsx
@@ -41,7 +41,7 @@ const CurrentPeriod: React.FC<React.PropsWithChildren<CurrentPeriodProps>> = ({
     t,
     currentLanguage: { locale },
   } = useTranslation()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { data: rank } = useUserTradeRank({ campaignId: currentUserCampaignInfo?.campaignId ?? '' })
 
   const currentDate = Date.now() / 1000
@@ -65,7 +65,7 @@ const CurrentPeriod: React.FC<React.PropsWithChildren<CurrentPeriodProps>> = ({
     timeRemaining,
     totalEstimateRewardUSD: currentUserCampaignInfo?.totalEstimateRewardUSD ?? 0,
     totalReward: currentUserCampaignInfo?.canClaim ?? '0',
-    cakePriceBusd,
+    cakePrice,
     rewardPrice: currentRewardInfo?.rewardPrice ?? '0',
     rewardTokenDecimal: currentRewardInfo?.rewardTokenDecimal ?? 0,
   })

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/QualifiedPreview.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/QualifiedPreview.tsx
@@ -53,7 +53,7 @@ const QualifiedPreview: React.FC<React.PropsWithChildren<QualifiedPreviewProps>>
 
   const timeUntil = getTimePeriods(timeRemaining)
 
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
 
   const rewardInUSD = useRewardInUSD({
     timeRemaining,
@@ -67,7 +67,7 @@ const QualifiedPreview: React.FC<React.PropsWithChildren<QualifiedPreviewProps>>
     timeRemaining,
     totalEstimateRewardUSD: currentUserCampaignInfo?.totalEstimateRewardUSD ?? 0,
     totalReward: currentUserCampaignInfo?.canClaim ?? '0',
-    cakePriceBusd,
+    cakePrice,
     rewardPrice: currentRewardInfo?.rewardPrice ?? '0',
     rewardTokenDecimal: currentRewardInfo?.rewardTokenDecimal ?? 0,
   })
@@ -79,8 +79,8 @@ const QualifiedPreview: React.FC<React.PropsWithChildren<QualifiedPreviewProps>>
   )
 
   const totalMapCapCovertCakeAmount = useMemo(
-    () => new BigNumber(totalMapCap).dividedBy(cakePriceBusd).toNumber() ?? 0,
-    [totalMapCap, cakePriceBusd],
+    () => new BigNumber(totalMapCap).dividedBy(cakePrice).toNumber() ?? 0,
+    [totalMapCap, cakePrice],
   )
 
   const additionalAmount = useMemo(() => {

--- a/apps/web/src/views/TradingReward/components/YourTradingReward/VeCake/VeCakePreview.tsx
+++ b/apps/web/src/views/TradingReward/components/YourTradingReward/VeCake/VeCakePreview.tsx
@@ -38,7 +38,7 @@ export const VeCakePreview: React.FC<React.PropsWithChildren<VeCakePreviewProps>
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const cakePriceBusd = useCakePrice()
+  const cakePrice = useCakePrice()
   const { status, cakeLockExpired, cakeLocked } = useCakeLockStatus()
   const timeUntil = getTimePeriods(timeRemaining)
 
@@ -72,7 +72,7 @@ export const VeCakePreview: React.FC<React.PropsWithChildren<VeCakePreviewProps>
     timeRemaining,
     totalEstimateRewardUSD: currentUserCampaignInfo?.totalEstimateRewardUSD ?? 0,
     totalReward: currentUserCampaignInfo?.canClaim ?? '0',
-    cakePriceBusd,
+    cakePrice,
     rewardPrice: currentRewardInfo?.rewardPrice ?? '0',
     rewardTokenDecimal: currentRewardInfo?.rewardTokenDecimal ?? 0,
   })

--- a/apps/web/src/views/TradingReward/hooks/useRewardInCake.tsx
+++ b/apps/web/src/views/TradingReward/hooks/useRewardInCake.tsx
@@ -5,7 +5,7 @@ interface UseRewardInCakeProps {
   timeRemaining: number
   totalEstimateRewardUSD: number
   totalReward: string
-  cakePriceBusd: BigNumber
+  cakePrice: BigNumber
   rewardPrice: string
   rewardTokenDecimal: number
 }
@@ -14,7 +14,7 @@ const useRewardInCake = ({
   timeRemaining,
   totalEstimateRewardUSD,
   totalReward,
-  cakePriceBusd,
+  cakePrice,
   rewardPrice,
   rewardTokenDecimal = 18,
 }: UseRewardInCakeProps) => {
@@ -23,7 +23,7 @@ const useRewardInCake = ({
   const rewardCakePrice = getBalanceAmount(new BigNumber(rewardPrice ?? '0'), rewardTokenDecimal ?? 0)
   const totalCakeReward = reward.div(rewardCakePrice).isNaN() ? 0 : reward.div(rewardCakePrice).toNumber()
 
-  return timeRemaining > 0 ? estimateRewardUSD.div(cakePriceBusd).toNumber() : totalCakeReward
+  return timeRemaining > 0 ? estimateRewardUSD.div(cakePrice).toNumber() : totalCakeReward
 }
 
 export default useRewardInCake


### PR DESCRIPTION
That hook instance in swap usually not directly fetching from rpc since instance in menu component doing the fetch but disabling it still bring some perf benefits 

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing instances of `cakePriceBusd` with `cakePrice` throughout various components. This change streamlines the code by ensuring a consistent reference to the cake price across the application.

### Detailed summary
- Replaced `cakePriceBusd` with `cakePrice` in multiple files.
- Updated calculations for `mcap`, `prizeInBusd`, and `balanceInBusd` to use `cakePrice`.
- Adjusted conditions and hooks to reference the new `cakePrice` variable.
- Ensured all related calculations maintain functionality with the new variable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->