### PR TITLE
fix: Gauges voting crash on voting power

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/index.tsx
@@ -141,7 +141,7 @@ export const VoteTable = () => {
         if (vote && !vote?.locked) {
           const row = gauges?.find((r) => r.hash === slope.hash)
           if (!row) return undefined
-          const currentPower = BigInt((Number(vote.power) * 100).toFixed(0))
+          const currentPower = Number(vote.power) ? BigInt((Number(vote.power) * 100).toFixed(0)) : 0n
           const { nativePower = 0, proxyPower = 0, nativeEnd, proxyEnd } = slope || {}
           // ignore vote if current power is 0 and never voted
           if (currentPower === 0n && nativePower === 0 && proxyPower === 0 && !nativeEnd && !proxyEnd) return undefined


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the power calculation in the `VoteTable` component by ensuring that `currentPower` is set to `0n` when `vote.power` is not a number, preventing potential errors in subsequent logic.

### Detailed summary
- Updated the calculation of `currentPower` to check if `vote.power` is a valid number.
- If `vote.power` is not valid, `currentPower` is set to `0n` instead of being undefined.
- Maintained the existing logic to ignore votes if `currentPower` and other power values are zero.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->