### PR TITLE
fix: Crash swap trade details

### DIFF
--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -135,12 +135,12 @@ export function useBetterQuote<A extends QuoteResult, B extends QuoteResult>(
     return quoteA.trade.tradeType === TradeType.EXACT_INPUT
       ? (
           (factorGasCost ? quoteB.trade.outputAmountWithGasAdjusted : undefined) ?? quoteB.trade.outputAmount
-        ).greaterThan(
+        )?.greaterThan(
           (factorGasCost ? quoteA.trade!.outputAmountWithGasAdjusted : undefined) ?? quoteA.trade!.outputAmount,
         )
         ? quoteB
         : quoteA
-      : ((factorGasCost ? quoteB.trade.inputAmountWithGasAdjusted : undefined) ?? quoteB.trade.inputAmount).lessThan(
+      : ((factorGasCost ? quoteB.trade.inputAmountWithGasAdjusted : undefined) ?? quoteB.trade.inputAmount)?.lessThan(
           (factorGasCost ? quoteA.trade!.inputAmountWithGasAdjusted : undefined) ?? quoteA.trade!.inputAmount,
         )
       ? quoteB

--- a/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
@@ -53,7 +53,7 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           priceImpactWithoutFee={priceImpactWithoutFee ?? undefined}
           realizedLPFee={lpFeeAmount ?? undefined}
           hasStablePair={hasStablePool}
-          gasTokenSelector={isPaymasterAvailable && <GasTokenSelector currency={order?.trade.inputAmount.currency} />}
+          gasTokenSelector={isPaymasterAvailable && inputAmount && <GasTokenSelector currency={inputAmount.currency} />}
         />
         {isXOrder(order) ? <XRoutesBreakdown /> : <RoutesBreakdown routes={order?.trade?.routes} />}
       </AutoColumn>

--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -75,14 +75,19 @@ export const useAllTypeBestTrade = () => {
     bestOrder.enabled && bestOrder.order?.type === OrderType.DUTCH_LIMIT && bestOrder.isValidQuote
   const betterQuote = useBetterQuote(classicAmmOrder, hasAvailableDutchOrder ? currentOrder : undefined)
   const finalOrder = xEnabled ? betterQuote : classicAmmOrder
+  const tradeLoaded = Boolean(finalOrder && !finalOrder.isLoading)
 
   return {
     ammOrder: classicAmmOrder,
     xOrder: currentOrder,
     // TODO: for log purpose in this stage
     betterOrder: betterQuote,
-    bestOrder: finalOrder as InterfaceOrder | undefined,
-    tradeLoaded: Boolean(finalOrder && !finalOrder.isLoading),
+    bestOrder: (tradeLoaded
+      ? finalOrder?.trade?.inputAmount && finalOrder?.trade?.outputAmount
+        ? finalOrder
+        : undefined
+      : finalOrder) as InterfaceOrder | undefined,
+    tradeLoaded,
     tradeError: finalOrder?.error,
     refreshDisabled:
       finalOrder?.type === OrderType.DUTCH_LIMIT


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of trade details and quotes in the `TradeDetails` and `useBestAMMTrade` components, ensuring better management of input amounts and the loading state of trades.

### Detailed summary
- Updated `gasTokenSelector` to use `inputAmount` instead of `order?.trade.inputAmount`.
- Enhanced conditional checks for trade amounts in `useBestAMMTrade`.
- Introduced `tradeLoaded` boolean to track the loading state of the final order in `useAllTypeBestTrade`.
- Adjusted `bestOrder` assignment logic to ensure it reflects the input and output amounts correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->