### PR TITLE
chore: Use next link for internal

### DIFF
--- a/apps/web/src/views/Home/components/Banners/NewIFOBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/NewIFOBanner.tsx
@@ -5,6 +5,7 @@ import { ASSET_CDN } from 'config/constants/endpoints'
 import useTheme from 'hooks/useTheme'
 import { memo } from 'react'
 import { styled } from 'styled-components'
+import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import * as S from './Styled'
 import { Countdown } from './Countdown'
 
@@ -169,7 +170,7 @@ const NewIFOBanner = () => {
           <StyledSubheading>{t('CKP cIFO')}</StyledSubheading>
           <Countdown startTime={1704369600} />
           <Flex style={{ gap: isMobile ? 4 : 16 }}>
-            <Link href="/ifo" style={{ textDecoration: 'none' }}>
+            <NextLinkFromReactRouter to="/ifo" style={{ textDecoration: 'none' }}>
               <Button variant="text" pl="0px" pt="0px" scale={isMobile ? 'sm' : 'md'}>
                 <Text
                   textTransform={isMobile ? 'uppercase' : 'capitalize'}
@@ -181,7 +182,7 @@ const NewIFOBanner = () => {
                 </Text>
                 <OpenNewIcon color={theme.colors.primaryDark} />
               </Button>
-            </Link>
+            </NextLinkFromReactRouter>
           </Flex>
         </S.LeftWrapper>
         <BackGroundLayer>

--- a/apps/web/src/views/ProfileCreation/Header.tsx
+++ b/apps/web/src/views/ProfileCreation/Header.tsx
@@ -1,6 +1,7 @@
 import { TranslateFunction, useTranslation } from '@pancakeswap/localization'
 import { Breadcrumbs, Button, Heading, Link, Text } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
+import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import useProfileCreation from './contexts/hook'
 
 const Wrapper = styled.div`
@@ -32,11 +33,11 @@ const Header: React.FC<React.PropsWithChildren> = () => {
       <Text color="textSubtle" mb="8px">
         {t('Total cost: 1.5 CAKE')}
       </Text>
-      <Link href="/profile">
+      <NextLinkFromReactRouter to="/profile">
         <Button mb="24px" scale="sm" variant="secondary">
           {t('Back to profile')}
         </Button>
-      </Link>
+      </NextLinkFromReactRouter>
       <Breadcrumbs>
         {steps(t).map((translationKey, index) => {
           return (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing the `Link` component with `NextLinkFromReactRouter` in two files, enhancing navigation functionality in the application.

### Detailed summary
- In `Header.tsx`:
  - Replaced `<Link href="/profile">` with `<NextLinkFromReactRouter to="/profile">`.
  
- In `NewIFOBanner.tsx`:
  - Replaced `<Link href="/ifo">` with `<NextLinkFromReactRouter to="/ifo">`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->