### PR TITLE
fix: video loaded issue on home page

### DIFF
--- a/apps/web/src/views/Home/components/Hero.tsx
+++ b/apps/web/src/views/Home/components/Hero.tsx
@@ -6,7 +6,7 @@ import { AdPanel } from 'components/AdPanel'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import useTheme from 'hooks/useTheme'
-import { useLayoutEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { styled } from 'styled-components'
 import { useAccount } from 'wagmi'
 import { useDrawCanvas } from '../hooks/useDrawCanvas'
@@ -129,6 +129,7 @@ const Hero = () => {
   const internalRef = useRef(0)
   const seqInternalRef = useRef(0)
   const { isIOS } = useIsIOS()
+
   const { drawImage, isVideoPlaying } = useDrawCanvas(
     videoRef,
     canvasRef,
@@ -152,7 +153,8 @@ const Hero = () => {
     [starVideoRef, cakeVideoRef, rock01VideoRef, rock02VideoRef, rock03VideoRef],
   )
 
-  useLayoutEffect(() => {
+  useEffect(() => {
+    videoRef.current?.play()
     starVideoRef.current?.play()
     cakeVideoRef.current?.play()
     rock01VideoRef.current?.play()
@@ -285,22 +287,22 @@ const Hero = () => {
               />
               {!(isIOS || isMobile) && (
                 <VideoWrapper>
-                  <CakeVideo ref={videoRef} width={width} autoPlay muted playsInline>
+                  <CakeVideo ref={videoRef} width={width} autoPlay muted playsInline preload="auto">
                     <source src={`${ASSET_CDN}/web/landing/bunnyv2.webm`} type="video/webm" />
                   </CakeVideo>
-                  <CakeVideo ref={starVideoRef} width={width} autoPlay loop muted playsInline>
+                  <CakeVideo ref={starVideoRef} width={width} autoPlay loop muted playsInline preload="auto">
                     <source src={`${ASSET_CDN}/web/landing/star.webm`} type="video/webm" />
                   </CakeVideo>
                   <CakeVideo ref={cakeVideoRef} width={width} autoPlay loop muted playsInline>
                     <source src={`${ASSET_CDN}/web/landing/hero-cake.webm`} type="video/webm" />
                   </CakeVideo>
-                  <CakeVideo ref={rock01VideoRef} width={width} autoPlay loop muted playsInline>
+                  <CakeVideo ref={rock01VideoRef} width={width} autoPlay loop muted playsInline preload="auto">
                     <source src={`${ASSET_CDN}/web/landing/rock01.webm`} type="video/webm" />
                   </CakeVideo>
-                  <CakeVideo ref={rock02VideoRef} width={width} autoPlay loop muted playsInline>
+                  <CakeVideo ref={rock02VideoRef} width={width} autoPlay loop muted playsInline preload="auto">
                     <source src={`${ASSET_CDN}/web/landing/rock02.webm`} type="video/webm" />
                   </CakeVideo>
-                  <CakeVideo ref={rock03VideoRef} width={width} autoPlay loop muted playsInline>
+                  <CakeVideo ref={rock03VideoRef} width={width} autoPlay loop muted playsInline preload="auto">
                     <source src={`${ASSET_CDN}/web/landing/rock03.webm`} type="video/webm" />
                   </CakeVideo>
                 </VideoWrapper>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `useDrawCanvas` hook and the `Hero` component by optimizing the use of refs and effect hooks, ensuring better performance and cleaner code.

### Detailed summary
- Changed `useLayoutEffect` to `useEffect` in `useDrawCanvas` and `Hero` for consistency.
- Simplified the check for `isElementReady` in `useDrawCanvas`.
- Refactored the `drawImage` function to use `canvasRef` and `videoRef` directly.
- Added `preload="auto"` attribute to multiple `CakeVideo` components for improved loading.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->