### PR TITLE
fix: remove layout can't connect issue

### DIFF
--- a/apps/web/src/components/Menu/index.tsx
+++ b/apps/web/src/components/Menu/index.tsx
@@ -14,6 +14,7 @@ import { IdType, useUserNotUsCitizenAcknowledgement } from 'hooks/useUserIsUsCit
 import { useWebNotifications } from 'hooks/useWebNotifications'
 import { useRouter } from 'next/router'
 import { Suspense, lazy, useCallback, useMemo } from 'react'
+import { styled } from 'styled-components'
 import { getOptionsUrl } from 'utils/getOptionsUrl'
 import GlobalSettings from './GlobalSettings'
 import { SettingsMode } from './GlobalSettings/types'
@@ -146,3 +147,26 @@ const Menu = (props) => {
 }
 
 export default Menu
+
+const SharedComponentWithOutMenuWrapper = styled.div`
+  display: none;
+`
+
+export const SharedComponentWithOutMenu: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { enabled } = useWebNotifications()
+  return (
+    <>
+      <SharedComponentWithOutMenuWrapper>
+        <GlobalSettings mode={SettingsMode.GLOBAL} />
+        {enabled && (
+          <Suspense fallback={null}>
+            <Notifications />
+          </Suspense>
+        )}
+        <NetworkSwitcher />
+        <UserMenu />
+      </SharedComponentWithOutMenuWrapper>
+      {children}
+    </>
+  )
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -115,7 +115,7 @@ function MyApp(props: AppProps<{ initialReduxState: any; dehydratedState: any }>
           // @ts-ignore
           <Component.Meta {...pageProps} />
         )}
-        {(Component as NextPageWithLayout).mp ? <MPGlobalHooks /> : <GlobalHooks />}
+        <GlobalHooks />
         <ResetCSS />
         <GlobalStyle />
         <GlobalCheckClaimStatus excludeLocations={[]} />

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -98,15 +98,6 @@ function MyApp(props: AppProps<{ initialReduxState: any; dehydratedState: any }>
           content="Cheaper and faster than Uniswap? Discover PancakeSwap, the leading DEX on BNB Smart Chain (BSC) with the best farms in DeFi and a lottery for CAKE."
         />
         <meta name="theme-color" content="#1FC7D4" />
-        {(Component as NextPageWithLayout).mp && (
-          // eslint-disable-next-line @next/next/no-sync-scripts
-          <script
-            src="https://public.bnbstatic.com/static/js/mp-webview-sdk/webview-v1.0.0.min.js"
-            integrity="sha384-PV6Pqh2oiQNNl9jwtcTIue3fwDnP5k80+DaPY8/AS4qxGA91MsE3G91BQ2jQ81oT"
-            crossOrigin="anonymous"
-            id="mp-webview"
-          />
-        )}
       </Head>
       <DefaultSeo {...SEO} />
       <Providers store={store} dehydratedState={pageProps.dehydratedState}>

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -44,7 +44,7 @@ import { usePollBlockNumber } from 'state/block/hooks'
 import { Blocklist, Updaters } from '..'
 import { SEO } from '../../next-seo.config'
 import Providers from '../Providers'
-import Menu from '../components/Menu'
+import Menu, { SharedComponentWithOutMenu } from '../components/Menu'
 import GlobalStyle from '../style/Global'
 
 const EasterEgg = dynamic(() => import('components/EasterEgg'), { ssr: false })
@@ -174,7 +174,7 @@ const App = ({ Component, pageProps }: AppPropsWithLayout) => {
 
   // Use the layout defined at the page level, if available
   const Layout = Component.Layout || Fragment
-  const ShowMenu = Component.mp ? Fragment : Menu
+  const ShowMenu = Component.mp ? SharedComponentWithOutMenu : Menu
   const isShowScrollToTopButton = Component.isShowScrollToTopButton || true
   const shouldScreenWallet = Component.screen || false
   const isShowV4IconButton = Component.isShowV4IconButton || false

--- a/apps/web/src/pages/ido/index.tsx
+++ b/apps/web/src/pages/ido/index.tsx
@@ -12,6 +12,6 @@ CurrentIdoPage.Layout = IdoPageLayout
 
 CurrentIdoPage.chains = IDO_SUPPORT_CHAINS
 
-CurrentIdoPage.mp = false
+CurrentIdoPage.mp = true
 
 export default CurrentIdoPage


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the behavior of the `CurrentIdoPage` component and enhancing the `Menu` component by introducing a new shared component that can render without the menu.

### Detailed summary
- Set `CurrentIdoPage.mp` to `true`.
- Added `SharedComponentWithOutMenu` styled component in `Menu`.
- Updated `MyApp` to use `SharedComponentWithOutMenu` instead of `Menu` when `mp` is `true`.
- Removed the script tag related to `mp` from `MyApp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->