### PR TITLE
fix: NaN staking balance causes roi modal my balance not loaded correctly

### DIFF
--- a/apps/web/src/state/pools/helpers.ts
+++ b/apps/web/src/state/pools/helpers.ts
@@ -24,10 +24,10 @@ type UserData =
 
 export const transformUserData = (userData: UserData) => {
   return {
-    allowance: userData ? new BigNumber(userData.allowance) : BIG_ZERO,
-    stakingTokenBalance: userData ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO,
-    stakedBalance: userData ? new BigNumber(userData.stakedBalance) : BIG_ZERO,
-    pendingReward: userData ? new BigNumber(userData.pendingReward) : BIG_ZERO,
+    allowance: userData?.allowance ? new BigNumber(userData.allowance) : BIG_ZERO,
+    stakingTokenBalance: userData?.stakingTokenBalance ? new BigNumber(userData.stakingTokenBalance) : BIG_ZERO,
+    stakedBalance: userData?.stakedBalance ? new BigNumber(userData.stakedBalance) : BIG_ZERO,
+    pendingReward: userData?.pendingReward ? new BigNumber(userData.pendingReward) : BIG_ZERO,
   }
 }
 


### PR DESCRIPTION
In syrup pools when user has staked tokens but not staking balance, roi modal my balance not showed correctly and becomes unclickable
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the null-checking logic for the `userData` properties in the `transformUserData` function. It utilizes optional chaining to simplify the checks before creating `BigNumber` instances.

### Detailed summary
- Updated `allowance` property to use optional chaining.
- Updated `stakingTokenBalance` property to use optional chaining.
- Updated `stakedBalance` property to use optional chaining.
- Updated `pendingReward` property to use optional chaining.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->