### PR TITLE
fix: 🐛 Fix search text not emptied on close

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
@@ -45,8 +45,8 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
   const { filterGauges, setSearchText, filter, setFilter, setSort } = useGaugesFilter(gauges)
   const dismissHandler = useCallback(() => {
     setSearchText('')
-    onDismiss()
-  }, [onDismiss])
+    onDismiss?.()
+  }, [onDismiss, setSearchText])
 
   const gaugesTable = isDesktop ? (
     <AddGaugesTable

--- a/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
+import { useCallback } from 'react'
 import styled from 'styled-components'
 import { useGauges } from 'views/GaugesVoting/hooks/useGauges'
 import { useGaugesFilter } from 'views/GaugesVoting/hooks/useGaugesFilter'
@@ -42,6 +43,10 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
   const totalGaugesWeight = useGaugesTotalWeight()
   const { data: gauges } = useGauges()
   const { filterGauges, setSearchText, filter, setFilter, setSort } = useGaugesFilter(gauges)
+  const dismissHandler = useCallback(() => {
+    setSearchText('')
+    onDismiss()
+  }, [])
 
   const gaugesTable = isDesktop ? (
     <AddGaugesTable
@@ -65,7 +70,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
 
   return (
     <>
-      <ModalV2 isOpen={isOpen} onDismiss={onDismiss}>
+      <ModalV2 isOpen={isOpen} onDismiss={dismissHandler}>
         <ModalWrapper
           maxHeight="90vh"
           minWidth={['80vw', null, null, null, null, null, '55vw']}
@@ -87,15 +92,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
                     {t('Search and add the gauge you want to vote')}
                   </Text>
                 </AutoColumn>
-                <Button
-                  variant="text"
-                  onClick={() => {
-                    setSearchText('')
-                    onDismiss()
-                  }}
-                  px={0}
-                  height="fit-content"
-                >
+                <Button variant="text" onClick={dismissHandler} px={0} height="fit-content">
                   <CloseIcon color="textSubtle" />
                 </Button>
               </FlexGap>
@@ -118,7 +115,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
               ) : null}
               <Box style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden' }}>{gaugesTable}</Box>
             </FlexGap>
-            <BottomAction pb="32px" style={{ marginTop: 'auto' }} onClick={onDismiss}>
+            <BottomAction pb="32px" style={{ marginTop: 'auto' }} onClick={dismissHandler}>
               <Button width={isMobile ? '100%' : '50%'}>{t(isMobile ? 'Continue' : 'Finish')}</Button>
             </BottomAction>
           </Flex>

--- a/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
@@ -46,7 +46,7 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
   const dismissHandler = useCallback(() => {
     setSearchText('')
     onDismiss()
-  }, [])
+  }, [onDismiss])
 
   const gaugesTable = isDesktop ? (
     <AddGaugesTable

--- a/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
+++ b/apps/web/src/views/GaugesVoting/components/Table/AddGauge/AddGaugeModal.tsx
@@ -87,7 +87,15 @@ export const AddGaugeModal = ({ isOpen, onDismiss, selectRows, onGaugeAdd }) => 
                     {t('Search and add the gauge you want to vote')}
                   </Text>
                 </AutoColumn>
-                <Button variant="text" onClick={onDismiss} px={0} height="fit-content">
+                <Button
+                  variant="text"
+                  onClick={() => {
+                    setSearchText('')
+                    onDismiss()
+                  }}
+                  px={0}
+                  height="fit-content"
+                >
                   <CloseIcon color="textSubtle" />
                 </Button>
               </FlexGap>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the dismissal handling of the `AddGaugeModal` component by introducing a `dismissHandler` function. This function resets the search text and calls the `onDismiss` callback, ensuring a consistent state when the modal is closed.

### Detailed summary
- Added `dismissHandler` function using `useCallback` to reset search text and handle modal dismissal.
- Updated the `onDismiss` prop in `<ModalV2>` to use `dismissHandler` instead of directly calling `onDismiss`.
- Changed the `onClick` prop of the close button to use `dismissHandler`.
- Updated the `onClick` prop of `<BottomAction>` to use `dismissHandler`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->