### PR TITLE
fix: Merkl link for pools with reward on different chain

### DIFF
--- a/apps/web/src/config/constants/merklPools.json
+++ b/apps/web/src/config/constants/merklPools.json
@@ -1,13 +1,13 @@
 [
   {
-    "chainId": 1923,
+    "chainId": 1,
     "address": "0x7B94A5622035207d3f527d236d47B7714Ee0acBa",
-    "link": "https://merkl.angle.money/undefined/pool/2/0x7B94A5622035207d3f527d236d47B7714Ee0acBa"
+    "link": "https://merkl.angle.money/ethereum/pool/2/0x7B94A5622035207d3f527d236d47B7714Ee0acBa"
   },
   {
-    "chainId": 1923,
+    "chainId": 1,
     "address": "0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14",
-    "link": "https://merkl.angle.money/undefined/pool/2/0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14"
+    "link": "https://merkl.angle.money/ethereum/pool/2/0x6db0f81Db2C3B2A85a802d511577d8522D0D8C14"
   },
   {
     "chainId": 56,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `merklPools.json` configuration and refines the `parseMerklConfig` function to handle a new structure for the Merkl configuration response. It also corrects the `chainId` values and updates the links to reflect the Ethereum network.

### Detailed summary
- Updated `chainId` from `1923` to `1` in `merklPools.json`.
- Changed pool links to use "ethereum" instead of "undefined".
- Refined `parseMerklConfig` function to accept `MerklConfigResponse` instead of an array.
- Adjusted the way pools are processed, now mapping `chainId` correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->