### PR TITLE
chore: Increase max chunk retries to 5

### DIFF
--- a/apps/aptos/next.config.mjs
+++ b/apps/aptos/next.config.mjs
@@ -47,7 +47,7 @@ const nextConfig = {
           retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-          maxRetries: 3,
+          maxRetries: 5,
         }),
     )
     return webpackConfig

--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -28,7 +28,7 @@ const nextConfig = {
           retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-          maxRetries: 3,
+          maxRetries: 5,
         }),
     )
     return webpackConfig

--- a/apps/bridge/next.config.mjs
+++ b/apps/bridge/next.config.mjs
@@ -38,7 +38,7 @@ const nextConfig = {
           retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-          maxRetries: 3,
+          maxRetries: 5,
         }),
     )
     return webpackConfig

--- a/apps/games/next.config.mjs
+++ b/apps/games/next.config.mjs
@@ -40,7 +40,7 @@ const nextConfig = {
           retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-          maxRetries: 3,
+          maxRetries: 5,
         }),
     )
     return webpackConfig

--- a/apps/gamification/next.config.mjs
+++ b/apps/gamification/next.config.mjs
@@ -93,7 +93,7 @@ const nextConfig = {
           retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-          maxRetries: 3,
+          maxRetries: 5,
         }),
     )
     if (!isServer && webpackConfig.optimization.splitChunks) {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -230,7 +230,7 @@ const config = {
         retryDelay: `function(retryAttempt) {
           return 2 ** (retryAttempt - 1) * 500;
         }`,
-        maxRetries: 3,
+        maxRetries: 5,
       }),
     )
     if (!isServer && webpackConfig.optimization.splitChunks) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `maxRetries` configuration in multiple `next.config.mjs` files across various applications from `3` to `5`, allowing for more retry attempts in case of failures.

### Detailed summary
- Updated `maxRetries` from `3` to `5` in:
  - `apps/blog/next.config.mjs`
  - `apps/aptos/next.config.mjs`
  - `apps/games/next.config.mjs`
  - `apps/bridge/next.config.mjs`
  - `apps/web/next.config.mjs`
  - `apps/gamification/next.config.mjs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->