### PR TITLE
fix: Update keep previous data param in info query hooks

### DIFF
--- a/apps/web/src/state/info/hooks.ts
+++ b/apps/web/src/state/info/hooks.ts
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { STABLE_SUPPORTED_CHAIN_IDS } from '@pancakeswap/stable-swap-sdk'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import BigNumber from 'bignumber.js'
 import { fetchAllTokenData, fetchAllTokenDataByAddresses } from 'state/info/queries/tokens/tokenData'
 import { Block, Transaction, TransactionType, TvlChartEntry, VolumeChartEntry } from 'state/info/types'
@@ -30,12 +30,11 @@ const QUERY_SETTINGS_IMMUTABLE = {
   refetchOnWindowFocus: false,
 }
 const QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH = {
-  retry: 3,
   retryDelay: 3000,
 }
 const QUERY_SETTINGS_INTERVAL_REFETCH = {
   refetchInterval: refreshIntervalForInfo,
-  keepPreviousData: true,
+  placeholderData: keepPreviousData,
   ...QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH,
 }
 
@@ -959,7 +958,7 @@ export const useTokenPriceDataQuery = (
       if (!chainName) {
         throw new Error('No chain name')
       }
-      return explorerApiClient
+      const result = await explorerApiClient
         .GET('/cached/tokens/chart/{chainName}/{address}/{protocol}/price', {
           signal,
           params: {
@@ -984,6 +983,7 @@ export const useTokenPriceDataQuery = (
             }
           }),
         )
+      return result
     },
     ...QUERY_SETTINGS_IMMUTABLE,
     ...QUERY_SETTINGS_INTERVAL_REFETCH,

--- a/apps/web/src/views/V3Info/hooks/index.ts
+++ b/apps/web/src/views/V3Info/hooks/index.ts
@@ -9,7 +9,7 @@ import { getDeltaTimestamps } from 'utils/getDeltaTimestamps'
 import { v3InfoClients } from 'utils/graphql'
 import { useBlocksFromTimestamps } from 'views/Info/hooks/useBlocksFromTimestamps'
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { chainIdToExplorerInfoChainName, explorerApiClient } from 'state/info/api/client'
 import { useExplorerChainNameByQuery } from 'state/info/api/hooks'
 import { components } from 'state/info/api/schema'
@@ -41,9 +41,8 @@ import {
 import { transformPoolData } from '../utils'
 
 const QUERY_SETTINGS_IMMUTABLE = {
-  retry: 3,
   retryDelay: 3000,
-  keepPreviousData: true,
+  placeholderData: keepPreviousData,
   refetchOnMount: false,
   refetchOnReconnect: false,
   refetchOnWindowFocus: false,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the query settings in the `useQuery` hooks across two files to use `placeholderData` instead of `keepPreviousData`. This change aims to improve data handling during queries.

### Detailed summary
- In `apps/web/src/views/V3Info/hooks/index.ts`:
  - Changed `keepPreviousData: true` to `placeholderData: keepPreviousData` in `QUERY_SETTINGS_IMMUTABLE`.
  
- In `apps/web/src/state/info/hooks.ts`:
  - Updated `keepPreviousData: true` to `placeholderData: keepPreviousData` in `QUERY_SETTINGS_INTERVAL_REFETCH`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->