### PR TITLE
chore: remove uniBTC warning

### DIFF
--- a/apps/web/src/config/constants/swapWarningTokens.ts
+++ b/apps/web/src/config/constants/swapWarningTokens.ts
@@ -7,7 +7,7 @@ import { bscWarningTokens } from 'config/constants/warningTokens/bscWarningToken
 
 const { alETH } = ethereumTokens
 const { bondly, itam, ccar, bttold, abnbc, metis } = bscTokens
-const { pokemoney, free, safemoon, gala, xcad, lusd, nfp, pnp, uniBTC } = bscWarningTokens
+const { pokemoney, free, safemoon, gala, xcad, lusd, nfp, pnp } = bscWarningTokens
 const { mPendle } = arbitrumWarningTokens
 const { usdPlus } = zksyncTokens
 const { ath } = baseWarningTokens
@@ -37,7 +37,6 @@ const SwapWarningTokens = <WarningTokenList>{
     lusd,
     nfp,
     pnp,
-    uniBTC,
   },
   [ChainId.ZKSYNC]: {
     usdPlus,

--- a/apps/web/src/views/Swap/components/SwapWarningModal/bsc/index.tsx
+++ b/apps/web/src/views/Swap/components/SwapWarningModal/bsc/index.tsx
@@ -13,10 +13,9 @@ import NFPWarning from './NFPWarning'
 import PNPWarning from './PNPWarning'
 import RugPullWarning from './RugPullWarning'
 import SafemoonWarning from './SafemoonWarning'
-import UniBTCWarning from './UniBTCWarning'
 import XCADWarning from './XCADWarning'
 
-const { safemoon, bondly, itam, ccar, bttold, pokemoney, free, gala, abnbc, xcad, metis, lusd, nfp, pnp, uniBTC } =
+const { safemoon, bondly, itam, ccar, bttold, pokemoney, free, gala, abnbc, xcad, metis, lusd, nfp, pnp } =
   SwapWarningTokensConfig[ChainId.BSC]
 
 const BSC_WARNING_LIST = {
@@ -75,10 +74,6 @@ const BSC_WARNING_LIST = {
   [pnp.address]: {
     symbol: pnp.symbol,
     component: <PNPWarning />,
-  },
-  [uniBTC.address]: {
-    symbol: uniBTC.symbol,
-    component: <UniBTCWarning />,
   },
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing references to the `uniBTC` token from the swap warning tokens configuration and related components, streamlining the warning system for BSC.

### Detailed summary
- Removed `uniBTC` from `bscWarningTokens` in `swapWarningTokens.ts`.
- Eliminated the import of `UniBTCWarning` in `index.tsx`.
- Deleted the `uniBTC` entry from the `BSC_WARNING_LIST`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->