### PR TITLE
fix: Gauges with wrong address

### DIFF
--- a/packages/gauges/src/constants/config/prod.ts
+++ b/packages/gauges/src/constants/config/prod.ts
@@ -1056,7 +1056,7 @@ export const CONFIG_PROD: GaugeConfig[] = [
 
   {
     gid: 104,
-    address: '0xb1Da7D2C257c5700612BdE35C8d7187dc80d79f1',
+    address: '0xB2Aa63f363196caba3154D4187949283F085a488',
     pairName: 'lisUSD-USDT',
     chainId: ChainId.BSC,
     type: GaugeType.StableSwap,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the address in the production config file for the `lisUSD-USDT` pair.

### Detailed summary
- Updated the address in `prod.ts` for the `lisUSD-USDT` pair from `0xb1Da7D2C257c5700612BdE35C8d7187dc80d79f1` to `0xB2Aa63f363196caba3154D4187949283F085a488`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->