### PR TITLE
chore: Use isAddressEqual for comparison

### DIFF
--- a/apps/web/src/components/AccessRisk/index.tsx
+++ b/apps/web/src/components/AccessRisk/index.tsx
@@ -22,6 +22,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useAllLists } from 'state/lists/hooks'
 import { useUserTokenRisk } from 'state/user/hooks/useUserTokenRisk'
 import { styled } from 'styled-components'
+import { isAddressEqual } from 'utils'
 
 const AnimatedButton = styled(Button)`
   animation: ${promotedGradient} 1.5s ease infinite;
@@ -137,7 +138,7 @@ const AccessRiskComponent: React.FC<AccessRiskProps> = ({ token }) => {
       .filter(Boolean)
     if (!tokenLists.length) return null
     return tokenLists.some((tokenInfoList) => {
-      return tokenInfoList?.some((tokenInfo) => tokenInfo.address === token.address)
+      return tokenInfoList?.some((tokenInfo) => isAddressEqual(tokenInfo.address, token.address))
     })
   }, [lists, token?.address])
 

--- a/apps/web/src/components/Paymaster/GasTokenSelector.tsx
+++ b/apps/web/src/components/Paymaster/GasTokenSelector.tsx
@@ -37,6 +37,7 @@ import { Currency } from '@pancakeswap/swap-sdk-core'
 import { watchAccount } from '@wagmi/core'
 import { DEFAULT_PAYMASTER_TOKEN, paymasterInfo, paymasterTokens } from 'config/paymaster'
 import { useGasToken } from 'hooks/useGasToken'
+import { isAddressEqual } from 'utils'
 
 // Selector Styles
 const GasTokenSelectButton = styled(Button).attrs({ variant: 'text', scale: 'xs' })`
@@ -143,7 +144,7 @@ export const GasTokenSelector = ({ currency: inputCurrency }: GasTokenSelectorPr
       // Check if input token is native ETH to avoid conflicts when WETH is selected as gas token
       !inputCurrency.isNative &&
       gasToken.isToken &&
-      inputCurrency.wrapped.address === gasToken.wrapped.address,
+      isAddressEqual(inputCurrency.wrapped.address, gasToken.wrapped.address),
     [inputCurrency, gasToken, gasTokenInfo],
   )
 

--- a/apps/web/src/hooks/useMerkl.tsx
+++ b/apps/web/src/hooks/useMerkl.tsx
@@ -18,6 +18,7 @@ import { getContract } from 'utils/contractHelpers'
 import { Address } from 'viem'
 import { useWalletClient } from 'wagmi'
 import { useMasterchefV3 } from 'hooks/useContract'
+import { isAddressEqual } from 'utils'
 
 export const MERKL_API_V2 = 'https://api.angle.money/v2/merkl'
 
