### PR TITLE
fix: wrong api query implement

### DIFF
--- a/apps/web/src/pages/api/configs/farms/v2/[chain].ts
+++ b/apps/web/src/pages/api/configs/farms/v2/[chain].ts
@@ -1,5 +1,5 @@
-import { ChainId, chainNames, chainNameToChainId } from '@pancakeswap/chains'
-import { formatUniversalFarmToSerializedFarm, UNIVERSAL_FARMS } from '@pancakeswap/farms'
+import { ChainId, chainNameToChainId, chainNames } from '@pancakeswap/chains'
+import { UNIVERSAL_FARMS_WITH_TESTNET, formatUniversalFarmToSerializedFarm } from '@pancakeswap/farms'
 import { NextApiHandler } from 'next'
 import { stringify } from 'viem'
 import { enum as enum_, nativeEnum } from 'zod'
@@ -24,7 +24,7 @@ const handler: NextApiHandler = async (req, res) => {
   }
 
   try {
-    const farmConfig = UNIVERSAL_FARMS.filter((farm) => farm.chainId === chainId)
+    const farmConfig = UNIVERSAL_FARMS_WITH_TESTNET.filter((farm) => farm.chainId === chainId)
     const legacyFarmConfig = formatUniversalFarmToSerializedFarm(farmConfig)
     // cache for long time, it should revalidate on every deployment
     res.setHeader('Cache-Control', `max-age=10800, s-maxage=31536000`)

--- a/apps/web/src/pages/api/configs/farms/v2/index.ts
+++ b/apps/web/src/pages/api/configs/farms/v2/index.ts
@@ -1,4 +1,4 @@
-import { formatUniversalFarmToSerializedFarm, UNIVERSAL_FARMS, UNIVERSAL_FARMS_WITH_TESTNET } from '@pancakeswap/farms'
+import { UNIVERSAL_FARMS, UNIVERSAL_FARMS_WITH_TESTNET, formatUniversalFarmToSerializedFarm } from '@pancakeswap/farms'
 import { NextApiHandler } from 'next'
 import { stringify } from 'viem'
 
@@ -6,7 +6,7 @@ const handler: NextApiHandler = async (req, res) => {
   const includeTestnet = !!req.query.includeTestnet
 
   try {
-    const farmConfig = includeTestnet ? UNIVERSAL_FARMS : UNIVERSAL_FARMS_WITH_TESTNET
+    const farmConfig = includeTestnet ? UNIVERSAL_FARMS_WITH_TESTNET : UNIVERSAL_FARMS
     const legacyFarmConfig = formatUniversalFarmToSerializedFarm(farmConfig)
     // cache for long time, it should revalidate on every deployment
     res.setHeader('Cache-Control', `max-age=10800, s-maxage=31536000`)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of farm configurations in two API endpoints by switching the order of farm configuration constants used, ensuring that the testnet farms are prioritized correctly.

### Detailed summary
- In `apps/web/src/pages/api/configs/farms/v2/index.ts`:
  - Changed the order of `farmConfig` assignment to prioritize `UNIVERSAL_FARMS_WITH_TESTNET` over `UNIVERSAL_FARMS`.
  
- In `apps/web/src/pages/api/configs/farms/v2/[chain].ts`:
  - Updated `farmConfig` to filter `UNIVERSAL_FARMS_WITH_TESTNET` instead of `UNIVERSAL_FARMS`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->