### PR TITLE
fix: filter gauges for all scope

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
@@ -19,10 +19,12 @@ export const useGauges = () => {
       if (response.ok) {
         const result = (await response.json()) as Response
 
-        const gauges = result.data.map((gauge) => ({
-          ...gauge,
-          weight: BigInt(gauge.weight),
-        }))
+        const gauges = result.data
+          .filter((g) => !g.hash)
+          .map((gauge) => ({
+            ...gauge,
+            weight: BigInt(gauge.weight),
+          }))
 
         return gauges
       }

--- a/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
@@ -38,24 +38,24 @@ export const useUserVoteSlopes = () => {
     initialData: [],
     queryFn: async (): Promise<VoteSlope[]> => {
       if (!gauges || gauges.length === 0 || !account || !publicClient) return []
+      const validGauges = gauges.filter((gauge) => !!gauge.hash)
+      if (validGauges.length === 0) return []
 
       const delegated = userInfo?.cakePoolType === CakePoolType.DELEGATED
 
       const hasProxy =
         userInfo?.cakePoolProxy && !isAddressEqual(userInfo?.cakePoolProxy, zeroAddress) && userInfo && !delegated
 
-      const contracts = gauges
-        .filter((g) => !!g.hash)
-        .map((gauge) => {
-          return {
-            ...gaugesVotingContract,
-            functionName: 'voteUserSlopes',
-            args: [account, gauge.hash as Hex],
-          } as const
-        })
+      const contracts = validGauges.map((gauge) => {
+        return {
+          ...gaugesVotingContract,
+          functionName: 'voteUserSlopes',
+          args: [account, gauge.hash as Hex],
+        } as const
+      })
 
       if (hasProxy) {
-        gauges.forEach((gauge) => {
+        validGauges.forEach((gauge) => {
           contracts.push({
             ...gaugesVotingContract,
             functionName: 'voteUserSlopes',
@@ -63,30 +63,34 @@ export const useUserVoteSlopes = () => {
           } as const)
         })
       }
+      try {
+        const response = await publicClient.multicall({
+          contracts,
+          allowFailure: false,
+        })
 
-      const response = await publicClient.multicall({
-        contracts,
-        allowFailure: false,
-      })
+        const len = validGauges.length
+        return validGauges.map((gauge, index) => {
+          const [nativeSlope, nativePower, nativeEnd] = response[index] ?? [0n, 0n, 0n]
+          const [proxySlope, proxyPower, proxyEnd] = response[index + len] ?? [0n, 0n, 0n]
 
-      const len = gauges.length
-      return gauges.map((gauge, index) => {
-        const [nativeSlope, nativePower, nativeEnd] = response[index] ?? [0n, 0n, 0n]
-        const [proxySlope, proxyPower, proxyEnd] = response[index + len] ?? [0n, 0n, 0n]
-
-        return {
-          hash: gauge.hash,
-          nativePower: Number(nativePower),
-          nativeSlope: Number(nativeSlope),
-          nativeEnd: Number(nativeEnd),
-          proxyPower: Number(proxyPower),
-          proxySlope: Number(proxySlope),
-          proxyEnd: Number(proxyEnd),
-        }
-      })
+          return {
+            hash: gauge.hash,
+            nativePower: Number(nativePower),
+            nativeSlope: Number(nativeSlope),
+            nativeEnd: Number(nativeEnd),
+            proxyPower: Number(proxyPower),
+            proxySlope: Number(proxySlope),
+            proxyEnd: Number(proxyEnd),
+          }
+        })
+      } catch (error) {
+        console.error('useUserVoteSlopes', error)
+        return []
+      }
     },
 
-    enabled: Boolean(gauges && gauges.length) && account && account !== '0x',
+    enabled: Boolean(gauges?.length) && account && account !== '0x',
   })
 
   return {

--- a/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
@@ -38,15 +38,13 @@ export const useUserVoteSlopes = () => {
     initialData: [],
     queryFn: async (): Promise<VoteSlope[]> => {
       if (!gauges || gauges.length === 0 || !account || !publicClient) return []
-      const validGauges = gauges.filter((gauge) => !!gauge.hash)
-      if (validGauges.length === 0) return []
 
       const delegated = userInfo?.cakePoolType === CakePoolType.DELEGATED
 
       const hasProxy =
         userInfo?.cakePoolProxy && !isAddressEqual(userInfo?.cakePoolProxy, zeroAddress) && userInfo && !delegated
 
-      const contracts = validGauges.map((gauge) => {
+      const contracts = gauges.map((gauge) => {
         return {
           ...gaugesVotingContract,
           functionName: 'voteUserSlopes',
@@ -55,7 +53,7 @@ export const useUserVoteSlopes = () => {
       })
 
       if (hasProxy) {
-        validGauges.forEach((gauge) => {
+        gauges.forEach((gauge) => {
           contracts.push({
             ...gaugesVotingContract,
             functionName: 'voteUserSlopes',
@@ -69,8 +67,8 @@ export const useUserVoteSlopes = () => {
           allowFailure: false,
         })
 
-        const len = validGauges.length
-        return validGauges.map((gauge, index) => {
+        const len = gauges.length
+        return gauges.map((gauge, index) => {
           const [nativeSlope, nativePower, nativeEnd] = response[index] ?? [0n, 0n, 0n]
           const [proxySlope, proxyPower, proxyEnd] = response[index + len] ?? [0n, 0n, 0n]
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `useGauges` and `useUserVoteGauges` hooks to filter out gauges with a `hash` before processing and adds error handling for the multicall response.

### Detailed summary
- In `useGauges.ts`, added a filter to exclude gauges with a `hash`.
- In `useUserVoteGauges.ts`, removed the filter for `g.hash` when mapping `contracts`.
- Added a `try-catch` block around the multicall to handle errors gracefully.
- Updated the `enabled` condition to use optional chaining for `gauges`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->