### PR TITLE
fix: Faq config hook crash

### DIFF
--- a/apps/web/src/components/AdPanel/FAQ/useFaqConfig.ts
+++ b/apps/web/src/components/AdPanel/FAQ/useFaqConfig.ts
@@ -5,5 +5,12 @@ import { FAQConfig } from './types'
 
 export const useFaqConfig = (): FAQConfig => {
   const router = useRouter()
-  return useMemo(() => faqConfig[faqTypeByPage[router.pathname]] ?? {}, [router.pathname])
+
+  return useMemo(() => {
+    if (!router.isReady) {
+      return (() => ({})) as unknown as FAQConfig
+    }
+
+    return faqConfig[faqTypeByPage[router.pathname]] ?? ((() => ({})) as unknown as FAQConfig)
+  }, [router])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useFaqConfig` hook to ensure that it only returns the FAQ configuration once the router is ready, preventing potential errors when accessing `router.pathname` prematurely.

### Detailed summary
- Added a check for `router.isReady` before accessing `router.pathname`.
- If `router.isReady` is false, it returns an empty object cast as `FAQConfig`.
- Modified the return statement to handle both cases (when router is ready and not).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->