### PR TITLE
chore: Rewrite info v3

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -88,20 +88,45 @@ const config = {
     ],
   },
   async rewrites() {
-    return [
-      {
-        source: '/info/token/:address',
-        destination: '/info/tokens/:address',
-      },
-      {
-        source: '/info/pool/:address',
-        destination: '/info/pools/:address',
-      },
-      {
-        source: '/.well-known/vercel/flags',
-        destination: '/api/vercel/flags',
-      },
-    ]
+    return {
+      afterFiles: [
+        {
+          source: '/info/token/:address',
+          destination: '/info/tokens/:address',
+        },
+        {
+          source: '/info/pool/:address',
+          destination: '/info/pools/:address',
+        },
+        {
+          source: '/.well-known/vercel/flags',
+          destination: '/api/vercel/flags',
+        },
+      ],
+      beforeFiles: [
+        // TODO: remove rewrite once explorer is fixed
+        {
+          source: '/info/v3',
+          destination: 'https://deprecated-info.pancake.run/info/v3',
+        },
+        {
+          source: '/info/v3/pairs',
+          destination: 'https://deprecated-info.pancake.run/info/v3/pairs',
+        },
+        {
+          source: '/info/v3/tokens',
+          destination: 'https://deprecated-info.pancake.run/info/v3/tokens',
+        },
+        {
+          source: '/info/v3/tokens/:path*',
+          destination: 'https://deprecated-info.pancake.run/info/v3/tokens/:path*',
+        },
+        {
+          source: '/info/v3/pairs/:path*',
+          destination: 'https://deprecated-info.pancake.run/info/v3/pairs/:path*',
+        },
+      ],
+    }
   },
   async headers() {
     return [


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `rewrites` function in `next.config.mjs` to include a new structure for handling URL rewrites, adding `beforeFiles` and `afterFiles` sections, and introduces several new rewrite rules for deprecated endpoints.

### Detailed summary
- Changed the return value of the `rewrites` function from an array to an object.
- Added `afterFiles` section with existing rewrite rules for `/info/token/:address`, `/info/pool/:address`, and `/.well-known/vercel/flags`.
- Introduced `beforeFiles` section with new rewrite rules for deprecated endpoints at `/info/v3` and its sub-paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->