### PR TITLE
fix: TON swap flip

### DIFF
--- a/apps/ton/src/components/TonSwap/FlipButton.tsx
+++ b/apps/ton/src/components/TonSwap/FlipButton.tsx
@@ -18,19 +18,20 @@ export const Line = styled.div`
   top: calc(50% + 6px);
 `
 
-export const FlipButton = memo(function FlipButton() {
-  const { onSwitchTokens } = useSwapActionHandlers()
+export const FlipButton = memo(function FlipButton({ typedValue = '' }: { typedValue?: string }) {
+  const { onSwitchTokens, onUserInput } = useSwapActionHandlers()
 
   const inputCurrency = useAtomValue(currencyFamily(Field.INPUT))
   const outputCurrency = useAtomValue(currencyFamily(Field.OUTPUT))
 
   const onFlip = useCallback(() => {
     onSwitchTokens()
+    onUserInput(Field.INPUT, typedValue)
     replaceBrowserHistoryMultiple({
       inputCurrency: outputCurrency?.isToken ? outputCurrency.address : outputCurrency?.symbol,
       outputCurrency: inputCurrency?.isToken ? inputCurrency.address : inputCurrency?.symbol,
     })
-  }, [onSwitchTokens, inputCurrency, outputCurrency])
+  }, [onUserInput, typedValue, onSwitchTokens, inputCurrency, outputCurrency])
 
   return (
     <AutoColumn justify="space-between" position="relative">

--- a/apps/ton/src/hooks/swap/useSwapActionHandlers.ts
+++ b/apps/ton/src/hooks/swap/useSwapActionHandlers.ts
@@ -16,8 +16,8 @@ export const useSwapActionHandlers = () => {
   const onSwitchTokens = useCallback(() => {
     setCurrency(Field.INPUT, outputCurrency)
     setCurrency(Field.OUTPUT, inputCurrency)
-    setIndependentField(independentField === Field.INPUT ? Field.OUTPUT : Field.INPUT)
-  }, [setCurrency, inputCurrency, outputCurrency, independentField, setIndependentField])
+    // setIndependentField(independentField === Field.INPUT ? Field.OUTPUT : Field.INPUT)
+  }, [setCurrency, inputCurrency, outputCurrency])
 
   const onCurrencySelection = useCallback(
     (field: Field, currency?: Currency) => {

--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -163,7 +163,7 @@ export const SwapForm = () => {
               onMax={noop}
               onCurrencySelect={(currency) => onCurrencySelection(Field.INPUT, currency)}
             />
-            <FlipButton />
+            <FlipButton typedValue={formattedAmounts[Field.OUTPUT]} />
             <CurrencyInputPanelSimplify
               id="swap-currency-output"
               field={Field.OUTPUT}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `FlipButton` component in the `TONSwap` application by adding a `typedValue` prop, refining the currency selection logic, and cleaning up unused code.

### Detailed summary
- Added `typedValue` prop to the `FlipButton` component.
- Updated `onFlip` function to utilize `typedValue` and call `onUserInput`.
- Removed the independent field toggle logic from the swap action handlers.
- Cleaned up dependencies in the `useCallback` hooks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->