### PR TITLE
fix: Log better quote type

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -77,6 +77,8 @@ export const useAllTypeBestTrade = () => {
   return {
     ammOrder: classicAmmOrder,
     xOrder: currentOrder,
+    // TODO: for log purpose in this stage
+    betterOrder: betterQuote,
     bestOrder: finalOrder as InterfaceOrder,
     tradeLoaded: !finalOrder?.isLoading,
     tradeError: finalOrder?.error,

--- a/apps/web/src/views/Swap/V3Swap/index.tsx
+++ b/apps/web/src/views/Swap/V3Swap/index.tsx
@@ -10,6 +10,7 @@ import { useCheckInsufficientError } from './hooks/useCheckSufficient'
 
 export function V3SwapForm() {
   const {
+    betterOrder,
     bestOrder,
     refreshOrder,
     tradeError,
@@ -52,7 +53,7 @@ export function V3SwapForm() {
             outputNative: outputCurrency.isNative,
             inputToken: inputCurrency.wrapped.address,
             outputToken: outputCurrency.wrapped.address,
-            bestOrderType: bestOrder.type,
+            bestOrderType: betterOrder?.type,
             ammOrder: {
               type: ammOrder.type,
               inputAmount: ammInputAmount,
@@ -76,7 +77,7 @@ export function V3SwapForm() {
       },
       afterCommit: resumeQuoting,
     }
-  }, [pauseQuoting, resumeQuoting, xOrder, ammOrder, inputUsdPrice, outputUsdPrice, bestOrder.type])
+  }, [pauseQuoting, resumeQuoting, xOrder, ammOrder, inputUsdPrice, outputUsdPrice, betterOrder?.type])
 
   return (
     <>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of trade orders in the `V3SwapForm` component by introducing a new `betterOrder` variable and updating the references to `bestOrder` accordingly.

### Detailed summary
- Added `betterOrder` in `useAllTypeBestTrade.ts` for logging purposes.
- Updated `V3SwapForm` to use `betterOrder?.type` instead of `bestOrder.type`.
- Adjusted dependencies in the effect hook to include `betterOrder?.type`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->