### PR TITLE
fix: Smart router unable to get quote for wrapped native

### DIFF
--- a/.changeset/unlucky-dots-behave.md
+++ b/.changeset/unlucky-dots-behave.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/smart-router': patch
+---
+
+Fix unable to fetch quote with wrapped native token as output

--- a/packages/smart-router/evm/v3-router/gasModel.ts
+++ b/packages/smart-router/evm/v3-router/gasModel.ts
@@ -153,9 +153,10 @@ export async function createGasModel({
     }
     return {
       gasEstimate: baseGasUse,
-      gasCostInToken: isQuoteNative
-        ? CurrencyAmount.fromRawAmount(Native.onChain(chainId), gasCostInToken.quotient)
-        : gasCostInToken,
+      gasCostInToken:
+        isQuoteNative && quoteCurrency.isNative
+          ? CurrencyAmount.fromRawAmount(Native.onChain(chainId), gasCostInToken.quotient)
+          : gasCostInToken,
       gasCostInUSD,
     }
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue where fetching a quote with a wrapped native token as output was not functioning correctly in the `smart-router` package.

### Detailed summary
- Updated the logic in the `gasModel.ts` file.
- Changed the conditional statement for `gasCostInToken` to check if `isQuoteNative` and if `quoteCurrency` is native.
- Adjusted the return object structure to ensure correct gas cost calculation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->