### PR TITLE
chore: rename PROS old token

### DIFF
--- a/packages/tokens/src/constants/bsc.ts
+++ b/packages/tokens/src/constants/bsc.ts
@@ -59,8 +59,8 @@ export const bscTokens = {
     ChainId.BSC,
     '0xEd8c8Aa8299C10f067496BB66f8cC7Fb338A3405',
     18,
-    'PROS',
-    'Prosper',
+    'PROS(old)',
+    'Prosper(old)',
     'https://prosper.so/',
   ),
   qbt: new ERC20Token(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `bsc.ts` file by modifying the naming conventions for the `PROS` token and its label, adding a suffix to indicate an older version.

### Detailed summary
- Changed the token symbol from `PROS` to `PROS(old)`.
- Changed the token label from `Prosper` to `Prosper(old)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->