### PR TITLE
fix: Add mBTC-BTCB on BSC and mBTC-WBTC on ARB

### DIFF
--- a/packages/farms/src/farms/arb.ts
+++ b/packages/farms/src/farms/arb.ts
@@ -46,6 +46,15 @@ const pinnedFarmConfig: UniversalFarmConfig[] = [
 export const arbFarmConfig: UniversalFarmConfig[] = [
   ...pinnedFarmConfig,
   {
+    pid: 94,
+    chainId: ChainId.ARBITRUM_ONE,
+    protocol: Protocol.V3,
+    lpAddress: Pool.getAddress(arbitrumTokens.mBtc, arbitrumTokens.wbtc, FeeAmount.LOWEST),
+    token0: arbitrumTokens.mBtc,
+    token1: arbitrumTokens.wbtc,
+    feeAmount: FeeAmount.LOWEST,
+  },
+  {
     pid: 93,
     chainId: ChainId.ARBITRUM_ONE,
     protocol: Protocol.V3,

--- a/packages/farms/src/farms/bsc.ts
+++ b/packages/farms/src/farms/bsc.ts
@@ -1678,6 +1678,15 @@ export const bscFarmConfig: UniversalFarmConfig[] = [
     lpAddress: Pool.getAddress(bscTokens.ada, bscTokens.wbnb, FeeAmount.MEDIUM),
   },
   {
+    pid: 187,
+    chainId: ChainId.BSC,
+    protocol: Protocol.V3,
+    token0: bscTokens.btcb,
+    token1: bscTokens.mBtc,
+    feeAmount: FeeAmount.LOWEST,
+    lpAddress: Pool.getAddress(bscTokens.btcb, bscTokens.mBtc, FeeAmount.LOWEST),
+  },
+  {
     pid: 19,
     chainId: ChainId.BSC,
     protocol: Protocol.V3,

--- a/packages/farms/src/farms/bsc.ts
+++ b/packages/farms/src/farms/bsc.ts
@@ -9,15 +9,6 @@ import { Protocol, SerializedFarmConfig, UniversalFarmConfig, UniversalFarmConfi
 
 const pinnedFarmConfig: UniversalFarmConfig[] = [
   {
-    pid: 187,
-    chainId: ChainId.BSC,
-    protocol: Protocol.V3,
-    token0: bscTokens.btcb,
-    token1: bscTokens.mBtc,
-    feeAmount: FeeAmount.LOWEST,
-    lpAddress: Pool.getAddress(bscTokens.btcb, bscTokens.mBtc, FeeAmount.LOWEST),
-  },
-  {
     pid: 137,
     chainId: ChainId.BSC,
     protocol: Protocol.V3,
@@ -102,6 +93,15 @@ const pinnedFarmConfig: UniversalFarmConfig[] = [
 
 export const bscFarmConfig: UniversalFarmConfig[] = [
   ...pinnedFarmConfig,
+  {
+    pid: 187,
+    chainId: ChainId.BSC,
+    protocol: Protocol.V3,
+    token0: bscTokens.btcb,
+    token1: bscTokens.mBtc,
+    feeAmount: FeeAmount.LOWEST,
+    lpAddress: Pool.getAddress(bscTokens.btcb, bscTokens.mBtc, FeeAmount.LOWEST),
+  },
   {
     pid: 186,
     chainId: ChainId.BSC,

--- a/packages/farms/src/farms/bsc.ts
+++ b/packages/farms/src/farms/bsc.ts
@@ -9,6 +9,15 @@ import { Protocol, SerializedFarmConfig, UniversalFarmConfig, UniversalFarmConfi
 
 const pinnedFarmConfig: UniversalFarmConfig[] = [
   {
+    pid: 187,
+    chainId: ChainId.BSC,
+    protocol: Protocol.V3,
+    token0: bscTokens.btcb,
+    token1: bscTokens.mBtc,
+    feeAmount: FeeAmount.LOWEST,
+    lpAddress: Pool.getAddress(bscTokens.btcb, bscTokens.mBtc, FeeAmount.LOWEST),
+  },
+  {
     pid: 137,
     chainId: ChainId.BSC,
     protocol: Protocol.V3,
@@ -1676,15 +1685,6 @@ export const bscFarmConfig: UniversalFarmConfig[] = [
     token1: bscTokens.wbnb,
     feeAmount: FeeAmount.MEDIUM,
     lpAddress: Pool.getAddress(bscTokens.ada, bscTokens.wbnb, FeeAmount.MEDIUM),
-  },
-  {
-    pid: 187,
-    chainId: ChainId.BSC,
-    protocol: Protocol.V3,
-    token0: bscTokens.btcb,
-    token1: bscTokens.mBtc,
-    feeAmount: FeeAmount.LOWEST,
-    lpAddress: Pool.getAddress(bscTokens.btcb, bscTokens.mBtc, FeeAmount.LOWEST),
   },
   {
     pid: 19,


### PR DESCRIPTION
The gauge configuration of this 2 farms is already online. 
But the related farms is not released.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new farm configurations for the `BSC` and `Arbitrum` networks, adding support for additional liquidity pools.

### Detailed summary
- Added a new farm configuration for `BSC`:
  - `pid`: 187
  - `chainId`: `ChainId.BSC`
  - `protocol`: `Protocol.V3`
  - `token0`: `bscTokens.btcb`
  - `token1`: `bscTokens.mBtc`
  - `feeAmount`: `FeeAmount.LOWEST`
  - `lpAddress`: generated using `Pool.getAddress()`

- Added a new farm configuration for `Arbitrum`:
  - `pid`: 94
  - `chainId`: `ChainId.ARBITRUM_ONE`
  - `protocol`: `Protocol.V3`
  - `token0`: `arbitrumTokens.mBtc`
  - `token1`: `arbitrumTokens.wbtc`
  - `feeAmount`: `FeeAmount.LOWEST`
  - `lpAddress`: generated using `Pool.getAddress()`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->