### PR TITLE
fix: typos in documentation files

### DIFF
--- a/locales/tr-TR.json
+++ b/locales/tr-TR.json
@@ -3536,7 +3536,7 @@
   "trading and gas fees on Ethereum and Arbitrum with": "yatırım ve gas ücreti için Ethereum ve Arbitrum ağlarında şununla işlem yapın:",
   "0 Trading Fees, Gasless Swaps, MEV Protection, and a Wide Range of Tokens — ALL on PancakeSwapX": "0 Yatırım Ücreti, Gas'siz Dönüştürme, MEV Koruması ve Çok Çeşitli Token'lar: HEPSİ PancakeSwapX'te",
   "ZERO": "SIFIR",
-  "Fee Swaps on Ethereum and Arbitrum": "Ücretli Dönüştürme İşlemleri: Ethereum ve Aribtrum Ağlarında",
+  "Fee Swaps on Ethereum and Arbitrum": "Ücretli Dönüştürme İşlemleri: Ethereum ve Arbitrum Ağlarında",
   "%amount% of your liquidity is currently staking in farm.": "Likiditenizin %amount% kadarı şu anda farm'a stake edilmiş durumda.",
   "Based on last 24 hours' performance. Does not account for impermanent loss": "Son 24 saatin performansına dayalıdır. Geçici kayıpları hesaba katmaz",
   "Please check your date and time settings, and ensure that they are synced correctly.": "Lütfen tarih ve saat ayarlarınızı kontrol edin ve doğru bir şekilde senkronize edildiğinden emin olun.",


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Aribtrum` to `Arbitrum`

Please review the changes and let me know if any additional changes are needed.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Turkish localization file (`locales/tr-TR.json`) for a trading platform, ensuring that the translations are accurate and consistent.

### Detailed summary
- Updated translation for the phrase `"Fee Swaps on Ethereum and Arbitrum"` to correct a typo in "Arbitrum".
- Maintained existing translations for other phrases without changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->