### PR TITLE
fix: Crash when output amount zero

### DIFF
--- a/packages/smart-router/evm/v3-router/utils/getPriceImpact.ts
+++ b/packages/smart-router/evm/v3-router/utils/getPriceImpact.ts
@@ -1,4 +1,4 @@
-import { CurrencyAmount, Percent, TradeType } from '@pancakeswap/sdk'
+import { CurrencyAmount, ONE_HUNDRED_PERCENT, Percent, TradeType } from '@pancakeswap/sdk'
 
 import { Route, SmartRouterTrade } from '../types'
 import { getMidPrice } from './route'
@@ -16,6 +16,9 @@ export function getPriceImpact(
     spotOutputAmount = spotOutputAmount.add(
       CurrencyAmount.fromRawAmount(trade.outputAmount.currency, midPrice.wrapped.quote(inputAmount.wrapped).quotient),
     )
+  }
+  if (spotOutputAmount.equalTo(0)) {
+    return ONE_HUNDRED_PERCENT
   }
   const priceImpact = spotOutputAmount.subtract(trade.outputAmount).divide(spotOutputAmount)
   return new Percent(priceImpact.numerator, priceImpact.denominator)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a check in the `getPriceImpact` function to handle cases where the `spotOutputAmount` is zero, ensuring that the function returns `ONE_HUNDRED_PERCENT` in such scenarios.

### Detailed summary
- Added a conditional check for `spotOutputAmount` being equal to 0.
- If true, the function now returns `ONE_HUNDRED_PERCENT`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->