### PR TITLE
fix: Use offchain quote if failed to verify on chain

### DIFF
--- a/apps/web/src/hooks/useTradeVerifiedByQuoter.ts
+++ b/apps/web/src/hooks/useTradeVerifiedByQuoter.ts
@@ -60,6 +60,7 @@ export function useTradeVerifiedByQuoter<P extends Params>(p: P): P {
         ...reviseGasUseEstimate(trade.tradeType, trade, gasUseEstimate),
       }
     },
+    retry: false,
     refetchOnWindowFocus: false,
     placeholderData: keepPreviousData,
     staleTime: trade?.inputAmount.currency.chainId ? POOLS_NORMAL_REVALIDATE[trade?.inputAmount.currency.chainId] : 0,
@@ -69,7 +70,6 @@ export function useTradeVerifiedByQuoter<P extends Params>(p: P): P {
     syncing: fetchStatus === 'fetching' || syncing,
     isLoading: isPlaceholderData || isLoading,
     trade: error ? trade : data,
-    error: error ?? p.error,
   }
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `useTradeVerifiedByQuoter` hook to enhance its behavior regarding data fetching and error handling.

### Detailed summary
- Added `retry: false` to the hook options.
- Set `refetchOnWindowFocus: false` to prevent refetching when the window is focused.
- Introduced `placeholderData: keepPreviousData` for improved data retention.
- Adjusted `staleTime` calculation based on `trade?.inputAmount.currency.chainId`.
- Removed the line setting `error` to `error ?? p.error`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->