### PR TITLE
fix: Crash when scaled number too big

### DIFF
--- a/packages/utils/formatFractions.ts
+++ b/packages/utils/formatFractions.ts
@@ -41,5 +41,11 @@ export function parseNumberToFraction(num: number, precision = 6) {
     return undefined
   }
   const scalar = 10 ** precision
-  return new Fraction(BigInt(Math.floor(num * scalar)), BigInt(scalar))
+  const scaledNum = num * scalar
+
+  if (Number.isNaN(scaledNum) || !Number.isFinite(scaledNum)) {
+    return undefined
+  }
+
+  return new Fraction(BigInt(Math.floor(scaledNum)), BigInt(scalar))
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `formatFractions` function in `packages/utils/formatFractions.ts` to include validation for the scaled number before creating a new `Fraction`. If the scaled number is invalid (NaN or infinite), it returns `undefined`.

### Detailed summary
- Introduced a new variable `scaledNum` to hold the value of `num * scalar`.
- Added a check for `scaledNum` to see if it is NaN or infinite.
- If `scaledNum` is invalid, the function returns `undefined`.
- Updated the return statement to use `scaledNum` instead of `num`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->