### PR TITLE
chore: list pepe syrup pool on bsc

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,14 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 389,
+    stakingToken: bscTokens.cake,
+    earningToken: bscTokens.pepe,
+    contractAddress: '0xAe5C953c0C7a179A08e2554C8A3506D7805E1254',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '5022.5008',
+  },
+  {
     sousId: 388,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.poolx,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new pool configuration to the `56.ts` file, introducing a new staking pool with specific parameters.

### Detailed summary
- Added a new pool object with the following properties:
  - `sousId`: 389
  - `stakingToken`: `bscTokens.cake`
  - `earningToken`: `bscTokens.pepe`
  - `contractAddress`: '0xAe5C953c0C7a179A08e2554C8A3506D7805E1254'
  - `poolCategory`: `PoolCategory.CORE`
  - `tokenPerBlock`: '5022.5008'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->