### PR TITLE
fix: topper-logo

### DIFF
--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -63,7 +63,7 @@ export const PROVIDER_ICONS = {
   [ONRAMP_PROVIDERS.MoonPay]: `${ASSET_CDN}/web/onramp/moonpay.svg`,
   [ONRAMP_PROVIDERS.Mercuryo]: `${ASSET_CDN}/web/onramp/mercuryo.svg`,
   [ONRAMP_PROVIDERS.Transak]: `${ASSET_CDN}/web/onramp/transak.svg`,
-  [ONRAMP_PROVIDERS.Topper]: `${ASSET_CDN}/web/onramp/topper.png`,
+  [ONRAMP_PROVIDERS.Topper]: `${ASSET_CDN}/web/onramp/topper.svg`,
 } satisfies Record<keyof typeof ONRAMP_PROVIDERS, string>
 
 export const providerFeeTypes: { [provider in ONRAMP_PROVIDERS]: FeeTypes[] } = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

@chefjackson  topper logo png not loading due no bad OPTIMIZATION REQUEST from the PCS assets repo. ive added new logo as svg asset to be consistent with the other onramp assets which are all svgs, as topper logo was previosly the only one which was a png

Merge the pr in the assets repo first before mergeing this PR. its link is
https://github.com/pancakeswap/assets/pull/142

current view on prod
<img width="430" alt="Screenshot 2025-02-13 at 17 04 00" src="https://github.com/user-attachments/assets/a990cc80-c9a2-4347-a073-5628db4a189b" />
<img width="407" alt="Screenshot 2025-02-13 at 17 04 04" src="https://github.com/user-attachments/assets/e7a964f0-cc1b-44b7-8ac6-073f9f7a8d43" />

fixed version
<img width="443" alt="Screenshot 2025-02-13 at 17 04 24" src="https://github.com/user-attachments/assets/d9895fd7-a1fc-4056-b067-cc4faee09f33" />



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the file `constants.ts` to change the file extension for the `Topper` onramp provider from `.png` to `.svg`, ensuring consistency in asset formats used for onramp providers.

### Detailed summary
- Changed the asset path for `ONRAMP_PROVIDERS.Topper` from `${ASSET_CDN}/web/onramp/topper.png` to `${ASSET_CDN}/web/onramp/topper.svg`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->