### PR TITLE
feat: Add ga in start quest

### DIFF
--- a/apps/gamification/utils/customGTMEventTracking.ts
+++ b/apps/gamification/utils/customGTMEventTracking.ts
@@ -1,0 +1,37 @@
+export enum GTMEvent {
+  StartQuest = 'startQuest',
+}
+
+export enum GTMCategory {
+  Quest = 'Quest',
+}
+
+export enum GTMAction {
+  ClickStartQuestButton = 'Click Start Quest Button',
+}
+
+interface CustomGTMDataLayer {
+  event: GTMEvent
+  category?: GTMCategory
+  action?: GTMAction
+  label?: string
+}
+
+type WindowWithDataLayer = Window & {
+  dataLayer: CustomGTMDataLayer[] | undefined
+}
+
+declare const window: WindowWithDataLayer
+
+export const customGTMEvent: WindowWithDataLayer['dataLayer'] =
+  typeof window !== 'undefined' ? window?.dataLayer : undefined
+
+export const logGTMClickStartQuestEvent = (label?: string) => {
+  console.info('---StartQuest---')
+  window?.dataLayer?.push({
+    event: GTMEvent.StartQuest,
+    action: GTMAction.ClickStartQuestButton,
+    category: GTMCategory.Quest,
+    label,
+  })
+}

--- a/apps/gamification/views/Quest/components/Tasks/index.tsx
+++ b/apps/gamification/views/Quest/components/Tasks/index.tsx
@@ -100,12 +100,12 @@ export const Tasks: React.FC<TasksProps> = ({
   }
 
   const handleStartQuest = () => {
-    logGTMClickStartQuestEvent(`${account}-${questId}`)
     if (new Date().getTime() / 1000 < Number(quest?.startDateTime)) {
       toastError(t('This quest is not started.'))
     } else if (!hasProfile) {
       onPressMakeProfileModal()
     } else {
+      logGTMClickStartQuestEvent(`${account}-${questId}`)
       handleLinkUserToQuest()
     }
   }

--- a/apps/gamification/views/Quest/components/Tasks/index.tsx
+++ b/apps/gamification/views/Quest/components/Tasks/index.tsx
@@ -11,6 +11,7 @@ import { MakeProfileModal } from 'views/Quest/components/MakeProfileModal'
 import { Task } from 'views/Quest/components/Tasks/Task'
 import { VerifyTaskStatus } from 'views/Quest/hooks/useVerifyTaskStatus'
 import { useAccount } from 'wagmi'
+import { logGTMClickStartQuestEvent } from 'utils/customGTMEventTracking'
 
 const OverlapContainer = styled(Box)`
   position: absolute;
@@ -99,6 +100,7 @@ export const Tasks: React.FC<TasksProps> = ({
   }
 
   const handleStartQuest = () => {
+    logGTMClickStartQuestEvent(`${account}-${questId}`)
     if (new Date().getTime() / 1000 < Number(quest?.startDateTime)) {
       toastError(t('This quest is not started.'))
     } else if (!hasProfile) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces Google Tag Manager (GTM) event tracking for starting a quest in the application. It adds functionality to log a specific event when a user initiates a quest, enhancing the tracking of user interactions.

### Detailed summary
- Added `logGTMClickStartQuestEvent` function in `utils/customGTMEventTracking.ts` to log quest start events.
- Introduced enums `GTMEvent`, `GTMCategory`, and `GTMAction` for structured event tracking.
- Updated the `Tasks` component in `apps/gamification/views/Quest/components/Tasks/index.tsx` to call `logGTMClickStartQuestEvent` when a quest is started.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->