### PR TITLE
chore: update TC ad and info stripe

### DIFF
--- a/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
+++ b/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
@@ -40,3 +40,7 @@ export const AdTradingCompetitionApt = (props: AdPlayerProps) => {
 export const AdTradingCompetitionBfg = (props: AdPlayerProps) => {
   return <AdTradingCompetition token="bfg" {...props} />
 }
+
+export const AdTradingCompetitionVinu = (props: AdPlayerProps) => {
+  return <AdTradingCompetition token="vinu" {...props} />
+}

--- a/apps/web/src/components/AdPanel/config.tsx
+++ b/apps/web/src/components/AdPanel/config.tsx
@@ -5,7 +5,7 @@ import { AdOptionsTrading } from './Ads/AdOptionsTrading'
 import { AdPCSX } from './Ads/AdPCSX'
 import { AdRocker } from './Ads/AdRocker'
 import { AdSpringboard } from './Ads/AdSpringboard'
-import { AdTradingCompetitionApt, AdTradingCompetitionBfg } from './Ads/AdTradingCompetition'
+import { AdTradingCompetitionBfg, AdTradingCompetitionVinu } from './Ads/AdTradingCompetition'
 import { ExpandableAd } from './Expandable/ExpandableAd'
 import { shouldRenderOnPages } from './renderConditions'
 
@@ -41,13 +41,14 @@ export const useAdConfig = () => {
         component: <AdSpringboard />,
       },
       {
+        id: 'ad-vinu-tc',
+        component: <AdTradingCompetitionVinu />,
+      },
+      {
         id: 'ad-bfg-tc',
         component: <AdTradingCompetitionBfg />,
       },
-      {
-        id: 'ad-apt-tc',
-        component: <AdTradingCompetitionApt />,
-      },
+
       // {
       //   id: 'ad-mev',
       //   component: <AdMevProtection />,

--- a/apps/web/src/components/PhishingWarningBanner/index.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/index.tsx
@@ -11,12 +11,7 @@ import { Countdown } from './Countdown'
 import { Step1 } from './Step1'
 import { Step2 } from './Step2'
 import { Step3 } from './Step3'
-import {
-  TradingCompetitionAiTech,
-  TradingCompetitionApt,
-  TradingCompetitionBfg,
-  TradingCompetitionVinu,
-} from './TradingCompetition'
+import { TradingCompetitionBfg, TradingCompetitionVinu } from './TradingCompetition'
 
 const Container = styled(Flex).withConfig({ shouldForwardProp: (prop) => !['$background'].includes(prop) })<{
   $background?: string
@@ -123,22 +118,10 @@ const CONFIG: BannerConfig[] = [
     stripeImageAlt: 'PCSX',
   },
   {
-    component: TradingCompetitionAiTech,
-    stripeImage: `${ASSET_CDN}/web/promotions/aitech_competition.png`,
-    stripeImageWidth: '92px',
-    stripeImageAlt: 'aitech_competition',
-  },
-  {
     component: TradingCompetitionBfg,
     stripeImage: `${ASSET_CDN}/web/promotions/bfg_competition.png`,
     stripeImageWidth: '92px',
     stripeImageAlt: 'bfg_competition',
-  },
-  {
-    component: TradingCompetitionApt,
-    stripeImage: `${ASSET_CDN}/web/promotions/apt_competition.png`,
-    stripeImageWidth: '92px',
-    stripeImageAlt: 'apt_competition',
   },
   {
     component: TradingCompetitionVinu,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new component, `AdTradingCompetitionVinu`, to the ad panel and updating the ad configuration to include this new component while removing references to certain existing components.

### Detailed summary
- Added `AdTradingCompetitionVinu` component in `AdTradingCompetition.tsx`.
- Updated imports in `config.tsx` to include `AdTradingCompetitionVinu`.
- Replaced the `AdTradingCompetitionBfg` entry with `AdTradingCompetitionVinu` in the ad configuration.
- Removed references to `TradingCompetitionAiTech` and `TradingCompetitionApt` in `index.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->