### PR TITLE
chore: list new farm on bsc

### DIFF
--- a/packages/farms/src/farms/bsc.ts
+++ b/packages/farms/src/farms/bsc.ts
@@ -94,6 +94,15 @@ const pinnedFarmConfig: UniversalFarmConfig[] = [
 export const bscFarmConfig: UniversalFarmConfig[] = [
   ...pinnedFarmConfig,
   {
+    pid: 186,
+    chainId: ChainId.BSC,
+    protocol: Protocol.V3,
+    lpAddress: Pool.getAddress(bscTokens.eth, bscTokens.pufETH, FeeAmount.LOW),
+    token0: bscTokens.eth,
+    token1: bscTokens.pufETH,
+    feeAmount: FeeAmount.LOW,
+  },
+  {
     pid: 185,
     chainId: ChainId.BSC,
     protocol: Protocol.V3,

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3325,4 +3325,12 @@ export const bscTokens = {
     'Wrapped BTC',
     'https://wbtc.network/',
   ),
+  pufETH: new ERC20Token(
+    ChainId.BSC,
+    '0x64274835D88F5c0215da8AADd9A5f2D2A2569381',
+    18,
+    'xPufETH',
+    'xPufETH',
+    'https://www.puffer.fi/',
+  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new ERC20 token called `pufETH` to the BSC network and adds a corresponding farm configuration for it.

### Detailed summary
- Added `pufETH` token to `packages/tokens/src/constants/bsc.ts` with:
  - Chain ID: `ChainId.BSC`
  - Address: `0x64274835D88F5c0215da8AADd9A5f2D2A2569381`
  - Decimals: `18`
  - Name: `xPufETH`
  - Symbol: `xPufETH`
  - Website: `https://www.puffer.fi/`
- Updated `bscFarmConfig` in `packages/farms/src/farms/bsc.ts` to include:
  - New farm configuration for `pufETH` with `pid: 186`
  - Uses `lpAddress` from `Pool.getAddress` for `bscTokens.eth` and `bscTokens.pufETH`
  - Set `feeAmount` to `FeeAmount.LOW`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->