### PR TITLE
chore: Enable experimental trading for 20% of existing traffic

### DIFF
--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -37,7 +37,7 @@ export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   },
   {
     feature: EXPERIMENTAL_FEATURES.PCSX,
-    percentage: 0,
+    percentage: 0.2,
     whitelist: [],
   },
 ]

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -94,7 +94,7 @@ interface useBestAMMTradeOptions extends Options {
 
 type QuoteTrade = Pick<
   NonNullable<ReturnType<ReturnType<typeof bestTradeHookFactory>>['trade']>,
-  'inputAmount' | 'outputAmount' | 'tradeType'
+  'inputAmount' | 'outputAmount' | 'tradeType' | 'inputAmountWithGasAdjusted' | 'outputAmountWithGasAdjusted'
 >
 
 type QuoteResult = Pick<ReturnType<ReturnType<typeof bestTradeHookFactory>>, 'isLoading' | 'error'> & {
@@ -119,10 +119,14 @@ export function useBetterQuote<A extends QuoteResult, B extends QuoteResult>(
       return quoteA
     }
     return quoteA.trade.tradeType === TradeType.EXACT_INPUT
-      ? quoteB.trade.outputAmount.greaterThan(quoteA.trade!.outputAmount)
+      ? (quoteB.trade.outputAmountWithGasAdjusted ?? quoteB.trade.outputAmount).greaterThan(
+          quoteA.trade!.outputAmountWithGasAdjusted ?? quoteA.trade!.outputAmount,
+        )
         ? quoteB
         : quoteA
-      : quoteB.trade.inputAmount.lessThan(quoteA.trade!.inputAmount)
+      : (quoteB.trade.inputAmountWithGasAdjusted ?? quoteB.trade.inputAmount).lessThan(
+          quoteA.trade!.inputAmountWithGasAdjusted ?? quoteA.trade!.inputAmount,
+        )
       ? quoteB
       : quoteA
   }, [quoteA, quoteB])
@@ -212,7 +216,10 @@ function createSimpleUseGetBestTradeHook<T>(
 }
 
 function bestTradeHookFactory<
-  T extends Pick<SmartRouterTrade<TradeType>, 'inputAmount' | 'outputAmount' | 'tradeType'> & {
+  T extends Pick<
+    SmartRouterTrade<TradeType>,
+    'inputAmount' | 'outputAmount' | 'tradeType' | 'inputAmountWithGasAdjusted' | 'outputAmountWithGasAdjusted'
+  > & {
     routes: Pick<Route, 'path' | 'pools' | 'inputAmount' | 'outputAmount'>[]
     blockNumber?: BigintIsh
   },

--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -82,7 +82,7 @@ export const useAllTypeBestTrade = () => {
     // TODO: for log purpose in this stage
     betterOrder: betterQuote,
     bestOrder: finalOrder as InterfaceOrder | undefined,
-    tradeLoaded: finalOrder && !finalOrder.isLoading,
+    tradeLoaded: Boolean(finalOrder && !finalOrder.isLoading),
     tradeError: finalOrder?.error,
     refreshDisabled:
       finalOrder?.type === OrderType.DUTCH_LIMIT

--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -82,7 +82,7 @@ export const useAllTypeBestTrade = () => {
     // TODO: for log purpose in this stage
     betterOrder: betterQuote,
     bestOrder: finalOrder as InterfaceOrder | undefined,
-    tradeLoaded: !finalOrder?.isLoading,
+    tradeLoaded: finalOrder && !finalOrder.isLoading,
     tradeError: finalOrder?.error,
     refreshDisabled:
       finalOrder?.type === OrderType.DUTCH_LIMIT

--- a/apps/web/src/views/Swap/V3Swap/index.tsx
+++ b/apps/web/src/views/Swap/V3Swap/index.tsx
@@ -1,5 +1,7 @@
 import { SmartRouter } from '@pancakeswap/smart-router/evm'
 import { useMemo } from 'react'
+import { OrderType } from '@pancakeswap/price-api-sdk'
+
 import { logger } from 'utils/datadog'
 import { useCurrencyUsdPrice } from 'hooks/useCurrencyUsdPrice'
 
@@ -63,6 +65,7 @@ export function V3SwapForm() {
             },
             xOrder: xOrder
               ? {
+                  filler: xOrder.type === OrderType.DUTCH_LIMIT ? xOrder.trade.orderInfo.exclusiveFiller : undefined,
                   type: xOrder.type,
                   inputAmount: xInputAmount,
                   outputAmount: xOutputAmount,

--- a/packages/routing-sdk/addons/v3/src/constants/gasCost.ts
+++ b/packages/routing-sdk/addons/v3/src/constants/gasCost.ts
@@ -13,6 +13,7 @@ export const BASE_SWAP_COST_V3 = (id: ChainId): bigint => {
     case ChainId.ZKSYNC_TESTNET:
     case ChainId.POLYGON_ZKEVM:
     case ChainId.POLYGON_ZKEVM_TESTNET:
+    case ChainId.ARBITRUM_ONE:
     case ChainId.OPBNB:
     case ChainId.OPBNB_TESTNET:
       return 2000n
@@ -30,6 +31,7 @@ export const COST_PER_INIT_TICK = (id: ChainId): bigint => {
     case ChainId.ZKSYNC_TESTNET:
     case ChainId.POLYGON_ZKEVM:
     case ChainId.POLYGON_ZKEVM_TESTNET:
+    case ChainId.ARBITRUM_ONE:
     case ChainId.OPBNB:
     case ChainId.OPBNB_TESTNET:
       return 31000n
@@ -48,6 +50,7 @@ export const COST_PER_HOP_V3 = (id: ChainId): bigint => {
     case ChainId.ZKSYNC_TESTNET:
     case ChainId.POLYGON_ZKEVM:
     case ChainId.POLYGON_ZKEVM_TESTNET:
+    case ChainId.ARBITRUM_ONE:
     case ChainId.OPBNB:
     case ChainId.OPBNB_TESTNET:
       return 80000n

--- a/packages/smart-router/evm/v3-router/types/trade.ts
+++ b/packages/smart-router/evm/v3-router/types/trade.ts
@@ -8,7 +8,9 @@ import { Route } from './route'
 export interface SmartRouterTrade<TTradeType extends TradeType> {
   tradeType: TTradeType
   inputAmount: CurrencyAmount<Currency>
+  inputAmountWithGasAdjusted?: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>
+  outputAmountWithGasAdjusted?: CurrencyAmount<Currency>
 
   // From routes we know how many splits and what percentage does each split take
   routes: Route[]


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the trading features and configurations within the application, including adjustments to trade calculations, gas costs, and improving the handling of order types.

### Detailed summary
- Increased `percentage` for `EXPERIMENTAL_FEATURES.PCSX` from `0` to `0.2`.
- Updated `tradeLoaded` logic in `useAllTypeBestTrade` for better readability.
- Added `inputAmountWithGasAdjusted` and `outputAmountWithGasAdjusted` to `trade.ts`.
- Introduced conditional `filler` in `V3SwapForm` based on `OrderType.DUTCH_LIMIT`.
- Added support for `ChainId.ARBITRUM_ONE` in gas cost calculations.
- Enhanced `useBetterQuote` function to include `factorGasCost` option.
- Adjusted logic in `useBetterQuote` to consider gas-adjusted amounts for comparisons.
- Modified `createUseWorkerGetBestTradeOffchain` to handle candidate pools and gas price retrieval more robustly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->