### PR TITLE
fix: TON whitelist token and pools

### DIFF
--- a/apps/ton/public/lists/testnet.json
+++ b/apps/ton/public/lists/testnet.json
@@ -70,18 +70,18 @@
     {
       "chainId": -3,
       "address": "kQD0zbW5arqfo7uaNs7TiBckhPp0m8xZgsMs6qdBU85p9UVB",
-      "name": "claude",
-      "symbol": "CLAUDE",
+      "name": "tTON",
+      "symbol": "tTON",
       "decimals": 9,
-      "logoURI": "https://cache.tonapi.io/imgproxy/cOMlJuViiVXDCkAghnyNj7plX8pAZ9pv3WhklvebpTY/rs:fill:200:200:1/g:no/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3RvbmtlZXBlci9vcGVudG9uYXBpL21hc3Rlci9wa2cvcmVmZXJlbmNlcy9tZWRpYS90b2tlbl9wbGFjZWhvbGRlci5wbmc.webp"
+      "logoURI": "https://cache.tonapi.io/imgproxy/EJvW71I48rv9e3yerUGTUBAbq-7vAvogCr5vnHfzD3I/rs:fill:200:200:1/g:no/aHR0cHM6Ly9jYWNoZS50b25hcGkuaW8vaW1ncHJveHkvYmM3c2c2WGk0LWNmVXdLLWVyMkNSLTZDVW5NcWw5bkZRd01WVTRJZVlOQS9yczpmaWxsOjIwMDoyMDA6MS9nOm5vL2FIUjBjSE02THk5allXTm9aUzUwYjI1aGNHa3VhVzh2YVcxbmNISnZlSGt2VTBKeGIxOUpkMk4wVlVkU1NqSTRXa05JUkhrMVUyMUNjVTh5UzFSMmFFYzRWVEZTYjBrMVNWcElheTl5Y3pwbWFXeHNPakl3TURveU1EQTZNUzluT201dkwyRklVakJqU0UwMlRIazVNR0l5TkhWaU0wcHVUREpzYW1JeU5YcE1NazR4WXpOU2RtSlRPVEJpTWpWbVlrYzVibUo1Tlhwa2JXTXVkMlZpY0Eud2VicA.webp"
     },
     {
       "chainId": -3,
       "address": "kQBN6HSn7GmAB30K_YmL3vhS2ms5LMm9aPW0PGzvUZASRzng",
-      "name": "Wrap Bitcoin",
-      "symbol": "wBTC",
+      "name": "USDC",
+      "symbol": "USDC",
       "decimals": 9,
-      "logoURI": "https://cache.tonapi.io/imgproxy/i7jumPCXC__AWJcr-0PvOjsfa-dzaZpwtIHEqQioLhE/rs:fill:200:200:1/g:no/aHR0cHM6Ly9iaXRjb2luY2FzaC1leGFtcGxlLmdpdGh1Yi5pby93ZWJzaXRlL2xvZ28ucG5n.webp"
+      "logoURI": "https://cache.tonapi.io/imgproxy/Ah3zvC4pJ0jg74ymj38e_FF-2ALz-5aqRD9ZUYVAacU/rs:fill:200:200:1/g:no/aHR0cHM6Ly9icmlkZ2UudG9uLm9yZy90b2tlbi8xLzB4YTBiODY5OTFjNjIxOGIzNmMxZDE5ZDRhMmU5ZWIwY2UzNjA2ZWI0OC5wbmc.webp"
     }
   ]
 }

