### PR TITLE
revert: fix(canonical-bridge): Remove stargate

### DIFF
--- a/packages/canonical-bridge/src/hooks/useTransferConfig.ts
+++ b/packages/canonical-bridge/src/hooks/useTransferConfig.ts
@@ -5,7 +5,7 @@ import axios from 'axios'
 import { env } from '../configs/env'
 import layerZeroConfig from '../token-config/mainnet/layerZero/config.json'
 import mesonConfig from '../token-config/mainnet/meson/config.json'
-// import stargateConfig from '../token-config/mainnet/stargate/config.json'
+import stargateConfig from '../token-config/mainnet/stargate/config.json'
 
 export function useTransferConfig() {
   const [transferConfig, setTransferConfig] = useState<ITransferConfig>()
@@ -149,18 +149,18 @@ export function useTransferConfig() {
             ['SWAP', 'SWAP.e'],
           ],
         },
-        // stargate: {
-        //   config: stargateConfig,
-        //   exclude: {
-        //     chains: [],
-        //     tokens: {},
-        //   },
-        //   bridgedTokenGroups: [
-        //     ['ETH', 'mETH'],
-        //     ['USDT', 'm.USDT'],
-        //     ['USDC', 'USDC.e'],
-        //   ],
-        // },
+        stargate: {
+          config: stargateConfig,
+          exclude: {
+            chains: [],
+            tokens: {},
+          },
+          bridgedTokenGroups: [
+            ['ETH', 'mETH'],
+            ['USDT', 'm.USDT'],
+            ['USDC', 'USDC.e'],
+          ],
+        },
         layerZero: {
           config: layerZeroConfig,
           exclude: {


### PR DESCRIPTION
Reverts pancakeswap/pancake-frontend#11079

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reintroducing the `stargateConfig` to the `useTransferConfig` function, enabling the configuration for the Stargate bridge in the application.

### Detailed summary
- Replaced the commented-out import of `stargateConfig` with an active import.
- Added the `stargate` configuration object back into the `useTransferConfig` function.
- Defined properties for `stargate` including `config`, `exclude`, and `bridgedTokenGroups`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->