### PR TITLE
fix: 🐛 stable swap network switch fix

### DIFF
--- a/apps/web/src/hooks/useAccountEventListener.ts
+++ b/apps/web/src/hooks/useAccountEventListener.ts
@@ -7,12 +7,14 @@ import { useSwitchNetworkLocal } from './useSwitchNetwork'
 
 export const useChainIdListener = () => {
   const switchNetworkCallback = useSwitchNetworkLocal()
+  const { chainId: oldChainId } = useAccount()
   const onChainChanged = useCallback(
     ({ chainId }: { chainId?: number }) => {
       if (chainId === undefined) return
+      if (oldChainId === chainId) return
       switchNetworkCallback(chainId)
     },
-    [switchNetworkCallback],
+    [switchNetworkCallback, oldChainId],
   )
   const { connector } = useAccount()
 
@@ -22,7 +24,7 @@ export const useChainIdListener = () => {
     return () => {
       connector?.emitter?.off('change', onChainChanged)
     }
-  }, [connector, onChainChanged])
+  }, [connector, onChainChanged, oldChainId])
 }
 
 const useAddressListener = () => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `useChainIdListener` hook by adding a check for the previous `chainId` before executing the network switch callback.

### Detailed summary
- Added a new constant `oldChainId` from `useAccount()`.
- Included a condition to return early if `oldChainId` matches the new `chainId`.
- Updated the dependency array of the `useCallback` to include `oldChainId`.
- Adjusted the cleanup function's dependency array to include `oldChainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->