### PR TITLE
fix: Farm API

### DIFF
--- a/apps/web/src/hooks/useV3FarmAPI.ts
+++ b/apps/web/src/hooks/useV3FarmAPI.ts
@@ -6,9 +6,10 @@ import {
   UniversalFarmConfigV3,
 } from '@pancakeswap/farms'
 import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 
 export const useV3FarmAPI = (chainId: ChainId) => {
-  const { data: farms } = useQuery({
+  const { data } = useQuery({
     queryKey: ['fetch-v3-farm-api'],
     queryFn: async () => {
       if (chainId) {
@@ -23,7 +24,9 @@ export const useV3FarmAPI = (chainId: ChainId) => {
     refetchOnMount: false,
   })
 
+  const farms = useMemo(() => data ?? [], [data])
+
   return {
-    farms: farms ?? [],
+    farms,
   }
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher.ts
@@ -139,9 +139,8 @@ export const getAccountV2LpDetails = async (
   const validLpTokens = lpTokens.filter((token) => token.chainId === chainId)
 
   const bCakeWrapperAddresses = await Promise.all(
-    validReserveTokens.map(async (tokens) => {
-      const lpAddress = getV2LiquidityToken(tokens).address
-      const bCakeWrapperAddress = await getBCakeWrapperAddress(lpAddress, chainId)
+    validLpTokens.map(async (tokens) => {
+      const bCakeWrapperAddress = await getBCakeWrapperAddress(tokens.address, chainId)
       return bCakeWrapperAddress
     }),
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the fetching logic for `bCakeWrapperAddresses` and improving the usage of the `useV3FarmAPI` hook by utilizing `useMemo` for better performance.

### Detailed summary
- In `fetcher.ts`, changed the mapping from `validReserveTokens` to `validLpTokens`.
- Directly accessed `tokens.address` instead of using `getV2LiquidityToken`.
- In `useV3FarmAPI.ts`, replaced `farms: farms ?? []` with `farms` for cleaner code.
- Introduced `useMemo` to memoize `farms` based on `data`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->