### PR TITLE
fix: Crash when number of pools invalid

### DIFF
--- a/apps/web/src/state/multicall/hooks.ts
+++ b/apps/web/src/state/multicall/hooks.ts
@@ -178,10 +178,11 @@ export function useSingleContractMultipleData<TAbi extends Abi | readonly unknow
 }: // FIXME: wagmiv2
 SingleContractMultipleDataCallParameters<TAbi, TFunctionName>): CallState<any>[] {
   const { chainId } = useActiveChainId()
+  const { enabled = true } = options ?? {}
 
   const calls = useMemo(
     () =>
-      contract && contract.abi && contract.address && args && args.length > 0
+      enabled && contract && contract.abi && contract.address && args && args.length > 0
         ? args.map((inputs) => {
             if (!contract.address) return undefined
             return {
@@ -235,7 +236,7 @@ export function useMultipleContractSingleData<TAbi extends Abi | readonly unknow
 }: // FIXME: wagmiv2
 // MultipleSameDataCallParameters<TAbi, TFunctionName>): CallState<ContractFunctionResult<TAbi, TFunctionName>>[] {
 MultipleSameDataCallParameters<TAbi, TFunctionName>): CallState<any>[] {
-  const { enabled, blocksPerFetch } = options ?? { enabled: true }
+  const { enabled = true, blocksPerFetch } = options ?? {}
   const callData: Hex | undefined = useMemo(
     () =>
       abi && enabled
@@ -299,8 +300,9 @@ export function useSingleCallResult<TAbi extends Abi | readonly unknown[], TFunc
   options,
 }: // FIXME: wagmiv2
 SingleCallParameters<TAbi, TFunctionName>): CallState<any> {
+  const { enabled = true } = options ?? {}
   const calls = useMemo<Call[]>(() => {
-    return contract && contract.abi && contract.address
+    return enabled && contract && contract.abi && contract.address
       ? [
           {
             address: contract.address,

--- a/apps/web/src/state/multicall/hooks.ts
+++ b/apps/web/src/state/multicall/hooks.ts
@@ -195,7 +195,7 @@ SingleContractMultipleDataCallParameters<TAbi, TFunctionName>): CallState<any>[]
             }
           })
         : [],
-    [args, contract, functionName],
+    [args, contract, enabled, functionName],
   )
 
   const results = useCallsData(calls, options)
@@ -314,7 +314,7 @@ SingleCallParameters<TAbi, TFunctionName>): CallState<any> {
           },
         ]
       : []
-  }, [contract, args, functionName])
+  }, [contract, args, enabled, functionName])
 
   const result = useCallsData(calls, options)[0]
 

--- a/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
+++ b/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
@@ -181,6 +181,7 @@ export function useStakedPools(): FixedStakingPool[] {
       () => Array.from(Array(numberOfPools).keys()).map((index) => [BigInt(index)] as const),
       [numberOfPools],
     ),
+    options: { enabled: Boolean(numberOfPools) },
   })
 
   return useMemo(() => {

--- a/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
+++ b/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
@@ -180,6 +180,9 @@ export function useStakedPools(): FixedStakingPool[] {
       () => Array.from(Array(numberOfPools).keys()).map((index) => [BigInt(index)] as const),
       [numberOfPools],
     ),
+    options: {
+      enabled: Boolean(numberOfPools && Number.isSafeInteger(numberOfPools) && numberOfPools >= 0),
+    },
   })
 
   return useMemo(() => {

--- a/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
+++ b/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
@@ -165,7 +165,8 @@ export function useStakedPools(): FixedStakingPool[] {
     args: [],
   })
 
-  const numberOfPools = poolLength ? toNumber(poolLength.toString()) : 0
+  const poolLengthNumber = poolLength ? toNumber(poolLength.toString()) : 0
+  const numberOfPools = Number.isSafeInteger(poolLengthNumber) && poolLengthNumber >= 0 ? poolLengthNumber : 0
 
   const fixedStakePools = useSingleContractMultipleData({
     contract: useMemo(
@@ -180,9 +181,6 @@ export function useStakedPools(): FixedStakingPool[] {
       () => Array.from(Array(numberOfPools).keys()).map((index) => [BigInt(index)] as const),
       [numberOfPools],
     ),
-    options: {
-      enabled: Boolean(numberOfPools && Number.isSafeInteger(numberOfPools) && numberOfPools >= 0),
-    },
   })
 
   return useMemo(() => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of the `enabled` option in various hooks related to contract calls, ensuring that calls are only made when appropriate conditions are met.

### Detailed summary
- Renamed `numberOfPools` to `poolLengthNumber` for clarity.
- Added a check for `poolLengthNumber` to ensure it's a safe integer and non-negative.
- Introduced `enabled` option in `useSingleContractMultipleData` to conditionally execute calls.
- Updated conditions in multiple hooks to respect the `enabled` flag before making contract calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->