### PR TITLE
fix: update calc gauges address

### DIFF
--- a/packages/gauges/src/constants/address.ts
+++ b/packages/gauges/src/constants/address.ts
@@ -9,6 +9,6 @@ export const GAUGES_ADDRESS = {
 }
 
 export const GAUGES_CALC_ADDRESS = {
-  [ChainId.BSC]: '0x94F8cBa8712B3E72C9BF8Ba4d6619Ac9046FE695' as const,
+  [ChainId.BSC]: '0x4fF7C80Df31e5864776314D89220Ae18626a6D67' as const,
   [ChainId.BSC_TESTNET]: '0x88B02E6238fa6279281eeA600CBfcAd5dd3597A5' as const,
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `GAUGES_CALC_ADDRESS` constant in the `address.ts` file, specifically modifying the address for the `ChainId.BSC` entry.

### Detailed summary
- Changed the address for `ChainId.BSC` from `0x94F8cBa8712B3E72C9BF8Ba4d6619Ac9046FE695` to `0x4fF7C80Df31e5864776314D89220Ae18626a6D67`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->