### PR TITLE
fix: Add undefined check for trade order

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -61,12 +61,14 @@ export const useAllTypeBestTrade = () => {
   const refreshOrder = useThrottleFn(bestOrder.refresh, 3000)
 
   const classicAmmOrder = useMemo(() => {
-    return {
-      trade: ammCurrentTrade,
-      type: OrderType.PCS_CLASSIC,
-      isLoading,
-      error: error ?? undefined,
-    }
+    return ammCurrentTrade
+      ? {
+          trade: ammCurrentTrade,
+          type: OrderType.PCS_CLASSIC,
+          isLoading,
+          error: error ?? undefined,
+        }
+      : undefined
   }, [ammCurrentTrade, isLoading, error])
 
   const hasAvailableDutchOrder =
@@ -79,7 +81,7 @@ export const useAllTypeBestTrade = () => {
     xOrder: currentOrder,
     // TODO: for log purpose in this stage
     betterOrder: betterQuote,
-    bestOrder: finalOrder as InterfaceOrder,
+    bestOrder: finalOrder as InterfaceOrder | undefined,
     tradeLoaded: !finalOrder?.isLoading,
     tradeError: finalOrder?.error,
     refreshDisabled:

--- a/apps/web/src/views/Swap/V3Swap/index.tsx
+++ b/apps/web/src/views/Swap/V3Swap/index.tsx
@@ -34,7 +34,7 @@ export function V3SwapForm() {
       beforeCommit: () => {
         pauseQuoting()
         try {
-          const validTrade = ammOrder.trade ?? xOrder?.trade
+          const validTrade = ammOrder?.trade ?? xOrder?.trade
           if (!validTrade) {
             throw new Error('No valid trade to log')
           }
@@ -42,8 +42,8 @@ export function V3SwapForm() {
           const { currency: inputCurrency } = inputAmount
           const { currency: outputCurrency } = outputAmount
           const { chainId } = inputCurrency
-          const ammInputAmount = ammOrder.trade?.inputAmount.toExact()
-          const ammOutputAmount = ammOrder.trade?.outputAmount.toExact()
+          const ammInputAmount = ammOrder?.trade?.inputAmount.toExact()
+          const ammOutputAmount = ammOrder?.trade?.outputAmount.toExact()
           const xInputAmount = xOrder?.trade?.inputAmount.toExact()
           const xOutputAmount = xOrder?.trade?.outputAmount.toExact()
           logger.info('X/AMM Quote Comparison', {
@@ -55,7 +55,7 @@ export function V3SwapForm() {
             outputToken: outputCurrency.wrapped.address,
             bestOrderType: betterOrder?.type,
             ammOrder: {
-              type: ammOrder.type,
+              type: ammOrder?.type,
               inputAmount: ammInputAmount,
               outputAmount: ammOutputAmount,
               inputUsdValue: inputUsdPrice && ammInputAmount ? Number(ammInputAmount) * inputUsdPrice : undefined,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of optional values in the `useAllTypeBestTrade` hook and the `V3SwapForm` component. It ensures that properties are accessed safely, preventing potential runtime errors when values are undefined.

### Detailed summary
- Updated `classicAmmOrder` to return `undefined` if `ammCurrentTrade` is falsy.
- Changed `bestOrder` type to allow `undefined`.
- Modified `validTrade` assignment to safely access `ammOrder.trade`.
- Updated `ammInputAmount` and `ammOutputAmount` to safely access values from `ammOrder`.
- Adjusted `ammOrder` structure to safely access `type`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->