### PR TITLE
fix: Warning not seen trx deadline setting, set value only when losing focus

### DIFF
--- a/apps/web/src/components/Menu/GlobalSettings/TransactionSettings.tsx
+++ b/apps/web/src/components/Menu/GlobalSettings/TransactionSettings.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, Button, Flex, FlexGap, Input, Message, QuestionHelper, Text } from '@pancakeswap/uikit'
 import { useUserSlippage } from '@pancakeswap/utils/user'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { escapeRegExp } from 'utils'
 
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
@@ -73,12 +73,15 @@ const SlippageTabs = () => {
     slippageError = undefined
   }
 
-  let deadlineError: DeadlineError | undefined
-  if (deadlineInput !== '' && !deadlineInputIsValid) {
-    deadlineError = DeadlineError.InvalidInput
-  } else {
-    deadlineError = undefined
-  }
+  const [deadlineError, setDeadlineError] = useState<DeadlineError | undefined>()
+
+  useEffect(() => {
+    if (deadlineInput !== '' && !deadlineInputIsValid) {
+      setDeadlineError(DeadlineError.InvalidInput)
+    } else {
+      setDeadlineError(undefined)
+    }
+  }, [deadlineInput, deadlineInputIsValid])
 
   const parseCustomSlippage = (value: string) => {
     if (value === '' || inputRegex.test(escapeRegExp(value))) {
@@ -96,14 +99,12 @@ const SlippageTabs = () => {
   }
 
   const parseCustomDeadline = (value: string) => {
-    setDeadlineInput(value)
-
     try {
       const valueAsInt: number = Number.parseInt(value) * 60
       if (!Number.isNaN(valueAsInt) && valueAsInt > 60 && valueAsInt < THREE_DAYS_IN_SECONDS) {
         setTTL(valueAsInt)
       } else {
-        deadlineError = DeadlineError.InvalidInput
+        setDeadlineError(DeadlineError.InvalidInput)
       }
     } catch (error) {
       console.error(error)
@@ -245,6 +246,11 @@ const SlippageTabs = () => {
               value={deadlineInput}
               onChange={(event) => {
                 if (event.currentTarget.validity.valid) {
+                  setDeadlineInput(event.target.value)
+                }
+              }}
+              onBlur={(event) => {
+                if (event.currentTarget.validity.valid) {
                   parseCustomDeadline(event.target.value)
                 }
               }}
@@ -262,7 +268,10 @@ const SlippageTabs = () => {
             mt="3px"
             variant="text"
             scale="sm"
-            onClick={() => parseCustomDeadline(DEFAULT_TXN_DEADLINE.toString())}
+            onClick={() => {
+              setDeadlineInput('')
+              parseCustomDeadline(DEFAULT_TXN_DEADLINE.toString())
+            }}
           >
             {t('Reset')}
           </PrimaryOutlineButton>


### PR DESCRIPTION
Current behaviour is misleading that it sets it to user ttl on every digit removal
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling for the `deadlineInput` state in the `SlippageTabs` component. It introduces the use of `useEffect` to manage the `deadlineError` state and enhances input validation.

### Detailed summary
- Added `useEffect` to manage `deadlineError` based on `deadlineInput` and `deadlineInputIsValid`.
- Replaced direct assignment of `deadlineError` with `setDeadlineError`.
- Updated `onChange` handler to validate input before setting `deadlineInput`.
- Modified `onClick` handler to reset `deadlineInput` before parsing the default deadline.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->