### PR TITLE
fix: Response cached by remote with query string

### DIFF
--- a/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useGauges.ts
@@ -15,7 +15,7 @@ export const useGauges = () => {
     queryKey: ['gaugesVoting', chainId],
 
     queryFn: async (): Promise<Gauge[]> => {
-      const response = await fetch(`/api/gauges/getAllGauges?testnet=${chainId === ChainId.BSC_TESTNET ? 1 : ''}`)
+      const response = await fetch(`/api/gauges/getAllGauges${chainId === ChainId.BSC_TESTNET ? '?testnet=1' : ''}`)
       if (response.ok) {
         const result = (await response.json()) as Response
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the URL construction for fetching gauges based on the `chainId`. It ensures that the query parameter `testnet` is only appended when necessary, improving the clarity of the URL.

### Detailed summary
- Changed the URL construction in the `fetch` call:
  - From: `/api/gauges/getAllGauges?testnet=...`
  - To: `/api/gauges/getAllGauges${chainId === ChainId.BSC_TESTNET ? '?testnet=1' : ''}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->