### PR TITLE
fix: Failed to quote if failed to get gauge list

### DIFF
--- a/.changeset/heavy-wolves-yawn.md
+++ b/.changeset/heavy-wolves-yawn.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/gauges': patch
+---
+
+Fix unable to get pair combination when failed to get gauge list

--- a/packages/gauges/src/getGaugesByChain.ts
+++ b/packages/gauges/src/getGaugesByChain.ts
@@ -20,7 +20,7 @@ export const getGaugesByChain = createGaugesByChainFetcher()
 
 export async function safeGetGaugesByChain(chainId?: ChainId) {
   try {
-    return getGaugesByChain(chainId)
+    return await getGaugesByChain(chainId)
   } catch (e) {
     console.error(e)
     return []


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling in the `safeGetGaugesByChain` function by ensuring that the `getGaugesByChain` call is awaited, which helps in properly managing asynchronous operations.

### Detailed summary
- Updated the `safeGetGaugesByChain` function to use `await` with `getGaugesByChain(chainId)`, ensuring the promise resolves before proceeding.
- Enhanced error handling by maintaining the existing `try-catch` structure to log errors and return an empty array on failure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->