@@ -127,7 +128,7 @@ export function useMerklInfo(poolAddress?: string): {
     const rewardCurrencies = (rewardTokenAddresses as string[])
       .reduce<TokenInfo[]>((result, address) => {
         Object.values(lists).find((list) => {
-          const token: TokenInfo | undefined = list?.current?.tokens.find((t) => t.address === address)
+          const token: TokenInfo | undefined = list?.current?.tokens.find((t) => isAddressEqual(t.address, address))
 
           if (token) return result.push(token)
 

--- a/apps/web/src/pages/add/[[...currency]].tsx
+++ b/apps/web/src/pages/add/[[...currency]].tsx
@@ -11,6 +11,7 @@ import LiquidityFormProvider from 'views/AddLiquidityV3/formViews/V3FormView/for
 import { useCurrencyParams } from 'views/AddLiquidityV3/hooks/useCurrencyParams'
 import { SELECTOR_TYPE } from 'views/AddLiquidityV3/types'
 import { PageWithoutFAQ } from 'views/Page'
+import { isAddressEqual } from 'utils'
 
 const AddLiquidityPage = () => {
   const router = useRouter()
@@ -43,8 +44,10 @@ const AddLiquidityPage = () => {
     const hasV2Farm = farmsV2Public?.find(
       (farm) =>
         farm.multiplier !== '0X' &&
-        ((farm.token.address === currencyA.wrapped.address && farm.quoteToken.address === currencyB.wrapped.address) ||
-          (farm.token.address === currencyB.wrapped.address && farm.quoteToken.address === currencyA.wrapped.address)),
+        ((isAddressEqual(farm.token.address, currencyA.wrapped.address) &&
+          isAddressEqual(farm.quoteToken.address, currencyB.wrapped.address)) ||
+          (isAddressEqual(farm.token.address, currencyB.wrapped.address) &&
+            isAddressEqual(farm.quoteToken.address, currencyA.wrapped.address))),
     )
     return hasV2Farm
       ? isStableFarm(hasV2Farm)

--- a/apps/web/src/pages/stable/[address].tsx
+++ b/apps/web/src/pages/stable/[address].tsx
@@ -38,6 +38,7 @@ import { formatFiatNumber } from '@pancakeswap/utils/formatFiatNumber'
 import { useTotalPriceUSD } from 'hooks/useTotalPriceUSD'
 import { useLPApr } from 'state/swap/useLPApr'
 import { formatAmount } from 'utils/formatInfoNumbers'
+import { isAddressEqual } from 'utils'
 
 export const BodyWrapper = styled(Card)`
   border-radius: 24px;
@@ -63,7 +64,7 @@ export default function StablePoolPage() {
   const { chainId } = useActiveChainId()
 
   const selectedLp = useMemo(
-    () => lpTokens.find(({ liquidityToken }) => liquidityToken.address === poolAddress),
+    () => lpTokens.find(({ liquidityToken }) => isAddressEqual(liquidityToken.address, poolAddress)),
     [lpTokens, poolAddress],
   )
 

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -16,7 +16,7 @@ import { useRouter } from 'next/router'
 import { ParsedUrlQuery } from 'querystring'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ChartPeriod, chainIdToExplorerInfoChainName, explorerApiClient } from 'state/info/api/client'
-import { safeGetAddress } from 'utils'
+import { isAddressEqual, safeGetAddress } from 'utils'
 import { computeSlippageAdjustedAmounts } from 'utils/exchange'
 import { getTokenAddress } from 'views/Swap/components/Chart/utils'
 import { useAccount } from 'wagmi'
@@ -43,8 +43,8 @@ const BAD_RECIPIENT_ADDRESSES: string[] = [
  */
 function involvesAddress(trade: Trade<Currency, Currency, TradeType>, checksummedAddress: string): boolean {
   return (
-    trade.route.path.some((token) => token.address === checksummedAddress) ||
-    trade.route.pairs.some((pair) => pair.liquidityToken.address === checksummedAddress)
+    trade.route.path.some((token) => isAddressEqual(token.address, checksummedAddress)) ||
+    trade.route.pairs.some((pair) => isAddressEqual(pair.liquidityToken.address, checksummedAddress))
   )
 }
 

--- a/apps/web/src/views/AddLiquidity/AddStableLiquidity/index.tsx
+++ b/apps/web/src/views/AddLiquidity/AddStableLiquidity/index.tsx
@@ -21,7 +21,7 @@ import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useAddLiquidityV2FormState } from 'state/mint/reducer'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { useGasPrice } from 'state/user/hooks'
-import { calculateGasMargin } from 'utils'
+import { calculateGasMargin, isAddressEqual } from 'utils'
 import { calculateSlippageAmount } from 'utils/exchange'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 import { Address } from 'viem'
@@ -206,10 +206,12 @@ export default function AddStableLiquidity({
     const quotientB = parsedAmountB?.quotient || 0n
 
     // Ensure the token order [token0, token1]
-    const tokenAmounts =
-      stableSwapConfig?.token0?.wrapped.address === parsedAmountA?.currency?.wrapped?.address
-        ? ([quotientA, quotientB] as const)
-        : ([quotientB, quotientA] as const)
+    const tokenAmounts = isAddressEqual(
+      stableSwapConfig?.token0?.wrapped.address,
+      parsedAmountA?.currency?.wrapped?.address,
+    )
+      ? ([quotientA, quotientB] as const)
+      : ([quotientB, quotientA] as const)
 
     let args_
 

--- a/apps/web/src/views/FixedStaking/index.tsx
+++ b/apps/web/src/views/FixedStaking/index.tsx
@@ -10,6 +10,7 @@ import partition from 'lodash/partition'
 import { useMemo, useState } from 'react'
 import { Address } from 'viem'
 
+import { isAddressEqual } from 'utils'
 import { FixedStakingCard } from './components/FixedStakingCard'
 import FixedStakingRow from './components/FixedStakingRow'
 import { useStakedPools, useStakedPositionsByUser } from './hooks/useStakedPools'
@@ -97,8 +98,8 @@ const FixedStaking = () => {
             {sortedPoolGroup.map((key) => (
               <FixedStakingRow
                 key={key}
-                stakedPositions={stakedPositions.filter(
-                  ({ pool: stakedPool }) => stakedPool.token.address === poolGroup[key].token.address,
+                stakedPositions={stakedPositions.filter(({ pool: stakedPool }) =>
+                  isAddressEqual(stakedPool.token.address, poolGroup[key].token.address),
                 )}
                 pool={poolGroup[key]}
               />
@@ -110,8 +111,8 @@ const FixedStaking = () => {
               <FixedStakingCard
                 key={key}
                 pool={poolGroup[key]}
-                stakedPositions={stakedPositions.filter(
-                  ({ pool: stakedPool }) => stakedPool.token.address === poolGroup[key].token.address,
+                stakedPositions={stakedPositions.filter(({ pool: stakedPool }) =>
+                  isAddressEqual(stakedPool.token.address, poolGroup[key].token.address),
                 )}
               />
             ))}

--- a/apps/web/src/views/GaugesVoting/components/TripleLogo.tsx
+++ b/apps/web/src/views/GaugesVoting/components/TripleLogo.tsx
@@ -12,6 +12,7 @@ import { ChainLogo, CurrencyLogo } from '@pancakeswap/widgets-internal'
 import { useMemo } from 'react'
 import styled from 'styled-components'
 import { Address } from 'viem'
+import { isAddressEqual } from 'utils'
 
 const StyledDualLogo = styled.div`
   display: flex;
@@ -29,7 +30,7 @@ function getCurrency(chainId: ChainId, address?: Address) {
   if (!address) {
     return undefined
   }
-  if (WNATIVE[chainId].address === address) {
+  if (isAddressEqual(WNATIVE[chainId].address, address)) {
     return Native.onChain(chainId)
   }
   return new Token(Number(chainId), address, 18, '', '')

--- a/apps/web/src/views/Migration/components/v3/Step1.tsx
+++ b/apps/web/src/views/Migration/components/v3/Step1.tsx
@@ -9,6 +9,7 @@ import { useFarms, usePollFarmsWithUserData } from 'state/farms/hooks'
 import { useFarmsV3Public } from 'state/farmsV3/hooks'
 import { getFarmApr } from 'utils/apr'
 import { useAccount } from 'wagmi'
+import { isAddressEqual } from 'utils'
 import MigrationFarmTable from '../MigrationFarmTable'
 import { V3Step1DesktopColumnSchema } from '../types'
 import { STABLE_LP_TO_MIGRATE } from './Step2'
@@ -35,8 +36,10 @@ const OldFarmStep1: React.FC<React.PropsWithChildren> = () => {
         .filter((f) => f.multiplier !== '0X')
         .find(
           (farmV3) =>
-            (farmV3.quoteToken.address === farm.quoteToken.address && farmV3.token.address === farm.token.address) ||
-            (farmV3.quoteToken.address === farm.token.address && farmV3.token.address === farm.quoteToken.address),
+            (isAddressEqual(farmV3.quoteToken.address, farm.quoteToken.address) &&
+              isAddressEqual(farmV3.token.address, farm.token.address)) ||
+            (isAddressEqual(farmV3.quoteToken.address, farm.token.address) &&
+              isAddressEqual(farmV3.token.address, farm.quoteToken.address)),
         )
     })
 

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
@@ -25,6 +25,7 @@ import { warningSeverity } from 'utils/exchange'
 import { paymasterInfo } from 'config/paymaster'
 import { usePaymaster } from 'hooks/usePaymaster'
 import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { isAddressEqual } from 'utils'
 import FormattedPriceImpact from '../../components/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from '../../components/styleds'
 import { SlippageAdjustedAmounts, formatExecutionPrice } from '../utils/exchange'
@@ -100,7 +101,7 @@ export const SwapModalFooter = memo(function SwapModalFooter({
       inputAmount.currency?.wrapped.address &&
       !inputAmount.currency.isNative &&
       gasToken.isToken &&
-      inputAmount.currency.wrapped.address === gasToken.wrapped.address,
+      isAddressEqual(inputAmount.currency.wrapped.address, gasToken.wrapped.address),
     [inputAmount, gasToken, isPaymasterAvailable, isPaymasterTokenActive, gasTokenInfo],
   )
 

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -28,6 +28,7 @@ import { PancakeSwapXTag } from 'components/PancakeSwapXTag'
 import { paymasterInfo } from 'config/paymaster'
 import { usePaymaster } from 'hooks/usePaymaster'
 import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { isAddressEqual } from 'utils'
 import FormattedPriceImpact from '../../components/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from '../../components/styleds'
 import { SlippageAdjustedAmounts, formatExecutionPrice } from '../utils/exchange'
@@ -109,7 +110,7 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
       inputAmount.currency?.wrapped.address &&
       !inputAmount.currency.isNative &&
       gasToken.isToken &&
-      inputAmount.currency.wrapped.address === gasToken.wrapped.address,
+      isAddressEqual(inputAmount.currency.wrapped.address, gasToken.wrapped.address),
     [inputAmount, gasToken, isPaymasterAvailable, isPaymasterTokenActive, gasTokenInfo],
   )
 

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapInputError.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapInputError.ts
@@ -4,7 +4,7 @@ import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
 
 import { Field } from 'state/swap/actions'
 import { useSwapState } from 'state/swap/hooks'
-import { safeGetAddress } from 'utils'
+import { isAddressEqual, safeGetAddress } from 'utils'
 
 import { ClassicOrder, PriceOrder } from '@pancakeswap/price-api-sdk'
 import { isClassicOrder } from 'views/Swap/utils'
@@ -23,7 +23,9 @@ interface Balances {
  */
 function involvesAddress(trade: ClassicOrder['trade'], checksummedAddress: string): boolean {
   // TODO check for pools
-  return trade.routes.some((r) => r.path.some((token) => token.isToken && token.address === checksummedAddress))
+  return trade.routes.some((r) =>
+    r.path.some((token) => token.isToken && isAddressEqual(token.address, checksummedAddress)),
+  )
 }
 
 // TODO: update

--- a/apps/web/src/views/Swap/hooks/useEstimatedAmount.ts
+++ b/apps/web/src/views/Swap/hooks/useEstimatedAmount.ts
@@ -1,6 +1,7 @@
 import { CurrencyAmount } from '@pancakeswap/sdk'
 import { useDeferredValue } from 'react'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { isAddressEqual } from 'utils'
 
 export function useEstimatedAmount({ estimatedCurrency, stableSwapConfig, quotient, stableSwapContract }) {
   const deferQuotient = useDeferredValue(quotient)
@@ -9,7 +10,7 @@ export function useEstimatedAmount({ estimatedCurrency, stableSwapConfig, quotie
     queryKey: ['swapContract', stableSwapConfig?.stableSwapAddress, deferQuotient],
 
     queryFn: async () => {
-      const isToken0 = stableSwapConfig?.token0?.address === estimatedCurrency?.address
+      const isToken0 = isAddressEqual(stableSwapConfig?.token0?.address, estimatedCurrency?.address)
 
       const args = isToken0 ? [1, 0, deferQuotient] : [0, 1, deferQuotient]
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving address comparison throughout the codebase by replacing direct equality checks with the `isAddressEqual` utility function. This enhances code readability and consistency.

### Detailed summary
- Replaced direct address comparisons with `isAddressEqual` in multiple files:
  - `TripleLogo.tsx`
  - `StablePoolPage.tsx`
  - `AccessRiskComponent.tsx`
  - `useMerkl.tsx`
  - `GasTokenSelector.tsx`
  - `useSwapInputError.ts`
  - `useEstimatedAmount.ts`
  - `SwapModalFooter.tsx`
  - `SwapModalFooterV2.tsx`
  - `AddLiquidityPage.tsx`
  - `Step1.tsx`
  - `AddStableLiquidity/index.tsx`
  - `hooks.ts`
  - `FixedStaking/index.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->