### PR TITLE
fix(canonical-bridge): Remove stargate

### DIFF
--- a/packages/canonical-bridge/src/hooks/useTransferConfig.ts
+++ b/packages/canonical-bridge/src/hooks/useTransferConfig.ts
@@ -5,7 +5,7 @@ import axios from 'axios'
 import { env } from '../configs/env'
 import layerZeroConfig from '../token-config/mainnet/layerZero/config.json'
 import mesonConfig from '../token-config/mainnet/meson/config.json'
-import stargateConfig from '../token-config/mainnet/stargate/config.json'
+// import stargateConfig from '../token-config/mainnet/stargate/config.json'
 
 export function useTransferConfig() {
   const [transferConfig, setTransferConfig] = useState<ITransferConfig>()
@@ -149,18 +149,18 @@ export function useTransferConfig() {
             ['SWAP', 'SWAP.e'],
           ],
         },
-        stargate: {
-          config: stargateConfig,
-          exclude: {
-            chains: [],
-            tokens: {},
-          },
-          bridgedTokenGroups: [
-            ['ETH', 'mETH'],
-            ['USDT', 'm.USDT'],
-            ['USDC', 'USDC.e'],
-          ],
-        },
+        // stargate: {
+        //   config: stargateConfig,
+        //   exclude: {
+        //     chains: [],
+        //     tokens: {},
+        //   },
+        //   bridgedTokenGroups: [
+        //     ['ETH', 'mETH'],
+        //     ['USDT', 'm.USDT'],
+        //     ['USDC', 'USDC.e'],
+        //   ],
+        // },
         layerZero: {
           config: layerZeroConfig,
           exclude: {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on commenting out the `stargate` configuration within the `useTransferConfig` function in the `packages/canonical-bridge/src/hooks/useTransferConfig.ts` file.

### Detailed summary
- The `import` statement for `stargateConfig` is commented out.
- The entire `stargate` configuration object is commented out, including its properties: `config`, `exclude`, and `bridgedTokenGroups`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->