### PR TITLE
fix: No active position shown when loading lp positions

### DIFF
--- a/apps/web/src/views/universalFarms/PositionPage.tsx
+++ b/apps/web/src/views/universalFarms/PositionPage.tsx
@@ -401,7 +401,7 @@ export const PositionPage = () => {
     if (!account) {
       return <EmptyListPlaceholder text={t('Please Connect Wallet to view positions.')} />
     }
-    if (v3Loading && v2Loading && stableLoading) {
+    if (v3Loading || v2Loading || stableLoading) {
       return (
         <>
           <PositionItemSkeleton />

--- a/apps/web/src/views/universalFarms/PositionPage.tsx
+++ b/apps/web/src/views/universalFarms/PositionPage.tsx
@@ -401,7 +401,7 @@ export const PositionPage = () => {
     if (!account) {
       return <EmptyListPlaceholder text={t('Please Connect Wallet to view positions.')} />
     }
-    if (v3Loading || v2Loading || stableLoading) {
+    if (v3Loading && v2Loading && stableLoading) {
       return (
         <>
           <PositionItemSkeleton />
@@ -412,7 +412,14 @@ export const PositionPage = () => {
       )
     }
 
-    if (!v3PositionList.length && !v2PositionList.length && !stablePositionList.length) {
+    if (
+      !v3Loading &&
+      !v2Loading &&
+      !stableLoading &&
+      !v3PositionList.length &&
+      !v2PositionList.length &&
+      !stablePositionList.length
+    ) {
       return (
         <EmptyListPlaceholder
           text={t('You have no %status% position in this wallet.', {
@@ -435,7 +442,19 @@ export const PositionPage = () => {
       [Protocol.V2]: v2PositionList,
       [Protocol.STABLE]: stablePositionList,
     }
-    return selectedPoolTypes.reduce((acc, type) => acc.concat(sectionMap[type]), []).slice(0, cursorVisible)
+    const elements = selectedPoolTypes.reduce((acc, type) => acc.concat(sectionMap[type]), []).slice(0, cursorVisible)
+    if (v3Loading || v2Loading || stableLoading) {
+      return [
+        ...elements,
+        <>
+          <PositionItemSkeleton />
+          <Text color="textSubtle" textAlign="center">
+            <Dots>{t('Loading')}</Dots>
+          </Text>
+        </>,
+      ]
+    }
+    return elements
   }, [
     account,
     t,


### PR DESCRIPTION
If user only has the positions in either of them (v3,v2,stable), no active position for a period of time shown if the type where there is no position loaded first

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the loading state management in the `PositionPage` component by checking loading flags before rendering the empty state and modifies how loading indicators are displayed.

### Detailed summary
- Updated the condition to check for loading states (`v3Loading`, `v2Loading`, `stableLoading`) before rendering the empty state.
- Introduced a loading skeleton (`<PositionItemSkeleton />`) and a loading text indicator when any of the position lists are loading.
- Stored the reduced elements in a constant `elements` for better readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->