### PR TITLE
fix: missed killed filter from cms

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableRow.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/GaugesTable/TableRow.tsx
@@ -64,7 +64,7 @@ const TableRowItem: React.FC<{
   const { managerName } = usePositionManagerName(data)
 
   const maxCapPercent = useMemo(() => {
-    return new Percent(data?.maxVoteCap, 10000)
+    return new Percent(data?.maxVoteCap ?? 0, 10000)
   }, [data.maxVoteCap])
 
   const currentWeightPercent = useMemo(() => {

--- a/packages/gauges/src/getAllGauges.ts
+++ b/packages/gauges/src/getAllGauges.ts
@@ -31,7 +31,7 @@ export const getAllGauges = async (
   const gaugesSC = await fetchGaugesSC(client, killed, blockNumber)
   const gaugesSCMap = keyBy(gaugesSC, 'gid')
 
-  const allGaugeInfoConfigs = gaugesCMS.map((config) => {
+  const allGaugeInfoConfigs = (killed ? gaugesCMS : gaugesCMS.filter((g) => !g.killed)).map((config) => {
     const correspondingSC = gaugesSCMap[config.gid]
     const mergedConfig: GaugeInfoConfig = { ...config, ...correspondingSC }
     return mergedConfig


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of gauge configurations and vote cap percentages in the `GaugesTable` component and the `getAllGauges` function. It ensures safer defaults and filters out killed gauges appropriately.

### Detailed summary
- In `TableRow.tsx`, updated `maxCapPercent` to return `new Percent(data?.maxVoteCap ?? 0, 10000)` for safer default handling.
- In `getAllGauges.ts`, modified `allGaugeInfoConfigs` to filter out killed gauges when `killed` is true, ensuring only active gauges are processed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->