### PR TITLE
fix: 🐛 reduce farms' cache time to 20s

### DIFF
--- a/apps/web/src/pages/api/configs/farms/v2/index.ts
+++ b/apps/web/src/pages/api/configs/farms/v2/index.ts
@@ -3,21 +3,34 @@ import {
   fetchAllUniversalFarms,
   formatUniversalFarmToSerializedFarm,
 } from '@pancakeswap/farms'
+import { cacheByLRU } from '@pancakeswap/utils/cacheByLRU'
 import { NextApiHandler } from 'next'
 import { stringify } from 'viem'
 
+const _fetchFarmData = async (includeTestnet: boolean) => {
+  const fetchFarmConfig = await fetchAllUniversalFarms()
+  const farmConfig = includeTestnet ? [...fetchFarmConfig, ...UNIVERSAL_FARMS_WITH_TESTNET] : fetchFarmConfig
+  return formatUniversalFarmToSerializedFarm(farmConfig)
+}
+
+const fetchFarmData = cacheByLRU(_fetchFarmData, {
+  ttl: 20_000,
+  key: (params) => {
+    return [params[0]]
+  },
+})
+
 const handler: NextApiHandler = async (req, res) => {
   try {
-    const fetchFarmConfig = await fetchAllUniversalFarms()
     const includeTestnet = !!req.query.includeTestnet
-    const farmConfig = includeTestnet ? [...fetchFarmConfig, ...UNIVERSAL_FARMS_WITH_TESTNET] : fetchFarmConfig
-    const legacyFarmConfig = await formatUniversalFarmToSerializedFarm(farmConfig)
+    const legacyFarmConfig = await fetchFarmData(includeTestnet)
+
     // cache for long time, it should revalidate on every deployment
     res.setHeader('Cache-Control', `max-age=300, s-maxage=300`)
 
     return res.status(200).json({
       data: JSON.parse(stringify(legacyFarmConfig)),
-      lastUpdatedAt: new Date().toISOString,
+      lastUpdatedAt: new Date().toISOString(),
     })
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces caching for farm data fetching in the API handler, improving performance by reducing repeated data fetching. It also updates the method of retrieving farm configuration to utilize the cache.

### Detailed summary
- Added import for `cacheByLRU` from `@pancakeswap/utils/cacheByLRU`.
- Created `_fetchFarmData` function to fetch and format farm data.
- Implemented `fetchFarmData` using `cacheByLRU` for caching.
- Replaced direct fetching of farm configuration with `fetchFarmData`.
- Fixed `lastUpdatedAt` to correctly call `toISOString()` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->