### PR TITLE
perf: Load polyfill only when timeout not available

### DIFF
--- a/apps/web/src/utils/abortcontroller-polyfill.ts
+++ b/apps/web/src/utils/abortcontroller-polyfill.ts
@@ -1,10 +1,14 @@
-import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
-
 if (!('timeout' in AbortSignal)) {
-  const timeoutFN = (ms: number) => {
-    const controller = new AbortController()
-    setTimeout(() => controller.abort(), ms)
-    return controller.signal
-  }
-  ;(AbortSignal as any).timeout = timeoutFN
+  import('abortcontroller-polyfill/dist/abortcontroller-polyfill-only')
+    .then(() => {
+      const timeoutFN = (ms: number) => {
+        const controller = new AbortController()
+        setTimeout(() => controller.abort(), ms)
+        return controller.signal
+      }
+      ;(AbortSignal as any).timeout = timeoutFN
+    })
+    .catch((err) => {
+      console.error('Error loading polyfill:', err)
+    })
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `abortcontroller-polyfill.ts` file to load the polyfill asynchronously. It ensures that the `AbortSignal` timeout functionality is defined only after the polyfill is successfully loaded, enhancing error handling for the polyfill loading process.

### Detailed summary
- Replaced synchronous polyfill definition with asynchronous loading using `import()`.
- Added a `.then()` block to define `timeoutFN` only after successful loading of the polyfill.
- Included a `.catch()` block to log an error message if the polyfill fails to load.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->