### PR TITLE
chore: list new pool on bsc

### DIFF
--- a/packages/pools/src/constants/pools/56.ts
+++ b/packages/pools/src/constants/pools/56.ts
@@ -14,6 +14,14 @@ export const livePools: SerializedPool[] = [
     isFinished: false,
   },
   {
+    sousId: 390,
+    stakingToken: bscTokens.dck,
+    earningToken: bscTokens.cake,
+    contractAddress: '0xBEB88b8Ae6fE37D12450cbbBEbe308c916213Abd',
+    poolCategory: PoolCategory.CORE,
+    tokenPerBlock: '0.0028',
+  },
+  {
     sousId: 389,
     stakingToken: bscTokens.cake,
     earningToken: bscTokens.pepe,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new staking pool configuration in the `56.ts` file, adding a new entry for a pool that allows users to stake `dck` tokens in exchange for `cake` tokens.

### Detailed summary
- Added a new pool configuration with the following properties:
  - `sousId`: 390
  - `stakingToken`: `bscTokens.dck`
  - `earningToken`: `bscTokens.cake`
  - `contractAddress`: '0xBEB88b8Ae6fE37D12450cbbBEbe308c916213Abd'
  - `poolCategory`: `PoolCategory.CORE`
  - `tokenPerBlock`: '0.0028'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->