### PR TITLE
fix: wrong filter

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
@@ -19,10 +19,12 @@ export const useGauges = () => {
       if (response.ok) {
         const result = (await response.json()) as Response
 
-        const gauges = result.data.map((gauge) => ({
-          ...gauge,
-          weight: BigInt(gauge.weight),
-        }))
+        const gauges = result.data
+          .filter((g) => !!g.hash)
+          .map((gauge) => ({
+            ...gauge,
+            weight: BigInt(gauge.weight),
+          }))
 
         return gauges
       }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the filtering logic in the `useGauges.ts` file to include only gauges that have a valid `hash`.

### Detailed summary
- Changed the filter condition from `!g.hash` to `!!g.hash` to include only gauges with a `hash`.
- The mapping of `gauge` objects remains unchanged, continuing to include the `weight` property as a `BigInt`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->