### PR TITLE
chore: Add api key for aptos api access

### DIFF
--- a/apps/aptos/client.ts
+++ b/apps/aptos/client.ts
@@ -7,11 +7,12 @@ import { PetraConnector } from '@pancakeswap/awgmi/connectors/petra'
 import { PontemConnector } from '@pancakeswap/awgmi/connectors/pontem'
 import { RiseConnector } from '@pancakeswap/awgmi/connectors/rise'
 import { SafePalConnector } from '@pancakeswap/awgmi/connectors/safePal'
-import { Aptos, AptosConfig, NetworkToNetworkName } from '@aptos-labs/ts-sdk'
+import { Aptos, AptosConfig, Network, NetworkToNetworkName } from '@aptos-labs/ts-sdk'
 import { chains, defaultChain } from 'config/chains'
 
 const NODE_REAL_API = process.env.NEXT_PUBLIC_NODE_REAL_API
 const NODE_REAL_API_TESTNET = process.env.NEXT_PUBLIC_NODE_REAL_API_TESTNET
+const APTOS_GATEWAY_API_KEY = process.env.NEXT_PUBLIC_APTOS_GATEWAY_API_KEY
 
 const nodeReal = {
   ...(NODE_REAL_API && {
@@ -38,6 +39,16 @@ export const client = createClient({
   ],
   provider: ({ networkName }) => {
     const networkNameLowerCase = networkName?.toLowerCase()
+    const network = NetworkToNetworkName[networkNameLowerCase ?? defaultChain.network.toLowerCase()]
+    const clientConfig =
+      network === Network.MAINNET
+        ? {
+            API_KEY: APTOS_GATEWAY_API_KEY,
+          }
+        : {
+            WITH_CREDENTIALS: false,
+          }
+
     if (networkNameLowerCase) {
       const foundChain = chains.find((c) => c.network === networkNameLowerCase)
       if (foundChain) {
@@ -46,15 +57,14 @@ export const client = createClient({
             new AptosConfig({
               network: NetworkToNetworkName[networkNameLowerCase],
               fullnode: `${foundChain.nodeUrls.nodeReal}/${nodeReal[networkNameLowerCase]}/v1`,
-              clientConfig: {
-                WITH_CREDENTIALS: false,
-              },
+              clientConfig,
             }),
           )
         }
         return new Aptos(
           new AptosConfig({
             network: NetworkToNetworkName[networkNameLowerCase],
+            clientConfig,
           }),
         )
       }
@@ -64,6 +74,7 @@ export const client = createClient({
       new AptosConfig({
         network: NetworkToNetworkName[defaultChain.network.toLowerCase()],
         fullnode: defaultChain.nodeUrls.default,
+        clientConfig,
       }),
     )
   },

--- a/apps/aptos/client.ts
+++ b/apps/aptos/client.ts
@@ -45,9 +45,7 @@ export const client = createClient({
         ? {
             API_KEY: APTOS_GATEWAY_API_KEY,
           }
-        : {
-            WITH_CREDENTIALS: false,
-          }
+        : undefined
 
     if (networkNameLowerCase) {
       const foundChain = chains.find((c) => c.network === networkNameLowerCase)
@@ -57,7 +55,9 @@ export const client = createClient({
             new AptosConfig({
               network: NetworkToNetworkName[networkNameLowerCase],
               fullnode: `${foundChain.nodeUrls.nodeReal}/${nodeReal[networkNameLowerCase]}/v1`,
-              clientConfig,
+              clientConfig: {
+                WITH_CREDENTIALS: false,
+              },
             }),
           )
         }

--- a/apps/aptos/client.ts
+++ b/apps/aptos/client.ts
@@ -53,7 +53,7 @@ export const client = createClient({
         if (foundChain.nodeUrls.nodeReal && nodeReal[networkNameLowerCase]) {
           return new Aptos(
             new AptosConfig({
-              network: NetworkToNetworkName[networkNameLowerCase],
+              network,
               fullnode: `${foundChain.nodeUrls.nodeReal}/${nodeReal[networkNameLowerCase]}/v1`,
               clientConfig: {
                 WITH_CREDENTIALS: false,
@@ -63,7 +63,7 @@ export const client = createClient({
         }
         return new Aptos(
           new AptosConfig({
-            network: NetworkToNetworkName[networkNameLowerCase],
+            network,
             clientConfig,
           }),
         )
@@ -72,7 +72,7 @@ export const client = createClient({
 
     return new Aptos(
       new AptosConfig({
-        network: NetworkToNetworkName[defaultChain.network.toLowerCase()],
+        network,
         fullnode: defaultChain.nodeUrls.default,
         clientConfig,
       }),

--- a/apps/aptos/next-env.d.ts
+++ b/apps/aptos/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.20.0"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.12.2",
+    "@aptos-labs/ts-sdk": "1.30.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/keccak256": "^5.7.0",
     "@pancakeswap/aptos-swap-sdk": "workspace:*",

--- a/apps/aptos/package.json
+++ b/apps/aptos/package.json
@@ -15,7 +15,7 @@
     "node": ">=18.20.0"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.30.0",
+    "@aptos-labs/ts-sdk": "catalog:",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/keccak256": "^5.7.0",
     "@pancakeswap/aptos-swap-sdk": "workspace:*",

--- a/packages/aptos-swap-sdk/package.json
+++ b/packages/aptos-swap-sdk/package.json
@@ -37,7 +37,7 @@
     "@aptos-labs/ts-sdk": "1.x"
   },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": "1.12.2",
+    "@aptos-labs/ts-sdk": "catalog:",
     "@types/big.js": "^4.0.5",
     "tsup": "^6.7.0"
   },

--- a/packages/awgmi/package.json
+++ b/packages/awgmi/package.json
@@ -25,7 +25,7 @@
     "react": "^18.2.0"
   },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": "1.12.2",
+    "@aptos-labs/ts-sdk": "catalog:",
     "@blocto/sdk": "^0.5.4",
     "@msafe/aptos-wallet": "^3.0.6",
     "@pancakeswap/tsconfig": "workspace:*",

--- a/packages/awgmi/src/hooks/useAccountBalances.ts
+++ b/packages/awgmi/src/hooks/useAccountBalances.ts
@@ -75,7 +75,7 @@ export function useAccountBalances<TData = unknown>({
   const v2Balances = coinsData?.[1]
   const v1AssetsTypes = useV1CoinAssetTypes({
     networkName,
-    assetTypes: v2Balances?.map((b) => b.asset_type) || [],
+    assetTypes: v2Balances?.map((b) => b.asset_type).filter((b): b is string => typeof b === 'string') || [],
     enabled: Boolean(isSuccess && v2Balances?.length),
   })
   const { isFetched, data: mappedV2Balances } = useMemo(() => {
@@ -108,6 +108,7 @@ export function useAccountBalances<TData = unknown>({
     for (const b of allBalances) {
       if (!b) continue
       const id = b.asset_type
+      if (typeof id !== 'string') continue
       const amount = assetTypeToBalance.get(id) || 0
       assetTypeToBalance.set(id, amount + b.amount)
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ importers:
   apps/aptos:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.12.2
-        version: 1.12.2
+        specifier: 1.30.0
+        version: 1.30.0
       '@ethersproject/bignumber':
         specifier: ^5.7.0
         version: 5.7.0
@@ -1676,7 +1676,7 @@ importers:
     dependencies:
       '@layerzerolabs/scan-client':
         specifier: ^0.0.6
-        version: 0.0.6(axios@1.7.2)
+        version: 0.0.6(axios@1.7.4)
       '@pancakeswap/chains':
         specifier: workspace:*
         version: link:../chains
@@ -2950,12 +2950,24 @@ packages:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
 
+  '@aptos-labs/aptos-cli@1.0.1':
+    resolution: {integrity: sha512-ANHX8O6akexkJgWu+aWEO09gRmg7NjIwztdLd/09sZw+XTZEWx1CPN3RsGESosM0c0uiWpjSGRa2phcYKZkjmw==}
+    hasBin: true
+
   '@aptos-labs/aptos-client@0.1.0':
     resolution: {integrity: sha512-q3s6pPq8H2buGp+tPuIRInWsYOuhSEwuNJPwd2YnsiID3YSLihn2ug39ktDJAcSOprUcp7Nid8WK7hKqnUmSdA==}
     engines: {node: '>=15.10.0'}
 
+  '@aptos-labs/aptos-client@0.1.1':
+    resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
+    engines: {node: '>=15.10.0'}
+
   '@aptos-labs/ts-sdk@1.12.2':
     resolution: {integrity: sha512-AjKkM5mc5Qx5W5uRFK0R3/PXNnBBheHm2qZwWsvFkhVv2WbHDwvZ/e3httcR1f1grM6VMIALpjqBKkq4WQE/SQ==}
+    engines: {node: '>=11.0.0'}
+
+  '@aptos-labs/ts-sdk@1.30.0':
+    resolution: {integrity: sha512-zlb8+YLcq+daKJUbNZvKr4JvV+tRLwCRQnn1PRebgYJ1pieZfhT3Dtz5Ve130cGOLpTcxMHRW9siXukvUUMHiQ==}
     engines: {node: '>=11.0.0'}
 
   '@aw-web-design/x-default-browser@1.4.126':
@@ -8997,6 +9009,9 @@ packages:
   axios@1.7.2:
     resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
+  axios@1.7.4:
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
+
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
 
@@ -9613,6 +9628,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -10159,9 +10178,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  defu@6.1.3:
-    resolution: {integrity: sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ==}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -12292,6 +12308,10 @@ packages:
   jwt-decode@3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
+
   keccak@3.0.4:
     resolution: {integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==}
     engines: {node: '>=10.0.0'}
@@ -13739,6 +13759,9 @@ packages:
 
   popper.js@1.16.1-lts:
     resolution: {integrity: sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==}
+
+  poseidon-lite@0.2.1:
+    resolution: {integrity: sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -16908,9 +16931,20 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
 
+  '@aptos-labs/aptos-cli@1.0.1':
+    dependencies:
+      commander: 12.1.0
+
   '@aptos-labs/aptos-client@0.1.0':
     dependencies:
       axios: 1.6.2
+      got: 11.8.6
+    transitivePeerDependencies:
+      - debug
+
+  '@aptos-labs/aptos-client@0.1.1':
+    dependencies:
+      axios: 1.7.4
       got: 11.8.6
     transitivePeerDependencies:
       - debug
@@ -16925,6 +16959,22 @@ snapshots:
       eventemitter3: 5.0.1
       form-data: 4.0.0
       tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@aptos-labs/ts-sdk@1.30.0':
+    dependencies:
+      '@aptos-labs/aptos-cli': 1.0.1
+      '@aptos-labs/aptos-client': 0.1.1
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      eventemitter3: 5.0.1
+      form-data: 4.0.0
+      js-base64: 3.7.7
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.1
     transitivePeerDependencies:
       - debug
 
@@ -20428,9 +20478,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@layerzerolabs/scan-client@0.0.6(axios@1.7.2)':
+  '@layerzerolabs/scan-client@0.0.6(axios@1.7.4)':
     dependencies:
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.4
 
   '@ledgerhq/connect-kit-loader@1.1.2(patch_hash=xlsebypdiwsukm3c2ow7voujra)': {}
 
@@ -27219,6 +27269,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  axios@1.7.4:
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.3.4)
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@3.2.1:
     dependencies:
       dequal: 2.0.3
@@ -27987,6 +28045,8 @@ snapshots:
   commander@10.0.1:
     optional: true
 
+  commander@12.1.0: {}
+
   commander@2.20.3: {}
 
   commander@3.0.2:
@@ -28636,8 +28696,6 @@ snapshots:
       define-data-property: 1.1.1
       has-property-descriptors: 1.0.1
       object-keys: 1.1.1
-
-  defu@6.1.3: {}
 
   defu@6.1.4: {}
 
@@ -30188,11 +30246,11 @@ snapshots:
   giget@1.1.3:
     dependencies:
       colorette: 2.0.20
-      defu: 6.1.3
+      defu: 6.1.4
       https-proxy-agent: 7.0.2
       mri: 1.2.0
       node-fetch-native: 1.4.1
-      pathe: 1.1.1
+      pathe: 1.1.2
       tar: 6.2.0
     transitivePeerDependencies:
       - supports-color
@@ -30408,11 +30466,11 @@ snapshots:
   h3@1.8.2:
     dependencies:
       cookie-es: 1.0.0
-      defu: 6.1.3
+      defu: 6.1.4
       destr: 2.0.2
       iron-webcrypto: 0.10.1
       radix3: 1.1.0
-      ufo: 1.3.1
+      ufo: 1.5.4
       uncrypto: 0.1.3
       unenv: 1.7.4
 
@@ -31470,6 +31528,8 @@ snapshots:
 
   jwt-decode@3.1.2: {}
 
+  jwt-decode@4.0.0: {}
+
   keccak@3.0.4:
     dependencies:
       node-addon-api: 2.0.2
@@ -31636,16 +31696,16 @@ snapshots:
       citty: 0.1.4
       clipboardy: 3.0.0
       consola: 3.2.3
-      defu: 6.1.3
+      defu: 6.1.4
       get-port-please: 3.1.1
       h3: 1.8.2
       http-shutdown: 1.2.2
       jiti: 1.21.0
       mlly: 1.4.2
       node-forge: 1.3.1
-      pathe: 1.1.1
+      pathe: 1.1.2
       std-env: 3.7.0
-      ufo: 1.3.1
+      ufo: 1.5.4
       untun: 0.1.2
       uqr: 0.1.2
 
@@ -32795,7 +32855,7 @@ snapshots:
     dependencies:
       destr: 2.0.2
       node-fetch-native: 1.4.1
-      ufo: 1.3.1
+      ufo: 1.5.4
 
   ohash@1.1.4: {}
 
@@ -33194,6 +33254,8 @@ snapshots:
   pony-cause@2.1.10: {}
 
   popper.js@1.16.1-lts: {}
+
+  poseidon-lite@0.2.1: {}
 
   postcss-import@15.1.0(postcss@8.4.33):
     dependencies:
@@ -36127,7 +36189,7 @@ snapshots:
       mri: 1.2.0
       node-fetch-native: 1.4.1
       ofetch: 1.3.3
-      ufo: 1.3.1
+      ufo: 1.5.4
     optionalDependencies:
       idb-keyval: 6.2.1
     transitivePeerDependencies:
@@ -36139,7 +36201,7 @@ snapshots:
     dependencies:
       citty: 0.1.4
       consola: 3.2.3
-      pathe: 1.1.1
+      pathe: 1.1.2
 
   update-browserslist-db@1.0.13(browserslist@4.22.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@aptos-labs/ts-sdk':
+      specifier: 1.30.0
+      version: 1.30.0
     next:
       specifier: 14.2.14
       version: 14.2.14
@@ -243,7 +246,7 @@ importers:
   apps/aptos:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.30.0
+        specifier: 'catalog:'
         version: 1.30.0
       '@ethersproject/bignumber':
         specifier: ^5.7.0
@@ -289,7 +292,7 @@ importers:
         version: link:../../packages/widgets-internal
       '@reduxjs/toolkit':
         specifier: ^1.9.1
-        version: 1.9.7(react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1))(react@18.2.0)
+        version: 1.9.7(react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1))(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^5.52.1
         version: 5.52.1(react@18.2.0)
@@ -298,7 +301,7 @@ importers:
         version: 1.14.0
       '@vanilla-extract/next-plugin':
         specifier: ^2.3.0
-        version: 2.3.2(@types/node@18.0.4)(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(terser@5.24.0)(webpack@5.89.0(esbuild@0.17.19))
+        version: 2.3.2(@types/node@18.0.4)(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(terser@5.24.0)(webpack@5.89.0(esbuild@0.17.19))
       '@vanilla-extract/recipes':
         specifier: ^0.5.0
         version: 0.5.1(@vanilla-extract/css@1.14.0)
@@ -316,13 +319,13 @@ importers:
         version: 4.17.21
       next:
         specifier: 'catalog:'
-        version: 14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-seo:
         specifier: ^5.15.0
-        version: 5.15.0(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 5.15.0(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -401,16 +404,16 @@ importers:
         version: 5.52.1(react@18.2.0)
       '@vanilla-extract/next-plugin':
         specifier: ^2.3.0
-        version: 2.3.2(@types/node@18.0.4)(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(terser@5.24.0)(webpack@5.89.0(esbuild@0.17.19))
+        version: 2.3.2(@types/node@18.0.4)(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(terser@5.24.0)(webpack@5.89.0(esbuild@0.17.19))
       next:
         specifier: 'catalog:'
-        version: 14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-seo:
         specifier: ^5.15.0
-        version: 5.15.0(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 5.15.0(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-themes:
         specifier: ^0.2.1
-        version: 0.2.1(next@14.2.14(@babel/core@7.23.9)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.2.1(next@14.2.14(@babel/core@7.23.3)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       qs:
         specifier: ^6.0.0
         version: 6.11.2
@@ -1423,8 +1426,8 @@ importers:
         version: 2.0.0
     devDependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.12.2
-        version: 1.12.2
+        specifier: 'catalog:'
+        version: 1.30.0
       '@types/big.js':
         specifier: ^4.0.5
         version: 4.0.5
@@ -1451,8 +1454,8 @@ importers:
         version: 4.4.6(@types/react@18.2.37)(immer@9.0.21)(react@18.2.0)
     devDependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.12.2
-        version: 1.12.2
+        specifier: 'catalog:'
+        version: 1.30.0
       '@blocto/sdk':
         specifier: ^0.5.4
         version: 0.5.5(@solana/web3.js@1.87.6(bufferutil@4.0.8)(utf-8-validate@5.0.10))(aptos@1.21.0)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -2961,10 +2964,6 @@ packages:
   '@aptos-labs/aptos-client@0.1.1':
     resolution: {integrity: sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==}
     engines: {node: '>=15.10.0'}
-
-  '@aptos-labs/ts-sdk@1.12.2':
-    resolution: {integrity: sha512-AjKkM5mc5Qx5W5uRFK0R3/PXNnBBheHm2qZwWsvFkhVv2WbHDwvZ/e3httcR1f1grM6VMIALpjqBKkq4WQE/SQ==}
-    engines: {node: '>=11.0.0'}
 
   '@aptos-labs/ts-sdk@1.30.0':
     resolution: {integrity: sha512-zlb8+YLcq+daKJUbNZvKr4JvV+tRLwCRQnn1PRebgYJ1pieZfhT3Dtz5Ve130cGOLpTcxMHRW9siXukvUUMHiQ==}
@@ -5497,9 +5496,6 @@ packages:
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
-
   '@noble/curves@1.6.0':
     resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
     engines: {node: ^14.21.3 || >=16}
@@ -5523,10 +5519,6 @@ packages:
 
   '@noble/hashes@1.3.3':
     resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
-    engines: {node: '>= 16'}
-
-  '@noble/hashes@1.4.0':
-    resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
 
   '@noble/hashes@1.5.0':
@@ -6620,9 +6612,6 @@ packages:
   '@scure/bip32@1.3.2':
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
 
-  '@scure/bip32@1.4.0':
-    resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
-
   '@scure/bip32@1.5.0':
     resolution: {integrity: sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==}
 
@@ -6631,9 +6620,6 @@ packages:
 
   '@scure/bip39@1.2.1':
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
-
-  '@scure/bip39@1.3.0':
-    resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
 
   '@scure/bip39@1.4.0':
     resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
@@ -16944,21 +16930,8 @@ snapshots:
 
   '@aptos-labs/aptos-client@0.1.1':
     dependencies:
-      axios: 1.7.4
+      axios: 1.7.4(debug@4.3.4)
       got: 11.8.6
-    transitivePeerDependencies:
-      - debug
-
-  '@aptos-labs/ts-sdk@1.12.2':
-    dependencies:
-      '@aptos-labs/aptos-client': 0.1.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/bip32': 1.4.0
-      '@scure/bip39': 1.3.0
-      eventemitter3: 5.0.1
-      form-data: 4.0.0
-      tweetnacl: 1.0.3
     transitivePeerDependencies:
       - debug
 
@@ -17354,15 +17327,6 @@ snapshots:
       '@babel/core': 7.23.3
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.3)
-    optional: true
-
   '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
@@ -17383,38 +17347,17 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.23.3)
-    optional: true
-
   '@babel/plugin-proposal-export-default-from@7.24.1(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.23.9)
 
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
-    optional: true
-
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.9)
-
-  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.3)
-    optional: true
 
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.23.9)':
     dependencies:
@@ -17440,26 +17383,11 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.9)
 
-  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.3)
-    optional: true
-
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.9)
-
-  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
-    optional: true
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.9)':
     dependencies:
@@ -17516,12 +17444,6 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-    optional: true
-
   '@babel/plugin-syntax-export-default-from@7.24.1(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
@@ -17536,12 +17458,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-    optional: true
 
   '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -17892,13 +17808,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.9)
 
-  '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.3)
-    optional: true
-
   '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
@@ -18197,22 +18106,10 @@ snapshots:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.9)
 
-  '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
-    optional: true
-
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-plugin-utils': 7.22.5
-    optional: true
 
   '@babel/plugin-transform-react-jsx-source@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -18270,19 +18167,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-runtime@7.24.3(@babel/core@7.23.3)':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-imports': 7.24.3
-      '@babel/helper-plugin-utils': 7.24.0
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.23.3)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.23.3)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.23.3)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@babel/plugin-transform-runtime@7.24.3(@babel/core@7.23.9)':
     dependencies:
@@ -18733,7 +18617,7 @@ snapshots:
       '@binance/w3w-types': 1.1.4
       '@binance/w3w-utils': 1.1.4
       '@ethersproject/abi': 5.7.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
       js-base64: 3.7.7
     transitivePeerDependencies:
       - bufferutil
@@ -18748,7 +18632,7 @@ snapshots:
       '@binance/w3w-types': 1.1.4
       '@binance/w3w-utils': 1.1.4
       '@ethersproject/abi': 5.7.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
       js-base64: 3.7.7
     transitivePeerDependencies:
       - bufferutil
@@ -20480,7 +20364,7 @@ snapshots:
 
   '@layerzerolabs/scan-client@0.0.6(axios@1.7.4)':
     dependencies:
-      axios: 1.7.4
+      axios: 1.7.4(debug@4.3.4)
 
   '@ledgerhq/connect-kit-loader@1.1.2(patch_hash=xlsebypdiwsukm3c2ow7voujra)': {}
 
@@ -20977,10 +20861,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.2
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
   '@noble/curves@1.6.0':
     dependencies:
       '@noble/hashes': 1.5.0
@@ -20997,8 +20877,6 @@ snapshots:
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.3.3': {}
-
-  '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.5.0': {}
 
@@ -21637,7 +21515,7 @@ snapshots:
     dependencies:
       '@pythnetwork/price-service-sdk': 1.4.1
       '@types/ws': 8.5.10
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
       axios-retry: 3.9.1
       isomorphic-ws: 4.0.1(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       ts-log: 2.2.5
@@ -22128,69 +22006,12 @@ snapshots:
 
   '@react-native/assets-registry@0.73.1': {}
 
-  '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.23.3(@babel/core@7.23.3))':
-    dependencies:
-      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-    optional: true
-
   '@react-native/babel-plugin-codegen@0.73.4(@babel/preset-env@7.23.3(@babel/core@7.23.9))':
     dependencies:
       '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.3(@babel/core@7.23.9))
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
-
-  '@react-native/babel-preset@0.73.21(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.3)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-export-default-from': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.3)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.3)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-export-default-from': 7.24.1(@babel/core@7.23.3)
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-block-scoping': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-classes': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-flow-strip-types': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.3)
-      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-private-property-in-object': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-runtime': 7.24.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-typescript': 7.23.3(@babel/core@7.23.3)
-      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.3)
-      '@babel/template': 7.23.9
-      '@react-native/babel-plugin-codegen': 0.73.4(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.23.3)
-      react-refresh: 0.14.0
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-    optional: true
 
   '@react-native/babel-preset@0.73.21(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))':
     dependencies:
@@ -22240,20 +22061,6 @@ snapshots:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/codegen@0.73.3(@babel/preset-env@7.23.3(@babel/core@7.23.3))':
-    dependencies:
-      '@babel/parser': 7.23.9
-      '@babel/preset-env': 7.23.3(@babel/core@7.23.3)
-      flow-parser: 0.206.0
-      glob: 7.2.3
-      invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@react-native/codegen@0.73.3(@babel/preset-env@7.23.3(@babel/core@7.23.9))':
     dependencies:
       '@babel/parser': 7.23.9
@@ -22266,28 +22073,6 @@ snapshots:
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@react-native/community-cli-plugin@0.73.17(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@react-native-community/cli-server-api': 12.3.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@react-native-community/cli-tools': 12.3.6
-      '@react-native/dev-middleware': 0.73.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@react-native/metro-babel-transformer': 0.73.15(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-      chalk: 4.1.2
-      execa: 5.1.1
-      metro: 0.80.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      metro-config: 0.80.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      metro-core: 0.80.8
-      node-fetch: 2.7.0
-      readline: 1.3.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   '@react-native/community-cli-plugin@0.73.17(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
@@ -22335,17 +22120,6 @@ snapshots:
 
   '@react-native/js-polyfills@0.73.1': {}
 
-  '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))':
-    dependencies:
-      '@babel/core': 7.23.3
-      '@react-native/babel-preset': 0.73.21(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-      hermes-parser: 0.15.0
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/preset-env'
-      - supports-color
-    optional: true
-
   '@react-native/metro-babel-transformer@0.73.15(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))':
     dependencies:
       '@babel/core': 7.23.9
@@ -22357,13 +22131,6 @@ snapshots:
       - supports-color
 
   '@react-native/normalize-colors@0.73.2': {}
-
-  '@react-native/virtualized-lists@0.73.4(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10)
-    optional: true
 
   '@react-native/virtualized-lists@0.73.4(react-native@0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))':
     dependencies:
@@ -22396,16 +22163,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@reduxjs/toolkit@1.9.7(react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1))(react@18.2.0)':
-    dependencies:
-      immer: 9.0.21
-      redux: 4.2.1
-      redux-thunk: 2.4.2(redux@4.2.1)
-      reselect: 4.1.8
-    optionalDependencies:
-      react: 18.2.0
-      react-redux: 8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1)
 
   '@reduxjs/toolkit@1.9.7(react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1))(react@18.2.0)':
     dependencies:
@@ -22586,12 +22343,6 @@ snapshots:
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.9
 
-  '@scure/bip32@1.4.0':
-    dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.7
-
   '@scure/bip32@1.5.0':
     dependencies:
       '@noble/curves': 1.6.0
@@ -22607,11 +22358,6 @@ snapshots:
   '@scure/bip39@1.2.1':
     dependencies:
       '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.7
-
-  '@scure/bip39@1.3.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
       '@scure/base': 1.1.7
 
   '@scure/bip39@1.4.0':
@@ -25792,7 +25538,7 @@ snapshots:
       '@walletconnect/did-jwt': 2.0.3
       '@walletconnect/types': 2.11.0
       '@walletconnect/utils': 2.11.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -25821,7 +25567,7 @@ snapshots:
       '@walletconnect/did-jwt': 2.0.3
       '@walletconnect/types': 2.11.0
       '@walletconnect/utils': 2.11.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -26048,7 +25794,7 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.7
       '@walletconnect/time': 1.0.2
       '@walletconnect/utils': 2.11.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
       jwt-decode: 3.1.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -26078,7 +25824,7 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.7
       '@walletconnect/time': 1.0.2
       '@walletconnect/utils': 2.11.0
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.2
       jwt-decode: 3.1.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27261,7 +27007,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.2(debug@4.3.4):
+  axios@1.7.2:
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
@@ -27269,7 +27015,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.4:
+  axios@1.7.4(debug@4.3.4):
     dependencies:
       follow-redirects: 1.15.6(debug@4.3.4)
       form-data: 4.0.0
@@ -27326,15 +27072,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.23.3):
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.3)
-      core-js-compat: 3.36.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.23.9):
     dependencies:
       '@babel/core': 7.23.9
@@ -27373,14 +27110,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.23.3):
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.3)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.23.9):
     dependencies:
       '@babel/core': 7.23.9
@@ -27397,13 +27126,6 @@ snapshots:
       styled-components: 6.0.7(babel-plugin-styled-components@1.13.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   babel-plugin-syntax-jsx@6.18.0: {}
-
-  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.23.3):
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.23.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-    optional: true
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.23.9):
     dependencies:
@@ -29484,7 +29206,7 @@ snapshots:
   eth-gas-reporter@0.2.27(bufferutil@4.0.8)(debug@4.3.4)(utf-8-validate@5.0.10):
     dependencies:
       '@solidity-parser/parser': 0.14.5
-      axios: 1.7.2(debug@4.3.4)
+      axios: 1.7.4(debug@4.3.4)
       cli-table3: 0.5.1
       colors: 1.4.0
       ethereum-cryptography: 1.2.0
@@ -31345,32 +31067,6 @@ snapshots:
   jsc-android@250231.0.0: {}
 
   jsc-safe-url@0.2.4: {}
-
-  jscodeshift@0.14.0(@babel/preset-env@7.23.3(@babel/core@7.23.3)):
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/parser': 7.23.9
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.9)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.9)
-      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
-      '@babel/preset-env': 7.23.3(@babel/core@7.23.3)
-      '@babel/preset-flow': 7.23.3(@babel/core@7.23.9)
-      '@babel/preset-typescript': 7.23.3(@babel/core@7.23.9)
-      '@babel/register': 7.22.15(@babel/core@7.23.9)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.23.9)
-      chalk: 4.1.2
-      flow-parser: 0.221.0
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      neo-async: 2.6.2
-      node-dir: 0.1.17
-      recast: 0.21.5
-      temp: 0.8.4
-      write-file-atomic: 2.4.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   jscodeshift@0.14.0(@babel/preset-env@7.23.3(@babel/core@7.23.9)):
     dependencies:
@@ -33855,56 +33551,6 @@ snapshots:
       react: 18.2.0
       react-native: 0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10)
 
-  react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 12.3.6(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@react-native-community/cli-platform-android': 12.3.6
-      '@react-native-community/cli-platform-ios': 12.3.6
-      '@react-native/assets-registry': 0.73.1
-      '@react-native/codegen': 0.73.3(@babel/preset-env@7.23.3(@babel/core@7.23.3))
-      '@react-native/community-cli-plugin': 0.73.17(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@react-native/gradle-plugin': 0.73.4
-      '@react-native/js-polyfills': 0.73.1
-      '@react-native/normalize-colors': 0.73.2
-      '@react-native/virtualized-lists': 0.73.4(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      base64-js: 1.5.1
-      chalk: 4.1.2
-      deprecated-react-native-prop-types: 5.0.0
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.80.8
-      metro-source-map: 0.80.8
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.2.0
-      react-devtools-core: 4.28.5(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      react-refresh: 0.14.0
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.24.0-canary-efb381bbf-20230505
-      stacktrace-parser: 0.1.10
-      whatwg-fetch: 3.6.20
-      ws: 6.2.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    optional: true
-
   react-native@0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
@@ -33972,23 +33618,6 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
       warning: 4.0.3
-
-  react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1):
-    dependencies:
-      '@babel/runtime': 7.23.9
-      '@types/hoist-non-react-statics': 3.3.5
-      '@types/use-sync-external-store': 0.0.3
-      hoist-non-react-statics: 3.3.2
-      react: 18.2.0
-      react-is: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
-    optionalDependencies:
-      '@types/react': 18.2.37
-      '@types/react-dom': 18.2.15
-      react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.73.6(@babel/core@7.23.3)(@babel/preset-env@7.23.3(@babel/core@7.23.3))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10)
-      redux: 4.2.1
-    optional: true
 
   react-redux@8.1.3(@types/react-dom@18.2.15)(@types/react@18.2.37)(react-dom@18.2.0(react@18.2.0))(react-native@0.73.6(@babel/core@7.23.9)(@babel/preset-env@7.23.3(@babel/core@7.23.9))(bufferutil@4.0.8)(react@18.2.0)(utf-8-validate@5.0.10))(react@18.2.0)(redux@4.2.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ catalog:
   wagmi: ^2.12.17
   next: 14.2.14
   wrangler: 3.81.0
+  '@aptos-labs/ts-sdk': 1.30.0


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily updates the dependency version of `@aptos-labs/ts-sdk` from `1.12.2` to `1.30.0` across multiple package files and improves type filtering in the `useAccountBalances` hook. It also modifies some import statements and documentation links.

### Detailed summary
- Updated `@aptos-labs/ts-sdk` version to `1.30.0` in:
  - `pnpm-workspace.yaml`
  - `packages/aptos-swap-sdk/package.json`
  - `packages/awgmi/package.json`
  - `apps/aptos/package.json`
- Changed type filtering in `useAccountBalances` to ensure string type.
- Modified import statements in `apps/aptos/client.ts` to include `Network`.
- Updated documentation link in `apps/aptos/next-env.d.ts`.
- Added `APTOS_GATEWAY_API_KEY` environment variable in `apps/aptos/client.ts`.
- Updated `pnpm-lock.yaml` to reflect changes in dependencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->