### PR TITLE
chore: fast routing by default

### DIFF
--- a/apps/web/src/components/Menu/GlobalSettings/SettingsModalV2/CustomizeRoutingTab.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/SettingsModalV2/CustomizeRoutingTab.tsx
@@ -11,9 +11,10 @@ import {
   Text,
   Toggle,
 } from '@pancakeswap/uikit'
-import { useSpeedQuote, useUserSingleHopOnly } from '@pancakeswap/utils/user'
+import { useUserSingleHopOnly } from '@pancakeswap/utils/user'
 import { PancakeSwapXTag } from 'components/PancakeSwapXTag'
 import { usePCSX, usePCSXFeatureEnabled } from 'hooks/usePCSX'
+import { useSpeedQuote } from 'hooks/useSpeedQuote'
 import { memo } from 'react'
 import {
   useOnlyOneAMMSourceEnabled,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the imports in the `CustomizeRoutingTab.tsx` file by removing and adding specific hooks related to user functionality.

### Detailed summary
- Removed import of `useSpeedQuote` from `@pancakeswap/utils/user`.
- Added import of `useSpeedQuote` from `hooks/useSpeedQuote`.
- Retained import of `useUserSingleHopOnly` from `@pancakeswap/utils/user`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->