### PR TITLE
fix:  🎸 replace ifo/token address

### DIFF
--- a/apps/web/src/__tests__/views/pancakeSquad/utils.test.ts
+++ b/apps/web/src/__tests__/views/pancakeSquad/utils.test.ts
@@ -123,7 +123,7 @@ describe('PancakeSquad/utils/getEventText', () => {
     const result = getEventText({ eventStatus, saleStatus, startTimestamp, t })
 
     // Then
-    expect(result).toEqual('Public Sale: Sold Out!')
+    expect(result).toEqual('Public IFO: Sold Out!')
   })
 
   it('Should return live text', () => {
@@ -137,7 +137,7 @@ describe('PancakeSquad/utils/getEventText', () => {
     const result = getEventText({ eventStatus, saleStatus, startTimestamp, t })
 
     // Then
-    expect(result).toEqual('Public Sale: Now Live')
+    expect(result).toEqual('Public IFO: Now Live')
   })
 
   it('Should return upcoming text', () => {
@@ -151,7 +151,7 @@ describe('PancakeSquad/utils/getEventText', () => {
     const result = getEventText({ eventStatus, saleStatus, startTimestamp, t })
 
     // Then
-    expect(result).toEqual('Public Sale: ')
+    expect(result).toEqual('Public IFO: ')
   })
 
   it('Should return past text', () => {
@@ -165,7 +165,7 @@ describe('PancakeSquad/utils/getEventText', () => {
     const result = getEventText({ eventStatus, saleStatus, startTimestamp, t })
 
     // Then
-    expect(result).toEqual('Public Sale')
+    expect(result).toEqual('Public IFO')
   })
 })
 

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/index.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/index.tsx
@@ -73,7 +73,7 @@ export const cardConfig = (
           .filter(Boolean)
 
         return {
-          title: t('Private Sale'),
+          title: t('Private IFO'),
           variant: 'blue',
           tooltip: msgs?.length ? (
             <>
@@ -103,7 +103,7 @@ export const cardConfig = (
       }
     case PoolIds.poolUnlimited:
       return {
-        title: meta?.version >= 3.1 ? t('Public Sale') : t('Unlimited Sale'),
+        title: meta?.version >= 3.1 ? t('Public IFO') : t('Unlimited IFO'),
         variant: 'violet',
         tooltip: meta.additionalClaimingFee
           ? t('No limits on the amount you can commit. Additional fee applies when claiming.')

--- a/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
+++ b/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx
@@ -48,10 +48,10 @@ const Info: React.FC<React.PropsWithChildren<InfoProps>> = ({
 
   const labelText =
     poolId === PoolIds.poolUnlimited
-      ? t('Public Sale')
+      ? t('Public IFO')
       : isBasicSale(ifoBasicSaleType)
-      ? t('Basic Sale')
-      : t('Private Sale')
+      ? t('Basic IFO')
+      : t('Private IFO')
 
   const currentBlock = useCurrentBlock()
   const publicIfoData = useGetPublicIfoV3Data(data.ifo)

--- a/apps/web/src/views/PancakeSquad/utils.ts
+++ b/apps/web/src/views/PancakeSquad/utils.ts
@@ -60,9 +60,9 @@ const eventTextMapping = (t: ContextApi['t'], saleStatus: SaleStatusEnum) => {
     case SaleStatusEnum.Presale:
       return t('Presale')
     case SaleStatusEnum.Sale:
-      return t('Public Sale')
+      return t('Public IFO')
     case SaleStatusEnum.DrawingRandomness:
-      return t('Public Sale')
+      return t('Public IFO')
     case SaleStatusEnum.Claim:
       return t('Claim Phase')
     default:

--- a/packages/ifos/src/constants/ifos/bsc.ts
+++ b/packages/ifos/src/constants/ifos/bsc.ts
@@ -6,7 +6,7 @@ import { cakeBnbLpToken } from '../lpTokens'
 export const ifos: BaseIfoConfig[] = [
   {
     id: 'solv',
-    address: '0xb0De22aAe05789C13E900688b420F1Bb7c2C3889',
+    address: '0xe1C5dc4d2f63B39c611A9D75C23dbC85d9146E46',
     isActive: true,
     cIFO: false,
     plannedStartTime: new Date('2025-01-16T10:00:00Z').getTime() / 1000,

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1292,7 +1292,6 @@
   "Sorry, you can’t claim any NFTs! Better luck next time.": "Sorry, you can’t claim any NFTs! Better luck next time.",
   "You need a profile to participate!": "You need a profile to participate!",
   "Randomizing NFT allocation with Chainlink": "Randomizing NFT allocation with Chainlink",
-  "Public Sale": "Public Sale",
   "You’re all set!": "You’re all set!",
   "How many can I mint?": "How many can I mint?",
   "Ready for Public Sale!": "Ready for Public Sale!",
@@ -1441,7 +1440,6 @@
   "You can choose one or both at the same time!": "You can choose one or both at the same time!",
   "We recommend you to check if you are eligible to participate in the Private Sale first. In the Public Sale, if the amount you commit is too small, you may not receive a meaningful amount of IFO tokens.": "We recommend you to check if you are eligible to participate in the Private Sale first. In the Public Sale, if the amount you commit is too small, you may not receive a meaningful amount of IFO tokens.",
   "How to Take Part in the Public Sale": "How to Take Part in the Public Sale",
-  "Private Sale": "Private Sale",
   "Unsupported Assets": "Unsupported Assets",
   "Some assets are not available through this interface because they may not work well with our smart contract or we are unable to allow trading for legal reasons.": "Some assets are not available through this interface because they may not work well with our smart contract or we are unable to allow trading for legal reasons.",
   "Trade the new BTT token": "Trade the new BTT token",
@@ -3685,5 +3683,9 @@
   "The time has already passed.": "The time has already passed.",
   "day(s)": "day(s)",
   "hour(s)": "hour(s)",
-  "SOON": "SOON"
+  "SOON": "SOON",
+  "Public IFO": "Public IFO",
+  "Private IFO": "Private IFO",
+  "Unlimited IFO": "Unlimited IFO",
+  "Basic IFO": "Basic IFO"
 }

--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -3351,7 +3351,7 @@ export const bscTokens = {
   ),
   solv: new ERC20Token(
     ChainId.BSC,
-    '0x04830A96a23EA718fAA695a5AAe74695AAE3A23f',
+    '0xabe8e5cabe24cb36df9540088fd7ce1175b9bc52',
     18,
     'SOLV',
     'Solv',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating references from "Public Sale" and related terms to "Public IFO" and its variants across multiple files, enhancing consistency in terminology for Initial Farm Offerings.

### Detailed summary
- Updated `solv` token address in `packages/tokens/src/constants/bsc.ts`.
- Changed `address` for `solv` in `packages/ifos/src/constants/ifos/bsc.ts`.
- Replaced "Public Sale" with "Public IFO" in various cases in `apps/web/src/views/PancakeSquad/utils.ts`.
- Updated label texts in `apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Info.tsx`.
- Modified titles in `apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/index.tsx`.
- Adjusted test expectations in `apps/web/src/__tests__/views/pancakeSquad/utils.test.ts`.
- Added new translations for "Public IFO", "Private IFO", "Unlimited IFO", and "Basic IFO" in `packages/localization/src/config/translations.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->