### PR TITLE
fix: 🐛 Fix Arguments passing order of usePoolTickData

### DIFF
--- a/apps/web/src/hooks/v3/usePoolTickData.ts
+++ b/apps/web/src/hooks/v3/usePoolTickData.ts
@@ -29,13 +29,19 @@ function useTicksFromSubgraph(
 }
 
 // Fetches all ticks for a given pool
-export function useAllV3Ticks(
-  currencyA: Currency | undefined | null,
-  currencyB: Currency | undefined | null,
-  feeAmount: FeeAmount | undefined,
-  activeTick: number | undefined,
+export function useAllV3Ticks({
+  currencyA,
+  currencyB,
+  feeAmount,
+  activeTick,
   enabled = true,
-): {
+}: {
+  currencyA?: Currency | null
+  currencyB?: Currency | null
+  feeAmount?: FeeAmount
+  activeTick?: number
+  enabled?: boolean
+}): {
   isLoading: boolean
   error: unknown
   ticks: TickData[] | undefined
@@ -64,7 +70,7 @@ export function usePoolActiveLiquidity(
   // Find nearest valid tick for pool in case tick is not initialized.
   const activeTick = useMemo(() => getActiveTick(pool[1]?.tickCurrent, feeAmount), [pool, feeAmount])
 
-  const { isLoading, error, ticks } = useAllV3Ticks(currencyA, currencyB, feeAmount, activeTick)
+  const { isLoading, error, ticks } = useAllV3Ticks({ currencyA, currencyB, feeAmount, activeTick })
 
   return useMemo(() => {
     if (

--- a/apps/web/src/hooks/v3/usePoolTickData.ts
+++ b/apps/web/src/hooks/v3/usePoolTickData.ts
@@ -64,7 +64,7 @@ export function usePoolActiveLiquidity(
   // Find nearest valid tick for pool in case tick is not initialized.
   const activeTick = useMemo(() => getActiveTick(pool[1]?.tickCurrent, feeAmount), [pool, feeAmount])
 
-  const { isLoading, error, ticks } = useAllV3Ticks(currencyA, currencyB, activeTick, feeAmount)
+  const { isLoading, error, ticks } = useAllV3Ticks(currencyA, currencyB, feeAmount, activeTick)
 
   return useMemo(() => {
     if (

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -114,7 +114,7 @@ export function AprCalculator({
     [sqrtRatioX96],
   )
   const activeTick = useMemo(() => getActiveTick(tickCurrent, feeAmount), [tickCurrent, feeAmount])
-  const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, activeTick, feeAmount)
+  const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount, activeTick)
   const volume24H = usePoolAvgTradingVolume({
     address: poolAddress,
     chainId: pool?.token0.chainId,

--- a/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/AprCalculator.tsx
@@ -114,7 +114,7 @@ export function AprCalculator({
     [sqrtRatioX96],
   )
   const activeTick = useMemo(() => getActiveTick(tickCurrent, feeAmount), [tickCurrent, feeAmount])
-  const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount, activeTick)
+  const { ticks: data } = useAllV3Ticks({ currencyA: baseCurrency, currencyB: quoteCurrency, feeAmount, activeTick })
   const volume24H = usePoolAvgTradingVolume({
     address: poolAddress,
     chainId: pool?.token0.chainId,

--- a/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
+++ b/apps/web/src/views/Farms/components/FarmCard/V3/FarmV3ApyButton.tsx
@@ -120,7 +120,13 @@ function FarmV3ApyButton_({
     [sqrtRatioX96],
   )
   const activeTick = useMemo(() => getActiveTick(tickCurrent, feeAmount), [tickCurrent, feeAmount])
-  const { ticks: data } = useAllV3Ticks(baseCurrency, quoteCurrency, feeAmount, activeTick, roiModal.isOpen)
+  const { ticks: data } = useAllV3Ticks({
+    currencyA: baseCurrency,
+    currencyB: quoteCurrency,
+    feeAmount,
+    activeTick,
+    enabled: roiModal.isOpen,
+  })
 
   const cakePrice = useCakePrice()
 

--- a/apps/web/src/views/universalFarms/components/PoolAprButton/V3PoolAprModal.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/V3PoolAprModal.tsx
@@ -53,13 +53,13 @@ const AprModal: React.FC<V3PoolAprModalProps> = ({ modal, poolInfo, userPosition
     [sqrtRatioX96],
   )
   const activeTick = useMemo(() => getActiveTick(tickCurrent, poolInfo.feeTier), [tickCurrent, poolInfo.feeTier])
-  const { ticks: ticksData } = useAllV3Ticks(
-    poolInfo.token0,
-    poolInfo.token1,
-    poolInfo.feeTier,
+  const { ticks: ticksData } = useAllV3Ticks({
+    currencyA: poolInfo.token0,
+    currencyB: poolInfo.token1,
+    feeAmount: poolInfo.feeTier,
     activeTick,
-    modal.isOpen,
-  )
+    enabled: modal.isOpen,
+  })
   const prices = usePairTokensPrice(poolInfo?.lpAddress, priceTimeWindow, poolInfo?.chainId, modal.isOpen)
   const depositUsdAsBN = useMemo(
     () =>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `useAllV3Ticks` function calls across multiple components to utilize an object parameter instead of individual arguments, improving code readability and maintainability.

### Detailed summary
- Updated `useAllV3Ticks` calls in `FarmV3ApyButton.tsx` to use an object parameter.
- Refactored `useAllV3Ticks` in `AprCalculator.tsx` similarly.
- Changed `useAllV3Ticks` in `V3PoolAprModal.tsx` to accept an object parameter.
- Modified the `useAllV3Ticks` function definition to accept an object with optional properties.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->