### PR TITLE
fix: TON swap error handle

### DIFF
--- a/apps/ton/src/atoms/modals/errorMsgModalAtom.tsx
+++ b/apps/ton/src/atoms/modals/errorMsgModalAtom.tsx
@@ -1,0 +1,24 @@
+import { atom } from 'jotai'
+import { ReactElement } from 'react'
+import { TransactionErrorContent } from '@pancakeswap/widgets-internal'
+
+import { appModalAtom } from './appModalAtom'
+
+export const setErrorMsgModalAtom = atom(
+  null,
+  (_, set, { msg, isOpen = true }: { msg: ReactElement | string; isOpen: boolean }) => {
+    const handleDismiss = () => {
+      set(appModalAtom, {
+        title: null,
+        content: null,
+        isOpen: false,
+      })
+    }
+    set(appModalAtom, {
+      title: null,
+      content: <TransactionErrorContent message={msg} onDismiss={handleDismiss} />,
+      closeable: true,
+      isOpen,
+    })
+  },
+)

--- a/apps/ton/src/atoms/modals/transactionModalAtom.tsx
+++ b/apps/ton/src/atoms/modals/transactionModalAtom.tsx
@@ -15,8 +15,6 @@ const Title = memo(({ type }: TitleProps) => {
   const titleByAction: { [type in ActionType]: string } = useMemo(
     () => ({
       [ActionType.ConfirmTransaction]: t('Confirm Transaction'),
-      [ActionType.TransactionSubmitted]: t('Transaction Submitted'),
-      [ActionType.TransactionCompleted]: t('Transaction Complete'),
 
       [ActionType.AddLiquiditySubmitted]: t('Transaction Submitted'),
       [ActionType.AddLiquidityComplete]: t('Transaction Complete'),

--- a/apps/ton/src/components/Modals/ActionModal.tsx
+++ b/apps/ton/src/components/Modals/ActionModal.tsx
@@ -26,8 +26,6 @@ const GridColumn = styled(FlexGap)`
 
 export enum ActionType {
   ConfirmTransaction = 'ConfirmTransaction',
-  TransactionSubmitted = 'TransactionSubmitted',
-  TransactionCompleted = 'TransactionCompleted',
   AddLiquiditySubmitted = 'AddLiquiditySubmitted',
   AddLiquidityComplete = 'AddLiquidityComplete',
   ConfirmLiquiditySupply = 'ConfirmSupply',
@@ -42,14 +40,6 @@ const iconByActionType: (t) => {
 } = (t) => ({
   [ActionType.ConfirmTransaction]: {
     icon: <AddCircleLoading />,
-  },
-  [ActionType.TransactionSubmitted]: {
-    icon: '/images/up-arrow-animated.gif',
-    alt: t('Up Arrow'),
-  },
-  [ActionType.TransactionCompleted]: {
-    icon: '/images/green-tick-animated.gif',
-    alt: t('Green Tick'),
   },
   [ActionType.AddLiquiditySubmitted]: {
     icon: '/images/up-arrow-animated.gif',

--- a/apps/ton/src/ton/atom/liquidity/poolDataQueriesAtom.ts
+++ b/apps/ton/src/ton/atom/liquidity/poolDataQueriesAtom.ts
@@ -32,6 +32,9 @@ export const poolDataQueriesAtom = atomFamily((pairs: PoolDataAtomParams[]) => {
           }
 
           const poolData = await get(poolContractAtom(poolAddress)).getGetPoolData()
+          if (!poolData) {
+            throw new Error('fetch poolData failed')
+          }
           return {
             ...poolData,
             poolAddress,
@@ -43,7 +46,6 @@ export const poolDataQueriesAtom = atomFamily((pairs: PoolDataAtomParams[]) => {
     enabled: !!key.length,
     refetchInterval: QUERY_DEFAULT_STALE_TIME,
     refetchOnWindowFocus: false,
-    retry: 10,
   }))
 }, isEqual)
 

--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -1,8 +1,10 @@
+import { useTranslation } from '@pancakeswap/localization'
 import { TradeType } from '@pancakeswap/swap-sdk-core'
 import { Contracts, Currency, TonContractNames, Trade, storeSwap } from '@pancakeswap/ton-v2-sdk'
 import { storeJettonTransferMessage } from '@ton-community/assets-sdk'
 import { beginCell, toNano } from '@ton/core'
-import { SendTransactionRequest, useTonConnectUI } from '@tonconnect/ui-react'
+import { SendTransactionRequest, TonConnectUIError, UserRejectsError, useTonConnectUI } from '@tonconnect/ui-react'
+import { setErrorMsgModalAtom } from 'atoms/modals/errorMsgModalAtom'
 import { setTransactionModalAtom } from 'atoms/modals/transactionModalAtom'
 import { ActionType } from 'components/Modals/ActionModal'
 import { useUserAddress } from 'hooks/useUserAddress'
@@ -23,8 +25,10 @@ interface SwapArgs {
 
 export const useSwap = () => {
   const [tonUI] = useTonConnectUI()
+  const { t } = useTranslation()
   const userAddress = useUserAddress()
   const setTransactionModal = useSetAtom(setTransactionModalAtom)
+  const setErrorMsgModal = useSetAtom(setErrorMsgModalAtom)
 
   const getTxRequest = useCallback(
     async ({ amount0, minOut, token0, trade }: SwapArgs) => {
@@ -99,48 +103,59 @@ export const useSwap = () => {
 
   const swap = useCallback(
     async ({ amount0, minOut, token0, token1, trade }: SwapArgs) => {
-      setTransactionModal({
-        type: ActionType.ConfirmSwap,
-        isOpen: true,
-        currency0: token0,
-        currency1: token1,
-        amount0,
-        amount1: minOut,
-      })
-
-      const txRequest: SendTransactionRequest = await getTxRequest({
-        amount0,
-        minOut,
-        token0,
-        token1,
-        trade,
-      })
-      const { boc } = await tonUI.sendTransaction(txRequest)
-
-      if (boc) {
+      try {
         setTransactionModal({
-          type: ActionType.SwapSubmitted,
+          type: ActionType.ConfirmSwap,
           isOpen: true,
           currency0: token0,
           currency1: token1,
           amount0,
           amount1: minOut,
         })
-      }
 
-      const hash = await getTransactionByBOC(userAddress, boc)
-      if (hash) {
-        setTransactionModal({
-          type: ActionType.SwapCompleted,
-          currency0: token0,
-          currency1: token1,
+        const txRequest: SendTransactionRequest = await getTxRequest({
           amount0,
-          amount1: minOut,
-          hash,
+          minOut,
+          token0,
+          token1,
+          trade,
+        })
+        const { boc } = await tonUI.sendTransaction(txRequest)
+
+        if (boc) {
+          setTransactionModal({
+            type: ActionType.SwapSubmitted,
+            isOpen: true,
+            currency0: token0,
+            currency1: token1,
+            amount0,
+            amount1: minOut,
+          })
+        }
+
+        const hash = await getTransactionByBOC(userAddress, boc)
+        if (hash) {
+          setTransactionModal({
+            type: ActionType.SwapCompleted,
+            currency0: token0,
+            currency1: token1,
+            amount0,
+            amount1: minOut,
+            hash,
+          })
+        }
+      } catch (e) {
+        let msg = typeof e === 'string' ? e : (e as Error)?.message
+        if (e instanceof UserRejectsError || e instanceof TonConnectUIError) {
+          msg = t('Transaction rejected')
+        }
+        setErrorMsgModal({
+          isOpen: true,
+          msg,
         })
       }
     },
-    [userAddress, tonUI, getTxRequest, setTransactionModal],
+    [setErrorMsgModal, t, userAddress, tonUI, getTxRequest, setTransactionModal],
   )
 
   return {

--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -64,7 +64,7 @@ export const SwapForm = () => {
             6,
             Rounding.ROUND_DOWN,
           )
-        : undefined,
+        : '',
     }),
     [independentField, typedValue, dependentField, dependentFieldAmount],
   )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling in the `TONSwap` application by introducing a new error message modal and refining transaction handling in the `useSwap` hook. It also removes unused transaction types and adds checks for pool data retrieval.

### Detailed summary
- Introduced `setErrorMsgModalAtom` for error handling.
- Added error handling in `useSwap` for transaction failures.
- Removed `TransactionSubmitted` and `TransactionCompleted` action types.
- Added a check for `poolData` retrieval failure in `poolDataQueriesAtom`.
- Updated transaction modal states to reflect swap submission.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->