### PR TITLE
chore: Remove turkey banner

### DIFF
--- a/apps/web/src/components/AdPanel/Card.tsx
+++ b/apps/web/src/components/AdPanel/Card.tsx
@@ -160,7 +160,7 @@ export const AdCard = forwardRef<HTMLDivElement, AdCardProps>(
           </CloseButtonContainer>
         )}
         <GraphicsContainer>
-          {imageUrl && <img ref={imageRef} src={imageUrl} alt={alt || 'Ad Image'} width={207} height={188} />}
+          {imageUrl && <img ref={imageRef} src={imageUrl} alt={alt || 'Card Image'} width={207} height={188} />}
         </GraphicsContainer>
       </BaseCard>
     )

--- a/apps/web/src/components/AdPanel/FAQ/config/buyCrypto.tsx
+++ b/apps/web/src/components/AdPanel/FAQ/config/buyCrypto.tsx
@@ -45,6 +45,7 @@ export const buyCryptoFAQConfig: FAQConfig = (t) => ({
   title: t('Quick start to Buy Crypto'),
   subtitle: t('Need Help?'),
   imageUrl: getImageUrl('faq_buy_crypto.png'),
+  alt: 'Buy crypto FAQ',
   docsUrl: 'https://docs.pancakeswap.finance/products/buy-crypto',
   data: [
     {

--- a/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
+++ b/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
@@ -4,6 +4,7 @@ import { FAQConfig } from '../types'
 export const predictionFAQConfig: FAQConfig = (t) => ({
   title: t('Quick start to Prediction (BETA)'),
   imageUrl: getImageUrl('ad_prediction_telegram_bot.png'),
+  alt: 'Prediction Telegram bot',
   docsUrl: 'https://docs.pancakeswap.finance/products/prediction',
   data: [
     {

--- a/apps/web/src/components/AdPanel/FAQ/config/swap.tsx
+++ b/apps/web/src/components/AdPanel/FAQ/config/swap.tsx
@@ -21,6 +21,7 @@ export const swapFAQConfig: FAQConfig = (t) => ({
   title: t('Quick start now on How to Swap!'),
   subtitle: t('Need Help?'),
   imageUrl: getImageUrl('faq_bunny.png'),
+  alt: 'FAQ bunny',
   docsUrl: 'https://docs.pancakeswap.finance/products/pancakeswap-exchange',
   data: [
     {

--- a/apps/web/src/components/AdPanel/FAQ/types.ts
+++ b/apps/web/src/components/AdPanel/FAQ/types.ts
@@ -3,6 +3,7 @@ import type { TranslateFunction } from '@pancakeswap/localization'
 export type FAQConfig = (t: TranslateFunction) => {
   title: string
   imageUrl: string
+  alt: string
   docsUrl: string
   data: Array<{ title: string; content: React.ReactNode }>
 

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -46,10 +46,6 @@ export const useMultipleBannerConfig = () => {
         banner: <UserBanner />,
       },
       {
-        shouldRender: true,
-        banner: <TurkeyMeetupBanner />,
-      },
-      {
         shouldRender: isRenderIFOBannerFromConfig,
         banner: <EigenpieIFOBanner />,
       },

--- a/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
+++ b/apps/web/src/views/Home/components/Banners/hooks/useMultipleBannerConfig.tsx
@@ -1,6 +1,5 @@
 import shuffle from 'lodash/shuffle'
 import { type ReactElement, useMemo } from 'react'
-import { TurkeyMeetupBanner } from 'views/Home/components/Banners/TurkeyMeetupBanner'
 import CompetitionBanner from '../CompetitionBanner'
 import { EigenpieIFOBanner } from '../EigenpieIFOBanner'
 import { FourMemeBanner } from '../FourMemeBanner'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an `alt` property to various components in the `FAQ` section and updates the image `alt` attributes in the `Card` component. It also removes the `TurkeyMeetupBanner` from the `useMultipleBannerConfig` hook.

### Detailed summary
- Added `alt` property to the `FAQ` types in `types.ts`.
- Updated `alt` attributes for images in `swap.tsx`, `buyCrypto.tsx`, and `prediction.ts`.
- Changed the default `alt` text in the `Card` component from 'Ad Image' to 'Card Image'.
- Removed the `TurkeyMeetupBanner` from the `useMultipleBannerConfig` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->