### PR TITLE
fix: Account position details not shown if chain doesn't have stable pairs

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
@@ -26,56 +26,54 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
     const { token0, token1 } = poolInfo
     return [token0.wrapped, token1.wrapped]
   }, [poolInfo])
-  const pairs = useStableSwapPairsByChainId(chainId)
   const protocol = useMemo(() => poolInfo?.protocol, [poolInfo])
-  const queryFn = useCallback(async () => {
-    if (protocol === 'v2') {
-      return getAccountV2LpDetails(
-        chainId,
-        account!,
-        currency0 && currency1 ? [[currency0.wrapped, currency1.wrapped]] : [],
-      )
-    }
-    if (protocol === 'stable') {
-      const stablePair = pairs.find((pair) => {
-        return isAddressEqual(pair.stableSwapAddress, poolInfo?.stableSwapAddress as Address)
-      })
-      return getStablePairDetails(chainId, account!, stablePair ? [stablePair] : [])
-    }
-    if (protocol === 'v3') {
-      return getAccountV3Positions(chainId, account!)
-    }
-    return Promise.resolve([])
-  }, [account, chainId, currency0, currency1, pairs, poolInfo, protocol])
-
-  const select = useCallback(
-    (data) => {
-      if (protocol === 'v3') {
-        // v3
-        const d = data.filter((position) => {
-          const { token0, token1, fee } = position as PositionDetail
-          return (
-            poolInfo?.token0.wrapped.address &&
-            isAddressEqual(token0, poolInfo?.token0.wrapped.address as Address) &&
-            poolInfo?.token1.address &&
-            isAddressEqual(token1, poolInfo?.token1.wrapped.address as Address) &&
-            fee === poolInfo?.feeTier
-          )
-        })
-        return d as PositionDetail[]
-      }
-
-      return data?.[0] && (data[0].nativeBalance.greaterThan('0') || data[0].farmingBalance.greaterThan('0'))
-        ? data[0]
-        : undefined
-    },
-    [poolInfo, protocol],
-  )
+  const pairs = useStableSwapPairsByChainId(chainId, protocol === 'stable')
   const [latestTxReceipt] = useLatestTxReceipt()
+
   return useQuery({
     queryKey: ['accountPosition', account, chainId, poolInfo?.lpAddress, latestTxReceipt?.blockHash],
-    queryFn,
-    enabled: Boolean(account && poolInfo?.lpAddress && pairs.length),
-    select,
+    queryFn: async () => {
+      if (protocol === 'v2') {
+        return getAccountV2LpDetails(
+          chainId,
+          account!,
+          currency0 && currency1 ? [[currency0.wrapped, currency1.wrapped]] : [],
+        )
+      }
+      if (protocol === 'stable') {
+        const stablePair = pairs.find((pair) => {
+          return isAddressEqual(pair.stableSwapAddress, poolInfo?.stableSwapAddress as Address)
+        })
+        return getStablePairDetails(chainId, account!, stablePair ? [stablePair] : [])
+      }
+      if (protocol === 'v3') {
+        return getAccountV3Positions(chainId, account!)
+      }
+      return Promise.resolve([])
+    },
+    enabled: Boolean(account && poolInfo?.lpAddress && (protocol === 'stable' ? pairs.length : true)),
+    select: useCallback(
+      (data) => {
+        if (protocol === 'v3') {
+          // v3
+          const d = data.filter((position) => {
+            const { token0, token1, fee } = position as PositionDetail
+            return (
+              poolInfo?.token0.wrapped.address &&
+              isAddressEqual(token0, poolInfo?.token0.wrapped.address as Address) &&
+              poolInfo?.token1.address &&
+              isAddressEqual(token1, poolInfo?.token1.wrapped.address as Address) &&
+              fee === poolInfo?.feeTier
+            )
+          })
+          return d as PositionDetail[]
+        }
+
+        return data?.[0] && (data[0].nativeBalance.greaterThan('0') || data[0].farmingBalance.greaterThan('0'))
+          ? data[0]
+          : undefined
+      },
+      [poolInfo, protocol],
+    ),
   })
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
@@ -58,7 +58,11 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
       return Promise.resolve([])
     },
     enabled: Boolean(
-      account && poolInfo?.lpAddress && poolInfo?.protocol && (poolInfo?.protocol === 'stable' ? pairs.length : true),
+      account &&
+        poolInfo &&
+        poolInfo.lpAddress &&
+        poolInfo.protocol &&
+        (poolInfo.protocol === 'stable' ? pairs.length : true),
     ),
     select: useCallback(
       (data) => {
@@ -81,7 +85,7 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
           ? data[0]
           : undefined
       },
-      [poolInfo, poolInfo?.protocol],
+      [poolInfo],
     ),
   })
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
@@ -26,35 +26,34 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
     const { token0, token1 } = poolInfo
     return [token0.wrapped, token1.wrapped]
   }, [poolInfo])
