### PR TITLE
fix: will switch back to bsc after switch chain

### DIFF
--- a/apps/web/src/views/Mev/hooks/index.ts
+++ b/apps/web/src/views/Mev/hooks/index.ts
@@ -12,14 +12,7 @@ async function checkWalletSupportAddEthereumChain(walletClient: WalletClient) {
     await walletClient.request({
       method: 'wallet_addEthereumChain',
       // @ts-ignore
-      params: [
-        // mock data without key params nativeCurrency
-        {
-          chainId: '0x38', // Chain ID in hexadecimal (56 for Binance Smart Chain)
-          chainName: 'PancakeSwap MEV Guard',
-          rpcUrls: ['https://bscrpc.pancakeswap.finance'], // PancakeSwap MEV RPC}
-        },
-      ],
+      params: [],
     })
 
     console.error('lack of parameter, should be error')


### PR DESCRIPTION
I found you will call `wallet_addEthereumChain` with invalid params for test if wallet support `wallet_addEthereumChain`
But for some multi-chain wallets like Rabby, when you call `wallet_addEthereumChain` with chainId, wallet will also switch to the target chain even you didn't set other params.
So I set up a PR, you can set params as `[]` which is invalid for all wallets and have the same effect as now