### PR TITLE
fix: Gauges list position manager name not visible

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/usePositionManagerName.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/usePositionManagerName.ts
@@ -1,12 +1,22 @@
 import { Gauge } from '@pancakeswap/gauges'
 import { useQuery } from '@tanstack/react-query'
 import { getPositionManagerName } from 'views/GaugesVoting/utils'
+import { fetchPositionManager } from '@pancakeswap/position-managers'
 
 export const usePositionManagerName = (data: Gauge) => {
-  const { data: managerName } = useQuery({
-    queryKey: ['position-manager-name'],
-    queryFn: async ({ signal }) => getPositionManagerName(data, undefined, signal),
+  const { data: chainPositionManagers } = useQuery({
+    queryKey: ['position-managers-chain', data?.chainId],
+    queryFn: async ({ signal }) => fetchPositionManager(data?.chainId, signal),
     enabled: Boolean(data),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+  })
+
+  const { data: managerName } = useQuery({
+    queryKey: ['position-manager-name', data?.hash],
+    queryFn: async ({ signal }) => getPositionManagerName(data, chainPositionManagers, signal),
+    enabled: Boolean(data && chainPositionManagers),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `usePositionManagerName` hook to fetch position manager names based on the chain ID and the position manager data. It introduces a new query for fetching position managers and modifies the existing logic to use this data when retrieving the manager name.

### Detailed summary
- Added import for `fetchPositionManager` from `@pancakeswap/position-managers`.
- Modified the first `useQuery` to fetch `chainPositionManagers` using `fetchPositionManager`.
- Updated the second `useQuery` to use `chainPositionManagers` for fetching `managerName`.
- Adjusted query keys to include relevant identifiers (`chainId` and `hash`).
- Set `enabled` conditions to ensure queries run only when necessary.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->