### PR TITLE
fix: User rejected error not shown properly in wallets

### DIFF
--- a/apps/gamification/utils/sentry.ts
+++ b/apps/gamification/utils/sentry.ts
@@ -1,4 +1,4 @@
-import { UnknownRpcError, UserRejectedRequestError } from 'viem'
+import { UserRejectedRequestError } from 'viem'
 
 const possibleRejectMessage = ['Cancelled by User', 'cancel', 'Transaction was rejected', 'denied']
 

--- a/apps/gamification/utils/sentry.ts
+++ b/apps/gamification/utils/sentry.ts
@@ -1,4 +1,4 @@
-import { UserRejectedRequestError } from 'viem'
+import { UnknownRpcError, UserRejectedRequestError } from 'viem'
 
 const possibleRejectMessage = ['Cancelled by User', 'cancel', 'Transaction was rejected', 'denied']
 
@@ -7,18 +7,18 @@ export const isUserRejected = (err: any): any => {
   if (err instanceof UserRejectedRequestError) {
     return true
   }
-  if ('details' in err) {
-    // fallback for some wallets that don't follow EIP 1193, trust, safe
-    if (possibleRejectMessage.some((msg) => err.details?.includes(msg))) {
-      return true
-    }
-  }
-
-  // fallback for raw rpc error code
   if (err && typeof err === 'object') {
+    if ('details' in err) {
+      // fallback for some wallets that don't follow EIP 1193, trust, safe
+      if (possibleRejectMessage.some((msg) => err.details?.includes(msg))) {
+        return true
+      }
+    }
+
+    // fallback for raw rpc error code
     if (
       ('code' in err && (err.code === 4001 || err.code === 'ACTION_REJECTED')) ||
-      ('cause' in err && 'code' in err.cause && err.cause.code === 4001)
+      ('cause' in err && err.cause && typeof err.cause === 'object' && 'code' in err.cause && err.cause.code === 4001)
     ) {
       return true
     }

--- a/apps/web/sentry.client.config.js
+++ b/apps/web/sentry.client.config.js
@@ -22,7 +22,7 @@ const isUserRejected = (err) => {
   if (err && typeof err === 'object') {
     if (
       ('code' in err && (err.code === 4001 || err.code === 'ACTION_REJECTED')) ||
-      ('cause' in err && err.cause && 'code' in err.cause && err.cause.code === 4001)
+      ('cause' in err && err.cause && typeof err.cause === 'object' && 'code' in err.cause && err.cause.code === 4001)
     ) {
       return true
     }

--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -1,5 +1,5 @@
 import { captureException } from '@sentry/nextjs'
-import { UnknownRpcError, UserRejectedRequestError } from 'viem'
+import { UserRejectedRequestError } from 'viem'
 
 const assignError = (maybeError: any) => {
   if (typeof maybeError === 'string') {

--- a/apps/web/src/utils/sentry.ts
+++ b/apps/web/src/utils/sentry.ts
@@ -1,5 +1,5 @@
 import { captureException } from '@sentry/nextjs'
-import { UserRejectedRequestError } from 'viem'
+import { UnknownRpcError, UserRejectedRequestError } from 'viem'
 
 const assignError = (maybeError: any) => {
   if (typeof maybeError === 'string') {
@@ -25,18 +25,18 @@ export const isUserRejected = (err) => {
   if (err instanceof UserRejectedRequestError) {
     return true
   }
-  if ('details' in err) {
-    // fallback for some wallets that don't follow EIP 1193, trust, safe
-    if (possibleRejectMessage.some((msg) => err.details?.includes(msg))) {
-      return true
-    }
-  }
-
-  // fallback for raw rpc error code
   if (err && typeof err === 'object') {
+    if ('details' in err) {
+      // fallback for some wallets that don't follow EIP 1193, trust, safe
+      if (possibleRejectMessage.some((msg) => err.details?.includes(msg))) {
+        return true
+      }
+    }
+
+    // fallback for raw rpc error code
     if (
       ('code' in err && (err.code === 4001 || err.code === 'ACTION_REJECTED')) ||
-      ('cause' in err && err.cause && 'code' in err.cause && err.cause.code === 4001)
+      ('cause' in err && err.cause && typeof err.cause === 'object' && 'code' in err.cause && err.cause.code === 4001)
     ) {
       return true
     }


### PR DESCRIPTION

![IMG_2656](https://github.com/user-attachments/assets/d4b17b83-ddb4-4fb0-8ed9-bb06f4412e06)


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing error handling in the code by ensuring that checks for the `err` object's properties are more robust, particularly when dealing with nested objects.

### Detailed summary
- In `apps/web/sentry.client.config.js`, the condition for checking `err.cause` was modified to ensure it is an object before accessing its `code`.
- In `apps/gamification/utils/sentry.ts`:
  - Added a check to confirm `err` is an object before checking for `details`.
- In `apps/web/src/utils/sentry.ts`:
  - Similar changes as in `apps/gamification/utils/sentry.ts` were made to enhance error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->