### PR TITLE
fix: Invalid volume

### DIFF
--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -68,8 +68,8 @@ function fetchV3PoolsTvlVolumeFromSubgraph(pools: PoolIdentifier[]): Promise<Poo
     }
     const result = await client.request<V3PoolResult>(
       gql`
-        query pools($addresses: [String!]!, $startAt: Int!) {
-          poolDayDatas(first: 1000, where: { date_gt: $startAt, pool_in: $addresses }) {
+        query pools($addresses: [String!]!, $startAt: Int!, $endAt: Int!) {
+          poolDayDatas(first: 1000, where: { date_gte: $startAt, date_lt: $endAt, pool_in: $addresses }) {
             volumeUSD
             tvlUSD
             pool {
@@ -81,6 +81,7 @@ function fetchV3PoolsTvlVolumeFromSubgraph(pools: PoolIdentifier[]): Promise<Poo
       {
         addresses: poolsOnChain.map((p) => p.id),
         startAt: dayjs().utc().startOf('day').subtract(1, 'days').unix(),
+        endAt: dayjs().utc().startOf('day').unix(),
       },
     )
     return result.poolDayDatas.map((data) => ({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the GraphQL query for fetching pool data to include an `endAt` parameter, allowing for more precise date filtering.

### Detailed summary
- Added `endAt: Int!` parameter to the `pools` query.
- Changed the filter from `date_gt` to `date_gte` for `startAt`.
- Added `date_lt: $endAt` filter to the query.
- Updated the `fetchV3PoolsTvlVolumeFromSubgraph` function to include `endAt` in its parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->