### PR TITLE
chore: Remove prod trigger for routing cron

### DIFF
--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -20,7 +20,6 @@ r2_buckets = [
 ]
 name = "routing"
 [env.production.triggers]
-crons = ["*/30 * * * *"]
 
 # The necessary secrets are:
 # - ETH_NODE


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the configuration for the `routing` API by removing a cron job trigger in the `wrangler.toml` file.

### Detailed summary
- Removed the cron job trigger line: `crons = ["*/30 * * * *"]` from the `[env.production.triggers]` section in the `apis/routing/wrangler.toml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->