### PR TITLE
chore: reset sponsored txns on ZKSync

### DIFF
--- a/apps/web/src/components/Paymaster/GasTokenSelector.tsx
+++ b/apps/web/src/components/Paymaster/GasTokenSelector.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   CircleLoader,
   Column,
+  DottedHelpText,
   Flex,
   Heading,
   ModalBody,
@@ -15,6 +16,7 @@ import {
   ModalTitle,
   ModalV2,
   QuestionHelper,
+  QuestionHelperV2,
   RowBetween,
   RowFixed,
   Text,
@@ -266,12 +268,9 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
 
   return (
     <>
-      <RowBetween style={{ padding: '4px 0 0 0' }}>
+      <RowBetween style={{ padding: '0 0 4px 0' }}>
         <RowFixed>
-          <Text fontSize="14px" color="textSubtle">
-            {t('Gas Token')}
-          </Text>
-          <QuestionHelper
+          <QuestionHelperV2
             text={
               <>
                 <Text mb="12px">
@@ -286,11 +285,14 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
                 </Text>
               </>
             }
-            ml="4px"
             placement="top"
-          />
+          >
+            <DottedHelpText fontSize="14px" color="textSubtle">
+              {t('Gas Token')}
+            </DottedHelpText>
+          </QuestionHelperV2>
           {gasTokenInfo && gasTokenInfo.discount && (
-            <Badge ref={targetRef} style={{ fontSize: '12px', fontWeight: 600, padding: '3px 5px', marginLeft: '4px' }}>
+            <Badge ref={targetRef} style={{ fontSize: '12px', fontWeight: 600, padding: '3px 5px', marginLeft: '6px' }}>
               ⛽️ {gasTokenInfo.discountLabel ?? gasTokenInfo.discount}
             </Badge>
           )}

--- a/apps/web/src/components/Paymaster/GasTokenSelector.tsx
+++ b/apps/web/src/components/Paymaster/GasTokenSelector.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import {
   ArrowDropDownIcon,
   ArrowForwardIcon,
+  AtomBoxProps,
   Box,
   Button,
   CircleLoader,
@@ -42,8 +43,10 @@ import { useGasToken } from 'hooks/useGasToken'
 import { isAddressEqual } from 'utils'
 
 // Selector Styles
-const GasTokenSelectButton = styled(Button).attrs({ variant: 'text', scale: 'xs' })`
-  padding: 18px 0 18px 6px;
+const GasTokenSelectButton = styled(Button).attrs({ variant: 'tertiary', scale: 'xs' })`
+  padding: 16px 0 14px 6px;
+  border-radius: 12px;
+  border-bottom: 2px solid rgba(0, 0, 0, 0.1);
 `
 
 // Modal Styles
@@ -109,7 +112,7 @@ const SameTokenWarningBox = styled(Box)`
   font-size: 13px;
   background-color: #ffb2371a;
   padding: 10px;
-  margin: 5px 0 8px;
+  margin-bottom: 8px;
   color: ${({ theme }) => theme.colors.yellow};
   border: 1px solid ${({ theme }) => theme.colors.yellow};
   border-radius: ${({ theme }) => theme.radii['12px']};
@@ -119,11 +122,11 @@ const StyledWarningIcon = styled(WarningIcon)`
   fill: ${({ theme }) => theme.colors.yellow};
 `
 
-interface GasTokenSelectorProps {
-  currency?: Currency
+interface GasTokenSelectorProps extends AtomBoxProps {
+  inputCurrency?: Currency
 }
 
-export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorProps) => {
+export const GasTokenSelector = ({ inputCurrency, ...props }: GasTokenSelectorProps) => {
   const { t } = useTranslation()
   const { isOpen, setIsOpen, onDismiss } = useModalV2()
   const { address: account } = useAccount()
@@ -268,7 +271,7 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
 
   return (
     <>
-      <RowBetween style={{ padding: '0 0 4px 0' }}>
+      <RowBetween style={{ padding: '0 0 4px 0' }} {...props}>
         <RowFixed>
           <QuestionHelperV2
             text={
@@ -310,7 +313,7 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
               <p style={{ position: 'absolute', bottom: '-2px', right: '-6px', fontSize: '14px' }}>⛽️</p>
             </div>
 
-            <Text marginLeft={2} fontSize={14} bold>
+            <Text color="primary60" marginLeft={2} fontSize={14} bold>
               {(gasToken && gasToken.symbol && gasToken.symbol.length > 10
                 ? `${gasToken.symbol.slice(0, 4)}...${gasToken.symbol.slice(
                     gasToken.symbol.length - 5,
@@ -318,7 +321,7 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
                   )}`
                 : gasToken?.symbol) || ''}
             </Text>
-            <ArrowDropDownIcon marginLeft={1} />
+            <ArrowDropDownIcon color="primary60" marginLeft={1} />
           </Flex>
         </GasTokenSelectButton>
       </RowBetween>

--- a/apps/web/src/config/paymaster.ts
+++ b/apps/web/src/config/paymaster.ts
@@ -83,7 +83,7 @@ export const paymasterInfo: {
 }
 
 /**
- * Contracts that the paymaster is allowed to interact with.
+ * Contracts that the paymaster is allowed to interact with if transaction is sponsored.
  * In addition, ERC20 Approve transactions are allowed.
  */
 export const PAYMASTER_CONTRACT_WHITELIST = [

--- a/apps/web/src/config/paymaster.ts
+++ b/apps/web/src/config/paymaster.ts
@@ -7,11 +7,11 @@ import addresses from 'config/constants/contracts'
 import { getAddressFromMap } from 'utils/addressHelpers'
 import { Address, Hex } from 'viem'
 
-// export const DEFAULT_PAYMASTER_TOKEN = Native.onChain(ChainId.ZKSYNC)
+export const DEFAULT_PAYMASTER_TOKEN = Native.onChain(ChainId.ZKSYNC)
 
 export const paymasterTokens: Currency[] = [
-  // DEFAULT_PAYMASTER_TOKEN,
-  Native.onChain(ChainId.ZKSYNC),
+  DEFAULT_PAYMASTER_TOKEN,
+  zksyncTokens.zk,
   zksyncTokens.wbtc,
   zksyncTokens.dai,
   zksyncTokens.usdc,
@@ -26,73 +26,55 @@ export const paymasterTokens: Currency[] = [
   zksyncTokens.weth,
   zksyncTokens.wethe,
   zksyncTokens.hold,
-  zksyncTokens.zk,
 ]
-
-export const DEFAULT_PAYMASTER_TOKEN = paymasterTokens[4]
 
 export const paymasterInfo: {
   [gasTokenAddress: Address]: { discount: `-${number}%` | 'FREE'; discountLabel?: string }
 } = {
   [zksyncTokens.wbtc.address]: {
-    discount: 'FREE', // Example: -20%, FREE
-    discountLabel: 'FREE SWAP',
+    discount: '-20%', // Example: -20%, FREE
   },
   [zksyncTokens.dai.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.usdc.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.usdcNative.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.usdt.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.grai.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.tes.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.busd.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.reth.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.wstETH.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.meow.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.weth.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.wethe.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.hold.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-20%',
   },
   [zksyncTokens.zk.address]: {
-    discount: 'FREE',
-    discountLabel: 'FREE SWAP',
+    discount: '-40%',
   },
 }
 

--- a/apps/web/src/config/paymaster.ts
+++ b/apps/web/src/config/paymaster.ts
@@ -12,6 +12,7 @@ export const DEFAULT_PAYMASTER_TOKEN = Native.onChain(ChainId.ZKSYNC)
 export const paymasterTokens: Currency[] = [
   DEFAULT_PAYMASTER_TOKEN,
   zksyncTokens.zk,
+  zksyncTokens.cake,
   zksyncTokens.wbtc,
   zksyncTokens.dai,
   zksyncTokens.usdc,
@@ -31,8 +32,11 @@ export const paymasterTokens: Currency[] = [
 export const paymasterInfo: {
   [gasTokenAddress: Address]: { discount: `-${number}%` | 'FREE'; discountLabel?: string }
 } = {
+  [zksyncTokens.zk.address]: {
+    discount: '-40%',
+  },
   [zksyncTokens.wbtc.address]: {
-    discount: '-20%', // Example: -20%, FREE
+    discount: '-20%',
   },
   [zksyncTokens.dai.address]: {
     discount: '-20%',
@@ -73,8 +77,8 @@ export const paymasterInfo: {
   [zksyncTokens.hold.address]: {
     discount: '-20%',
   },
-  [zksyncTokens.zk.address]: {
-    discount: '-40%',
+  [zksyncTokens.cake.address]: {
+    discount: '-20%',
   },
 }
 

--- a/apps/web/src/config/paymaster.ts
+++ b/apps/web/src/config/paymaster.ts
@@ -27,6 +27,7 @@ export const paymasterTokens: Currency[] = [
   zksyncTokens.weth,
   zksyncTokens.wethe,
   zksyncTokens.hold,
+  zksyncTokens.zfi,
 ]
 
 export const paymasterInfo: {
@@ -34,6 +35,9 @@ export const paymasterInfo: {
 } = {
   [zksyncTokens.zk.address]: {
     discount: '-40%',
+  },
+  [zksyncTokens.zfi.address]: {
+    discount: '-20%',
   },
   [zksyncTokens.wbtc.address]: {
     discount: '-20%',

--- a/apps/web/src/config/paymaster.ts
+++ b/apps/web/src/config/paymaster.ts
@@ -27,7 +27,6 @@ export const paymasterTokens: Currency[] = [
   zksyncTokens.weth,
   zksyncTokens.wethe,
   zksyncTokens.hold,
-  zksyncTokens.zfi,
 ]
 
 export const paymasterInfo: {
@@ -35,9 +34,6 @@ export const paymasterInfo: {
 } = {
   [zksyncTokens.zk.address]: {
     discount: '-40%',
-  },
-  [zksyncTokens.zfi.address]: {
-    discount: '-20%',
   },
   [zksyncTokens.wbtc.address]: {
     discount: '-20%',

--- a/apps/web/src/pages/api/paymaster/index.ts
+++ b/apps/web/src/pages/api/paymaster/index.ts
@@ -25,7 +25,7 @@ const handler: NextApiHandler = async (req, res) => {
       // Check calldata for ERC20 approve
       const decodedCalldata = decodeFunctionData({ data: call.calldata, abi: erc20Abi })
       if (decodedCalldata.functionName === 'approve') isTransactionWhitelisted = true
-    } catch (e) {
+    } catch {
       // do nothing. must be another type of transaction if decoding failed
     }
 

--- a/apps/web/src/pages/api/paymaster/index.ts
+++ b/apps/web/src/pages/api/paymaster/index.ts
@@ -19,22 +19,24 @@ const handler: NextApiHandler = async (req, res) => {
   }
 
   try {
-    let isTransactionWhitelisted = PAYMASTER_CONTRACT_WHITELIST.includes(call.address.toLowerCase())
-
-    try {
-      // Check calldata for ERC20 approve
-      const decodedCalldata = decodeFunctionData({ data: call.calldata, abi: erc20Abi })
-      if (decodedCalldata.functionName === 'approve') isTransactionWhitelisted = true
-    } catch {
-      // do nothing. must be another type of transaction if decoding failed
-    }
-
-    if (!isTransactionWhitelisted) {
-      return res.status(400).json({ error: 'Transaction type not whitelisted for Paymaster' })
-    }
-
     const gasTokenInfo = paymasterInfo[gasTokenAddress]
     const isSponsored = gasTokenInfo?.discount === 'FREE'
+
+    if (isSponsored) {
+      let isTransactionWhitelisted = PAYMASTER_CONTRACT_WHITELIST.includes(call.address.toLowerCase())
+
+      try {
+        // Check calldata for ERC20 approve
+        const decodedCalldata = decodeFunctionData({ data: call.calldata, abi: erc20Abi })
+        if (decodedCalldata.functionName === 'approve') isTransactionWhitelisted = true
+      } catch {
+        // do nothing. must be another type of transaction if decoding failed
+      }
+
+      if (!isTransactionWhitelisted) {
+        return res.status(400).json({ error: 'Transaction type not whitelisted for Paymaster' })
+      }
+    }
 
     const PAYMASTER_URL = isSponsored ? ZYFI_SPONSORED_PAYMASTER_URL : ZYFI_PAYMASTER_URL
     const gas = calculateGasMargin(BigInt(call.gas), 2000n)

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -27,8 +27,8 @@ import { warningSeverity } from 'utils/exchange'
 import { PancakeSwapXTag } from 'components/PancakeSwapXTag'
 import { paymasterInfo } from 'config/paymaster'
 import { usePaymaster } from 'hooks/usePaymaster'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
 import { isAddressEqual } from 'utils'
+import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
 import FormattedPriceImpact from '../../components/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from '../../components/styleds'
 import { SlippageAdjustedAmounts, formatExecutionPrice } from '../utils/exchange'
@@ -265,7 +265,9 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
         {isPaymasterAvailable && isPaymasterTokenActive && (
           <RowBetween mt="8px">
             <RowFixed>
-              <Text fontSize="14px">{t('Gas Token')}</Text>
+              <Text color="textSubtle" fontSize="14px">
+                {t('Gas Token')}
+              </Text>
               {gasTokenInfo && gasTokenInfo.discount && (
                 <Badge
                   ref={targetRef}

--- a/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
@@ -5,9 +5,9 @@ import { memo, useMemo } from 'react'
 import { TradeSummary } from 'views/Swap/components/AdvancedSwapDetails'
 import { AdvancedDetailsFooter } from 'views/Swap/components/AdvancedSwapDetailsDropdown'
 
+import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { GasTokenSelector } from 'components/Paymaster/GasTokenSelector'
 import { usePaymaster } from 'hooks/usePaymaster'
-import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { isClassicOrder, isXOrder } from 'views/Swap/utils'
 import { RoutesBreakdown, XRoutesBreakdown } from '../components'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../hooks'
@@ -53,7 +53,9 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           priceImpactWithoutFee={priceImpactWithoutFee ?? undefined}
           realizedLPFee={lpFeeAmount ?? undefined}
           hasStablePair={hasStablePool}
-          gasTokenSelector={isPaymasterAvailable && inputAmount && <GasTokenSelector currency={inputAmount.currency} />}
+          gasTokenSelector={
+            isPaymasterAvailable && inputAmount && <GasTokenSelector inputCurrency={inputAmount.currency} />
+          }
         />
         {isXOrder(order) ? <XRoutesBreakdown /> : <RoutesBreakdown routes={order?.trade?.routes} />}
       </AutoColumn>

--- a/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
@@ -15,7 +15,7 @@ import {
 } from '@pancakeswap/uikit'
 import { formatAmount, formatFraction } from '@pancakeswap/utils/formatFractions'
 import { useUserSlippage } from '@pancakeswap/utils/user'
-import React, { memo, useState } from 'react'
+import { memo, useState } from 'react'
 
 import { NumberDisplay } from '@pancakeswap/widgets-internal'
 import { RowBetween, RowFixed } from 'components/Layout/Row'
@@ -44,7 +44,6 @@ export const TradeSummary = memo(function TradeSummary({
   slippageAdjustedAmounts,
   priceImpactWithoutFee,
   realizedLPFee,
-  gasTokenSelector,
   isX = false,
   loading = false,
 }: {
@@ -55,7 +54,6 @@ export const TradeSummary = memo(function TradeSummary({
   slippageAdjustedAmounts: SlippageAdjustedAmounts
   priceImpactWithoutFee?: Percent | null
   realizedLPFee?: CurrencyAmount<Currency> | null
-  gasTokenSelector?: React.ReactNode
   isX?: boolean
   loading?: boolean
 }) {
@@ -66,7 +64,6 @@ export const TradeSummary = memo(function TradeSummary({
 
   return (
     <AutoColumn px="4px">
-      {gasTokenSelector}
       <RowBetween>
         <RowFixed>
           <QuestionHelperV2

--- a/apps/web/src/views/SwapSimplify/V4Swap/ButtonAndDetailsPanel.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/ButtonAndDetailsPanel.tsx
@@ -13,24 +13,29 @@ export const PanelWrapper = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.cardBorder};
 `
 interface ButtonAndDetailsPanelProps {
+  shouldRenderDetails?: boolean
+
   swapCommitButton: React.ReactNode
   pricingAndSlippage: React.ReactNode
   tradeDetails: React.ReactNode
-  shouldRenderDetails?: boolean
   mevSlot?: React.ReactNode
+
+  gasTokenSelector?: React.ReactNode
 }
 
 export const ButtonAndDetailsPanel: React.FC<ButtonAndDetailsPanelProps> = ({
+  shouldRenderDetails,
   swapCommitButton,
   pricingAndSlippage,
   tradeDetails,
-  shouldRenderDetails,
   mevSlot,
+  gasTokenSelector,
 }) => {
   const [isOpen, setIsOpen] = useState(false)
   return (
     <PanelWrapper>
       {swapCommitButton}
+      {gasTokenSelector}
       {shouldRenderDetails && (
         <SwapUIV2.Collapse
           isOpen={isOpen}

--- a/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
@@ -5,9 +5,6 @@ import { memo, useMemo } from 'react'
 import { styled } from 'styled-components'
 
 import { PriceOrder } from '@pancakeswap/price-api-sdk'
-import { GasTokenSelector } from 'components/Paymaster/GasTokenSelector'
-import { usePaymaster } from 'hooks/usePaymaster'
-
 import { MevSwapDetail } from 'views/Mev/MevSwapDetail'
 import { isClassicOrder, isXOrder } from 'views/Swap/utils'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
@@ -46,8 +43,6 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
     [order],
   )
 
-  const { isPaymasterAvailable } = usePaymaster()
-
   if (isWrapping || !order || !slippageAdjustedAmounts || !order.trade) {
     return null
   }
@@ -66,7 +61,6 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           priceImpactWithoutFee={priceImpactWithoutFee ?? undefined}
           realizedLPFee={lpFeeAmount ?? undefined}
           hasStablePair={hasStablePool}
-          gasTokenSelector={isPaymasterAvailable && <GasTokenSelector currency={order?.trade.inputAmount.currency} />}
           loading={!loaded}
         />
         <Box mt="10px" pl="4px">

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -5,9 +5,11 @@ import { useUserSlippage } from '@pancakeswap/utils/user'
 import { SwapUIV2 } from '@pancakeswap/widgets-internal'
 import { useTokenRisk } from 'components/AccessRisk'
 import { RiskDetailsPanel, useShouldRiskPanelDisplay } from 'components/AccessRisk/SwapRevampRiskDisplay'
+import { GasTokenSelector } from 'components/Paymaster/GasTokenSelector'
 import { useCurrency } from 'hooks/Tokens'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useCurrencyUsdPrice } from 'hooks/useCurrencyUsdPrice'
+import { usePaymaster } from 'hooks/usePaymaster'
 import { useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import { useSwapState } from 'state/swap/hooks'
@@ -121,6 +123,8 @@ export function V4SwapForm() {
   const token0Risk = useTokenRisk(inputCurrency?.wrapped)
   const token1Risk = useTokenRisk(outputCurrency?.wrapped)
 
+  const { isPaymasterAvailable } = usePaymaster()
+
   return (
     <SwapUIV2.SwapFormWrapper>
       <SwapUIV2.SwapTabAndInputPanelWrapper>
@@ -183,6 +187,9 @@ export function V4SwapForm() {
         tradeDetails={<TradeDetails loaded={tradeLoaded} order={bestOrder} />}
         shouldRenderDetails={Boolean(executionPrice) && Boolean(bestOrder) && !isWrapping && !tradeError}
         mevSlot={<MevToggle />}
+        gasTokenSelector={
+          isPaymasterAvailable && <GasTokenSelector mt="8px" inputCurrency={inputCurrency || undefined} />
+        }
       />
     </SwapUIV2.SwapFormWrapper>
   )

--- a/packages/tokens/src/constants/zkSync.ts
+++ b/packages/tokens/src/constants/zkSync.ts
@@ -135,4 +135,12 @@ export const zksyncTokens = {
     'ReactorFusion',
     'https://reactorfusion.xyz/',
   ),
+  zfi: new ERC20Token(
+    ChainId.ZKSYNC,
+    '0x5d0d7BCa050e2E98Fd4A5e8d3bA823B49f39868d',
+    18,
+    'ZFI',
+    'Zyfi Token',
+    'https://www.zyfi.org/',
+  ),
 }

--- a/packages/tokens/src/constants/zkSync.ts
+++ b/packages/tokens/src/constants/zkSync.ts
@@ -135,12 +135,4 @@ export const zksyncTokens = {
     'ReactorFusion',
     'https://reactorfusion.xyz/',
   ),
-  zfi: new ERC20Token(
-    ChainId.ZKSYNC,
-    '0x5d0d7BCa050e2E98Fd4A5e8d3bA823B49f39868d',
-    18,
-    'ZFI',
-    'Zyfi Token',
-    'https://www.zyfi.org/',
-  ),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `GasTokenSelector` component and related functionalities across various swap views. It introduces new props, modifies existing structures, and improves the UI for better user experience.

### Detailed summary
- Added `gasTokenSelector` prop to `ButtonAndDetailsPanelProps`.
- Updated `ButtonAndDetailsPanel` to render `gasTokenSelector`.
- Enhanced `TradeSummary` to remove `gasTokenSelector`.
- Modified `TradeDetails` to properly use `GasTokenSelector`.
- Updated `V4SwapForm` to incorporate `gasTokenSelector`.
- Improved `GasTokenSelector` styling and props.
- Revised `paymaster` logic for better handling of sponsored transactions.
- Adjusted discount values in `paymasterInfo` for various tokens.
- Cleaned up imports and unused variables across files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->