### PR TITLE
fix: Inaccurate quote after on chain verification

### DIFF
--- a/.changeset/red-mangos-try.md
+++ b/.changeset/red-mangos-try.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/routing-sdk-addon-quoter': major
+---
+
+Add gas use estimate to quote

--- a/packages/routing-sdk/addons/quoter/src/fetchQuotes.ts
+++ b/packages/routing-sdk/addons/quoter/src/fetchQuotes.ts
@@ -25,7 +25,10 @@ export const fetchQuotes: FetchQuotes<SupportedPool> = async ({ routes, client }
     }
     const { path: currentPath } = routes[i]
     const outCurrency = isExactOut ? currentPath[0] : currentPath[currentPath.length - 1]
-    const [quote] = result.result
-    return CurrencyAmount.fromRawAmount(outCurrency, quote)
+    const [quote, , , gasUseEstimate] = result.result
+    return {
+      quote: CurrencyAmount.fromRawAmount(outCurrency, quote),
+      gasUseEstimate,
+    }
   })
 }

--- a/packages/routing-sdk/addons/quoter/src/fetchV3Quote.ts
+++ b/packages/routing-sdk/addons/quoter/src/fetchV3Quote.ts
@@ -33,7 +33,10 @@ export const fetchV3Quote: FetchQuote<SupportedPool> = async ({ route, client })
     allowFailure: false,
   })
 
-  const [[quote]] = result
+  const [[quote, , , gasUseEstimate]] = result
   const outCurrency = isExactOut ? path[0] : path[path.length - 1]
-  return CurrencyAmount.fromRawAmount(outCurrency, quote)
+  return {
+    quote: CurrencyAmount.fromRawAmount(outCurrency, quote),
+    gasUseEstimate,
+  }
 }

--- a/packages/routing-sdk/addons/quoter/src/types.ts
+++ b/packages/routing-sdk/addons/quoter/src/types.ts
@@ -16,10 +16,11 @@ export type FetchQuotesParams<P extends Pool = Pool> = {
   routes: QuoteRoute<P>[]
 }
 
-export type FetchQuote<P extends Pool = Pool> = (
-  params: FetchQuoteParams<P>,
-) => Promise<CurrencyAmount<Currency> | undefined>
+export type Quote = {
+  quote: CurrencyAmount<Currency>
+  gasUseEstimate: bigint
+}
 
-export type FetchQuotes<P extends Pool = Pool> = (
-  params: FetchQuotesParams<P>,
-) => Promise<(CurrencyAmount<Currency> | undefined)[]>
+export type FetchQuote<P extends Pool = Pool> = (params: FetchQuoteParams<P>) => Promise<Quote | undefined>
+
+export type FetchQuotes<P extends Pool = Pool> = (params: FetchQuotesParams<P>) => Promise<(Quote | undefined)[]>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds gas usage estimates to the quote functionality in the `@pancakeswap/routing-sdk-addon-quoter`. It modifies the quote fetching logic and updates types to include gas usage information, enhancing the functionality for users to better understand transaction costs.

### Detailed summary
- Updated `fetchV3Quote.ts` to return `gasUseEstimate` alongside the quote.
- Modified `fetchQuotes.ts` to include `gasUseEstimate` in the results.
- Revised `types.ts` to define a new `Quote` type that includes `gasUseEstimate`.
- Enhanced `useTradeVerifiedByQuoter.ts` to handle the new quote structure and adjust amounts based on gas estimates.
- Introduced a `reviseGasUseEstimate` function to adjust gas estimates based on trade type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->