### PR TITLE
fix: User gauges takes too much time to load on slow networks and fix loading indicator

### DIFF
--- a/apps/web/src/utils/viem.ts
+++ b/apps/web/src/utils/viem.ts
@@ -31,7 +31,7 @@ export function createViemPublicClients({ transportSignal }: CreatePublicClientP
         ),
         batch: {
           multicall: {
-            batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 200,
+            batchSize: cur.id === ChainId.POLYGON_ZKEVM ? 128 : 1024 * 25,
             wait: 16,
           },
         },

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -43,12 +43,13 @@ export const useVeCakeUserInfo = (
   targetChain?: ChainId,
 ): {
   data?: VeCakeUserInfo
+  isLoading: boolean
   refetch: () => void
 } => {
   const veCakeContract = useVeCakeContract(targetChain)
   const { account } = useAccountActiveChain()
 
-  const { data, refetch } = useReadContract({
+  const { data, refetch, isLoading, isPending } = useReadContract({
     chainId: targetChain ?? veCakeContract?.chain?.id,
     abi: veCakeContract.abi,
     address: veCakeContract.address,
@@ -76,6 +77,7 @@ export const useVeCakeUserInfo = (
 
   return {
     data,
+    isLoading: isPending || isLoading,
     refetch,
   }
 }

--- a/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
+++ b/apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts
@@ -75,7 +75,7 @@ export const useGaugeRows = () => {
 
     return selectRowsHash.map((hash) => gaugesMap.get(hash)).filter(Boolean) as Gauge[]
   }, [gauges, selectRowsHash])
-  const isLoading = useMemo(() => gaugeIsLoading && voteIsLoading, [gaugeIsLoading, voteIsLoading])
+  const isLoading = useMemo(() => gaugeIsLoading || voteIsLoading, [gaugeIsLoading, voteIsLoading])
 
   return {
     gauges,

--- a/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
@@ -35,7 +35,6 @@ export const useUserVoteSlopes = () => {
       userInfo?.cakePoolProxy,
       publicClient,
     ],
-    initialData: [],
     queryFn: async (): Promise<VoteSlope[]> => {
       if (!gauges || gauges.length === 0 || !account || !publicClient) return []
 
@@ -93,7 +92,7 @@ export const useUserVoteSlopes = () => {
   })
 
   return {
-    data,
+    data: useMemo(() => data || [], [data]),
     refetch,
     isLoading,
   }

--- a/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
+++ b/apps/web/src/views/GaugesVoting/hooks/useUserVoteGauges.ts
@@ -21,7 +21,7 @@ export type VoteSlope = {
 
 export const useUserVoteSlopes = () => {
   const { data: gauges } = useGauges()
-  const { data: userInfo } = useVeCakeUserInfo()
+  const { data: userInfo, isLoading: isUserInfoLoading } = useVeCakeUserInfo()
   const gaugesVotingContract = useGaugesVotingContract()
   const { account, chainId } = useAccountActiveChain()
   const publicClient = useMemo(() => getPublicClient({ chainId }), [chainId])
@@ -42,11 +42,12 @@ export const useUserVoteSlopes = () => {
       const delegated = userInfo?.cakePoolType === CakePoolType.DELEGATED
 
       const hasProxy =
-        userInfo?.cakePoolProxy && !isAddressEqual(userInfo?.cakePoolProxy, zeroAddress) && userInfo && !delegated
+        !delegated && userInfo && userInfo.cakePoolProxy && !isAddressEqual(userInfo.cakePoolProxy, zeroAddress)
 
       const contracts = gauges.map((gauge) => {
         return {
-          ...gaugesVotingContract,
+          address: gaugesVotingContract.address,
+          abi: gaugesVotingContract.abi,
           functionName: 'voteUserSlopes',
           args: [account, gauge.hash as Hex],
         } as const
@@ -55,7 +56,8 @@ export const useUserVoteSlopes = () => {
       if (hasProxy) {
         gauges.forEach((gauge) => {
           contracts.push({
-            ...gaugesVotingContract,
+            address: gaugesVotingContract.address,
+            abi: gaugesVotingContract.abi,
             functionName: 'voteUserSlopes',
             args: [userInfo.cakePoolProxy, gauge.hash as Hex],
           } as const)
@@ -87,8 +89,7 @@ export const useUserVoteSlopes = () => {
         return []
       }
     },
-
-    enabled: Boolean(gauges?.length) && account && account !== '0x',
+    enabled: Boolean(gauges?.length) && !isUserInfoLoading && account && account !== '0x',
   })
 
   return {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing loading states and improving the handling of contract calls in the application. It adjusts batch sizes and refines how loading states are determined across various hooks.

### Detailed summary
- Reduced `batchSize` in `apps/web/src/utils/viem.ts`.
- Changed `isLoading` logic in `apps/web/src/views/GaugesVoting/components/Table/VoteTable/hooks/useGaugeRows.ts` from AND to OR.
- Added `isLoading` to the return of `useVeCakeUserInfo` in `apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts`.
- Updated `useUserVoteSlopes` to use `isLoading` for user info.
- Refined contract call parameters in `useUserVoteSlopes` to explicitly include `address` and `abi`. 
- Enhanced query enabling logic in `useUserVoteSlopes` to consider `isUserInfoLoading`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->