### PR TITLE
fix: Warnings and dependency of select hook of overridden initial timestamp

### DIFF
--- a/apps/web/src/state/block/hooks.ts
+++ b/apps/web/src/state/block/hooks.ts
@@ -98,12 +98,15 @@ export const useInitialBlockTimestamp = (chainId?: number): number => {
       refetchOnReconnect: false,
       refetchOnMount: false,
       enabled: !initialBlockTimestamp && isTargetDifferent,
-      select: useCallback((block) => {
-        queryClient.setQueryData(
-          getInitialBlockTimestampQueryKey(chainId),
-          block !== undefined ? Number(block.timestamp) : undefined,
-        )
-      }, []),
+      select: useCallback(
+        (block) => {
+          queryClient.setQueryData(
+            getInitialBlockTimestampQueryKey(chainId),
+            block !== undefined ? Number(block.timestamp) : undefined,
+          )
+        },
+        [chainId, queryClient],
+      ),
     },
   })
   return initialBlockTimestamp

--- a/apps/web/src/views/CakeStaking/components/CakeRewardsCard.tsx
+++ b/apps/web/src/views/CakeStaking/components/CakeRewardsCard.tsx
@@ -38,7 +38,6 @@ import BenefitsTooltipsText from 'views/Pools/components/RevenueSharing/Benefits
 import { timeFormat } from 'views/TradingReward/utils/timeFormat'
 import { poolStartWeekCursors } from 'views/CakeStaking/config'
 import { WEEK } from 'config/constants/veCake'
-import { useInitialBlockTimestamp } from 'state/block/hooks'
 import {
   useCakePoolEmission,
   useRevShareEmission,

--- a/apps/web/src/views/CakeStaking/hooks/useCurrentBlockTimestamp.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCurrentBlockTimestamp.ts
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs'
-
 import { useCurrentBlockTimestamp as useBlockTimestamp } from 'state/block/hooks'
 import { verifyBscNetwork } from 'utils/verifyBscNetwork'
 import { useActiveChainId } from 'hooks/useActiveChainId'

--- a/apps/web/src/views/Home/components/Banners/NewIFOBanner.tsx
+++ b/apps/web/src/views/Home/components/Banners/NewIFOBanner.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Button, Flex, Link, OpenNewIcon, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Button, Flex, OpenNewIcon, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 
 import { ASSET_CDN } from 'config/constants/endpoints'
 import useTheme from 'hooks/useTheme'

--- a/apps/web/src/views/ProfileCreation/Header.tsx
+++ b/apps/web/src/views/ProfileCreation/Header.tsx
@@ -1,5 +1,5 @@
 import { TranslateFunction, useTranslation } from '@pancakeswap/localization'
-import { Breadcrumbs, Button, Heading, Link, Text } from '@pancakeswap/uikit'
+import { Breadcrumbs, Button, Heading, Text } from '@pancakeswap/uikit'
 import { styled } from 'styled-components'
 import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import useProfileCreation from './contexts/hook'

--- a/apps/web/src/views/SwapSimplify/V4Swap/FlipButton.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/FlipButton.tsx
@@ -11,7 +11,6 @@ import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { styled } from 'styled-components'
 
 import { SwapUIV2 } from '@pancakeswap/widgets-internal'
-import { useRouter } from 'next/router'
 import { useAllowRecipient } from '../../Swap/V3Swap/hooks'
 
 export const Line = styled.div`


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining imports across various components, improving code readability, and enhancing the functionality of hooks within the application.

### Detailed summary
- Removed unused imports from `apps/web/src/views/SwapSimplify/V4Swap/FlipButton.tsx`.
- Removed unused import `useInitialBlockTimestamp` from `apps/web/src/views/CakeStaking/components/CakeRewardsCard.tsx`.
- Simplified imports in `apps/web/src/views/Home/components/Banners/NewIFOBanner.tsx` and `apps/web/src/views/ProfileCreation/Header.tsx`.
- Updated the `select` function in `apps/web/src/state/block/hooks.ts` to include `chainId` and `queryClient` as dependencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->