### PR TITLE
feat: Disabled stake button when pool finished

### DIFF
--- a/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
+++ b/apps/web/src/views/Pools/components/PoolsTable/ActionPanel/Stake.tsx
@@ -418,7 +418,7 @@ const Staked: React.FunctionComponent<React.PropsWithChildren<StackedActionProps
                   <IconButton
                     variant="secondary"
                     onClick={stakingTokenBalance.gt(0) ? onStake : onPresentTokenRequired}
-                    disabled={vaultPosition === VaultPosition.Flexible}
+                    disabled={vaultPosition === VaultPosition.Flexible || isFinished}
                   >
                     <AddIcon color="primary" width="14px" />
                   </IconButton>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `disabled` property of an `IconButton` in the `Stake.tsx` component to include a new condition, `isFinished`, which affects the button's interactivity based on the state of the staking process.

### Detailed summary
- Updated the `disabled` property of the `IconButton` to include `isFinished` alongside `vaultPosition === VaultPosition.Flexible`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->


Before
![Screenshot 2024-10-07 at 3 06 18 PM](https://github.com/user-attachments/assets/532bc280-824a-4308-980d-63573be1862f)

After
![Screenshot 2024-10-07 at 3 05 54 PM](https://github.com/user-attachments/assets/58667258-766a-4c81-b0a0-e70ed59bd2b9)