### PR TITLE
fix: Swap Infinite loading and error message not shown when user routing setting customized

### DIFF
--- a/apps/web/src/components/AccessRisk/SwapRevampRiskDisplay.tsx
+++ b/apps/web/src/components/AccessRisk/SwapRevampRiskDisplay.tsx
@@ -363,7 +363,7 @@ export const RiskDetailsModal: React.FC<React.PropsWithChildren<RiskDetailsModal
   const { t } = useTranslation()
   return (
     <ModalV2 isOpen={isOpen} closeOnOverlayClick onDismiss={onDismiss}>
-      <Modal title={t('Note for this swap')} hideCloseButton maxWidth={[null, null, null, '480px']}>
+      <Modal title={t('Note for this swap')} maxWidth={[null, null, null, '480px']}>
         {children}
       </Modal>
     </ModalV2>

--- a/apps/web/src/hooks/useBestAMMTrade.ts
+++ b/apps/web/src/hooks/useBestAMMTrade.ts
@@ -869,25 +869,32 @@ function createUseWorkerGetBestTrade() {
         })
 
         const quoterConfig = (quoteProvider as ReturnType<typeof SmartRouter.createQuoteProvider>)?.getConfig?.()
-        const result = await worker.getBestTrade({
-          chainId: currency.chainId,
-          currency: SmartRouter.Transformer.serializeCurrency(currency),
-          tradeType,
-          amount: {
-            currency: SmartRouter.Transformer.serializeCurrency(amount.currency),
-            value: amount.quotient.toString(),
-          },
-          gasPriceWei: typeof gasPriceWei !== 'function' ? gasPriceWei?.toString() : undefined,
-          maxHops,
-          maxSplits,
-          poolTypes: allowedPoolTypes,
-          candidatePools: candidatePools.map(SmartRouter.Transformer.serializePool),
-          onChainQuoterGasLimit: quoterConfig?.gasLimit?.toString(),
-          quoteCurrencyUsdPrice,
-          nativeCurrencyUsdPrice,
-          signal,
-        })
-        return SmartRouter.Transformer.parseTrade(currency.chainId, result as any)
+        try {
+          const result = await worker.getBestTrade({
+            chainId: currency.chainId,
+            currency: SmartRouter.Transformer.serializeCurrency(currency),
+            tradeType,
+            amount: {
+              currency: SmartRouter.Transformer.serializeCurrency(amount.currency),
+              value: amount.quotient.toString(),
+            },
+            gasPriceWei: typeof gasPriceWei !== 'function' ? gasPriceWei?.toString() : undefined,
+            maxHops,
+            maxSplits,
+            poolTypes: allowedPoolTypes,
+            candidatePools: candidatePools.map(SmartRouter.Transformer.serializePool),
+            onChainQuoterGasLimit: quoterConfig?.gasLimit?.toString(),
+            quoteCurrencyUsdPrice,
+            nativeCurrencyUsdPrice,
+            signal,
+          })
+          return SmartRouter.Transformer.parseTrade(currency.chainId, result as any)
+        } catch (e) {
+          if (e === 'Cannot find a valid swap route') {
+            throw new NoValidRouteError()
+          }
+          throw e
+        }
       },
       [worker],
     )

--- a/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useAllTypeBestTrade.ts
@@ -88,7 +88,7 @@ export const useAllTypeBestTrade = () => {
         : undefined
       : finalOrder) as InterfaceOrder | undefined,
     tradeLoaded,
-    tradeError: finalOrder?.error,
+    tradeError: finalOrder ? finalOrder.error : error,
     refreshDisabled:
       finalOrder?.type === OrderType.DUTCH_LIMIT
         ? bestOrder.isLoading || !bestOrder.isStale

--- a/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
@@ -30,6 +30,7 @@ import { warningSeverity } from 'utils/exchange'
 import { isClassicOrder, isXOrder } from 'views/Swap/utils'
 import { ConfirmSwapModalV2 } from 'views/Swap/V3Swap/containers/ConfirmSwapModalV2'
 import { useAccount, useChainId } from 'wagmi'
+import { NoValidRouteError } from 'hooks/useBestAMMTrade'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../../Swap/V3Swap/hooks'
 import { useConfirmModalState } from '../../Swap/V3Swap/hooks/useConfirmModalState'
 import { useSwapConfig } from '../../Swap/V3Swap/hooks/useSwapConfig'
@@ -200,9 +201,17 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
     setTradeToConfirm(order)
   }, [order])
 
