### PR TITLE
perf: Memoize mev rpc callbacks

### DIFF
--- a/apps/web/src/views/Mev/AddMevRpcButton.tsx
+++ b/apps/web/src/views/Mev/AddMevRpcButton.tsx
@@ -3,7 +3,7 @@ import { Button, CheckmarkCircleFillIcon, SwapLoading } from '@pancakeswap/uikit
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useTheme from 'hooks/useTheme'
-import { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useAddMevRpc, useIsMEVEnabled, useShouldShowMEVToggle } from './hooks'
 
 export const AddMevRpcButton: React.FC = () => {
@@ -15,11 +15,11 @@ export const AddMevRpcButton: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false)
   const { theme } = useTheme()
   const { addMevRpc } = useAddMevRpc(
-    () => {
+    useCallback(() => {
       refetch()
-    },
-    () => setIsLoading(true),
-    () => setIsLoading(false),
+    }, [refetch]),
+    useCallback(() => setIsLoading(true), []),
+    useCallback(() => setIsLoading(false), []),
   )
 
   if (!account) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `AddMevRpcButton` component by optimizing the use of `useCallback` for better performance and clarity when handling loading states.

### Detailed summary
- Added `React` to the import statement.
- Wrapped the `refetch` function in `useCallback` for memoization.
- Changed loading state functions to use `useCallback` for improved performance:
  - `setIsLoading(true)`
  - `setIsLoading(false)`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->