### PR TITLE
revert: Hide optional icon (#10762)

### DIFF
--- a/apps/gamification/next-env.d.ts
+++ b/apps/gamification/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/gamification/views/Quest/components/Tasks/Task.tsx
+++ b/apps/gamification/views/Quest/components/Tasks/Task.tsx
@@ -25,7 +25,7 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { styled } from 'styled-components'
-// import { StyledOptionIcon } from 'views/DashboardQuestEdit/components/Tasks/StyledOptionIcon'
+import { StyledOptionIcon } from 'views/DashboardQuestEdit/components/Tasks/StyledOptionIcon'
 import {
   TaskBlogPostConfig,
   TaskConfigType,
@@ -432,7 +432,7 @@ export const Task: React.FC<TaskProps> = ({ questId, task, taskStatus, hasIdRegi
           <Flex mr="auto">
             <Flex position="relative">
               {taskIcon(taskType)}
-              {/* {task.isOptional && <StyledOptionIcon />} */}
+              {task.isOptional && <StyledOptionIcon />}
             </Flex>
             <Text ml="16px" bold>
               {title || taskNaming(taskType)}

--- a/apps/gamification/views/Quest/components/Tasks/index.tsx
+++ b/apps/gamification/views/Quest/components/Tasks/index.tsx
@@ -5,12 +5,13 @@ import { GAMIFICATION_PUBLIC_API } from 'config/constants/endpoints'
 import { useProfile } from 'hooks/useProfile'
 import { useSiwe } from 'hooks/useSiwe'
 import { styled } from 'styled-components'
-import { logGTMClickStartQuestEvent } from 'utils/customGTMEventTracking'
+import { OptionIcon } from 'views/DashboardQuestEdit/components/Tasks/OptionIcon'
 import { SingleQuestData } from 'views/DashboardQuestEdit/hooks/useGetSingleQuestData'
 import { MakeProfileModal } from 'views/Quest/components/MakeProfileModal'
 import { Task } from 'views/Quest/components/Tasks/Task'
 import { VerifyTaskStatus } from 'views/Quest/hooks/useVerifyTaskStatus'
 import { useAccount } from 'wagmi'
+import { logGTMClickStartQuestEvent } from 'utils/customGTMEventTracking'
 
 const OverlapContainer = styled(Box)`
   position: absolute;
@@ -159,7 +160,7 @@ export const Tasks: React.FC<TasksProps> = ({
               />
             ))}
           </FlexGap>
-          {/* {hasOptionsInTasks && (
+          {hasOptionsInTasks && (
             <Box ml="8px">
               <Box mt="16px">
                 <Text fontSize="12px" bold as="span" color="textSubtle">
@@ -180,7 +181,7 @@ export const Tasks: React.FC<TasksProps> = ({
                 </Text>
               )}
             </Box>
-          )} */}
+          )}
           {(!account || !isSiweValid || (isSocialHubFetched && !hasIdRegister)) && !isQuestFinished && (
             <OverlapContainer>
               {account ? (


### PR DESCRIPTION
This reverts commit 493dbe7e3fa97e913efba239dc083e7eee19d5f2.

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates TypeScript documentation links and modifies the rendering logic of optional task icons in the `Task` component. It also adjusts imports related to icon components and event tracking.

### Detailed summary
- Updated TypeScript documentation link in `next-env.d.ts`.
- Changed the import statement for `StyledOptionIcon` in `Task.tsx`.
- Modified rendering logic to display the optional task icon conditionally.
- Changed the import statement for `OptionIcon` in `index.tsx`.
- Reordered the import for `logGTMClickStartQuestEvent` in `index.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->