### PR TITLE
fix: Network switch in swap

### DIFF
--- a/apps/web/src/components/NetworkModal/WrongNetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/WrongNetworkModal.tsx
@@ -59,7 +59,12 @@ export function WrongNetworkModal({ currentChain, onDismiss }: { currentChain: C
   }, [chainId, logout, setQueryChainId, router])
 
   return (
-    <Modal title={t('You are in wrong network')} headerBackground="gradientCardHeader" onDismiss={onDismiss}>
+    <Modal
+      title={t('You are in wrong network')}
+      headerBackground="gradientCardHeader"
+      hideCloseButton
+      onDismiss={onDismiss}
+    >
       <Grid style={{ gap: '16px' }} maxWidth={['100%', null, '336px']}>
         <Text>{t('This page is located for %network%.', { network: currentChain.name })}</Text>
         <Text>

--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -16,7 +16,6 @@ import {
 } from '@pancakeswap/uikit'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import { useActiveChainId, useLocalNetworkChain } from 'hooks/useActiveChainId'
-import { useNetworkConnectorUpdater } from 'hooks/useActiveWeb3React'
 import { useHover } from 'hooks/useHover'
 import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
 import Image from 'next/image'
@@ -171,8 +170,6 @@ export const NetworkSwitcher = () => {
   const { chainId, isWrongNetwork, isNotMatched } = useActiveChainId()
   const { isLoading, canSwitch, switchNetworkAsync } = useSwitchNetwork()
   const router = useRouter()
-
-  useNetworkConnectorUpdater()
 
   const foundChain = useMemo(() => chains.find((c) => c.id === chainId), [chainId])
   const symbol =

--- a/apps/web/src/hooks/useActiveChainId.ts
+++ b/apps/web/src/hooks/useActiveChainId.ts
@@ -31,13 +31,12 @@ export function useLocalNetworkChain() {
   const [queryChainId, setQueryChainId] = useAtom(queryChainIdAtom)
   const { query } = useRouter()
   const chainId = +(getChainId(query.chain as string) || queryChainId)
-  const { chainId: wagmiChainId } = useAccount()
 
   useEffect(() => {
-    if (wagmiChainId) {
-      setQueryChainId(wagmiChainId)
+    if (chainId) {
+      setQueryChainId(chainId)
     }
-  }, [wagmiChainId, setQueryChainId])
+  }, [chainId, setQueryChainId])
 
   if (isChainSupported(chainId)) {
     return chainId


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the active chain ID in the application, enhancing the `useActiveChainId` hook, updating the `NetworkModal`, and refining the `NetworkSwitcher` and `useSwitchNetworkLocal` functionalities to streamline network switching.

### Detailed summary
- Removed `wagmiChainId` usage in `useActiveChainId` and replaced it with `chainId`.
- Updated `useEffect` dependency in `useActiveChainId` to track `chainId`.
- Added `hideCloseButton` prop to `Modal` in `WrongNetworkModal`.
- Removed unused `useNetworkConnectorUpdater` in `NetworkSwitcher`.
- Enhanced `useSwitchNetworkLocal` to manage query parameters effectively and prevent unnecessary updates.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->