### PR TITLE
fix: 🐛 change text

### DIFF
--- a/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -194,7 +194,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
                 label={t('Vested percentage:')}
                 value={`${poolCharacteristic.vestingInformation.percentage}%`}
                 tooltipContent={t(
-                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.',
+                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.',
                   {
                     percentageVested: poolCharacteristic.vestingInformation.percentage,
                     percentageTgeRelease: new BigNumber(100)

--- a/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/aptos/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -1,15 +1,15 @@
-import { ReactNode } from 'react'
-import { Text, Flex, Box, Skeleton, TooltipText, useTooltip, IfoSkeletonCardDetails } from '@pancakeswap/uikit'
-import { PublicIfoData, WalletIfoData } from 'views/Ifos/types'
 import { useTranslation } from '@pancakeswap/localization'
-import { Ifo, PoolIds } from 'config/constants/types'
-import BigNumber from 'bignumber.js'
-import { getBalanceNumber, formatNumber } from '@pancakeswap/utils/formatBalance'
-import useStablePrice from 'hooks/useStablePrice'
+import { Box, Flex, IfoSkeletonCardDetails, Skeleton, Text, TooltipText, useTooltip } from '@pancakeswap/uikit'
+import { formatNumber, getBalanceNumber } from '@pancakeswap/utils/formatBalance'
 import { DAY_IN_SECONDS } from '@pancakeswap/utils/getTimePeriods'
-import { getStatus } from 'views/Ifos/hooks/helpers'
-import { multiplyPriceByAmount } from 'utils/prices'
+import BigNumber from 'bignumber.js'
+import { Ifo, PoolIds } from 'config/constants/types'
 import useLedgerTimestamp from 'hooks/useLedgerTimestamp'
+import useStablePrice from 'hooks/useStablePrice'
+import { ReactNode } from 'react'
+import { multiplyPriceByAmount } from 'utils/prices'
+import { getStatus } from 'views/Ifos/hooks/helpers'
+import { PublicIfoData, WalletIfoData } from 'views/Ifos/types'
 
 export interface IfoCardDetailsProps {
   poolId: PoolIds
@@ -194,7 +194,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
                 label={t('Vested percentage:')}
                 value={`${poolCharacteristic.vestingInformation.percentage}%`}
                 tooltipContent={t(
-                  '%percentageVested%% of the purchased token will get vested and released linearly over a period of time. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.',
+                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.',
                   {
                     percentageVested: poolCharacteristic.vestingInformation.percentage,
                     percentageTgeRelease: new BigNumber(100)
@@ -206,7 +206,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
               <FooterEntry
                 label={t('Vesting schedule:')}
                 value={`${vestingDays} days`}
-                tooltipContent={t('The vested tokens will be released linearly over a period of %days% days.', {
+                tooltipContent={t('The vested tokens will be released at the end of %countdown%.', {
                   days: vestingDays,
                 })}
               />

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -282,7 +282,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
                 label={t('Vested percentage:')}
                 value={`${poolCharacteristic.vestingInformation.percentage}%`}
                 tooltipContent={t(
-                  '%percentageVested%% of the purchased token will get vested and released linearly over a period of time. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.',
+                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends',
                   {
                     percentageVested: poolCharacteristic.vestingInformation.percentage,
                     percentageTgeRelease: BIG_ONE_HUNDRED.minus(
@@ -294,7 +294,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
               <FooterEntry
                 label={t('Vesting schedule:')}
                 value={vestingCountdown}
-                tooltipContent={t('The vested tokens will be released linearly over a period of %countdown%.', {
+                tooltipContent={t('The vested tokens will be released at the end of %countdown%.', {
                   countdown: vestingCountdown,
                 })}
               />

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -282,7 +282,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
                 label={t('Vested percentage:')}
                 value={`${poolCharacteristic.vestingInformation.percentage}%`}
                 tooltipContent={t(
-                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends',
+                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.',
                   {
                     percentageVested: poolCharacteristic.vestingInformation.percentage,
                     percentageTgeRelease: BIG_ONE_HUNDRED.minus(

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/IfoCardDetails.tsx
@@ -282,7 +282,7 @@ const IfoCardDetails: React.FC<React.PropsWithChildren<IfoCardDetailsProps>> = (
                 label={t('Vested percentage:')}
                 value={`${poolCharacteristic.vestingInformation.percentage}%`}
                 tooltipContent={t(
-                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.',
+                  '%percentageVested%% of the purchased token will be released at the end of the vesting schedule. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.',
                   {
                     percentageVested: poolCharacteristic.vestingInformation.percentage,
                     percentageTgeRelease: BIG_ONE_HUNDRED.minus(

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3686,5 +3686,5 @@
   "Private IFO": "Private IFO",
   "Unlimited IFO": "Unlimited IFO",
   "Basic IFO": "Basic IFO",
-  "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends": "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends"
+  "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.": "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends."
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1774,7 +1774,6 @@
   "Boosted by vCAKE": "Boosted by vCAKE",
   "Boosting Expired": "Boosting Expired",
   "Your vCAKE boosting was expired at the snapshot block. Renew your fixed-term staking position to activate the boost for future voting proposals.": "Your vCAKE boosting was expired at the snapshot block. Renew your fixed-term staking position to activate the boost for future voting proposals.",
-  "The vested tokens will be released linearly over a period of %days% days.": "The vested tokens will be released linearly over a period of %days% days.",
   "Yield Booster": "Yield Booster",
   "Connect wallet to view booster": "Connect wallet to view booster",
   "No CAKE locked": "No CAKE locked",

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3685,5 +3685,5 @@
   "Private IFO": "Private IFO",
   "Unlimited IFO": "Unlimited IFO",
   "Basic IFO": "Basic IFO",
-  "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends.": "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends."
+  "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.": "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends."
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1774,7 +1774,6 @@
   "Boosted by vCAKE": "Boosted by vCAKE",
   "Boosting Expired": "Boosting Expired",
   "Your vCAKE boosting was expired at the snapshot block. Renew your fixed-term staking position to activate the boost for future voting proposals.": "Your vCAKE boosting was expired at the snapshot block. Renew your fixed-term staking position to activate the boost for future voting proposals.",
-  "%percentageVested%% of the purchased token will get vested and released linearly over a period of time. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.": "%percentageVested%% of the purchased token will get vested and released linearly over a period of time. %percentageTgeRelease%% of the purchased token will be released immediately and available for claiming when IFO ends.",
   "The vested tokens will be released linearly over a period of %days% days.": "The vested tokens will be released linearly over a period of %days% days.",
   "Yield Booster": "Yield Booster",
   "Connect wallet to view booster": "Connect wallet to view booster",
@@ -3677,7 +3676,7 @@
   "Title is required": "Title is required",
   "Content is required": "Content is required",
   "Please provide valid choices": "Please provide valid choices",
-  "The vested tokens will be released linearly over a period of %countdown%.": "The vested tokens will be released linearly over a period of %countdown%.",
+  "The vested tokens will be released at the end of %countdown%.": "The vested tokens will be released at the end of %countdown%.",
   "%token% IFO starts in": "%token% IFO starts in",
   "Join the %token% Token Launch (IFO) on BNB Chain PancakeSwap": "Join the %token% Token Launch (IFO) on BNB Chain PancakeSwap",
   "The time has already passed.": "The time has already passed.",
@@ -3686,5 +3685,6 @@
   "Public IFO": "Public IFO",
   "Private IFO": "Private IFO",
   "Unlimited IFO": "Unlimited IFO",
-  "Basic IFO": "Basic IFO"
+  "Basic IFO": "Basic IFO",
+  "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends": "%percentageVested%% of the purchased token will be released at the end of the vesting schedule. 0% of the purchased token will be released immediately and available for claiming when IFO ends"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the tooltip content in the `IfoCardDetails` component to clarify the vesting schedule of tokens. It modifies the language to indicate that tokens will be released at the end of the vesting period rather than linearly over time.

### Detailed summary
- Updated tooltip for vested percentage in `IfoCardDetails`:
  - Changed text from "will get vested and released linearly over a period of time" to "will be released at the end of the vesting schedule."
- Updated tooltip for vesting schedule in `IfoCardDetails`:
  - Changed text from "will be released linearly over a period of %countdown%" to "will be released at the end of %countdown%."
- Updated translations in `translations.json` to reflect the new wording for vested tokens and vesting schedule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->