+  const hasNoValidRouteError = useMemo(
+    () =>
+      tradeError &&
+      (tradeError instanceof NoValidRouteError ||
+        (typeof tradeError === 'string' && tradeError === 'Cannot find a valid swap route')),
+    [tradeError],
+  )
+
   const noRoute = useMemo(
-    () => (isClassicOrder(order) && !((order.trade?.routes?.length ?? 0) > 0)) || tradeError,
-    [order, tradeError],
+    () => (isClassicOrder(order) && !((order.trade?.routes?.length ?? 0) > 0)) || hasNoValidRouteError,
+    [order, hasNoValidRouteError],
   )
   const isValid = useMemo(() => !swapInputError && !tradeLoading, [swapInputError, tradeLoading])
   const disabled = useMemo(
@@ -280,7 +289,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
     )
   }, [isExpertMode, isRecipientEmpty, isRecipientError, priceImpactSeverity, swapInputError, t, tradeLoading])
 
-  if (noRoute && userHasSpecifiedInputOutput && !tradeLoading) {
+  if (noRoute && userHasSpecifiedInputOutput && (hasNoValidRouteError || !tradeLoading)) {
     return <ResetRoutesButton />
   }
 

--- a/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
@@ -202,10 +202,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   }, [order])
 
   const hasNoValidRouteError = useMemo(
-    () =>
-      tradeError &&
-      (tradeError instanceof NoValidRouteError ||
-        (typeof tradeError === 'string' && tradeError === 'Cannot find a valid swap route')),
+    () => Boolean(tradeError && tradeError instanceof NoValidRouteError),
     [tradeError],
   )
 

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -180,7 +180,7 @@ export function V4SwapForm() {
           </FlexGap>
         }
         tradeDetails={<TradeDetails loaded={tradeLoaded} order={bestOrder} />}
-        shouldRenderDetails={Boolean(executionPrice) && Boolean(bestOrder) && !isWrapping}
+        shouldRenderDetails={Boolean(executionPrice) && Boolean(bestOrder) && !isWrapping && !tradeError}
       />
     </SwapUIV2.SwapFormWrapper>
   )

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -54,7 +54,7 @@ export function V4SwapForm() {
     () => (bestOrder?.trade ? SmartRouter.getExecutionPrice(bestOrder.trade) : undefined),
     [bestOrder?.trade],
   )
-  const { isPriceImpactTooHigh } = useIsPriceImpactTooHigh(bestOrder, !tradeLoaded)
+  const { isPriceImpactTooHigh } = useIsPriceImpactTooHigh(!tradeError ? bestOrder : undefined, !tradeLoaded)
 
   const commitHooks = useMemo(() => {
     return {

--- a/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
+++ b/packages/smart-router/evm/v3-router/providers/quoteProviders.ts
@@ -55,7 +55,7 @@ export function createQuoteProvider(config: QuoterConfig): QuoteProvider<QuoterC
       routes: RouteWithoutQuote[],
       { blockNumber, gasModel, signal }: QuoterOptions,
     ): Promise<RouteWithQuote[]> {
-      const { chainId } = routes[0].input
+      const { chainId } = routes[0]?.input || {}
       const getMixedRouteQuotes = createMixedRouteQuoteFetcher(chainId)
 
       const v4ClRoutes: RouteWithoutQuote[] = []


### PR DESCRIPTION
To reproduce

Turn off v2 from customize routing
Pick a token that doesn't have v3 pool
See it infinitely loading without showing message

Before: 

![image](https://github.com/user-attachments/assets/b00246c1-f9b5-42e9-9a7e-6dd762bf55c8)

After: 

![image](https://github.com/user-attachments/assets/a4b4f3b7-c1d4-4456-90f2-e647c2841cdd)


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling and refining trade logic in the swap functionality. It introduces checks for trade errors and modifies how trade-related data is processed and displayed in various components.

### Detailed summary
- Updated `tradeError` handling in `useAllTypeBestTrade.ts`.
- Added optional chaining for `chainId` in `quoteProviders.ts`.
- Removed the close button from the `Modal` in `SwapRevampRiskDisplay.tsx`.
- Adjusted price impact checks in `V4Swap/index.tsx` to account for `tradeError`.
- Introduced `NoValidRouteError` handling in `SwapCommitButton.tsx`.
- Modified logic for determining valid routes in `SwapCommitButton.tsx`.
- Wrapped `getBestTrade` in a `try-catch` block in `useBestAMMTrade.ts` to handle errors gracefully.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->