### PR TITLE
fix: v2 miss stake button

### DIFF
--- a/apps/web/src/state/farmsV4/state/extendPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/extendPools/fetcher.ts
@@ -1,5 +1,5 @@
 import { getChainNameInKebabCase } from '@pancakeswap/chains'
-import { fetchAllUniversalFarms, fetchAllUniversalFarmsMap } from '@pancakeswap/farms'
+import { fetchAllUniversalFarms, fetchAllUniversalFarmsMap, getFarmConfigKey } from '@pancakeswap/farms'
 import set from 'lodash/set'
 import { chainIdToExplorerInfoChainName, explorerApiClient } from 'state/info/api/client'
 import { PoolInfo, StablePoolInfo, V2PoolInfo } from '../type'
@@ -48,7 +48,7 @@ const composeFarmConfig = async (farm: PoolInfo) => {
   if (farm.protocol !== 'stable' && farm.protocol !== 'v2') return farm
 
   const farmConfig = await fetchAllUniversalFarmsMap()
-  const localFarm = farmConfig[`${farm.chainId}:${farm.lpAddress}`] as V2PoolInfo | StablePoolInfo | undefined
+  const localFarm = farmConfig[getFarmConfigKey(farm)] as V2PoolInfo | StablePoolInfo | undefined
 
   if (!localFarm) {
     return farm

--- a/packages/farms/index.test.ts
+++ b/packages/farms/index.test.ts
@@ -19,6 +19,7 @@ test('exports', () => {
       "Protocol",
       "isActiveV3Farm",
       "formatUniversalFarmToSerializedFarm",
+      "getFarmConfigKey",
       "deserializeFarm",
       "deserializeFarmUserData",
       "deserializeFarmBCakeUserData",

--- a/packages/farms/src/farms/index.ts
+++ b/packages/farms/src/farms/index.ts
@@ -5,6 +5,7 @@ import { UniversalFarmConfig } from '../types'
 import { bscTestnetFarmConfig } from './bscTestnet'
 import { polygonZkEVMTestnetFarmConfig } from './polygonZkEVMTestnet'
 import { zkSyncTestnetFarmConfig } from './zkSyncTestnet'
+import { getFarmConfigKey } from '../utils'
 
 const chainIds: ChainId[] = [
   ChainId.BSC,
@@ -35,7 +36,7 @@ export const fetchAllUniversalFarmsMap = async (): Promise<Record<string, Univer
     const farmConfig = await fetchAllUniversalFarms()
 
     return farmConfig.reduce((acc, farm) => {
-      set(acc, `${farm.chainId}:${farm.lpAddress}`, farm)
+      set(acc, getFarmConfigKey(farm), farm)
       return acc
     }, {} as Record<string, UniversalFarmConfig>)
   } catch (error) {

--- a/packages/farms/src/utils.ts
+++ b/packages/farms/src/utils.ts
@@ -112,3 +112,7 @@ const formatV3UniversalFarmToSerializedFarm = (farm: UniversalFarmConfigV3): Leg
     version: 3,
   }
 }
+
+export const getFarmConfigKey = (farm: Pick<UniversalFarmConfig, 'chainId' | 'lpAddress'>) => {
+  return `${farm.chainId}:${farm.lpAddress.toLowerCase()}`
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the `getFarmConfigKey` utility function to standardize the key generation for farm configurations, enhancing code readability and maintainability. It replaces direct string interpolation with this new function across various files.

### Detailed summary
- Added `getFarmConfigKey` function in `packages/farms/src/utils.ts`.
- Updated `fetchAllUniversalFarmsMap` in `packages/farms/src/farms/index.ts` to use `getFarmConfigKey`.
- Modified `composeFarmConfig` in `apps/web/src/state/farmsV4/state/extendPools/fetcher.ts` to utilize `getFarmConfigKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->