### PR TITLE
fix: Web3 inbox account error

### DIFF
--- a/apps/web/src/hooks/useInitializeNotifications.ts
+++ b/apps/web/src/hooks/useInitializeNotifications.ts
@@ -6,7 +6,7 @@ export const useInitializeNotifications = () => {
   const { address } = useAccount()
 
   const { data: client } = useWeb3InboxClient()
-  const { data: account, isRegistered } = useWeb3InboxAccount(`eip155:1:${address}`)
+  const { data: account, isRegistered } = useWeb3InboxAccount(address ? `eip155:1:${address}` : undefined)
 
   const isReady = useMemo(() => Boolean(client && account), [account, client])
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/7c738f63-55ea-4d55-9e26-a4fa96c5c990)


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `useInitializeNotifications` hook to handle the case where `address` might be undefined when calling `useWeb3InboxAccount`. It ensures that the account data is fetched correctly only if an `address` is provided.

### Detailed summary
- Modified the `useWeb3InboxAccount` call to check if `address` is defined.
- If `address` is undefined, it passes `undefined` to `useWeb3InboxAccount` instead of constructing the string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->