### PR TITLE
fix: Legacy farm page not showing stable pairs

### DIFF
--- a/packages/farms/src/getLegacyFarmConfig.ts
+++ b/packages/farms/src/getLegacyFarmConfig.ts
@@ -2,7 +2,13 @@ import { ChainId, getChainName } from '@pancakeswap/chains'
 import { getStableSwapPools } from '@pancakeswap/stable-swap-sdk'
 import { isAddressEqual } from 'viem'
 import { supportedChainIdV4 } from './const'
-import { SerializedFarmConfig, SerializedFarmPublicData, UniversalFarmConfig, UniversalFarmConfigV2 } from './types'
+import {
+  SerializedFarmConfig,
+  SerializedFarmPublicData,
+  UniversalFarmConfig,
+  UniversalFarmConfigStableSwap,
+  UniversalFarmConfigV2,
+} from './types'
 
 /**
  * @deprecated only used for legacy farms
@@ -30,22 +36,24 @@ export async function getLegacyFarmConfig(chainId?: ChainId): Promise<Serialized
                   return isAddressEqual(s.lpAddress, farm.lpAddress)
                 })
               : undefined
+          const bCakeWrapperAddress = (farm as UniversalFarmConfigV2 | UniversalFarmConfigStableSwap)
+            .bCakeWrapperAddress
+
           return {
             pid: farm.pid ?? 0,
             lpAddress: farm.lpAddress,
             lpSymbol: `${farm.token0.symbol}-${farm.token1.symbol}`,
             token: farm.token0.serialize,
             quoteToken: farm.token1.serialize,
-            ...(stablePair
-              ? {
-                  stableSwapAddress: stablePair.stableSwapAddress,
-                  infoStableSwapAddress: stablePair.infoStableSwapAddress,
-                  stableLpFee: stablePair.stableLpFee,
-                  stableLpFeeRateOfTotalFee: stablePair.stableLpFeeRateOfTotalFee,
-                }
-              : (farm as UniversalFarmConfigV2).bCakeWrapperAddress
-              ? { bCakeWrapperAddress: (farm as UniversalFarmConfigV2).bCakeWrapperAddress }
-              : {}),
+            ...{
+              ...(stablePair && {
+                stableSwapAddress: stablePair.stableSwapAddress,
+                infoStableSwapAddress: stablePair.infoStableSwapAddress,
+                stableLpFee: stablePair.stableLpFee,
+                stableLpFeeRateOfTotalFee: stablePair.stableLpFeeRateOfTotalFee,
+              }),
+              ...(bCakeWrapperAddress && { bCakeWrapperAddress }),
+            },
           } satisfies SerializedFarmConfig
         })
 

--- a/packages/farms/src/getLegacyFarmConfig.ts
+++ b/packages/farms/src/getLegacyFarmConfig.ts
@@ -2,13 +2,7 @@ import { ChainId, getChainName } from '@pancakeswap/chains'
 import { getStableSwapPools } from '@pancakeswap/stable-swap-sdk'
 import { isAddressEqual } from 'viem'
 import { supportedChainIdV4 } from './const'
-import {
-  SerializedFarmConfig,
-  SerializedFarmPublicData,
-  UniversalFarmConfig,
-  UniversalFarmConfigStableSwap,
-  UniversalFarmConfigV2,
-} from './types'
+import { SerializedFarmConfig, SerializedFarmPublicData, UniversalFarmConfig } from './types'
 
 /**
  * @deprecated only used for legacy farms
@@ -36,8 +30,7 @@ export async function getLegacyFarmConfig(chainId?: ChainId): Promise<Serialized
                   return isAddressEqual(s.lpAddress, farm.lpAddress)
                 })
               : undefined
-          const bCakeWrapperAddress = (farm as UniversalFarmConfigV2 | UniversalFarmConfigStableSwap)
-            .bCakeWrapperAddress
+          const bCakeWrapperAddress = 'bCakeWrapperAddress' in farm ? farm.bCakeWrapperAddress : undefined
 
           return {
             pid: farm.pid ?? 0,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `getLegacyFarmConfig` function in the `packages/farms/src/getLegacyFarmConfig.ts` file to streamline the handling of farm configurations by removing the `UniversalFarmConfigV2` type and improving the structure of the returned object.

### Detailed summary
- Removed `UniversalFarmConfigV2` from imports.
- Introduced a new variable `bCakeWrapperAddress` to simplify access.
- Changed the object spread syntax for conditional properties to improve readability.
- Ensured the returned object structure is clearer and more concise.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->