### PR TITLE
fix: missing chain query

### DIFF
--- a/apps/web/src/utils/addQueryToPath.ts
+++ b/apps/web/src/utils/addQueryToPath.ts
@@ -5,9 +5,8 @@ export function addQueryToPath(path: string, queryParams: { [key: string]: strin
   Object.keys(queryParams).forEach((key) => {
     if (key === 'chain') {
       searchParams.delete('chainId')
-    } else {
-      searchParams.set(key, queryParams[key])
     }
+    searchParams.set(key, queryParams[key])
   })
 
   return `${pathname}?${searchParams.toString()}`


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the `addQueryToPath.ts` utility function to handle query parameters more effectively by ensuring that when the `key` is `'chain'`, the `chainId` is deleted from `searchParams`. 

### Detailed summary
- Removed the conditional block that deletes `chainId` when `key` is `'chain'`.
- Ensured `searchParams.set(key, queryParams[key])` is always executed regardless of the `key`.
- The return statement constructs the URL with updated `searchParams`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->