### PR TITLE
fix: Currency error on limit when one currency undefined

### DIFF
--- a/apps/web/src/state/swap/useSwapActionHandlers.ts
+++ b/apps/web/src/state/swap/useSwapActionHandlers.ts
@@ -5,7 +5,7 @@ import { swapReducerAtom } from 'state/swap/reducer'
 import { Field, selectCurrency, switchCurrencies, typeInput, setRecipient } from './actions'
 
 export function useSwapActionHandlers(): {
-  onCurrencySelection: (field: Field, currency: Currency) => void
+  onCurrencySelection: (field: Field, currency?: Currency) => void
   onSwitchTokens: () => void
   onUserInput: (field: Field, typedValue: string) => void
   onChangeRecipient: (recipient: string | null) => void
@@ -17,7 +17,7 @@ export function useSwapActionHandlers(): {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const onCurrencySelection = useCallback((field: Field, currency: Currency) => {
+  const onCurrencySelection = useCallback((field: Field, currency?: Currency) => {
     dispatch(
       selectCurrency({
         field,

--- a/apps/web/src/views/Swap/Twap/Twap.tsx
+++ b/apps/web/src/views/Swap/Twap/Twap.tsx
@@ -147,13 +147,13 @@ export function TWAPPanel({ limit }: { limit?: boolean }) {
   } = useSwapState()
 
   const handleCurrencySelect = useCallback(
-    (isInput: boolean, newCurrency: Currency) => {
+    (isInput: boolean, newCurrency?: Currency) => {
       onCurrencySelection(isInput ? Field.INPUT : Field.OUTPUT, newCurrency)
       warningSwapHandler(newCurrency)
 
       const oldCurrencyId = isInput ? inputCurrencyId : outputCurrencyId
       const otherCurrencyId = isInput ? outputCurrencyId : inputCurrencyId
-      const newCurrencyId = currencyId(newCurrency)
+      const newCurrencyId = newCurrency ? currencyId(newCurrency) : undefined
       replaceBrowserHistoryMultiple({
         ...(newCurrencyId === otherCurrencyId && { [isInput ? 'outputCurrency' : 'inputCurrency']: oldCurrencyId }),
         [isInput ? 'inputCurrency' : 'outputCurrency']: newCurrencyId,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `onCurrencySelection` function to allow an optional `currency` parameter, enhancing flexibility in handling currency selection.

### Detailed summary
- Updated `onCurrencySelection` in `useSwapActionHandlers` to accept an optional `currency` parameter.
- Modified `handleCurrencySelect` in `Twap.tsx` to accept an optional `newCurrency` parameter.
- Adjusted logic for `newCurrencyId` to handle cases when `newCurrency` is undefined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->