### PR TITLE
fix: v2 stake fetch allowance fail

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher.ts
@@ -1,4 +1,10 @@
-import { BCakeWrapperFarmConfig, Protocol, fetchAllUniversalFarms, fetchAllUniversalFarmsMap } from '@pancakeswap/farms'
+import {
+  BCakeWrapperFarmConfig,
+  Protocol,
+  fetchAllUniversalFarms,
+  fetchAllUniversalFarmsMap,
+  getFarmConfigKey,
+} from '@pancakeswap/farms'
 import { CurrencyAmount, ERC20Token, Pair, Token, pancakePairV2ABI } from '@pancakeswap/sdk'
 import { LegacyStableSwapPair } from '@pancakeswap/smart-router/legacy-router'
 import { deserializeToken } from '@pancakeswap/token-lists'
@@ -119,7 +125,7 @@ export const getTrackedV2LpTokens = memoize(
 export const getBCakeWrapperAddress = async (lpAddress: Address, chainId: number) => {
   const fetchUniversalFarmsMap = await fetchAllUniversalFarmsMap()
 
-  const f = fetchUniversalFarmsMap[`${chainId}:${lpAddress}`] as V2PoolInfo | StablePoolInfo | undefined
+  const f = fetchUniversalFarmsMap[getFarmConfigKey({ lpAddress, chainId })] as V2PoolInfo | StablePoolInfo | undefined
 
   return f?.bCakeWrapperAddress ?? '0x'
 }


### PR DESCRIPTION
- **fix: v2 miss stake button**
- **fix: v2 stake fetch allowance fail**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the way the `bCakeWrapperAddress` is fetched in the `getBCakeWrapperAddress` function by using a new key generation method for the `fetchUniversalFarmsMap`. This change enhances the clarity and consistency of how the farm configuration is accessed.

### Detailed summary
- Updated the key used to access `fetchUniversalFarmsMap` in the `getBCakeWrapperAddress` function.
- Replaced the direct use of template literals with the `getFarmConfigKey` function to generate the key.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->