### PR TITLE
chore: remove xmax effect on swap page

### DIFF
--- a/apps/web/src/views/Swap/Twap/TwapSwap.tsx
+++ b/apps/web/src/views/Swap/Twap/TwapSwap.tsx
@@ -9,7 +9,6 @@ import { useContext, useEffect, useState } from 'react'
 import { Field } from 'state/swap/actions'
 import { useDefaultsFromURLSearch, useSingleTokenSwapInfo, useSwapState } from 'state/swap/hooks'
 import { styled } from 'styled-components'
-import { XmasEffect } from 'views/SwapSimplify/V4Swap/XmasEffect'
 // import { SwapSelection } from '../components/SwapSelection'
 import { SwapSelection } from '../../SwapSimplify/V4Swap/SwapSelectionTab'
 import { SwapFeaturesContext } from '../SwapFeaturesContext'
@@ -130,7 +129,6 @@ export default function TwapAndLimitSwap({ limit }: { limit?: boolean }) {
           </StyledSwapContainer>
         </Flex>
       </Flex>
-      <XmasEffect />
     </>
   )
 }

--- a/apps/web/src/views/SwapSimplify/index.tsx
+++ b/apps/web/src/views/SwapSimplify/index.tsx
@@ -14,7 +14,6 @@ import PriceChartContainer from '../Swap/components/Chart/PriceChartContainer'
 import { StyledSwapContainer } from '../Swap/styles'
 import { SwapFeaturesContext } from '../Swap/SwapFeaturesContext'
 import { V4SwapForm } from './V4Swap'
-import { XmasEffect } from './V4Swap/XmasEffect'
 
 const Wrapper = styled(Box)`
   width: 100%;
@@ -136,7 +135,6 @@ export default function V4Swap() {
       </Flex>
 
       <AdPanel.MobileCard />
-      <XmasEffect />
     </Page>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `XmasEffect` component from two files: `V4Swap` and `TwapAndLimitSwap`. This change likely aims to simplify the swap interfaces by eliminating the festive effect, possibly in preparation for a more streamlined user experience.

### Detailed summary
- Removed `<XmasEffect />` from the `V4Swap` component in `apps/web/src/views/SwapSimplify/index.tsx`.
- Removed `<XmasEffect />` from the `TwapAndLimitSwap` component in `apps/web/src/views/Swap/Twap/TwapSwap.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->