### PR TITLE
fix: Crash when document body null

### DIFF
--- a/packages/uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/uikit/src/components/Overlay/Overlay.tsx
@@ -39,16 +39,20 @@ const StyledOverlay = styled(Box)<{ isUnmounting?: boolean }>`
 
 const BodyLock = () => {
   useEffect(() => {
-    document.body.style.cssText = `
+    if (document?.body?.style) {
+      document.body.style.cssText = `
       overflow: hidden;
     `;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.cssText = `
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.cssText = `
         overflow: visible;
         overflow: overlay;
       `;
-    };
+      };
+    }
+
+    return undefined;
   }, []);
 
   return null;


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `BodyLock` component in `Overlay.tsx` to enhance the handling of the `document.body.style`. It adds checks for the existence of `document.body.style` and adjusts the cleanup function to ensure proper restoration of styles.

### Detailed summary
- Added a check for `document?.body?.style` before modifying styles.
- Changed the style application to use `cssText` for both locking and unlocking body overflow.
- Updated the cleanup function to restore styles to `overflow: visible;` and `overflow: overlay;`.
- Adjusted the return statement to return `undefined` explicitly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->