### PR TITLE
chore: Revert back to use explorer api

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -103,29 +103,6 @@ const config = {
           destination: '/api/vercel/flags',
         },
       ],
-      beforeFiles: [
-        // TODO: remove rewrite once explorer is fixed
-        {
-          source: '/info/v3',
-          destination: 'https://info-v1.pancakeswap.finance/info/v3',
-        },
-        {
-          source: '/info/v3/pairs',
-          destination: 'https://info-v1.pancakeswap.finance/info/v3/pairs',
-        },
-        {
-          source: '/info/v3/tokens',
-          destination: 'https://info-v1.pancakeswap.finance/info/v3/tokens',
-        },
-        {
-          source: '/info/v3/tokens/:path*',
-          destination: 'https://info-v1.pancakeswap.finance/info/v3/tokens/:path*',
-        },
-        {
-          source: '/info/v3/pairs/:path*',
-          destination: 'https://info-v1.pancakeswap.finance/info/v3/pairs/:path*',
-        },
-      ],
     }
   },
   async headers() {

--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -1,134 +1,23 @@
-import { ChainId, getChainNameInKebabCase } from '@pancakeswap/chains'
+import { getChainNameInKebabCase } from '@pancakeswap/chains'
 import {
   FarmV4SupportedChainId,
-  Protocol,
   fetchAllUniversalFarms,
   masterChefV3Addresses,
+  Protocol,
   supportedChainIdV4,
 } from '@pancakeswap/farms'
 import { smartChefABI } from '@pancakeswap/pools'
 import { getStableSwapPools } from '@pancakeswap/stable-swap-sdk'
 import { FeeAmount, masterChefV3ABI } from '@pancakeswap/v3-sdk'
-import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import { GraphQLClient, gql } from 'graphql-request'
-import groupBy from 'lodash/groupBy'
 import { explorerApiClient } from 'state/info/api/client'
 import { isAddressEqual } from 'utils'
-import { v3Clients } from 'utils/graphql'
 import { publicClient } from 'utils/viem'
 import { type Address } from 'viem'
 import { PoolInfo } from '../type'
 import { parseFarmPools } from '../utils'
 
-dayjs.extend(utc)
-
 const DEFAULT_PROTOCOLS: Protocol[] = [Protocol.V3, Protocol.V2, Protocol.STABLE]
 const DEFAULT_CHAINS: FarmV4SupportedChainId[] = Object.values(supportedChainIdV4)
-
-type PoolIdentifier = {
-  id: string
-  chainId: ChainId
-  protocol: 'v2' | 'v3' | 'stable' | 'v4cl' | 'v4bin'
-}
-
-type WithTvlAndVolume = {
-  tvlUSD: string
-  volumeUSD24h: string
-}
-
-type PoolWithTvlVolume = PoolIdentifier & WithTvlAndVolume
-
-type V3PoolResult = {
-  poolDayDatas: {
-    pool: {
-      id: string
-    }
-    volumeUSD: string
-    tvlUSD: string
-  }[]
-}
-
-function getPoolKey({ id, chainId, protocol }: PoolIdentifier): string {
-  return `${chainId}_${id}_${protocol}`
-}
-
-function fetchV3PoolsTvlVolumeFromSubgraph(pools: PoolIdentifier[]): Promise<PoolWithTvlVolume[]>[] {
-  const groupByChain = groupBy(pools, (p) => p.chainId)
-  const res = Object.keys(groupByChain).map(async (chain) => {
-    const poolsOnChain = groupByChain[chain]
-    const chainId = Number(chain) as ChainId
-    // NOTE: only fix bsc tvl and volume
-    if (chainId !== ChainId.BSC) {
-      return []
-    }
-    const client: GraphQLClient = v3Clients[chainId]
-    if (!client) {
-      return []
-    }
-    const result = await client.request<V3PoolResult>(
-      gql`
-        query pools($addresses: [String!]!, $startAt: Int!, $endAt: Int!) {
-          poolDayDatas(first: 1000, where: { date_gte: $startAt, date_lt: $endAt, pool_in: $addresses }) {
-            volumeUSD
-            tvlUSD
-            pool {
-              id
-            }
-          }
-        }
-      `,
-      {
-        addresses: poolsOnChain.map((p) => p.id),
-        startAt: dayjs().utc().startOf('day').subtract(1, 'days').unix(),
-        endAt: dayjs().utc().startOf('day').unix(),
-      },
-    )
-    return result.poolDayDatas.map((data) => ({
-      id: data.pool.id,
-      chainId,
-      protocol: 'v3' as const,
-      tvlUSD: data.tvlUSD,
-      volumeUSD24h: data.volumeUSD,
-    }))
-  })
-  return res
-}
-
-function createSubgraphTvlVolumeFetcher() {
-  let cache: {
-    [key: string]: PoolWithTvlVolume
-  } = {}
-
-  return async function fetchTvlVolumeFromSubgraph(pools: PoolIdentifier[]): Promise<{
-    [key: string]: PoolWithTvlVolume
-  }> {
-    const groupByProtocol = groupBy(
-      pools.filter((p) => !cache[getPoolKey(p)]),
-      (p) => p.protocol,
-    )
-    const v3Pools = groupByProtocol.v3
-    const res = await Promise.allSettled(fetchV3PoolsTvlVolumeFromSubgraph(v3Pools))
-    const data = res.reduce<{ [key: string]: PoolWithTvlVolume }>((acc, cur) => {
-      if (cur.status === 'rejected') {
-        return acc
-      }
-      return cur.value.reduce(
-        (list, p) => ({
-          ...list,
-          [getPoolKey(p)]: p,
-        }),
-        acc,
-      )
-    }, {})
-    cache = {
-      ...cache,
-      ...data,
-    }
-    return cache
-  }
-}
-const fetchTvlVolumeFromSubgraph = createSubgraphTvlVolumeFetcher()
 
 export const fetchExplorerFarmPools = async (
   args: {
@@ -161,20 +50,8 @@ export const fetchExplorerFarmPools = async (
   if (!resp.data) {
     return []
   }
-  const tvlAndVolume = await fetchTvlVolumeFromSubgraph(resp.data)
 
-  return parseFarmPools(
-    resp.data.map((p) => {
-      const infoFromSubgraph = tvlAndVolume[getPoolKey(p)]
-      if (!infoFromSubgraph) return p
-      return {
-        ...p,
-        tvlUSD: infoFromSubgraph.tvlUSD,
-        volumeUSD24h: infoFromSubgraph.volumeUSD24h,
-      }
-    }),
-    { isFarming: true },
-  )
+  return parseFarmPools(resp.data, { isFarming: true })
 }
 
 export const fetchFarmPools = async (


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on cleaning up the `next.config.mjs` by removing outdated rewrites and refactoring the `fetcher.ts` to simplify the fetching of farm pool data without relying on subgraph TVL and volume.

### Detailed summary
- Removed the `beforeFiles` rewrite rules in `next.config.mjs`.
- Refactored `fetcher.ts`:
  - Removed unused imports and dependencies.
  - Simplified the `fetchExplorerFarmPools` function by eliminating TVL and volume fetching logic.
  - Updated `parseFarmPools` to directly use `resp.data` without additional processing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->