-  const protocol = useMemo(() => poolInfo?.protocol, [poolInfo])
-  const pairs = useStableSwapPairsByChainId(chainId, protocol === 'stable')
+  const pairs = useStableSwapPairsByChainId(chainId, poolInfo?.protocol === 'stable')
   const [latestTxReceipt] = useLatestTxReceipt()
 
   return useQuery({
     queryKey: ['accountPosition', account, chainId, poolInfo?.lpAddress, latestTxReceipt?.blockHash],
     queryFn: async () => {
-      if (protocol === 'v2') {
+      if (poolInfo?.protocol === 'v2') {
         return getAccountV2LpDetails(
           chainId,
           account!,
           currency0 && currency1 ? [[currency0.wrapped, currency1.wrapped]] : [],
         )
       }
-      if (protocol === 'stable') {
+      if (poolInfo?.protocol === 'stable') {
         const stablePair = pairs.find((pair) => {
           return isAddressEqual(pair.stableSwapAddress, poolInfo?.stableSwapAddress as Address)
         })
         return getStablePairDetails(chainId, account!, stablePair ? [stablePair] : [])
       }
-      if (protocol === 'v3') {
+      if (poolInfo?.protocol === 'v3') {
         return getAccountV3Positions(chainId, account!)
       }
       return Promise.resolve([])
     },
-    enabled: Boolean(account && poolInfo?.lpAddress && (protocol === 'stable' ? pairs.length : true)),
+    enabled: Boolean(account && poolInfo?.lpAddress && (poolInfo?.protocol === 'stable' ? pairs.length : true)),
     select: useCallback(
       (data) => {
-        if (protocol === 'v3') {
+        if (poolInfo?.protocol === 'v3') {
           // v3
           const d = data.filter((position) => {
             const { token0, token1, fee } = position as PositionDetail
@@ -73,7 +72,7 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
           ? data[0]
           : undefined
       },
-      [poolInfo, protocol],
+      [poolInfo, poolInfo?.protocol],
     ),
   })
 }

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountPositionDetailByPool.ts
@@ -30,7 +30,14 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
   const [latestTxReceipt] = useLatestTxReceipt()
 
   return useQuery({
-    queryKey: ['accountPosition', account, chainId, poolInfo?.lpAddress, latestTxReceipt?.blockHash],
+    queryKey: [
+      'accountPosition',
+      account,
+      chainId,
+      poolInfo?.lpAddress,
+      poolInfo?.protocol,
+      latestTxReceipt?.blockHash,
+    ],
     queryFn: async () => {
       if (poolInfo?.protocol === 'v2') {
         return getAccountV2LpDetails(
@@ -50,7 +57,9 @@ export const useAccountPositionDetailByPool = <TProtocol extends keyof PoolPosit
       }
       return Promise.resolve([])
     },
-    enabled: Boolean(account && poolInfo?.lpAddress && (poolInfo?.protocol === 'stable' ? pairs.length : true)),
+    enabled: Boolean(
+      account && poolInfo?.lpAddress && poolInfo?.protocol && (poolInfo?.protocol === 'stable' ? pairs.length : true),
+    ),
     select: useCallback(
       (data) => {
         if (poolInfo?.protocol === 'v3') {

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useStableSwapPairsByChainId.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useStableSwapPairsByChainId.ts
@@ -3,7 +3,7 @@ import { LegacyRouter } from '@pancakeswap/smart-router/legacy-router'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
-export const useStableSwapPairsByChainId = (chainId: ChainId) => {
+export const useStableSwapPairsByChainId = (chainId: ChainId, enabled = true) => {
   const { data } = useQuery({
     queryKey: ['fetch-stable-swap-pairs', chainId],
     queryFn: async () => {
@@ -13,7 +13,7 @@ export const useStableSwapPairsByChainId = (chainId: ChainId) => {
       }
       return []
     },
-    enabled: Boolean(chainId),
+    enabled: Boolean(chainId && enabled),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,

--- a/apps/web/src/views/PoolDetail/components/PoolStatus.tsx
+++ b/apps/web/src/views/PoolDetail/components/PoolStatus.tsx
@@ -18,7 +18,7 @@ type PoolStatusProps = {
 }
 export const PoolStatus: React.FC<PoolStatusProps> = ({ poolInfo }) => {
   const { t } = useTranslation()
-  const pairs = useStableSwapPairsByChainId(poolInfo?.chainId ?? ChainId.BSC)
+  const pairs = useStableSwapPairsByChainId(poolInfo?.chainId ?? ChainId.BSC, poolInfo?.protocol === 'stable')
 
   const tvlChange = useMemo(() => {
     if (!poolInfo) return null

--- a/apps/web/src/views/universalFarms/components/PoolAprButton/V2PoolAprModal.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/V2PoolAprModal.tsx
@@ -46,7 +46,7 @@ const AprModal: React.FC<Omit<V2PoolAprModalProps, 'modal'>> = ({ poolInfo, comb
     poolInfo,
   )
 
-  const pairs = useStableSwapPairsByChainId(poolInfo.chainId)
+  const pairs = useStableSwapPairsByChainId(poolInfo?.chainId, poolInfo?.protocol === 'stable')
 
   const stakingTokenBalance = useMemo(() => {
     return BIG_ZERO.plus(userPosition?.farmingBalance?.quotient.toString() ?? 0).plus(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useStableSwapPairsByChainId` function and its usage throughout the codebase to conditionally handle the `protocol` parameter, specifically for `stable` pairs, improving the logic for fetching and processing stable swap pairs.

### Detailed summary
- Updated `useStableSwapPairsByChainId` to accept a second parameter `enabled`.
- Modified calls to `useStableSwapPairsByChainId` in `V2PoolAprModal.tsx` and `PoolStatus.tsx` to include the `protocol` check.
- Adjusted logic in `useAccountPositionDetailByPool.ts` to handle `stable` protocol more effectively.
- Improved query logic to ensure pairs are only fetched when appropriate based on the protocol.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->