### PR TITLE
chore: Remove routing crons

### DIFF
--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -8,8 +8,6 @@ r2_buckets = [
 main = "src/index.ts"
 name = "routing-dev"
 node_compat = true
-[triggers]
-crons = ["0 0 * * *"]
 
 [env.production]
 kv_namespaces = [
@@ -19,7 +17,6 @@ r2_buckets = [
   { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools", preview_bucket_name = "subgraph-pools-dev" }
 ]
 name = "routing"
-[env.production.triggers]
 
 # The necessary secrets are:
 # - ETH_NODE


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the configuration in the `wrangler.toml` file for a project named `routing-dev`. It removes the `triggers` section, specifically the `crons` entry, and the reference to `env.production.triggers`.

### Detailed summary
- Removed the entire `[triggers]` section.
- Deleted the `crons` entry: `crons = ["0 0 * * *"]`.
- Removed the line `[env.production.triggers]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->