### PR TITLE
chore: Return to positions page from v2,stable details and import pages

### DIFF
--- a/apps/web/src/pages/stable/[address].tsx
+++ b/apps/web/src/pages/stable/[address].tsx
@@ -156,7 +156,7 @@ export default function StablePoolPage() {
       <BodyWrapper>
         <AppHeader
           title={`${stableLp?.token0?.symbol}-${stableLp?.token1?.symbol} LP`}
-          backTo="/liquidity/pools"
+          backTo="/liquidity/positions"
           noConfig
           buttons={
             !isMobile && (

--- a/apps/web/src/pages/v2/pair/[[...currency]].tsx
+++ b/apps/web/src/pages/v2/pair/[[...currency]].tsx
@@ -148,7 +148,7 @@ export default function PoolV2Page() {
               </Heading>
             </Flex>
           }
-          backTo="/liquidity/pools"
+          backTo="/liquidity/positions"
           noConfig
           buttons={
             !isMobile && (

--- a/apps/web/src/views/PoolFinder/index.tsx
+++ b/apps/web/src/views/PoolFinder/index.tsx
@@ -97,7 +97,7 @@ export default function PoolFinder() {
   return (
     <Page>
       <AppBody>
-        <AppHeader title={t('Import Pool')} subtitle={t('Import an existing pool')} backTo="/liquidity/pools" />
+        <AppHeader title={t('Import Pool')} subtitle={t('Import an existing pool')} backTo="/liquidity/positions" />
         <AutoColumn style={{ padding: '1rem' }} gap="md">
           <StyledButton
             endIcon={<ChevronDownIcon />}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the navigation paths in multiple components to direct users to `/liquidity/positions` instead of `/liquidity/pools`.

### Detailed summary
- In `apps/web/src/pages/v2/pair/[[...currency]].tsx`, changed `backTo` from `/liquidity/pools` to `/liquidity/positions`.
- In `apps/web/src/pages/stable/[address].tsx`, changed `backTo` from `/liquidity/pools` to `/liquidity/positions`.
- In `apps/web/src/views/PoolFinder/index.tsx`, changed `backTo` from `/liquidity/pools` to `/liquidity/positions`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->