### PR TITLE
fix: update limit logic for ifo basic sale

### DIFF
--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ContributeModal.tsx
@@ -1,5 +1,6 @@
 import { Ifo, PoolIds } from '@pancakeswap/ifos'
 import { useTranslation } from '@pancakeswap/localization'
+import { MaxUint256 } from '@pancakeswap/swap-sdk-core'
 import { CAKE } from '@pancakeswap/tokens'
 import {
   BalanceInput,
@@ -98,6 +99,9 @@ const ContributeModal: React.FC<React.PropsWithChildren<Props>> = ({
   // in v3 max token entry is based on ifo credit and hard cap limit per user minus amount already committed
   const maximumTokenEntry = useMemo(() => {
     if (!creditLeft || (ifo.version >= 3.1 && poolId === PoolIds.poolBasic)) {
+      // limit of 0 in Basic Sale means Unlimited
+      if (limitPerUserInLP?.isEqualTo(0)) return BigNumber(MaxUint256.toString())
+
       return limitPerUserInLP?.minus(amountTokenCommittedInLP || new BigNumber(0))
     }
     if (limitPerUserInLP?.isGreaterThan(0)) {
@@ -150,11 +154,15 @@ const ContributeModal: React.FC<React.PropsWithChildren<Props>> = ({
           <Flex justifyContent="space-between" mb="16px">
             {tooltipVisible && tooltip}
             <TooltipText ref={targetRef}>{label}:</TooltipText>
-            <Text>{`${formatNumber(
-              getBalanceAmount(maximumTokenEntry || new BigNumber(0), currency.decimals).toNumber(),
-              3,
-              3,
-            )} ${ifo.currency.symbol}`}</Text>
+            <Text>
+              {limitPerUserInLP?.isEqualTo(0) && poolId === PoolIds.poolBasic
+                ? t('No limit')
+                : `${formatNumber(
+                    getBalanceAmount(maximumTokenEntry || new BigNumber(0), currency.decimals).toNumber(),
+                    3,
+                    3,
+                  )} ${ifo.currency.symbol}`}
+            </Text>
           </Flex>
           <Flex justifyContent="space-between" mb="8px">
             <Text>{t('Commit')}:</Text>

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -210,7 +210,14 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
   const maxToken = ifo.version >= 3.1 && poolId === PoolIds.poolBasic && !isEligible ? 0 : maxLpTokens
   const basicSale = useMemo(() => isBasicSale(poolCharacteristic?.saleType), [poolCharacteristic?.saleType])
 
-  const tokenEntry = <MaxTokenEntry poolId={poolId} ifo={ifo} maxToken={maxToken} basicSale={basicSale} />
+  const tokenEntry = useMemo(
+    () =>
+      // For Basic Pool, if max lp tokens is 0, it means Unlimited so don't show the max token entry
+      !(basicSale && maxToken === 0) && (
+        <MaxTokenEntry poolId={poolId} ifo={ifo} maxToken={maxToken} basicSale={basicSale} />
+      ),
+    [poolId, ifo, maxToken, basicSale],
+  )
 
   const durationInSeconds = ifo.version >= 3.2 ? poolCharacteristic?.vestingInformation?.duration ?? 0 : 0
   const vestingDays = Math.ceil(durationInSeconds / DAY_IN_SECONDS)

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3528,5 +3528,6 @@
   "You’ll need an active PancakeSwap Profile to take part in the IFO’s Public Sale!": "You’ll need an active PancakeSwap Profile to take part in the IFO’s Public Sale!",
   "This is not investment advice. Participation involves risks and may be restricted in some regions. Please ensure compliance with local laws and regulations before participating.": "This is not investment advice. Participation involves risks and may be restricted in some regions. Please ensure compliance with local laws and regulations before participating.",
   "Eigenpie IFO": "Eigenpie IFO",
-  "Join IFO": "Join IFO"
+  "Join IFO": "Join IFO",
+  "No limit": "No limit"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of token entries in the `IfoCardDetails` and `ContributeModal` components, particularly for basic sales, and updates the localization strings in the `translations.json` file.

### Detailed summary
- Updated localization strings in `translations.json` to include "No limit".
- Refactored token entry logic in `IfoCardDetails.tsx` to conditionally render `MaxTokenEntry`.
- Modified `maximumTokenEntry` calculation in `ContributeModal.tsx` to handle unlimited token entries for basic sales.
- Adjusted displayed text for token entry limits in `ContributeModal.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->