### PR TITLE
fix: 🐛 Change blog link

### DIFF
--- a/apps/web/src/components/Modal/SimpleStakingSunsetModal.tsx
+++ b/apps/web/src/components/Modal/SimpleStakingSunsetModal.tsx
@@ -62,8 +62,12 @@ export function SimpleStakingSunsetModal() {
           <Text mt="0.5rem">2️⃣ {t('Connect your wallet')}</Text>
           <Text mt="0.5rem">3️⃣ {t('Select your stake and withdraw')}</Text>
           <Text mt="1.5rem">
-            {/* TODO: update the link after MKT team prepare for it */}
-            <LinkExternal bold style={{ display: 'inline-flex' }} showExternalIcon href="/simple-staking">
+            <LinkExternal
+              bold
+              style={{ display: 'inline-flex' }}
+              showExternalIcon
+              href="https://blog.pancakeswap.finance/articles/action-required-simple-staking-product-retirement"
+            >
               {t('Learn more here')}
             </LinkExternal>
           </Text>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `SimpleStakingSunsetModal` component by modifying a link to provide users with more relevant information regarding the simple staking product retirement.

### Detailed summary
- Replaced a placeholder comment about updating the link with a direct link to a blog article.
- Changed the `href` of the `LinkExternal` component to point to `https://blog.pancakeswap.finance/articles/action-required-simple-staking-product-retirement`.
- Updated the link text to `{t('Learn more here')}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->