### PR TITLE
chore: inject rpc for bridge package

### DIFF
--- a/apps/web/src/pages/bridge/index.tsx
+++ b/apps/web/src/pages/bridge/index.tsx
@@ -1,6 +1,6 @@
 import { Flex, useMatchBreakpoints } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import { SERVER_NODES } from 'config/nodes'
+import { PUBLIC_NODES } from 'config/nodes'
 import { lazy, Suspense } from 'react'
 import { CHAIN_IDS } from 'utils/wagmi'
 import Page from 'views/Page'
@@ -30,7 +30,7 @@ const BridgePage = () => {
             connectWalletButton={<ConnectWalletButton width="100%" />}
             supportedChainIds={CHAIN_IDS}
             // @ts-ignore
-            rpcConfig={SERVER_NODES}
+            rpcConfig={PUBLIC_NODES}
           />
         </Suspense>
       </Flex>

--- a/apps/web/src/pages/bridge/index.tsx
+++ b/apps/web/src/pages/bridge/index.tsx
@@ -1,5 +1,6 @@
 import { Flex, useMatchBreakpoints } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
+import { SERVER_NODES } from 'config/nodes'
 import { lazy, Suspense } from 'react'
 import { CHAIN_IDS } from 'utils/wagmi'
 import Page from 'views/Page'
@@ -25,7 +26,12 @@ const BridgePage = () => {
         max-width="unset"
       >
         <Suspense>
-          <CanonicalBridge connectWalletButton={<ConnectWalletButton width="100%" />} supportedChainIds={CHAIN_IDS} />
+          <CanonicalBridge
+            connectWalletButton={<ConnectWalletButton width="100%" />}
+            supportedChainIds={CHAIN_IDS}
+            // @ts-ignore
+            rpcConfig={SERVER_NODES}
+          />
         </Suspense>
       </Flex>
     </Page>

--- a/packages/canonical-bridge/src/views/index.tsx
+++ b/packages/canonical-bridge/src/views/index.tsx
@@ -25,6 +25,7 @@ import GlobalStyle from './GlobalStyle'
 export interface CanonicalBridgeProps {
   connectWalletButton: CanonicalBridgeProviderProps['connectWalletButton']
   supportedChainIds: number[]
+  rpcConfig: Record<number, string[]>
 }
 
 export const CanonicalBridge = (props: CanonicalBridgeProps) => {
@@ -63,7 +64,8 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
     return chains
       .filter((e) => supportedChainIds.includes(e.id))
       .filter((e) => !(connector?.id === 'BinanceW3WSDK' && e.id === 1101))
-  }, [connector?.id, supportedChainIds])
+      .map((chain) => ({ ...chain, rpcUrl: props.rpcConfig?.[chain.id]?.[0] ?? chain.rpcUrl }))
+  }, [supportedChainIds, connector?.id, props.rpcConfig])
 
   return (
     <BridgeWalletProvider>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `rpcConfig` prop to the `CanonicalBridge` component, allowing it to receive configuration for RPC nodes. This enhances the bridge's flexibility in handling different blockchain networks.

### Detailed summary
- Added import for `PUBLIC_NODES` from `config/nodes`.
- Updated `CanonicalBridge` in `BridgePage` to include `rpcConfig={PUBLIC_NODES}`.
- Modified `CanonicalBridge` prop types to include `rpcConfig: Record<number, string[]>`.
- Updated the mapping of chains to utilize `props.rpcConfig` for `rpcUrl`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->