### PR TITLE
fix: Failed to deposit in aptos new farms

### DIFF
--- a/apps/aptos/config/constants/farms/1.ts
+++ b/apps/aptos/config/constants/farms/1.ts
@@ -55,6 +55,54 @@ const farms: SerializedFarmConfig[] = [
   },
   // * By order of release
   {
+    pid: 28,
+    lpSymbol: 'MOOMOO-APT LP',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xc5fbbcc4637aeebb4e732767abee8a21f2b0776f73b73e16ce13e7d31d6700da::MOOMOO::MOOMOO>',
+    token: mainnetTokens.apt,
+    quoteToken: mainnetTokens.MOOMOO, // MOOMOO
+    dual: {
+      token: mainnetTokens.apt,
+      aptIncentiveInfo: 0,
+    },
+  },
+  {
+    pid: 27,
+    lpSymbol: 'aBTC-APT LP',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0x4e1854f6d332c9525e258fb6e66f84b6af8aba687bbcb832a24768c4e175feec::abtc::ABTC>',
+    token: mainnetTokens.apt,
+    quoteToken: mainnetTokens.aBTC, // aBTC
+    dual: {
+      token: mainnetTokens.apt,
+      aptIncentiveInfo: 0,
+    },
+  },
+  {
+    pid: 26,
+    lpSymbol: 'MOD-lzUSDC LP',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x6f986d146e4a90b828d8c12c14b6f4e003fdff11a8eecceceb63744363eaac01::mod_coin::MOD, 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC>',
+    token: mainnetTokens.MOD, // MOD
+    quoteToken: mainnetTokens.lzusdc, // lzUSDC
+    dual: {
+      token: mainnetTokens.apt,
+      aptIncentiveInfo: 0,
+    },
+  },
+  {
+    pid: 25,
+    lpSymbol: 'APT-lzUSDT LP',
+    lpAddress:
+      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT>',
+    token: mainnetTokens.apt, // APT
+    quoteToken: mainnetTokens.lzusdt, // lzUSDT
+    dual: {
+      token: mainnetTokens.apt,
+      aptIncentiveInfo: 0,
+    },
+  },
+  {
     pid: 24,
     lpSymbol: 'whUSDC-lzUSDC LP',
     lpAddress:
@@ -301,54 +349,6 @@ const farms: SerializedFarmConfig[] = [
       '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0xd11107bdf0d6d7040c6c0bfbdecb6545191fdf13e8d8d259952f53e1713f61b5::staked_coin::StakedAptos, 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC>',
     token: mainnetTokens.lzusdc,
     quoteToken: mainnetTokens.stapt,
-    dual: {
-      token: mainnetTokens.apt,
-      aptIncentiveInfo: 0,
-    },
-  },
-  {
-    pid: 25,
-    lpSymbol: 'APT-lzUSDT LP',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x1::aptos_coin::AptosCoin, 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT>',
-    token: mainnetTokens.lzusdt, // lzUSDT
-    quoteToken: mainnetTokens.apt, // APT
-    dual: {
-      token: mainnetTokens.apt,
-      aptIncentiveInfo: 0,
-    },
-  },
-  {
-    pid: 26,
-    lpSymbol: 'MOD-lzUSDC LP',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x6f986d146e4a90b828d8c12c14b6f4e003fdff11a8eecceceb63744363eaac01::mod_coin::MOD, 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC>',
-    token: mainnetTokens.MOD, // MOD
-    quoteToken: mainnetTokens.lzusdc, // lzUSDC
-    dual: {
-      token: mainnetTokens.apt,
-      aptIncentiveInfo: 0,
-    },
-  },
-  {
-    pid: 27,
-    lpSymbol: 'aBTC-APT LP',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0x4e1854f6d332c9525e258fb6e66f84b6af8aba687bbcb832a24768c4e175feec::abtc::ABTC, 0x1::aptos_coin::AptosCoin>',
-    token: mainnetTokens.aBTC, // aBTC
-    quoteToken: mainnetTokens.apt,
-    dual: {
-      token: mainnetTokens.apt,
-      aptIncentiveInfo: 0,
-    },
-  },
-  {
-    pid: 28,
-    lpSymbol: 'MOOMOO-APT LP',
-    lpAddress:
-      '0xc7efb4076dbe143cbcd98cfaaa929ecfc8f299203dfff63b95ccb6bfe19850fa::swap::LPToken<0xc5fbbcc4637aeebb4e732767abee8a21f2b0776f73b73e16ce13e7d31d6700da::MOOMOO::MOOMOO, 0x1::aptos_coin::AptosCoin>',
-    token: mainnetTokens.MOOMOO, // MOOMOO
-    quoteToken: mainnetTokens.apt,
     dual: {
       token: mainnetTokens.apt,
       aptIncentiveInfo: 0,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `farms` configuration in the `1.ts` file by adding new liquidity pools and removing some existing ones. 

### Detailed summary
- Added new liquidity pools:
  - `pid: 28` for `MOOMOO-APT LP`
  - `pid: 27` for `aBTC-APT LP`
  - `pid: 26` for `MOD-lzUSDC LP`
  - `pid: 25` for `APT-lzUSDT LP`
- Removed existing liquidity pools:
  - `pid: 25` for `APT-lzUSDT LP`
  - `pid: 26` for `MOD-lzUSDC LP`
  - `pid: 27` for `aBTC-APT LP`
  - `pid: 28` for `MOOMOO-APT LP`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->