### PR TITLE
fix: update the tokenList cache in universal pages

### DIFF
--- a/apps/web/src/config/constants/exchange.ts
+++ b/apps/web/src/config/constants/exchange.ts
@@ -174,3 +174,4 @@ export const GENERIC_GAS_LIMIT_ORDER_EXECUTION = 500000n
 export const LIMIT_ORDERS_DOCS_URL = 'https://docs.pancakeswap.finance/products/pancakeswap-exchange/limit-orders'
 
 export const EXCHANGE_PAGE_PATHS = ['/swap', '/limit-orders', 'liquidity', '/add', '/find', '/remove', '/stable', '/v2']
+export const UNIVERSAL_PAGE_PATHS = ['/liquidity/pools', '/liquidity/positions']

--- a/apps/web/src/state/lists/updater.ts
+++ b/apps/web/src/state/lists/updater.ts
@@ -1,7 +1,7 @@
 import { getVersionUpgrade, VersionUpgrade } from '@pancakeswap/token-lists'
 import { acceptListUpdate, updateListVersion, useFetchListCallback } from '@pancakeswap/token-lists/react'
 import { useQuery } from '@tanstack/react-query'
-import { EXCHANGE_PAGE_PATHS } from 'config/constants/exchange'
+import { EXCHANGE_PAGE_PATHS, UNIVERSAL_PAGE_PATHS } from 'config/constants/exchange'
 import { UNSUPPORTED_LIST_URLS } from 'config/constants/lists'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useRouter } from 'next/router'
@@ -21,7 +21,7 @@ export function UpdaterByChainId({ chainId }: { chainId: number }): null {
   const [listState, dispatch] = useListState()
   const router = useRouter()
   const includeListUpdater = useMemo(() => {
-    return EXCHANGE_PAGE_PATHS.some((item) => {
+    return [...EXCHANGE_PAGE_PATHS, ...UNIVERSAL_PAGE_PATHS].some((item) => {
       return router.pathname.startsWith(item)
     })
   }, [router.pathname])
@@ -61,7 +61,7 @@ export function UpdaterByChainId({ chainId }: { chainId: number }): null {
   })
 
   useQuery({
-    queryKey: ['token-list'],
+    queryKey: ['token-list', chainId],
 
     queryFn: async () => {
       return Promise.all(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new constant for universal page paths and integrates it into the `UpdaterByChainId` function to enhance routing checks.

### Detailed summary
- Introduced `UNIVERSAL_PAGE_PATHS` with paths for liquidity pools and positions in `exchange.ts`.
- Updated the import statement in `updater.ts` to include `UNIVERSAL_PAGE_PATHS`.
- Modified the `includeListUpdater` logic to check against both `EXCHANGE_PAGE_PATHS` and `UNIVERSAL_PAGE_PATHS`.
- Adjusted the `queryKey` in the `useQuery` hook to include `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->