### PR TITLE
fix: ton swap details fee

### DIFF
--- a/apps/ton/src/atoms/swap/swapDetailPanelStateAtom.ts
+++ b/apps/ton/src/atoms/swap/swapDetailPanelStateAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai'
+
+export const swapDetailPanelOpenAtom = atom(false)

--- a/apps/ton/src/components/TonSwap/ButtonAndDetailsPanel.tsx
+++ b/apps/ton/src/components/TonSwap/ButtonAndDetailsPanel.tsx
@@ -1,5 +1,5 @@
 import { SwapUIV2 } from 'components/widgets/swap-v2'
-import { useState } from 'react'
+import { useIsSwapDetailPanelOpen } from 'hooks/swap/useIsSwapDetailPanelOpen'
 import { styled } from 'styled-components'
 
 export const PanelWrapper = styled.div`
@@ -25,7 +25,7 @@ export const ButtonAndDetailsPanel: React.FC<ButtonAndDetailsPanelProps> = ({
   tradeDetails,
   shouldRenderDetails,
 }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useIsSwapDetailPanelOpen()
   return (
     <PanelWrapper>
       {swapCommitButton}

--- a/apps/ton/src/components/TonSwap/PricingAndSlippage.tsx
+++ b/apps/ton/src/components/TonSwap/PricingAndSlippage.tsx
@@ -1,16 +1,20 @@
-import { Currency, Price } from '@pancakeswap/ton-v2-sdk'
-import { useModal } from '@pancakeswap/uikit'
+import { Currency, CurrencyAmount, Price } from '@pancakeswap/ton-v2-sdk'
+import { FlexGap, Text, useModal } from '@pancakeswap/uikit'
 import { useUserSlippage } from '@pancakeswap/utils/user'
-import { SwapUIV2 } from '@pancakeswap/widgets-internal'
+import { RefreshButton, SwapUIV2 } from '@pancakeswap/widgets-internal'
 import { SettingsModal } from 'components/Modals/SettingsModal'
+import { memo } from 'react'
 
 interface Props {
-  showSlippage?: boolean
-  priceLoading?: boolean
-  price?: Price<Currency, Currency>
+  showSlippage: boolean
+  showFee: boolean
+  isLoading: boolean
+  price?: Price<Currency, Currency> | null
+  fee?: CurrencyAmount<Currency> | null
+  onRefresh: () => void
 }
 
-export const PricingAndSlippage = ({ priceLoading, price, showSlippage = true }: Props) => {
+export const PricingAndSlippage = memo(({ isLoading, price, showSlippage, showFee, fee, onRefresh }: Props) => {
   const [allowedSlippage] = useUserSlippage()
   const [onPresentSettingsModal] = useModal(<SettingsModal isOpen={false} />)
 
@@ -18,13 +22,30 @@ export const PricingAndSlippage = ({ priceLoading, price, showSlippage = true }:
     return null
   }
 
-  const priceNode = price ? <SwapUIV2.TradePrice price={price as any} loading={priceLoading} /> : null
+  const priceNode = price ? <SwapUIV2.TradePrice price={price as any} loading={isLoading} /> : null
 
   return (
-    <SwapUIV2.SwapInfo
-      price={priceNode}
-      allowedSlippage={showSlippage ? allowedSlippage : undefined}
-      onSlippageClick={onPresentSettingsModal}
-    />
+    <FlexGap alignItems="center" flexWrap="wrap" justifyContent="space-between" width="calc(100% - 20px)" gap="8px">
+      <FlexGap
+        marginLeft="-8px"
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+        alignItems="center"
+        flexWrap="wrap"
+      >
+        <RefreshButton refreshDuration={12_000} onRefresh={onRefresh} refreshDisabled={isLoading} loading={isLoading} />
+        <SwapUIV2.SwapInfo
+          price={priceNode}
+          allowedSlippage={showSlippage ? allowedSlippage : undefined}
+          onSlippageClick={onPresentSettingsModal}
+        />
+      </FlexGap>
+      {showFee ? (
+        <Text fontSize="14px" color="textSubtle">
+          Fee {fee ? `${fee.toSignificant(4)} ${fee.currency.symbol}` : '-'}
+        </Text>
+      ) : null}
+    </FlexGap>
   )
-}
+})

--- a/apps/ton/src/components/TonSwap/SwapCommitButton.tsx
+++ b/apps/ton/src/components/TonSwap/SwapCommitButton.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Button, ButtonProps } from '@pancakeswap/uikit'
 import { inputCurrencyAtom, typedValueAtom } from 'atoms/swap/swapStateAtom'
 import { useAtomValue } from 'jotai'
+import { memo } from 'react'
 import { isConnectedAtom } from 'ton/atom/isConnectedAtom'
 import { balanceAtom } from 'ton/logic/balanceAtom'
 import { tryParseAmount } from 'utils/tryParseAmount'
@@ -10,7 +11,7 @@ interface SwapCommitButtonProps extends ButtonProps {
   isLoading?: boolean
 }
 
-export const SwapCommitButton = ({ isLoading = false, disabled = false, ...props }: SwapCommitButtonProps) => {
+export const SwapCommitButton = memo(({ isLoading = false, disabled = false, ...props }: SwapCommitButtonProps) => {
   const { t } = useTranslation()
   const isConnected = useAtomValue(isConnectedAtom)
 
@@ -36,4 +37,4 @@ export const SwapCommitButton = ({ isLoading = false, disabled = false, ...props
         : t('Swap')}
     </Button>
   )
-}
+})

--- a/apps/ton/src/hooks/swap/useIsSwapDetailPanelOpen.ts
+++ b/apps/ton/src/hooks/swap/useIsSwapDetailPanelOpen.ts
@@ -1,0 +1,6 @@
+import { swapDetailPanelOpenAtom } from 'atoms/swap/swapDetailPanelStateAtom'
+import { useAtom } from 'jotai'
+
+export const useIsSwapDetailPanelOpen = () => {
+  return useAtom(swapDetailPanelOpenAtom)
+}

--- a/apps/ton/src/views/TONSwap/AdvancedSwapDetails.tsx
+++ b/apps/ton/src/views/TONSwap/AdvancedSwapDetails.tsx
@@ -58,7 +58,14 @@ function TradeSummary({
 
       <RowBetween>
         <RowFixed>
-          <DetailsTitle>{t('Slippage Tolerance')}</DetailsTitle>
+          <QuestionHelperV2
+            text={t(
+              'Setting a high slippage tolerance can help transactions succeed, but you may not get such a good price. Use with caution.',
+            )}
+            placement="top"
+          >
+            <DetailsTitle>{t('Slippage Tolerance')}</DetailsTitle>
+          </QuestionHelperV2>
         </RowFixed>
         <SlippageButton />
       </RowBetween>

--- a/apps/ton/src/views/TONSwap/AdvancedSwapDetailsDropdown.tsx
+++ b/apps/ton/src/views/TONSwap/AdvancedSwapDetailsDropdown.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { styled } from 'styled-components'
 import { usePreviousValue } from '@pancakeswap/hooks'
 import { AdvancedSwapDetails, AdvancedSwapDetailsProps } from './AdvancedSwapDetails'
@@ -9,7 +10,7 @@ const AdvancedDetailsFooter = styled.div<{ show: boolean }>`
   background-color: ${({ theme }) => theme.colors.invertedContrast};
 `
 
-export const AdvancedSwapDetailsDropdown = ({ trade, ...rest }: AdvancedSwapDetailsProps) => {
+export const AdvancedSwapDetailsDropdown = memo(({ trade, ...rest }: AdvancedSwapDetailsProps) => {
   const lastTrade = usePreviousValue(trade)
 
   return (
@@ -17,4 +18,4 @@ export const AdvancedSwapDetailsDropdown = ({ trade, ...rest }: AdvancedSwapDeta
       <AdvancedSwapDetails {...rest} trade={trade ?? lastTrade ?? undefined} />
     </AdvancedDetailsFooter>
   )
-}
+})

--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Rounding } from '@pancakeswap/swap-sdk-core'
 import { Native, TonNetworks } from '@pancakeswap/ton-v2-sdk'
-import { Column, FlexGap, Text } from '@pancakeswap/uikit'
+import { Column, Text } from '@pancakeswap/uikit'
 import { formatFraction } from '@pancakeswap/utils/formatFractions'
 import { useUserSlippage } from '@pancakeswap/utils/user'
-import { RefreshButton } from '@pancakeswap/widgets-internal'
 import { fetchListAtom } from 'atoms/lists/fetchListAtom'
 import { setApprovalModalAtom } from 'atoms/modals/approvalModalAtom'
 import { setTransactionModalAtom } from 'atoms/modals/transactionModalAtom'
@@ -25,6 +24,9 @@ import { balanceAtom } from 'ton/logic/balanceAtom'
 import { useSwap } from 'ton/logic/swap/useSwap'
 import { Field } from 'types'
 import { tryParseAmount } from 'utils/tryParseAmount'
+import { useIsSwapDetailPanelOpen } from 'hooks/swap/useIsSwapDetailPanelOpen'
+import { computeTradePriceBreakdown } from 'utils/exchange'
+
 import { AdvancedSwapDetailsDropdown } from './AdvancedSwapDetailsDropdown'
 
 export const SwapForm = () => {
@@ -86,6 +88,10 @@ export const SwapForm = () => {
     () => (parsedAmounts[Field.INPUT] ? parsedAmounts[Field.INPUT].greaterThan(balance0) : false),
     [balance0, parsedAmounts],
   )
+
+  const [isSwapDetailPanelOpen] = useIsSwapDetailPanelOpen()
+  const { realizedLPFee } = computeTradePriceBreakdown(trade)
+
   const { swap } = useSwap()
 
   const handleSwap = useCallback(async () => {
@@ -181,34 +187,14 @@ export const SwapForm = () => {
         shouldRenderDetails={Boolean(typedValue)}
         swapCommitButton={<SwapCommitButton disabled={!trade} isLoading={isTradeLoading} onClick={handleSwap} />}
         pricingAndSlippage={
-          <FlexGap
-            alignItems="center"
-            flexWrap="wrap"
-            justifyContent="space-between"
-            width="calc(100% - 20px)"
-            gap="8px"
-            marginLeft="-8px"
-          >
-            <FlexGap
-              onClick={(e) => {
-                e.stopPropagation()
-              }}
-              alignItems="center"
-              flexWrap="wrap"
-            >
-              <RefreshButton
-                refreshDuration={12_000}
-                onRefresh={refreshTrade}
-                refreshDisabled={isTradeLoading}
-                loading={isTradeLoading}
-              />
-              <PricingAndSlippage
-                priceLoading={isTradeLoading}
-                price={trade?.executionPrice ?? undefined}
-                showSlippage={false}
-              />
-            </FlexGap>
-          </FlexGap>
+          <PricingAndSlippage
+            isLoading={isTradeLoading}
+            price={trade?.executionPrice}
+            showSlippage={false}
+            showFee={Boolean(trade && !isSwapDetailPanelOpen)}
+            fee={realizedLPFee}
+            onRefresh={refreshTrade}
+          />
         }
         tradeDetails={<AdvancedSwapDetailsDropdown trade={trade} />}
       />


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on implementing a state management solution for the swap detail panel using `jotai`, enhancing the user interface with additional helper text, and optimizing component rendering through memoization.

### Detailed summary
- Added `swapDetailPanelOpenAtom` in `swapDetailPanelStateAtom.ts`.
- Created `useIsSwapDetailPanelOpen` hook to manage panel state.
- Updated `AdvancedSwapDetails.tsx` to include a `QuestionHelperV2` for slippage tolerance.
- Replaced local state with `useIsSwapDetailPanelOpen` in `ButtonAndDetailsPanel.tsx`.
- Memoized `AdvancedSwapDetailsDropdown` and `SwapCommitButton` components.
- Enhanced `PricingAndSlippage` component with additional props and layout adjustments.
- Updated `SwapForm` to utilize the new state management and pass relevant props.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->