### PR TITLE
chore: update Ton center API endpoint and token

### DIFF
--- a/apps/ton/src/ton/context/TonContext.ts
+++ b/apps/ton/src/ton/context/TonContext.ts
@@ -1,5 +1,4 @@
-import { getHttpEndpoint } from '@orbs-network/ton-access'
-import { TonContextEvents, TonNetworks } from '@pancakeswap/ton-v2-sdk'
+import { TonContextEvents } from '@pancakeswap/ton-v2-sdk'
 import { TonClient } from '@ton/ton'
 import { tonState } from 'ton/atom/tonStateAtom'
 import { Emiter } from 'ton/utils/Emiter'
@@ -14,9 +13,6 @@ export class TonContext extends Emiter<TonContextEvents> {
     const { network } = tonState
 
     this.tonClient = new TonClient({ endpoint: TonEndPoints[network] })
-    getHttpEndpoint({ network: network === TonNetworks.Mainnet ? 'mainnet' : 'testnet' }).then((endpoint) => {
-      this.tonClient = new TonClient({ endpoint })
-    })
   }
 
   public getClient() {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the `TonContext` class by removing the dynamic HTTP endpoint retrieval based on the network type, which streamlines the client initialization process.

### Detailed summary
- Removed the import of `TonNetworks` from `@pancakeswap/ton-v2-sdk`.
- Eliminated the asynchronous call to `getHttpEndpoint` that determined the `TonClient` endpoint based on the network.
- Directly initialized `TonClient` with a static endpoint derived from `tonState`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->