### PR TITLE
chore: list egp syrup pool on arb

### DIFF
--- a/packages/pools/src/constants/pools/42161.ts
+++ b/packages/pools/src/constants/pools/42161.ts
@@ -5,6 +5,15 @@ import { PoolCategory, SerializedPool } from '../../types'
 
 export const livePools: SerializedPool[] = [
   {
+    sousId: 7,
+    stakingToken: arbitrumTokens.cake,
+    earningToken: arbitrumTokens.egp,
+    contractAddress: '0xd8c20746A3045859D20171C9a47261378AdfbDdE',
+    poolCategory: PoolCategory.CORE,
+    tokenPerSecond: '0.000643004',
+    version: 3,
+  },
+  {
     sousId: 6,
     stakingToken: arbitrumTokens.alp,
     earningToken: arbitrumTokens.arb,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool configuration to the `livePools` array for the Arbitrum network, enhancing the pool offerings.

### Detailed summary
- Added a new pool object with the following properties:
  - `sousId`: 7
  - `stakingToken`: `arbitrumTokens.cake`
  - `earningToken`: `arbitrumTokens.egp`
  - `contractAddress`: `'0xd8c20746A3045859D20171C9a47261378AdfbDdE'`
  - `poolCategory`: `PoolCategory.CORE`
  - `tokenPerSecond`: `'0.000643004'`
  - `version`: 3

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->