### PR TITLE
chore: Ramp up experimental trading

### DIFF
--- a/apps/web/src/components/App/Transactions/XTransaction.tsx
+++ b/apps/web/src/components/App/Transactions/XTransaction.tsx
@@ -48,7 +48,7 @@ export function XTransaction({ order }: { order: GetXOrderReceiptResponseOrder }
       <TransactionListItem
         onClick={modal.onOpen}
         status={status}
-        title={<TransactionListItemTitle>{t('Experimental Trading')}</TransactionListItemTitle>}
+        title={<TransactionListItemTitle>PancakeSwap X</TransactionListItemTitle>}
         action={
           <FlexGap gap="0.25rem" justifyContent="flex-end">
             {status === TransactionStatus.Pending ? <Countdown to={order.deadline} /> : null}

--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModal.tsx
@@ -377,7 +377,7 @@ function RoutingSettings() {
         {xFeatureEnabled ? (
           <Flex justifyContent="space-between" alignItems="flex-start" mb="24px">
             <Flex flexDirection="column">
-              <Text>{t('Experimental Trading')}</Text>
+              <Text>PancakeSwap X</Text>
               <Text fontSize="12px" color="textSubtle" maxWidth={360} mt={10}>
                 When applicable, aggregates liquidity to provide better price, more token options, and gas free swaps.
               </Text>

--- a/apps/web/src/config/experimentalFeatures.ts
+++ b/apps/web/src/config/experimentalFeatures.ts
@@ -37,7 +37,7 @@ export const EXPERIMENTAL_FEATURE_CONFIGS: ExperimentalFeatureConfigs = [
   },
   {
     feature: EXPERIMENTAL_FEATURES.PCSX,
-    percentage: 0.2,
+    percentage: 1,
     whitelist: [],
   },
 ]

--- a/apps/web/src/views/Swap/V3Swap/components/RoutesBreakdown.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RoutesBreakdown.tsx
@@ -90,7 +90,7 @@ export const XRoutesBreakdown = memo(function XRoutesBreakdown() {
         <Box>
           <span style={{ display: 'flex', alignItems: 'center' }}>
             <Text color="primary" fontSize="14px">
-              {t('Experimental Trading')}
+              PancakeSwap X
             </Text>
           </span>
         </Box>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3514,7 +3514,6 @@
   "Unfilled orders will automatically expires after the countdown.": "Unfilled orders will automatically expires after the countdown.",
   "Order has been successfully filled.": "Order has been successfully filled.",
   "Output tokens have been sent to your wallet.": "Output tokens have been sent to your wallet.",
-  "Experimental Trading": "Experimental Trading",
   "Swap order filled": "Swap order filled",
   "We are having some trouble filling your order. Please retry.": "We are having some trouble filling your order. Please retry.",
   "No gas cost or fee will be charged on failed orders.": "No gas cost or fee will be charged on failed orders.",

--- a/packages/widgets-internal/swap/ApproveModalContent.tsx
+++ b/packages/widgets-internal/swap/ApproveModalContent.tsx
@@ -104,7 +104,7 @@ export const ApproveModalContent: React.FC<ApproveModalContentProps> = ({
                     <Text fontSize="14px">{t("Swapping thru:")}</Text>
                     {isX ? (
                       <Text ml="4px" fontSize="14px">
-                        {t("Experimental Trading")}
+                        PancakeSwap X
                       </Text>
                     ) : isBonus ? (
                       <Text ml="4px" fontSize="14px">

--- a/packages/widgets-internal/swap/ApproveModalContentV1.tsx
+++ b/packages/widgets-internal/swap/ApproveModalContentV1.tsx
@@ -29,7 +29,7 @@ export const ApproveModalContentV1: React.FC<ApproveModalContentProps> = ({ titl
           <Text fontSize="14px">{t("Swapping thru:")}</Text>
           {isX ? (
             <Text ml="4px" fontSize="14px">
-              {t("Experimental Trading")}
+              PancakeSwap X
             </Text>
           ) : isBonus ? (
             <Text ml="4px" fontSize="14px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming instances of `Experimental Trading` to `PancakeSwap X` across multiple files, reflecting a shift in branding or feature naming.

### Detailed summary
- In `experimentalFeatures.ts`, `percentage` changed from `0.2` to `1`.
- In `ApproveModalContent.tsx`, `Experimental Trading` replaced with `PancakeSwap X`.
- In `ApproveModalContentV1.tsx`, `Experimental Trading` replaced with `PancakeSwap X`.
- In `RoutesBreakdown.tsx`, `Experimental Trading` replaced with `PancakeSwap X`.
- In `XTransaction.tsx`, `title` changed from `Experimental Trading` to `PancakeSwap X`.
- In `SettingsModal.tsx`, `Experimental Trading` replaced with `PancakeSwap X`.
- In `translations.json`, the entry for `Experimental Trading` removed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->