### PR TITLE
fix: only display pcs space proposal

### DIFF
--- a/apps/web/src/pages/voting/proposal/[id].tsx
+++ b/apps/web/src/pages/voting/proposal/[id].tsx
@@ -48,7 +48,7 @@ export const getStaticProps = (async ({ params }) => {
       queryKey: ['voting', 'proposal', id],
       queryFn: () => getProposal(id),
     })
-    if (!fetchedProposal) {
+    if (!fetchedProposal || fetchedProposal.space.id !== 'cakevote.eth') {
       return {
         notFound: true,
         revalidate: 1,

--- a/apps/web/src/state/types.ts
+++ b/apps/web/src/state/types.ts
@@ -411,6 +411,10 @@ export interface Proposal {
   type: ProposalTypeName
   scores: number[]
   scores_total: number
+  space: {
+    id: string
+    name: string
+  }
 }
 
 export interface Vote {

--- a/apps/web/src/state/voting/helpers.ts
+++ b/apps/web/src/state/voting/helpers.ts
@@ -53,11 +53,16 @@ export const getProposal = async (id: string): Promise<Proposal> => {
           type
           scores
           scores_total
+          space {
+            id
+            name
+          }
         }
       }
     `,
     { id },
   )
+
   return response.proposal
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `space` object to the voting state management, enhancing proposal data handling. It modifies the voting proposal page to include a check for the `space.id`, ensuring that only proposals from a specific space are processed.

### Detailed summary
- Added a `space` object with `id` and `name` properties in `apps/web/src/state/types.ts`.
- Updated the `scores` and `scores_total` definitions to include the new `space` object.
- Modified the proposal fetching logic in `apps/web/src/pages/voting/proposal/[id].tsx` to check if `fetchedProposal.space.id` is equal to `'cakevote.eth'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->