### PR TITLE
fix: Partial key frame error on ad card

### DIFF
--- a/apps/web/src/components/AdPanel/Card.tsx
+++ b/apps/web/src/components/AdPanel/Card.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, CloseIcon, IconButton, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { forwardRef, useEffect, useRef } from 'react'
+import { forwardRef, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
+import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import { useShowAdPanel } from './useShowAdPanel'
 
 const BaseCard = styled(Box)<{ $isExpanded?: boolean }>`
@@ -99,6 +100,7 @@ interface AdCardProps extends BoxProps {
 export const AdCard = forwardRef<HTMLDivElement, AdCardProps>(
   ({ children, imageUrl, alt, isExpanded, forceMobile, isDismissible = true, ...props }, ref) => {
     const imageRef = useRef<HTMLImageElement>(null)
+    const [isExpandTriggered, setIsExpandTriggered] = useState(false)
 
     // Drag handle, Slider and other slots will come here
     const { isDesktop } = useMatchBreakpoints()
@@ -107,22 +109,40 @@ export const AdCard = forwardRef<HTMLDivElement, AdCardProps>(
     const isMobile = forceMobile || !isDesktop
 
     useEffect(() => {
-      if (imageRef.current) {
+      if (isExpanded) {
+        setIsExpandTriggered(true)
+      }
+    }, [isExpanded])
+
+    useEffect(() => {
+      if (imageRef.current && !isUndefinedOrNull(isExpanded) && isExpandTriggered) {
         if (isExpanded) {
-          imageRef.current.animate([{ opacity: 0, zIndex: -1, transform: 'scale(0.96)' }], {
-            duration: 50,
-            fill: 'forwards',
-            easing: 'ease-in-out',
-          })
+          imageRef.current.animate(
+            [
+              { opacity: 1, zIndex: 1, transform: 'scale(1)' },
+              { opacity: 0, zIndex: -1, transform: 'scale(0.96)' },
+            ],
+            {
+              duration: 50,
+              fill: 'forwards',
+              easing: 'ease-in-out',
+            },
+          )
         } else {
-          imageRef.current.animate([{ opacity: 1, zIndex: 1, transform: 'scale(1)' }], {
-            duration: 200,
-            fill: 'forwards',
-            easing: 'ease-in-out',
-          })
+          imageRef.current.animate(
+            [
+              { opacity: 0, zIndex: -1, transform: 'scale(0.96)' },
+              { opacity: 1, zIndex: 1, transform: 'scale(1)' },
+            ],
+            {
+              duration: 200,
+              fill: 'forwards',
+              easing: 'ease-in-out',
+            },
+          )
         }
       }
-    }, [imageRef, isExpanded])
+    }, [imageRef, isExpandTriggered, isExpanded])
 
     return (
       <BaseCard $isExpanded={isExpanded} {...props} ref={ref}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `AdCard` component in `Card.tsx` by adding state management for animation triggers based on the `isExpanded` prop, improving the animation behavior for expanding and collapsing the card.

### Detailed summary
- Added `useState` for `isExpandTriggered` to manage animation triggers.
- Modified the first `useEffect` to set `isExpandTriggered` when `isExpanded` changes.
- Updated the animation logic to use `isExpandTriggered` for conditional animations.
- Adjusted animation sequences for both expanding and collapsing states.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->