### PR TITLE
chore: TON whitelist pool

### DIFF
--- a/apps/ton/src/config/presetPools.ts
+++ b/apps/ton/src/config/presetPools.ts
@@ -5,6 +5,9 @@ export const PRESET_POOLS = {
   [TonNetworks.Mainnet]: [],
   [TonNetworks.Testnet]: {
     // ...testnetPools,
+    // RUBY-USDC
+    'kQBN6HSn7GmAB30K_YmL3vhS2ms5LMm9aPW0PGzvUZASRzng<>kQDrYGRT12rOkdJFFvtDIS5xS_tnatlTEO55hnkClQYAv0q3':
+      'kQArNuzh9UZ3zZY28m2CwHfgIfKsP900sWyZ1tYXl3Evt_Gj',
     // SYRUP-PAN
     'kQArzX0-In2BjRhaq5pB2vmZH80saystVwwbPIpEyGrh723F<>kQABtdKCYuAAIrEAD4LbONdybLTYsYleyYhsy6CfsXkkP0tg':
       'EQB53lcd4hlB4VuZ2mTSjcZd1JSJJ1iY-kN9SIPIL9RrQU5B',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding new preset pool configurations for the `TonNetworks.Testnet`, specifically for the `RUBY-USDC` and `SYRUP-PAN` pools.

### Detailed summary
- Added a new entry for the `RUBY-USDC` pool with the key `'kQBN6HSn7GmAB30K_YmL3vhS2ms5LMm9aPW0PGzvUZASRzng<>kQDrYGRT12rOkdJFFvtDIS5xS_tnatlTEO55hnkClQYAv0q3'` and value `'kQArNuzh9UZ3zZY28m2CwHfgIfKsP900sWyZ1tYXl3Evt_Gj'`.
- Added a new entry for the `SYRUP-PAN` pool with the key `'kQArzX0-In2BjRhaq5pB2vmZH80saystVwwbPIpEyGrh723F<>kQABtdKCYuAAIrEAD4LbONdybLTYsYleyYhsy6CfsXkkP0tg'` and value `'EQB53lcd4hlB4VuZ2mTSjcZd1JSJJ1iY-kN9SIPIL9RrQU5B'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->