### PR TITLE
fix: undefined gauge hash

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
@@ -44,13 +44,15 @@ export const useUserVoteSlopes = () => {
       const hasProxy =
         userInfo?.cakePoolProxy && !isAddressEqual(userInfo?.cakePoolProxy, zeroAddress) && userInfo && !delegated
 
-      const contracts = gauges.map((gauge) => {
-        return {
-          ...gaugesVotingContract,
-          functionName: 'voteUserSlopes',
-          args: [account, gauge.hash as Hex],
-        } as const
-      })
+      const contracts = gauges
+        .filter((g) => !!g.hash)
+        .map((gauge) => {
+          return {
+            ...gaugesVotingContract,
+            functionName: 'voteUserSlopes',
+            args: [account, gauge.hash as Hex],
+          } as const
+        })
 
       if (hasProxy) {
         gauges.forEach((gauge) => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the filtering of `gauges` in the `useUserVoteGauges` hook to ensure only valid gauges with a `hash` are processed when creating the `contracts` array.

### Detailed summary
- Added a `.filter((g) => !!g.hash)` to ensure only gauges with a valid `hash` are included.
- The structure of the `contracts` array creation remains the same, but now excludes any invalid gauges.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->