### PR TITLE
fix: limit swap width

### DIFF
--- a/apps/web/src/views/Swap/Twap/TwapSwap.tsx
+++ b/apps/web/src/views/Swap/Twap/TwapSwap.tsx
@@ -10,10 +10,10 @@ import { Field } from 'state/swap/actions'
 import { useDefaultsFromURLSearch, useSingleTokenSwapInfo, useSwapState } from 'state/swap/hooks'
 import { styled } from 'styled-components'
 import { XmasEffect } from 'views/SwapSimplify/V4Swap/XmasEffect'
-import PriceChartContainer from '../components/Chart/PriceChartContainer'
 // import { SwapSelection } from '../components/SwapSelection'
 import { SwapSelection } from '../../SwapSimplify/V4Swap/SwapSelectionTab'
 import { SwapFeaturesContext } from '../SwapFeaturesContext'
+import PriceChartContainer from '../components/Chart/PriceChartContainer'
 import { SwapType } from '../types'
 import { OrderHistory, TWAPPanel } from './Twap'
 
@@ -149,6 +149,9 @@ export const StyledSwapContainer = styled(Flex)<{ $isChartExpanded: boolean }>`
 `
 
 export const StyledInputCurrencyWrapper = styled(Box)`
-  max-width: 400px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    width: 400px;
+  }
 `


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `TwapSwap.tsx` component by re-importing `PriceChartContainer` and modifying the `StyledInputCurrencyWrapper` to adjust its width based on the theme's media queries.

### Detailed summary
- Re-imported `PriceChartContainer` from its original path.
- Updated `StyledInputCurrencyWrapper` to set `width` to `400px` for medium and larger screens using media queries.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->