### PR TITLE
chore: update ad panel image path

### DIFF
--- a/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
+++ b/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
@@ -3,7 +3,7 @@ import { FAQConfig } from '../types'
 
 export const predictionFAQConfig: FAQConfig = (t) => ({
   title: t('Quick start to Prediction (BETA)'),
-  imageUrl: getImageUrl('ad_prediction_telegram_bot'),
+  imageUrl: getImageUrl('prediction_telegram_bot'),
   alt: 'Prediction Telegram bot',
   docsUrl: 'https://docs.pancakeswap.finance/products/prediction',
   data: [


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `imageUrl` in the `predictionFAQConfig` configuration for the prediction feature in the application.

### Detailed summary
- Changed the `imageUrl` from `ad_prediction_telegram_bot` to `prediction_telegram_bot` in the `predictionFAQConfig`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->