### PR TITLE
fix: 🐛 change ifo article url

### DIFF
--- a/apps/web/src/components/PhishingWarningBanner/ListapieStripe.tsx
+++ b/apps/web/src/components/PhishingWarningBanner/ListapieStripe.tsx
@@ -38,7 +38,7 @@ export const ListapieStripe = () => {
         external
         display="inline !important"
         fontSize={['12px', '12px', '14px']}
-        href="https://pancakeswap.finance/ifo"
+        href="https://forum.pancakeswap.finance/t/listapie-ifo-discussion-thread/1019 "
       >
         {t('Learn More')}
       </Link>

--- a/packages/ifos/src/constants/ifos/bsc.ts
+++ b/packages/ifos/src/constants/ifos/bsc.ts
@@ -21,7 +21,7 @@ export const ifos: BaseIfoConfig[] = [
     currency: bscTokens.cake,
     token: bscTokens.listapie,
     campaignId: '512700000',
-    articleUrl: 'https://pancakeswap.finance/ifo',
+    articleUrl: 'https://forum.pancakeswap.finance/t/listapie-ifo-discussion-thread/1019 ',
     tokenOfferingPrice: 1,
     version: 8,
     twitterUrl: 'https://x.com/Listapiexyz_io',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the URLs related to the `Listapie` project in two files, changing links from the PancakeSwap website to a discussion thread on the PancakeSwap forum.

### Detailed summary
- In `ListapieStripe.tsx`, the `href` for a `Link` component is updated to point to the discussion thread.
- In `bsc.ts`, the `articleUrl` is changed to the new discussion thread URL, replacing the previous PancakeSwap IFO link.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->