### PR TITLE
fix: mismatch gauge in cms and sc side

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next info && next build --debug",
     "start": "next start",
-    "test": "LC_ALL=\"en_US.UTF-8\" vitest --run",
+    "test": "LC_ALL=\"en_US.UTF-8\" vitest --exclude **/gauges*.test.ts --run",
     "test:watch": "LC_ALL=\"en_US.UTF-8\" vitest --watch",
     "test:config": "vitest --run --config vitest-config-test.config.ts",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next info && next build --debug",
     "start": "next start",
-    "test": "LC_ALL=\"en_US.UTF-8\" vitest --exclude **/gauges*.test.ts --run",
+    "test": "LC_ALL=\"en_US.UTF-8\" vitest --run",
     "test:watch": "LC_ALL=\"en_US.UTF-8\" vitest --watch",
     "test:config": "vitest --run --config vitest-config-test.config.ts",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",

--- a/apps/web/src/__tests__/gagues/gauges.test.ts
+++ b/apps/web/src/__tests__/gagues/gauges.test.ts
@@ -1,0 +1,22 @@
+import { ChainId } from '@pancakeswap/chains'
+import { getAllGauges } from '@pancakeswap/gauges'
+import { getViemClients } from 'utils/viem'
+import { describe, it } from 'vitest'
+
+describe('get all guages', () => {
+  it('contract gaguges and cms gauges should be match', async () => {
+    const gauges = await getAllGauges(
+      getViemClients({
+        chainId: ChainId.BSC,
+      }),
+      {
+        testnet: false,
+        inCap: false,
+        bothCap: false,
+        killed: true,
+      },
+    )
+    const notMatched = gauges.find((x) => !x.pairAddress)
+    expect(notMatched).toBeUndefined()
+  }, 300000)
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -22,6 +22,6 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.js'],
     environment: 'happy-dom',
     globals: true,
-    exclude: ['src/config/__tests__', 'node_modules'],
+    exclude: ['src/config/__tests__', 'src/__tests__/gagues', 'node_modules'],
   },
 })

--- a/apps/web/vitest.setup.js
+++ b/apps/web/vitest.setup.js
@@ -4,6 +4,7 @@
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
 import { vi } from 'vitest'
+import './src/utils/abortcontroller-polyfill.ts'
 
 global.setImmediate = vi.useRealTimers
 

--- a/packages/gauges/src/fetchAllGauges.ts
+++ b/packages/gauges/src/fetchAllGauges.ts
@@ -30,19 +30,17 @@ export const fetchAllGauges = async (
     ...options,
   })) as ContractFunctionReturnType<typeof gaugesVotingABI, AbiStateMutability, 'gauges'>[]
 
-  return response.reduce((prev, curr) => {
-    const [pid, masterChef, chainId, pairAddress, boostMultiplier, maxVoteCap] = curr
-    return [
-      ...prev,
-      {
-        pid: Number(pid),
-        hash: getGaugeHash(pairAddress, Number(chainId)),
-        pairAddress,
-        masterChef,
-        chainId: Number(chainId),
-        boostMultiplier: Number(boostMultiplier),
-        maxVoteCap: Number(maxVoteCap),
-      },
-    ]
-  }, [] as GaugeInfo[])
+  return response.map((x, i) => {
+    const [pid, masterChef, chainId, pairAddress, boostMultiplier, maxVoteCap] = x
+    return {
+      gid: i,
+      pid: Number(pid),
+      hash: getGaugeHash(pairAddress, Number(chainId)),
+      pairAddress,
+      masterChef,
+      chainId: Number(chainId),
+      boostMultiplier: Number(boostMultiplier),
+      maxVoteCap: Number(maxVoteCap),
+    } as GaugeInfo
+  })
 }

--- a/packages/gauges/src/types.ts
+++ b/packages/gauges/src/types.ts
@@ -69,6 +69,7 @@ export interface GaugeVeCakePoolConfig extends GaugeBaseConfig {
 export type GaugeConfig = GaugeV2Config | GaugeStableSwapConfig | GaugeV3Config | GaugeALMConfig | GaugeVeCakePoolConfig
 
 export type GaugeInfo = {
+  gid: number
   hash: Hash
   pairAddress: Address
   masterChef: Address


### PR DESCRIPTION
The old alg using sc side data as the source, this cause some data in cms not reflect in google sheets. 
1. The original algorithm using address as condition to match, now I modified to gid. 
2. CMS side data is used as SSOT.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `GaugeInfo` type structure, introducing new tests for gauge retrieval, and refining the logic for fetching and merging gauge configurations.

### Detailed summary
- Added `gid` property to `GaugeInfo` type.
- Included an import for `abortcontroller-polyfill.ts`.
- Updated test exclusions in `vitest.config.ts`.
- Created tests for gauge retrieval in `gauges.test.ts`.
- Modified `fetchAllGauges` to use `gid` instead of `pid`.
- Introduced `fetchGaugesSC` function for fetching smart contract gauges.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->