### PR TITLE
chore: Missing titles in swap and info v3 and calculate basepath only no exact

### DIFF
--- a/apps/web/src/config/constants/meta.ts
+++ b/apps/web/src/config/constants/meta.ts
@@ -14,7 +14,7 @@ interface PathList {
   defaultTitleSuffix: string
 }
 
-const getPathList = (t: ContextApi['t']): PathList => {
+const getPathList = memoize((t: ContextApi['t']): PathList => {
   return {
     paths: {
       '/': { title: t('Home') },
@@ -38,6 +38,7 @@ const getPathList = (t: ContextApi['t']): PathList => {
       '/voting/proposal': { title: t('Proposals'), image: `${ASSET_CDN}/web/og/voting.jpg` },
       '/voting/proposal/create': { title: t('Make a Proposal'), image: `${ASSET_CDN}/web/og/voting.jpg` },
       '/info': {
+        basePath: true,
         title: `${t('Overview')} - ${t('Info')}`,
         description: 'View statistics for Pancakeswap exchanges.',
         image: `${ASSET_CDN}/web/og/info.jpg`,
@@ -47,15 +48,25 @@ const getPathList = (t: ContextApi['t']): PathList => {
         description: 'View statistics for Pancakeswap exchanges.',
         image: `${ASSET_CDN}/web/og/info.jpg`,
       },
+      '/info/tokens': {
+        title: `${t('Tokens')} - ${t('Info')}`,
+        description: 'View statistics for Pancakeswap exchanges.',
+        image: `${ASSET_CDN}/web/og/info.jpg`,
+      },
+      '/info/v3/pairs': {
+        title: `${t('Pairs')} - ${t('Info')}`,
+        description: 'View statistics for Pancakeswap exchanges.',
+        image: `${ASSET_CDN}/web/og/info.jpg`,
+      },
+      '/info/v3/tokens': {
+        title: `${t('Tokens')} - ${t('Info')}`,
+        description: 'View statistics for Pancakeswap exchanges.',
+        image: `${ASSET_CDN}/web/og/info.jpg`,
+      },
       '/liquidity/pool': {
         basePath: true,
         title: `${t('Pool Detail')}`,
         description: 'View statistics for Pancakeswap pool.',
-        image: `${ASSET_CDN}/web/og/info.jpg`,
-      },
-      '/info/tokens': {
-        title: `${t('Tokens')} - ${t('Info')}`,
-        description: 'View statistics for Pancakeswap exchanges.',
         image: `${ASSET_CDN}/web/og/info.jpg`,
       },
       '/nfts': { title: t('NFT Marketplace'), image: `${ASSET_CDN}/web/og/nft.jpg` },
@@ -71,13 +82,18 @@ const getPathList = (t: ContextApi['t']): PathList => {
     },
     defaultTitleSuffix: t('PancakeSwap'),
   }
-}
+})
 
 export const getCustomMeta = memoize(
   (path: string, t: ContextApi['t'], _: string): PageMeta | null => {
     const pathList = getPathList(t)
-    const basePath = Object.entries(pathList.paths).find(([url, data]) => data.basePath && path.startsWith(url))?.[0]
-    const pathMetadata = pathList.paths[path] ?? (basePath && pathList.paths[basePath])
+    let pathMetadata = pathList.paths[path]
+    if (!pathMetadata) {
+      const basePath = Object.entries(pathList.paths).find(([url, data]) => data.basePath && path.startsWith(url))?.[0]
+      if (basePath) {
+        pathMetadata = pathList.paths[basePath]
+      }
+    }
 
     if (pathMetadata) {
       return {

--- a/apps/web/src/config/constants/meta.ts
+++ b/apps/web/src/config/constants/meta.ts
@@ -17,7 +17,8 @@ interface PathList {
 const getPathList = memoize((t: ContextApi['t']): PathList => {
   return {
     paths: {
-      '/': { title: t('Home') },
+      '/home': { title: t('Home') },
+      '/': { basePath: true, title: t('Exchange'), image: `${ASSET_CDN}/web/og/swap.jpg` },
       '/swap': { basePath: true, title: t('Exchange'), image: `${ASSET_CDN}/web/og/swap.jpg` },
       '/limit-orders': { basePath: true, title: t('Limit Orders'), image: `${ASSET_CDN}/web/og/limit.jpg` },
       '/add': { basePath: true, title: t('Add Liquidity'), image: `${ASSET_CDN}/web/og/liquidity.jpg` },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `getPathList` function to use `memoize`, updates path definitions, and enhances the handling of metadata for specific routes in the application. It also improves the retrieval of base paths and associated metadata.

### Detailed summary
- Changed `getPathList` to use `memoize`.
- Updated paths: 
  - Added `/home` and modified `/` to include `basePath` and an image.
- Added new paths for `/info/tokens`, `/info/v3/pairs`, and `/info/v3/tokens`.
- Enhanced `/liquidity/pool` with `basePath`.
- Improved metadata retrieval logic in `getCustomMeta`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->