### PR TITLE
perf: Use query instead of queries to reduce rerenders initially

### DIFF
--- a/apps/web/src/hooks/v3/usePools.ts
+++ b/apps/web/src/hooks/v3/usePools.ts
@@ -215,17 +215,23 @@ export function usePoolsWithMultiChains(
             functionName: 'liquidity',
           }))
 
-          const [slot0Data, liquidityData] = await Promise.all([
-            client.multicall({
-              contracts: slot0Calls,
-              allowFailure: false,
-            }),
-            client.multicall({
-              contracts: liquidityCalls,
-              allowFailure: false,
-            }),
-          ])
-          return { [chainId]: { slot0: slot0Data, liquidity: liquidityData } }
+          try {
+            const [slot0Data, liquidityData] = await Promise.all([
+              client.multicall({
+                contracts: slot0Calls,
+                allowFailure: false,
+              }),
+              client.multicall({
+                contracts: liquidityCalls,
+                allowFailure: false,
+              }),
+            ])
+
+            return { [chainId]: { slot0: slot0Data, liquidity: liquidityData } }
+          } catch (error) {
+            console.error(`Error fetching data for chainId ${chainId}:`, error)
+            return { [chainId]: { slot0: undefined, liquidity: undefined } }
+          }
         }),
       )
       return results.reduce((acc, result) => {

--- a/apps/web/src/hooks/v3/usePools.ts
+++ b/apps/web/src/hooks/v3/usePools.ts
@@ -5,7 +5,7 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useMemo } from 'react'
 import { Address } from 'viem'
 import { publicClient } from 'utils/viem'
-import { keepPreviousData, useQueries } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH, QUERY_SETTINGS_IMMUTABLE } from 'config/constants'
 import { useMultipleContractSingleData } from 'state/multicall/hooks'
 import { PoolState } from './types'
@@ -190,57 +190,56 @@ export function usePoolsWithMultiChains(
   }, [poolTokens])
 
   const chainIds = useMemo(() => Object.keys(poolAddressMap), [poolAddressMap])
+  const poolAddressesString = useMemo(
+    () => chainIds.flatMap((chainId) => poolAddressMap[chainId]).join(','),
+    [chainIds, poolAddressMap],
+  )
 
