### PR TITLE
fix: dropdown menu button onclick missed

### DIFF
--- a/.changeset/twenty-swans-prove.md
+++ b/.changeset/twenty-swans-prove.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/uikit': patch
+---
+
+Fixed DropdownMenu component missed pass `onClick` props

--- a/packages/uikit/.storybook/main.js
+++ b/packages/uikit/.storybook/main.js
@@ -3,7 +3,11 @@ import { mergeConfig } from "vite";
 module.exports = {
   framework: {
     name: "@storybook/react-vite",
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: ".storybook/vite.config.ts",
+      },
+    },
   },
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [

--- a/packages/uikit/.storybook/vite.config.ts
+++ b/packages/uikit/.storybook/vite.config.ts
@@ -1,0 +1,7 @@
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [vanillaExtractPlugin()],
+  assetsInclude: ["/sb-preview/runtime.js"],
+});

--- a/packages/uikit/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/uikit/src/components/DropdownMenu/DropdownMenu.tsx
@@ -73,7 +73,7 @@ const MenuItem: React.FC<{
   return (
     <StyledDropdownMenuItemContainer key={label?.toString()}>
       {type === DropdownMenuItemType.BUTTON && (
-        <DropdownMenuItem $isActive={isActive} disabled={disabled || isDisabled} type="button">
+        <DropdownMenuItem $isActive={isActive} disabled={disabled || isDisabled} type="button" {...itemProps}>
           {MenuItemContent}
         </DropdownMenuItem>
       )}

--- a/packages/uikit/src/components/DropdownMenu/mock.tsx
+++ b/packages/uikit/src/components/DropdownMenu/mock.tsx
@@ -1,4 +1,3 @@
-import noop from "lodash/noop";
 import { DropdownMenuItems, DropdownMenuItemType } from "./types";
 
 const ItemsMock: DropdownMenuItems[] = [
@@ -20,7 +19,10 @@ const ItemsMock: DropdownMenuItems[] = [
   },
   {
     label: "Disconnect",
-    onClick: noop,
+    onClick: () => {
+      // eslint-disable-next-line no-alert
+      alert("disconnect");
+    },
     type: DropdownMenuItemType.BUTTON,
   },
 ];


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `DropdownMenu` component by ensuring it correctly passes the `onClick` prop and updating the Storybook configuration for better integration with Vite.

### Detailed summary
- Updated `DropdownMenu` component to properly pass `onClick` props.
- Modified `DropdownMenu` mock to trigger an alert on disconnect.
- Configured Storybook to use Vite with a specified configuration file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->