### PR TITLE
chore: Fix info page domain blocking issue

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -107,23 +107,23 @@ const config = {
         // TODO: remove rewrite once explorer is fixed
         {
           source: '/info/v3',
-          destination: 'https://deprecated-info.pancake.run/info/v3',
+          destination: 'https://info-v1.pancakeswap.finance/info/v3',
         },
         {
           source: '/info/v3/pairs',
-          destination: 'https://deprecated-info.pancake.run/info/v3/pairs',
+          destination: 'https://info-v1.pancakeswap.finance/info/v3/pairs',
         },
         {
           source: '/info/v3/tokens',
-          destination: 'https://deprecated-info.pancake.run/info/v3/tokens',
+          destination: 'https://info-v1.pancakeswap.finance/info/v3/tokens',
         },
         {
           source: '/info/v3/tokens/:path*',
-          destination: 'https://deprecated-info.pancake.run/info/v3/tokens/:path*',
+          destination: 'https://info-v1.pancakeswap.finance/info/v3/tokens/:path*',
         },
         {
           source: '/info/v3/pairs/:path*',
-          destination: 'https://deprecated-info.pancake.run/info/v3/pairs/:path*',
+          destination: 'https://info-v1.pancakeswap.finance/info/v3/pairs/:path*',
         },
       ],
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `destination` URLs in the `next.config.mjs` file to point to a new endpoint for the PancakeSwap API, replacing deprecated URLs.

### Detailed summary
- Updated `destination` for `/info/v3` from `https://deprecated-info.pancake.run/info/v3` to `https://info-v1.pancakeswap.finance/info/v3`
- Updated `destination` for `/info/v3/pairs` from `https://deprecated-info.pancake.run/info/v3/pairs` to `https://info-v1.pancakeswap.finance/info/v3/pairs`
- Updated `destination` for `/info/v3/tokens` from `https://deprecated-info.pancake.run/info/v3/tokens` to `https://info-v1.pancakeswap.finance/info/v3/tokens`
- Updated `destination` for `/info/v3/tokens/:path*` from `https://deprecated-info.pancake.run/info/v3/tokens/:path*` to `https://info-v1.pancakeswap.finance/info/v3/tokens/:path*`
- Updated `destination` for `/info/v3/pairs/:path*` from `https://deprecated-info.pancake.run/info/v3/pairs/:path*` to `https://info-v1.pancakeswap.finance/info/v3/pairs/:path*`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->