--- a/apps/ton/src/config/constants/exchange.ts
+++ b/apps/ton/src/config/constants/exchange.ts
@@ -37,8 +37,8 @@ export const ADDITIONAL_BASES: { [chainId in TonChainId]?: { [tokenAddress: stri
 export const CUSTOM_BASES: { [chainId in TonChainId]?: { [tokenAddress: string]: Token[] } } = {}
 
 // todo:@eric mock bases to test multihops
-const wBTC = tokenList.tokens.find((t) => t.symbol === 'wBTC')!
-const CLAUDE = tokenList.tokens.find((t) => t.symbol === 'CLAUDE')!
+const USDC = tokenList.tokens.find((t) => t.symbol === 'USDC')!
+const tTON = tokenList.tokens.find((t) => t.symbol === 'tTON')!
 export const BASES_TO_CHECK_TRADES_AGAINST: { [chainId: number]: Currency[] } = {
   [TonChainId.Testnet]: [
     /* new Native(NATIVE[TonChainId.Testnet]),
@@ -50,8 +50,8 @@ export const BASES_TO_CHECK_TRADES_AGAINST: { [chainId: number]: Currency[] } = 
       'USDT',
       'https://cache.tonapi.io/imgproxy/JHJ0sotb2B_DU6JIHdIMKEz_5wmkeY4EboeQLPlpUBY/rs:fill:200:200:1/g:no/aHR0cHM6Ly90b25hcGktaW1nLWNhY2hlLmZyYTEuZGlnaXRhbG9jZWFuc3BhY2VzLmNvbS9jYThiNTk1Mzc3Nzg0OGNkNzE4YzYzZDE5OTQzZDEyOWFjOTI5OGJjYTdjZTFhZGNjMDBiMTVlYWU4M2U4NjhlLnBuZw.webp',
     ), */
-    new Token(wBTC.chainId, wBTC.address, wBTC.decimals, wBTC.name, wBTC.symbol, wBTC.logoURI),
-    new Token(CLAUDE.chainId, CLAUDE.address, CLAUDE.decimals, CLAUDE.name, CLAUDE.symbol, CLAUDE.logoURI),
+    new Token(USDC.chainId, USDC.address, USDC.decimals, USDC.name, USDC.symbol, USDC.logoURI),
+    new Token(tTON.chainId, tTON.address, tTON.decimals, tTON.name, tTON.symbol, tTON.logoURI),
   ] satisfies Currency[],
   [TonChainId.Mainnet]: [],
 }

--- a/apps/ton/src/config/presetPools.ts
+++ b/apps/ton/src/config/presetPools.ts
@@ -8,7 +8,14 @@ export const PRESET_POOLS = {
     // SYRUP-PAN
     'kQArzX0-In2BjRhaq5pB2vmZH80saystVwwbPIpEyGrh723F<>kQABtdKCYuAAIrEAD4LbONdybLTYsYleyYhsy6CfsXkkP0tg':
       'EQB53lcd4hlB4VuZ2mTSjcZd1JSJJ1iY-kN9SIPIL9RrQU5B',
+    // USDC-tTON
     'kQBN6HSn7GmAB30K_YmL3vhS2ms5LMm9aPW0PGzvUZASRzng<>kQD0zbW5arqfo7uaNs7TiBckhPp0m8xZgsMs6qdBU85p9UVB':
       'kQBd0roLuicL47ortnzPc2tNQfYkD1LH27ippaO-6ba7srBd',
+    // SYRUP-tTON
+    'kQArzX0-In2BjRhaq5pB2vmZH80saystVwwbPIpEyGrh723F<>kQD0zbW5arqfo7uaNs7TiBckhPp0m8xZgsMs6qdBU85p9UVB':
+      'kQCY0hvhAb2aoovS76xidnk0in04ngvZsVNxECqBs3deEnve',
+    // PAN-tTON
+    'kQABtdKCYuAAIrEAD4LbONdybLTYsYleyYhsy6CfsXkkP0tg<>kQD0zbW5arqfo7uaNs7TiBckhPp0m8xZgsMs6qdBU85p9UVB':
+      'kQCgANQV9W0L7p0NaXYtHgjIRs8kFq6hRn5SDhq5Gdnz5eC0',
   },
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces updates to the `presetPools.ts`, `exchange.ts`, and `testnet.json` files, primarily focusing on replacing certain token references and adding new tokens, specifically `USDC` and `tTON`, while removing references to `wBTC` and `CLAUDE`.

### Detailed summary
- In `presetPools.ts`, added mappings for `USDC-tTON`, `SYRUP-tTON`, and `PAN-tTON`.
- In `exchange.ts`, replaced `wBTC` and `CLAUDE` with `USDC` and `tTON`.
- In `testnet.json`, updated token details for `tTON` and `USDC`, including names and logos, while removing `wBTC`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->