### PR TITLE
chore: set ifo learn more link to forum post

### DIFF
--- a/packages/ifos/src/constants/ifos/arb.ts
+++ b/packages/ifos/src/constants/ifos/arb.ts
@@ -16,8 +16,7 @@ export const ifos: BaseIfoConfig[] = [
       'Eigenpie is a Liquid Restaking Platform built on top of EigenLayer that allows users to restake their ETH or LSTs to validate new services while earning rewards and maintaining liquidity through LRTs',
     currency: arbitrumTokens.cake,
     token: arbitrumTokens.egp,
-    articleUrl:
-      'https://blog.pancakeswap.finance/articles/pancake-swap-launches-first-ifo-on-arbitrum-featuring-eigenpie?utm_source=Homepage&utm_medium=website&utm_campaign=Eigenpie&utm_id=IFO',
+    articleUrl: 'https://forum.pancakeswap.finance/t/eigenpie-ifo-discussion-thread/778/1',
     campaignId: '',
     poolBasic: {
       raiseAmount: '$30,000',

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1746,7 +1746,6 @@
   "You have successfully claimed your rewards.": "You have successfully claimed your rewards.",
   "Pottery (BETA)": "Pottery (BETA)",
   "This IFO has token vesting. Purchased tokens are released over a period of time.": "This IFO has token vesting. Purchased tokens are released over a period of time.",
-  "Learn more in the vote proposal": "Learn more in the vote proposal",
   "What is the difference between an IFO and a cIFO?": "What is the difference between an IFO and a cIFO?",
   "If you don’t commit enough CAKE, you may not receive a meaningful amount of IFO tokens, or you may not receive any IFO tokens at all.": "If you don’t commit enough CAKE, you may not receive a meaningful amount of IFO tokens, or you may not receive any IFO tokens at all.",
   "~%num% available to claim at sales end": "~%num% available to claim at sales end",

--- a/packages/uikit/src/widgets/Ifo/IfoHasVestingNotice.tsx
+++ b/packages/uikit/src/widgets/Ifo/IfoHasVestingNotice.tsx
@@ -13,7 +13,7 @@ const IfoHasVestingNotice: React.FC<React.PropsWithChildren<{ url: string }>> = 
             {t("This IFO has token vesting. Purchased tokens are released over a period of time.")}
           </Text>
           <IfoMessageTextLink external href={url} color="#1FC7D4" display="inline">
-            {t("Learn more in the vote proposal")}
+            {t("Learn more")}
           </IfoMessageTextLink>
         </Box>
       </Message>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating text and URLs related to an Initial Farm Offering (IFO) in the `IfoHasVestingNotice.tsx` and `arb.ts` files, as well as modifying translation strings in the `translations.json` file.

### Detailed summary
- Updated text in `IfoHasVestingNotice.tsx` from "Learn more in the vote proposal" to "Learn more".
- Changed `articleUrl` in `arb.ts` to a new URL: 'https://forum.pancakeswap.finance/t/eigenpie-ifo-discussion-thread/778/1'.
- Removed "Learn more in the vote proposal" from `translations.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->