### PR TITLE
fix: Object not found crash on barchart tooltip

### DIFF
--- a/apps/web/src/views/V3Info/components/DensityChart/CustomToolTip.tsx
+++ b/apps/web/src/views/V3Info/components/DensityChart/CustomToolTip.tsx
@@ -27,6 +27,11 @@ interface CustomToolTipProps {
 function CustomToolTip({ chartProps, poolData, currentPrice }: CustomToolTipProps) {
   const { t } = useTranslation()
   const { theme } = useTheme()
+
+  if (!chartProps?.active || !chartProps?.payload || !chartProps?.payload.length) {
+    return null
+  }
+
   const price0 = chartProps?.payload?.[0]?.payload.price0
   const price1 = chartProps?.payload?.[0]?.payload.price1
   const tvlToken0 = chartProps?.payload?.[0]?.payload.tvlToken0

--- a/apps/web/src/views/V3Info/components/DensityChart/index.tsx
+++ b/apps/web/src/views/V3Info/components/DensityChart/index.tsx
@@ -256,6 +256,7 @@ export default function DensityChart({ address }: DensityChartProps) {
               content={(props) => (
                 <CustomToolTip chartProps={props} poolData={poolData} currentPrice={poolData?.token0Price ?? 0} />
               )}
+              isAnimationActive={false}
             />
             <XAxis reversed tick={false} />
             <Bar


### PR DESCRIPTION
Happens intermittently in density chart on pools info

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `DensityChart` component by adding a condition to prevent rendering the `CustomToolTip` when there is no active chart or payload data. It also modifies the properties of the `Bar` component.

### Detailed summary
- Added `isAnimationActive={false}` to the `Bar` component in `DensityChart/index.tsx`.
- Implemented a conditional check in `CustomToolTip.tsx` to return `null` if `chartProps?.active` is false or if `chartProps?.payload` is empty.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->