### PR TITLE
fix: Swap warning error when currency undefined

### DIFF
--- a/apps/web/src/utils/shouldShowSwapWarning.ts
+++ b/apps/web/src/utils/shouldShowSwapWarning.ts
@@ -1,9 +1,9 @@
-import { Token } from '@pancakeswap/sdk'
+import { Currency } from '@pancakeswap/sdk'
 import { ChainId } from '@pancakeswap/chains'
 import SwapWarningTokens from 'config/constants/swapWarningTokens'
 
-const shouldShowSwapWarning = (chainId: ChainId | undefined, swapCurrency: Token): boolean => {
-  if (chainId && SwapWarningTokens[chainId]) {
+const shouldShowSwapWarning = (chainId: ChainId | undefined, swapCurrency?: Currency): boolean => {
+  if (chainId && SwapWarningTokens[chainId] && swapCurrency) {
     const swapWarningTokens = Object.values(SwapWarningTokens[chainId])
     return swapWarningTokens.some((warningToken) => warningToken.equals(swapCurrency))
   }

--- a/apps/web/src/views/Swap/hooks/useWarningImport.tsx
+++ b/apps/web/src/views/Swap/hooks/useWarningImport.tsx
@@ -1,4 +1,4 @@
-import { Token } from '@pancakeswap/sdk'
+import { Currency, Token } from '@pancakeswap/sdk'
 import { useModal } from '@pancakeswap/uikit'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -63,7 +63,7 @@ export default function useWarningImport() {
   }, [swapWarningCurrency])
 
   const swapWarningHandler = useCallback(
-    (currencyInput) => {
+    (currencyInput?: Currency) => {
       const showSwapWarning = shouldShowSwapWarning(chainId, currencyInput)
       if (showSwapWarning) {
         setSwapWarningCurrency(currencyInput)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `useWarningImport` hook and the `shouldShowSwapWarning` utility function to handle optional `Currency` parameters. This enhances the flexibility of the code by allowing the functions to work with undefined values for currency inputs.

### Detailed summary
- Updated `swapWarningHandler` to accept an optional `Currency` parameter.
- Modified `shouldShowSwapWarning` to accept an optional `Currency` parameter instead of a required `Token`.
- Added a check for `swapCurrency` being defined before processing in `shouldShowSwapWarning`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->