### PR TITLE
fix: Crash bcake migration page with unsupported chain

### DIFF
--- a/apps/web/src/views/Migration/components/bCake/PositionManagerTable.tsx
+++ b/apps/web/src/views/Migration/components/bCake/PositionManagerTable.tsx
@@ -42,19 +42,13 @@ export const PosManagerMigrationFarmTable: React.FC<React.PropsWithChildren<ITab
   const { t } = useTranslation()
   const { chainId } = useActiveWeb3React()
 
-  const needToMigrateList: VaultConfig[] = useMemo(() => {
-    if (!chainId) return []
-    return (
+  const rows = useMemo(() => {
+    if (!chainId || columnSchema !== V3Step1DesktopColumnSchema) return []
+
+    const needToMigrateList: VaultConfig[] =
       VAULTS_CONFIG_BY_CHAIN[chainId]?.filter(
         (vault) => vault.address && vault?.bCakeWrapperAddress && vault?.bCakeWrapperAddress !== vault.address,
       ) ?? []
-    )
-  }, [chainId])
-
-  const rows = useMemo(() => {
-    if (columnSchema !== V3Step1DesktopColumnSchema) {
-      return []
-    }
 
     return needToMigrateList.map((d) => ({
       id: d.id,
@@ -71,7 +65,7 @@ export const PosManagerMigrationFarmTable: React.FC<React.PropsWithChildren<ITab
       onStake: noop,
       onUnStake: noop,
     }))
-  }, [needToMigrateList, columnSchema])
+  }, [chainId, columnSchema])
 
   return (
     <Container>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `PosManagerMigrationFarmTable` component in `PositionManagerTable.tsx`, optimizing the logic for generating the rows and simplifying the handling of onStake and onUnStake functions.

### Detailed summary
- Introduced `noop` from `lodash` for `onStake` and `onUnStake` functions.
- Changed the logic for generating `needToMigrateList` to use optional chaining and a default empty array.
- Updated the `rows` mapping to directly return objects with structured data.
- Removed conditional rendering based on `columnSchema` for the row mapping.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->