### PR TITLE
feat: Momota test

### DIFF
--- a/apps/gamification/pages/api/auth/[...nextauth].ts
+++ b/apps/gamification/pages/api/auth/[...nextauth].ts
@@ -51,7 +51,7 @@ export default NextAuth({
           case TwitterFollowersId.TWITTER_ID_2:
           case TwitterFollowersId.TWITTER_ID_3:
           case TwitterFollowersId.TWITTER_ID_4:
-          case TwitterFollowersId.TWITTER_ID_5:
+            // case TwitterFollowersId.TWITTER_ID_5:
             // eslint-disable-next-line no-param-reassign
             token.twitter = {
               providerId: account.provider,

--- a/apps/gamification/views/Profile/utils/verifyTwitterFollowersIds.ts
+++ b/apps/gamification/views/Profile/utils/verifyTwitterFollowersIds.ts
@@ -3,7 +3,7 @@ export enum TwitterFollowersId {
   TWITTER_ID_2 = 'twitter-2',
   TWITTER_ID_3 = 'twitter-3',
   TWITTER_ID_4 = 'twitter-4',
-  TWITTER_ID_5 = 'twitter-5',
+  // TWITTER_ID_5 = 'twitter-5',
 }
 
 export const verifyTwitterFollowersIds = [
@@ -30,8 +30,8 @@ export const TWITTER_CONSUMER_KEY = {
     consumerKey: process.env.TWITTER_CONSUMER_KEY_4,
     consumerKeySecret: process.env.TWITTER_CONSUMER_SECRET_4,
   },
-  [TwitterFollowersId.TWITTER_ID_5]: {
-    consumerKey: process.env.TWITTER_CONSUMER_KEY_5,
-    consumerKeySecret: process.env.TWITTER_CONSUMER_SECRET_5,
-  },
+  // [TwitterFollowersId.TWITTER_ID_5]: {
+  //   consumerKey: process.env.TWITTER_CONSUMER_KEY_5,
+  //   consumerKeySecret: process.env.TWITTER_CONSUMER_SECRET_5,
+  // },
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on commenting out the usage of `TwitterFollowersId.TWITTER_ID_5` in the codebase, which includes its references in the authentication logic and the `verifyTwitterFollowersIds` configuration.

### Detailed summary
- Commented out the case for `TwitterFollowersId.TWITTER_ID_5` in `apps/gamification/pages/api/auth/[...nextauth].ts`.
- Commented out the definition of `TWITTER_ID_5` in `apps/gamification/views/Profile/utils/verifyTwitterFollowersIds.ts`.
- Commented out the configuration for `TwitterFollowersId.TWITTER_ID_5` in the `TWITTER_CONSUMER_KEY` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->