### PR TITLE
fix: Throw error to retry query

### DIFF
--- a/packages/awgmi/core/src/view/fetchAptosView.ts
+++ b/packages/awgmi/core/src/view/fetchAptosView.ts
@@ -18,6 +18,6 @@ export const fetchAptosView = async ({ networkName, params }: FetchAptosViewArgs
     return data
   } catch (error) {
     console.error('Fetch Aptos View Error: ', error)
-    return null
+    throw error
   }
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing error handling in the `fetchAptosView.ts` file. Instead of returning `null` when an error occurs, it now throws the error, allowing the caller to handle it appropriately.

### Detailed summary
- Replaced `return null` with `throw error` in the `catch` block of the error handling section.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->