### PR TITLE
fix: Check worker event data has iterator

### DIFF
--- a/apps/gamification/utils/worker.ts
+++ b/apps/gamification/utils/worker.ts
@@ -23,7 +23,7 @@ class WorkerProxy {
     this.id = id
     const promise = new Promise<T>((resolve, reject) => {
       const handler = (e: any) => {
-        if (typeof e?.data?.[Symbol.iterator] === 'function') {
+        if (Array.isArray(e?.data)) {
           const [eId, data] = e.data
           if (id === eId) {
             this.worker.removeEventListener('message', handler)

--- a/apps/gamification/utils/worker.ts
+++ b/apps/gamification/utils/worker.ts
@@ -23,13 +23,15 @@ class WorkerProxy {
     this.id = id
     const promise = new Promise<T>((resolve, reject) => {
       const handler = (e: any) => {
-        const [eId, data] = e.data
-        if (id === eId) {
-          this.worker.removeEventListener('message', handler)
-          if (data.success === false) {
-            reject(data.error)
-          } else {
-            resolve(data.result)
+        if (typeof e?.data?.[Symbol.iterator] === 'function') {
+          const [eId, data] = e.data
+          if (id === eId) {
+            this.worker.removeEventListener('message', handler)
+            if (data.success === false) {
+              reject(data.error)
+            } else {
+              resolve(data.result)
+            }
           }
         }
       }

--- a/apps/web/src/utils/worker.ts
+++ b/apps/web/src/utils/worker.ts
@@ -23,7 +23,7 @@ class WorkerProxy {
     this.id = id
     const promise = new Promise<T>((resolve, reject) => {
       const handler = (e: any) => {
-        if (typeof e?.data?.[Symbol.iterator] === 'function') {
+        if (Array.isArray(e?.data)) {
           const [eId, data] = e.data
           if (id === eId) {
             this.worker.removeEventListener('message', handler)

--- a/apps/web/src/utils/worker.ts
+++ b/apps/web/src/utils/worker.ts
@@ -23,13 +23,15 @@ class WorkerProxy {
     this.id = id
     const promise = new Promise<T>((resolve, reject) => {
       const handler = (e: any) => {
-        const [eId, data] = e.data
-        if (id === eId) {
-          this.worker.removeEventListener('message', handler)
-          if (data.success === false) {
-            reject(data.error)
-          } else {
-            resolve(data.result)
+        if (typeof e?.data?.[Symbol.iterator] === 'function') {
+          const [eId, data] = e.data
+          if (id === eId) {
+            this.worker.removeEventListener('message', handler)
+            if (data.success === false) {
+              reject(data.error)
+            } else {
+              resolve(data.result)
+            }
           }
         }
       }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of messages received in web workers by adding a check to ensure the data received is an array before destructuring it. This change enhances the robustness of the code by preventing potential errors when processing unexpected message formats.

### Detailed summary
- Added a check to verify if `e?.data` is an array before destructuring it into `[eId, data]`.
- Maintained the existing logic for resolving or rejecting the promise based on the `data.success` property.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->