### PR TITLE
fix: add universal farm constants for bCake on base

### DIFF
--- a/apps/web/src/state/farmsV4/state/poolApr/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/poolApr/fetcher.ts
@@ -163,12 +163,14 @@ export const DEFAULT_V2_CAKE_APR_BOOST_MULTIPLIER = {
   [ChainId.BSC]: 2.5,
   [ChainId.ZKSYNC]: 2.5,
   [ChainId.ARBITRUM_ONE]: 2.5,
+  [ChainId.BASE]: 2.5,
 }
 export const DEFAULT_V3_CAKE_APR_BOOST_MULTIPLIER = {
   [ChainId.ETHEREUM]: 2,
   [ChainId.BSC]: 2,
   [ChainId.ZKSYNC]: 2,
   [ChainId.ARBITRUM_ONE]: 2,
+  [ChainId.BASE]: 2,
 }
 export const getV2PoolCakeApr = async (
   pool: V2PoolInfo | StablePoolInfo,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for the `BASE` chain by including it in the APR (Annual Percentage Rate) configurations for both the default APR multiplier and the `DEFAULT_V3_CAKE_APR_BOOST_MULTIPLIER`.

### Detailed summary
- Added `ChainId.BASE` with a value of `2.5` to the APR configuration.
- Added `ChainId.BASE` with a value of `2` to the `DEFAULT_V3_CAKE_APR_BOOST_MULTIPLIER`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->