### PR TITLE
fix: typos in documentation files

### DIFF
--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -541,7 +541,7 @@
   "%symbol% to receive": "%symbol% к получению",
   "This transaction will not succeed either due to price movement or fee on transfer. Try increasing your": "Эта транзакция не пройдет из-за движения цены или комиссии за перевод. Попробуйте повысить",
   "slippage tolerance.": "допустимый слипедж.",
-  "Eggscellent! Celebrating Syrup Storm winning the Easter Battle!": "Отяично! Празднуем победу Сиропной бури в Пасхальной битве!",
+  "Eggscellent! Celebrating Syrup Storm winning the Easter Battle!": "Отлично! Празднуем победу Сиропной бури в Пасхальной битве!",
   "Melting Easter eggs and melting hearts!": "Тают пасхальные яйца и сердца!",
   "Watch out for Flipsie’s spatula smash!": "Остерегайтесь метких ударов кулинарной лопаткой от Флипси!",
   "Do you like chocolate with your syrup? Go long!": "Вам нравится шоколад в сиропе? Бесподобно!",


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `Отяично` to `Отлично`

Please review the changes and let me know if any additional changes are needed.