-  const queries = chainIds.map((chainId) => {
-    const poolAddresses: Address[] = poolAddressMap[chainId]
-    return {
-      queryKey: ['slot0', 'liquidity', chainId, ...poolAddresses],
-      placeholderData: keepPreviousData,
-      queryFn: async () => {
-        const client = publicClient({ chainId: Number(chainId) })
+  const { data: poolInfoByChainId } = useQuery({
+    queryKey: ['v3PoolInfo', chainIds.join(','), poolAddressesString],
+    queryFn: async () => {
+      const results = await Promise.all(
+        chainIds.map(async (chainId) => {
+          const poolAddresses: Address[] = poolAddressMap[chainId]
+          const client = publicClient({ chainId: Number(chainId) })
 
-        const slot0Calls = poolAddresses.map((addr) => ({
-          address: addr,
-          abi: v3PoolStateABI,
-          functionName: 'slot0',
-        }))
+          const slot0Calls = poolAddresses.map((addr) => ({
+            address: addr,
+            abi: v3PoolStateABI,
+            functionName: 'slot0',
+          }))
 
-        const liquidityCalls = poolAddresses.map((addr) => ({
-          address: addr,
-          abi: v3PoolStateABI,
-          functionName: 'liquidity',
-        }))
+          const liquidityCalls = poolAddresses.map((addr) => ({
+            address: addr,
+            abi: v3PoolStateABI,
+            functionName: 'liquidity',
+          }))
 
-        return Promise.all([
-          client.multicall({
-            contracts: slot0Calls,
-            allowFailure: false,
-          }),
-          client.multicall({
-            contracts: liquidityCalls,
-            allowFailure: false,
-          }),
-        ])
-      },
-      enabled: !!chainId && !!poolAddresses.length,
-      ...QUERY_SETTINGS_IMMUTABLE,
-      ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
-    }
+          const [slot0Data, liquidityData] = await Promise.all([
+            client.multicall({
+              contracts: slot0Calls,
+              allowFailure: false,
+            }),
+            client.multicall({
+              contracts: liquidityCalls,
+              allowFailure: false,
+            }),
+          ])
+          return { [chainId]: { slot0: slot0Data, liquidity: liquidityData } }
+        }),
+      )
+      return results.reduce((acc, result) => {
+        const chainId = Object.keys(result)[0]
+        // eslint-disable-next-line no-param-reassign
+        acc[chainId] = result[chainId]
+        return acc
+      }, {} as { slot0: [bigint, number, number, number, number, number, boolean]; liquidity: [bigint, number, number, number, number, number, boolean] })
+    },
+    enabled: chainIds?.length > 0,
+    placeholderData: keepPreviousData,
+    ...QUERY_SETTINGS_IMMUTABLE,
+    ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
   })
-  const poolInfoQueries = useQueries({
-    queries,
-  })
-
-  const poolInfoByChainId = useMemo(() => {
-    return poolInfoQueries.reduce((acc, query, idx) => {
-      const chainId = chainIds[idx]
-      // eslint-disable-next-line no-param-reassign
-      acc[chainId] = acc[chainId] ?? []
-      // eslint-disable-next-line no-param-reassign
-      acc[chainId] = query.data
-      return acc
-    }, {})
-  }, [chainIds, poolInfoQueries])
 
   return useMemo(() => {
     const indexMap = {}
@@ -250,7 +249,7 @@ export function usePoolsWithMultiChains(
       const [token0, token1, fee] = tokens
 
       indexMap[token0.chainId] = (indexMap[token0.chainId] ?? -1) + 1
-      const [slot0s = [], liquidities = []] = poolInfoByChainId[token0.chainId] || []
+      const { slot0: slot0s = [], liquidity: liquidities = [] } = poolInfoByChainId?.[token0.chainId] || {}
       const slot0 = slot0s[indexMap[token0.chainId]]
       const liquidity = liquidities[indexMap[token0.chainId]]
       if (typeof slot0 === 'undefined' || typeof liquidity === 'undefined') return [PoolState.INVALID, null]

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
@@ -1,43 +1,44 @@
 import { LegacyRouter } from '@pancakeswap/smart-router/legacy-router'
-import { useQueries, UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { SLOW_INTERVAL } from 'config/constants'
-import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
+import { useMemo } from 'react'
 import { getStablePairDetails } from '../fetcher'
 import { StableLPDetail } from '../type'
 import { useLatestTxReceipt } from './useLatestTxReceipt'
 
 export const useAccountStableLpDetails = (chainIds: number[], account?: Address | null) => {
   const [latestTxReceipt] = useLatestTxReceipt()
-  const queries = useMemo(() => {
-    return chainIds.map((chainId) => {
-      const stablePairs = LegacyRouter.stableSwapPairsByChainId[chainId]
-      return {
-        queryKey: ['accountStableLpBalance', account, chainId, latestTxReceipt?.blockHash],
-        // @todo @ChefJerry add signal
-        queryFn: () => getStablePairDetails(chainId, account!, stablePairs),
-        enabled: !!account && stablePairs && stablePairs.length > 0,
-        select(data) {
-          return data.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
-        },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        refetchInterval: SLOW_INTERVAL,
-        // Prevents re-fetching while the data is still fresh
-        staleTime: SLOW_INTERVAL,
-      } satisfies UseQueryOptions<StableLPDetail[]>
-    })
-  }, [account, chainIds, latestTxReceipt?.blockHash])
 
-  const combine = useCallback((results: UseQueryResult<StableLPDetail[], Error>[]) => {
-    return {
-      data: results.reduce((acc, result) => acc.concat(result.data ?? []), [] as StableLPDetail[]),
-      pending: results.some((result) => result.isPending),
-    }
-  }, [])
-  return useQueries({
-    queries,
-    combine,
+  const { data, isPending } = useQuery<StableLPDetail[], Error>({
+    queryKey: ['accountStableLpBalance', account, chainIds.join(','), latestTxReceipt?.blockHash],
+    // @todo @ChefJerry add signal
+    queryFn: async () => {
+      if (!account) return []
+      const results = await Promise.all(
+        chainIds.map(async (chainId) => {
+          const stablePairs = LegacyRouter.stableSwapPairsByChainId[chainId]
+          if (!stablePairs || stablePairs.length === 0) return []
+          const details = await getStablePairDetails(chainId, account, stablePairs)
+          return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+        }),
+      )
+      return results.flat()
+    },
+    enabled: !!account,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    // Prevents re-fetching while the data is still fresh
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: data ?? [],
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountStableLpDetails.ts
@@ -19,8 +19,13 @@ export const useAccountStableLpDetails = (chainIds: number[], account?: Address 
         chainIds.map(async (chainId) => {
           const stablePairs = LegacyRouter.stableSwapPairsByChainId[chainId]
           if (!stablePairs || stablePairs.length === 0) return []
-          const details = await getStablePairDetails(chainId, account, stablePairs)
-          return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+          try {
+            const details = await getStablePairDetails(chainId, account, stablePairs)
+            return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+          } catch (error) {
+            console.error(`Error fetching details for chainId ${chainId}:`, error)
+            return []
+          }
         }),
       )
       return results.flat()

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
@@ -1,8 +1,8 @@
 import { ERC20Token } from '@pancakeswap/sdk'
-import { useQueries, UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { SLOW_INTERVAL } from 'config/constants'
 import { useOfficialsAndUserAddedTokensByChainIds } from 'hooks/Tokens'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { AppState } from 'state'
 import { Address } from 'viem'
@@ -34,39 +34,42 @@ export const useAccountV2LpDetails = (chainIds: number[], account?: Address | nu
     fetchLpTokens()
   }, [chainIds, tokens, userSavedPairs])
 
+  const totalTokenPairCount = useMemo(() => {
+    if (!lpTokensByChain) return 0
+
+    return Object.values(lpTokensByChain).reduce((total, tokenPairs) => {
+      return total + tokenPairs.length
+    }, 0)
+  }, [lpTokensByChain])
+
   const [latestTxReceipt] = useLatestTxReceipt()
-  const queries = useMemo(() => {
-    if (!lpTokensByChain) {
-      return []
-    }
 
-    return Object.entries(lpTokensByChain).map(([chainId, lpTokens]) => {
-      return {
-        queryKey: ['accountV2LpDetails', account, chainId, lpTokens.length, latestTxReceipt?.blockHash],
-        // @todo @ChefJerry add signal
-        queryFn: () => getAccountV2LpDetails(Number(chainId), account!, lpTokens),
-        enabled: !!account && lpTokens && lpTokens.length > 0,
-        select(data) {
-          return data.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
-        },
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        // Prevents re-fetching while the data is still fresh
-        staleTime: SLOW_INTERVAL,
-      } satisfies UseQueryOptions<V2LPDetail[]>
-    })
-  }, [account, lpTokensByChain, latestTxReceipt?.blockHash])
-
-  const combine = useCallback((results: UseQueryResult<V2LPDetail[], Error>[]) => {
-    return {
-      data: results.reduce((acc, result) => acc.concat(result.data ?? []), [] as V2LPDetail[]),
-      pending: results.some((result) => result.isPending),
-    }
-  }, [])
-
-  return useQueries({
-    queries,
-    combine,
+  const query = useQuery<V2LPDetail[], Error>({
+    queryKey: ['accountV2LpDetails', account, chainIds.join('-'), totalTokenPairCount, latestTxReceipt?.blockHash],
+    queryFn: async () => {
+      if (!account || !lpTokensByChain) return []
+      const results = await Promise.all(
+        Object.entries(lpTokensByChain).map(async ([chainId, lpTokens]) => {
+          if (lpTokens.length === 0) return []
+          const details = await getAccountV2LpDetails(Number(chainId), account, lpTokens)
+          return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+        }),
+      )
+      return results.flat()
+    },
+    enabled: !!account && !!lpTokensByChain,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    // Prevents re-fetching while the data is still fresh
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: query.data ?? [],
+      pending: query.isLoading || query.isFetching,
+    }),
+    [query.data, query.isLoading, query.isFetching],
+  )
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV2LpDetails.ts
@@ -51,8 +51,13 @@ export const useAccountV2LpDetails = (chainIds: number[], account?: Address | nu
       const results = await Promise.all(
         Object.entries(lpTokensByChain).map(async ([chainId, lpTokens]) => {
           if (lpTokens.length === 0) return []
-          const details = await getAccountV2LpDetails(Number(chainId), account, lpTokens)
-          return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+          try {
+            const details = await getAccountV2LpDetails(Number(chainId), account, lpTokens)
+            return details.filter((d) => d.nativeBalance.greaterThan('0') || d.farmingBalance.greaterThan('0'))
+          } catch (error) {
+            console.error(`Error fetching LP details for chainId ${chainId}:`, error)
+            return []
+          }
         }),
       )
       return results.flat()

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
@@ -1,6 +1,6 @@
-import { useQueries, UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { SLOW_INTERVAL } from 'config/constants'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Address } from 'viem'
 import { getAccountV3Positions } from '../fetcher/v3'
 import { PositionDetail } from '../type'
@@ -8,31 +8,36 @@ import { useLatestTxReceipt } from './useLatestTxReceipt'
 
 export const useAccountV3Positions = (chainIds: number[], account?: Address | null) => {
   const [latestTxReceipt] = useLatestTxReceipt()
-  const queries = useMemo(() => {
-    return chainIds.map((chainId) => {
-      return {
-        queryKey: ['accountV3Positions', account, chainId, latestTxReceipt?.blockHash],
-        // @todo @ChefJerry add signal
-        queryFn: () => getAccountV3Positions(chainId, account!),
-        enabled: !!account && !!chainId,
-        refetchOnMount: false,
-        refetchOnWindowFocus: false,
-        refetchOnReconnect: false,
-        refetchInterval: SLOW_INTERVAL,
-        // Prevents re-fetching while the data is still fresh
-        staleTime: SLOW_INTERVAL,
-      } satisfies UseQueryOptions<PositionDetail[]>
-    })
-  }, [account, chainIds, latestTxReceipt?.blockHash])
 
-  const combine = useCallback((results: UseQueryResult<PositionDetail[], Error>[]) => {
-    return {
-      data: results.reduce((acc, result) => acc.concat(result.data ?? []), [] as PositionDetail[]),
-      pending: results.some((result) => result.isPending),
-    }
-  }, [])
-  return useQueries({
-    queries,
-    combine,
+  const { data, isPending } = useQuery<PositionDetail[], Error>({
+    queryKey: ['accountV3Positions', account, chainIds.join('-'), latestTxReceipt?.blockHash],
+    // @todo @ChefJerry add signal
+    queryFn: async () => {
+      if (!account) return []
+      const results = await Promise.all(
+        chainIds.map(async (chainId) => {
+          // Fetch the account V3 positions for the current chainId
+          const positions = await getAccountV3Positions(chainId, account)
+          return positions ?? []
+        }),
+      )
+      return results.flat()
+    },
+    enabled: !!account,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    // Prevents re-fetching while the data is still fresh
+    staleTime: SLOW_INTERVAL,
   })
+
+  // Memoize the result object
+  return useMemo(
+    () => ({
+      data: data ?? [],
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountV3Positions.ts
@@ -16,9 +16,13 @@ export const useAccountV3Positions = (chainIds: number[], account?: Address | nu
       if (!account) return []
       const results = await Promise.all(
         chainIds.map(async (chainId) => {
-          // Fetch the account V3 positions for the current chainId
-          const positions = await getAccountV3Positions(chainId, account)
-          return positions ?? []
+          try {
+            const positions = await getAccountV3Positions(chainId, account)
+            return positions ?? []
+          } catch (error) {
+            console.error(`Error fetching V3 positions for chainId ${chainId}:`, error)
+            return []
+          }
         }),
       )
       return results.flat()

--- a/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
@@ -74,82 +74,79 @@ export const useFarmPools = () => {
 }
 
 export const useV3PoolsLength = (chainIds: number[]) => {
-  const queries = useMemo(() => {
-    return chainIds.map((chainId) => {
-      return {
-        queryKey: ['useV3PoolsLength', chainId],
-        queryFn: () => {
+  const { data, isPending } = useQuery<{ [key: number]: number }, Error>({
+    queryKey: ['useV3PoolsLength', chainIds?.join('-')],
+    queryFn: async () => {
+      const results = await Promise.all(
+        chainIds.map(async (chainId) => {
           const client = publicClient({ chainId })
-          return client.readContract({
+          const poolLength = await client.readContract({
             address: masterChefV3Addresses[chainId],
             abi: masterChefV3ABI,
             functionName: 'poolLength',
           })
-        },
-        enabled: !!chainId,
-        ...QUERY_SETTINGS_IMMUTABLE,
-        refetchInterval: SLOW_INTERVAL,
-        staleTime: SLOW_INTERVAL,
-      }
-    })
-  }, [chainIds])
-
-  const combine = useCallback(
-    (results: UseQueryResult<bigint, Error>[]) => {
-      return {
-        data: results.reduce((acc, result, idx) => {
-          Object.assign(acc, { [chainIds[idx]]: Number(result.data ?? 0) })
-          return acc
-        }, {} as { [key: `${number}`]: number }),
-        pending: results.some((result) => result.isPending),
-      }
+          return { chainId, length: Number(poolLength) }
+        }),
+      )
+      return results.reduce((acc, { chainId, length }) => {
+        // eslint-disable-next-line no-param-reassign
+        acc[chainId] = length
+        return acc
+      }, {} as { [key: number]: number })
     },
-    [chainIds],
-  )
-
-  return useQueries({
-    queries,
-    combine,
+    enabled: chainIds?.length > 0,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: data ?? {},
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }
 
 export const useV2PoolsLength = (chainIds: number[]) => {
-  const queries = useMemo(() => {
-    return chainIds.map((chainId) => {
-      return {
-        queryKey: ['useV2PoolsLength', chainId],
-        queryFn: () => {
+  const { data, isPending } = useQuery<{ [key: number]: number }, Error>({
+    queryKey: ['useV2PoolsLength', chainIds?.join('-')],
+    queryFn: async () => {
+      const results = await Promise.all(
+        chainIds.map(async (chainId) => {
           const client = publicClient({ chainId })
-          return client.readContract({
-            address: masterChefAddresses[ChainId.BSC],
+          const poolLength = await client.readContract({
+            address: masterChefAddresses[chainId],
             abi: masterChefV2ABI,
             functionName: 'poolLength',
           })
-        },
-        enabled: !!chainId,
-        ...QUERY_SETTINGS_IMMUTABLE,
-        refetchInterval: SLOW_INTERVAL,
-        staleTime: SLOW_INTERVAL,
-      }
-    })
-  }, [chainIds])
-
-  const combine = useCallback(
-    (results: UseQueryResult<bigint, Error>[]) => {
-      return {
-        data: results.reduce((acc, result, idx) => {
-          return Object.assign(acc, { [chainIds[idx]]: Number(result.data ?? 0) })
-        }, {} as { [key: `${number}`]: number }),
-        pending: results.some((result) => result.isPending),
-      }
+          return { chainId, length: Number(poolLength) }
+        }),
+      )
+      return results.reduce((acc, { chainId, length }) => {
+        // eslint-disable-next-line no-param-reassign
+        acc[chainId] = length
+        return acc
+      }, {} as { [key: number]: number })
     },
-    [chainIds],
-  )
-
-  return useQueries({
-    queries,
-    combine,
+    enabled: chainIds?.length > 0,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: data ?? {},
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }
 
 type IPoolsStatusType = {
@@ -163,33 +160,39 @@ export const useMultiChainV3PoolsStatus = (pools: UniversalFarmConfig[]) => {
   const poolsGroupByChains = useMemo(() => groupBy(v3Pools, 'chainId'), [v3Pools])
   const poolsEntries = useMemo(() => Object.entries(poolsGroupByChains), [poolsGroupByChains])
 
-  const queries = poolsEntries.map(([chainId, poolList]) => ({
-    queryKey: ['useMultiChainV3PoolsStatus', chainId, ...poolList.map((p) => p.lpAddress)],
-    queryFn: () => {
-      return fetchV3PoolsStatusByChainId(Number(chainId), poolList)
-    },
-    enabled: !!chainId && !!poolList.length,
-    ...QUERY_SETTINGS_IMMUTABLE,
-    refetchInterval: SLOW_INTERVAL,
-    staleTime: SLOW_INTERVAL,
-  }))
-  const combine = useCallback(
-    (results: UseQueryResult<UnwrapPromise<ReturnType<typeof fetchV3PoolsStatusByChainId>>, Error>[]) => {
-      return {
-        data: results.reduce((acc, result, idx) => {
-          return Object.assign(acc, {
-            [poolsEntries[idx][0]]: keyBy(result.data ?? [], ([, lpAddress]) => lpAddress),
-          })
-        }, {} as IPoolsStatusType),
-        pending: results.some((result) => result.isPending),
-      }
-    },
+  const chainIds = useMemo(() => poolsEntries.map(([chainId]) => chainId).join(','), [poolsEntries])
+  const lpAddresses = useMemo(
+    () => poolsEntries.flatMap(([, poolList]) => poolList.map((p) => p.lpAddress)).join(','),
     [poolsEntries],
   )
-  return useQueries({
-    queries,
-    combine,
+
+  const { data, isPending } = useQuery<IPoolsStatusType, Error>({
+    queryKey: ['useMultiChainV3PoolsStatus', chainIds, lpAddresses],
+    queryFn: async () => {
+      const results = await Promise.all(
+        poolsEntries.map(async ([chainId, poolList]) => {
+          if (!poolList.length) return { [chainId]: {} }
+          const poolStatus = await fetchV3PoolsStatusByChainId(Number(chainId), poolList)
+          return { [chainId]: keyBy(poolStatus ?? [], ([, lpAddress]) => lpAddress) }
+        }),
+      )
+      return results.reduce((acc, result) => ({ ...acc, ...result }), {} as IPoolsStatusType)
+    },
+    enabled: poolsEntries.length > 0,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: data ?? {},
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }
 
 export const useV3PoolStatus = (pool?: PoolInfo | null) => {
@@ -244,38 +247,44 @@ export const useMultiChainPoolsTimeFrame = (pools: UniversalFarmConfig[]) => {
   const poolsGroupByChains = useMemo(() => groupBy(v2Pools, 'chainId'), [v2Pools])
   const poolsEntries = useMemo(() => Object.entries(poolsGroupByChains), [poolsGroupByChains])
 
-  const queries = poolsEntries.map(([chainId_, poolList]) => {
-    const chainId = Number(chainId_)
-    return {
-      queryKey: ['useMultiChainPoolTimeFrame', chainId, ...poolList.map((p) => p.lpAddress)],
-      queryFn: () => {
-        const bCakeAddresses = poolList.map(({ bCakeWrapperAddress }) => bCakeWrapperAddress ?? zeroAddress)
-        return fetchPoolsTimeFrame(bCakeAddresses, chainId)
-      },
-      enabled: !!chainId && !!poolList.length,
-      ...QUERY_SETTINGS_IMMUTABLE,
-      refetchInterval: SLOW_INTERVAL,
-      staleTime: SLOW_INTERVAL,
-    }
-  })
-  const combine = useCallback(
-    (results: UseQueryResult<UnwrapPromise<ReturnType<typeof fetchPoolsTimeFrame>>, Error>[]) => {
-      return {
-        data: results.reduce((acc, result, idx) => {
-          let dataIdx = 0
-          return Object.assign(acc, {
-            [poolsEntries[idx][0]]: keyBy(result.data ?? [], () => {
-              return poolsEntries[idx][1][dataIdx++].lpAddress
-            }),
-          })
-        }, {} as IPoolsTimeFrameType),
-        pending: results.some((result) => result.isPending),
-      }
-    },
+  const chainIds = useMemo(() => poolsEntries.map(([chainId]) => chainId).join(','), [poolsEntries])
+  const lpAddresses = useMemo(
+    () => poolsEntries.flatMap(([, poolList]) => poolList.map((p) => p.lpAddress)).join(','),
     [poolsEntries],
   )
-  return useQueries({
-    queries,
-    combine,
+
+  const { data, isPending } = useQuery<IPoolsTimeFrameType, Error>({
+    queryKey: ['useMultiChainPoolTimeFrame', chainIds, lpAddresses],
+    queryFn: async () => {
+      const results = await Promise.all(
+        poolsEntries.map(async ([chainId_, poolList]) => {
+          const chainId = Number(chainId_)
+          const bCakeAddresses = poolList.map(({ bCakeWrapperAddress }) => bCakeWrapperAddress ?? zeroAddress)
+          if (bCakeAddresses.length === 0) return { [chainId]: {} }
+          const timeFrameData = await fetchPoolsTimeFrame(bCakeAddresses, chainId)
+          return timeFrameData ?? []
+        }),
+      )
+      return results.reduce((acc, result, idx) => {
+        let dataIdx = 0
+        return Object.assign(acc, {
+          [poolsEntries[idx][0]]: keyBy(result, () => poolsEntries[idx][1][dataIdx++].lpAddress),
+        })
+      }, {} as IPoolsTimeFrameType)
+    },
+    enabled: poolsEntries.length > 0,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: SLOW_INTERVAL,
+    staleTime: SLOW_INTERVAL,
   })
+
+  return useMemo(
+    () => ({
+      data: data ?? {},
+      pending: isPending,
+    }),
+    [data, isPending],
+  )
 }

--- a/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/hooks.ts
@@ -1,15 +1,14 @@
-import { ChainId } from '@pancakeswap/chains'
 import { Protocol, UniversalFarmConfig, fetchAllUniversalFarms, masterChefV3Addresses } from '@pancakeswap/farms'
 import { masterChefAddresses } from '@pancakeswap/farms/src/const'
 import { masterChefV3ABI } from '@pancakeswap/v3-sdk'
-import { UseQueryResult, useQueries, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { masterChefV2ABI } from 'config/abi/masterchefV2'
 import { QUERY_SETTINGS_IMMUTABLE, SLOW_INTERVAL } from 'config/constants'
 import dayjs from 'dayjs'
 import { useAtom } from 'jotai'
 import groupBy from 'lodash/groupBy'
 import keyBy from 'lodash/keyBy'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { publicClient } from 'utils/viem'
 import { zeroAddress } from 'viem'
 import { Address } from 'viem/accounts'
@@ -80,12 +79,17 @@ export const useV3PoolsLength = (chainIds: number[]) => {
       const results = await Promise.all(
         chainIds.map(async (chainId) => {
           const client = publicClient({ chainId })
-          const poolLength = await client.readContract({
-            address: masterChefV3Addresses[chainId],
-            abi: masterChefV3ABI,
-            functionName: 'poolLength',
-          })
-          return { chainId, length: Number(poolLength) }
+          try {
+            const poolLength = await client.readContract({
+              address: masterChefV3Addresses[chainId],
+              abi: masterChefV3ABI,
+              functionName: 'poolLength',
+            })
+            return { chainId, length: Number(poolLength) }
+          } catch (error) {
+            console.error(`Error fetching pool length for chainId ${chainId}:`, error)
+            return { chainId, length: 0 }
+          }
         }),
       )
       return results.reduce((acc, { chainId, length }) => {
@@ -118,12 +122,17 @@ export const useV2PoolsLength = (chainIds: number[]) => {
       const results = await Promise.all(
         chainIds.map(async (chainId) => {
           const client = publicClient({ chainId })
-          const poolLength = await client.readContract({
-            address: masterChefAddresses[chainId],
-            abi: masterChefV2ABI,
-            functionName: 'poolLength',
-          })
-          return { chainId, length: Number(poolLength) }
+          try {
+            const poolLength = await client.readContract({
+              address: masterChefAddresses[chainId],
+              abi: masterChefV2ABI,
+              functionName: 'poolLength',
+            })
+            return { chainId, length: Number(poolLength) }
+          } catch (error) {
+            console.error(`Error fetching pool length for chainId ${chainId}:`, error)
+            return { chainId, length: 0 }
+          }
         }),
       )
       return results.reduce((acc, { chainId, length }) => {
@@ -172,8 +181,13 @@ export const useMultiChainV3PoolsStatus = (pools: UniversalFarmConfig[]) => {
       const results = await Promise.all(
         poolsEntries.map(async ([chainId, poolList]) => {
           if (!poolList.length) return { [chainId]: {} }
-          const poolStatus = await fetchV3PoolsStatusByChainId(Number(chainId), poolList)
-          return { [chainId]: keyBy(poolStatus ?? [], ([, lpAddress]) => lpAddress) }
+          try {
+            const poolStatus = await fetchV3PoolsStatusByChainId(Number(chainId), poolList)
+            return { [chainId]: keyBy(poolStatus ?? [], ([, lpAddress]) => lpAddress) }
+          } catch (error) {
+            console.error(`Error fetching pool status for chainId ${chainId}:`, error)
+            return { [chainId]: {} }
+          }
         }),
       )
       return results.reduce((acc, result) => ({ ...acc, ...result }), {} as IPoolsStatusType)
@@ -261,8 +275,13 @@ export const useMultiChainPoolsTimeFrame = (pools: UniversalFarmConfig[]) => {
           const chainId = Number(chainId_)
           const bCakeAddresses = poolList.map(({ bCakeWrapperAddress }) => bCakeWrapperAddress ?? zeroAddress)
           if (bCakeAddresses.length === 0) return { [chainId]: {} }
-          const timeFrameData = await fetchPoolsTimeFrame(bCakeAddresses, chainId)
-          return timeFrameData ?? []
+          try {
+            const timeFrameData = await fetchPoolsTimeFrame(bCakeAddresses, chainId)
+            return timeFrameData ?? []
+          } catch (error) {
+            console.error(`Error fetching time frame data for chainId ${chainId}:`, error)
+            return []
+          }
         }),
       )
       return results.reduce((acc, result, idx) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring multiple hooks in the codebase to replace `useQueries` with `useQuery`, simplifying the data fetching logic and improving error handling across various components.

### Detailed summary
- Replaced `useQueries` with `useQuery` in several hooks.
- Streamlined query functions to use `Promise.all` for concurrent fetching.
- Enhanced error handling with `console.error` in query functions.
- Updated query keys to utilize `join` for better string formatting.
- Simplified memoization of results using `useMemo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->