### PR TITLE
chore: Use general download links for wallets to cover all browsers

### DIFF
--- a/apps/web/src/config/wallet.ts
+++ b/apps/web/src/config/wallet.ts
@@ -100,7 +100,7 @@ const walletsConfig = <config extends Config = Config, context = unknown>({
         return !!getTrustWalletProvider()
       },
       deepLink: 'https://link.trustwallet.com/open_url?coin_id=20000714&url=https://pancakeswap.finance/',
-      downloadLink: 'https://chrome.google.com/webstore/detail/trust-wallet/egjidjbpglichdcondbcbdnbeeppgdph',
+      downloadLink: 'https://trustwallet.com/browser-extension',
       guide: {
         desktop: 'https://trustwallet.com/browser-extension',
         mobile: 'https://trustwallet.com/',
@@ -115,7 +115,7 @@ const walletsConfig = <config extends Config = Config, context = unknown>({
       get installed() {
         return typeof window !== 'undefined' && Boolean(window.okxwallet)
       },
-      downloadLink: 'https://chromewebstore.google.com/detail/okx-wallet/mcohilncbfahbmgdjkbpemcciiolgcge',
+      downloadLink: 'https://www.okx.com/download',
       deepLink:
         'https://www.okx.com/download?deeplink=okx%3A%2F%2Fwallet%2Fdapp%2Furl%3FdappUrl%3Dhttps%253A%252F%252Fpancakeswap.finance',
       guide: {
@@ -180,7 +180,7 @@ const walletsConfig = <config extends Config = Config, context = unknown>({
         desktop: 'https://rabby.io/',
       },
       downloadLink: {
-        desktop: 'https://chrome.google.com/webstore/detail/rabby/acmacodkjbdgmoleebolmdjonilkdbch',
+        desktop: 'https://rabby.io/',
       },
     },
     {
@@ -211,8 +211,7 @@ const walletsConfig = <config extends Config = Config, context = unknown>({
       get installed() {
         return typeof window !== 'undefined' && Boolean((window.ethereum as ExtendEthereum)?.isSafePal)
       },
-      downloadLink:
-        'https://chrome.google.com/webstore/detail/safepal-extension-wallet/lgmpcpglpngdoalbgeoldeajfclnhafa',
+      downloadLink: 'https://safepal.com/en/extension',
       qrCode,
     },
     {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `downloadLink` URLs for various wallet configurations in the `wallet.ts` file, ensuring users are directed to the correct resources for downloading the respective wallet extensions.

### Detailed summary
- Updated `downloadLink` for `Trust Wallet` to `https://trustwallet.com/browser-extension`.
- Updated `downloadLink` for `OKX Wallet` to `https://www.okx.com/download`.
- Updated `downloadLink` for `Rabby` to `https://rabby.io/`.
- Updated `downloadLink` for `SafePal` to `https://safepal.com/en/extension`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->