### PR TITLE
fix: user slippage

### DIFF
--- a/apps/ton/src/atoms/settings/settingsAtom.ts
+++ b/apps/ton/src/atoms/settings/settingsAtom.ts
@@ -1,4 +1,6 @@
+import { Percent } from '@pancakeswap/swap-sdk-core'
 import { DEFAULT_DEADLINE, DEFAULT_MULTIHOP_ENABLED, Slippage } from 'config/constants/settings'
+import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 
 export const settingsAtom = atomWithStorage('pcs:settings', {
@@ -9,4 +11,9 @@ export const settingsAtom = atomWithStorage('pcs:settings', {
   transactionDeadline: DEFAULT_DEADLINE,
 
   allowMultihops: DEFAULT_MULTIHOP_ENABLED,
+})
+
+export const userSlippagePercentAtom = atom((get) => {
+  const { slippage } = get(settingsAtom)
+  return new Percent(slippage, 10_000)
 })

--- a/apps/ton/src/components/Buttons/SlippageButton.tsx
+++ b/apps/ton/src/components/Buttons/SlippageButton.tsx
@@ -11,9 +11,8 @@ import {
   useTooltip,
   WarningIcon,
 } from '@pancakeswap/uikit'
-import { settingsAtom } from 'atoms/settings/settingsAtom'
 import { SettingsModal } from 'components/Modals/SettingsModal'
-import { useAtomValue } from 'jotai'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 
 import styled from 'styled-components'
 import { basisPointsToPercent } from 'utils/exchange'
@@ -31,7 +30,7 @@ export const SlippageButton = (props: BoxProps) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
 
-  const { slippage } = useAtomValue(settingsAtom)
+  const [slippage] = useUserSlippage()
 
   const { isOpen, setIsOpen, onDismiss } = useModalV2()
 

--- a/apps/ton/src/components/Modals/AddLiquidityModal.tsx
+++ b/apps/ton/src/components/Modals/AddLiquidityModal.tsx
@@ -1,12 +1,11 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency } from '@pancakeswap/ton-v2-sdk'
 import { Button, Flex, FlexGap, Text } from '@pancakeswap/uikit'
-import { settingsAtom } from 'atoms/settings/settingsAtom'
 import { LightGreyCard } from 'components/Card'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'components/widgets'
 import { NumberDisplay } from 'components/widgets/NumberDisplay'
 import { MAXIMUM_SIGNIFICANT_DIGITS } from 'config/constants/exchange'
-import { useAtomValue } from 'jotai'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 import styled from 'styled-components'
 import { CircleSvg, Dot } from 'styles'
 
@@ -38,8 +37,7 @@ export const AddLiquidityModal = ({
   onConfirm,
 }: AddLiquidityModalProps) => {
   const { t } = useTranslation()
-  const settings = useAtomValue(settingsAtom)
-  const { slippage } = settings
+  const [slippage] = useUserSlippage()
 
   return (
     <StyledFlexGap gap="8px">

--- a/apps/ton/src/components/Modals/RemoveLiquidityModal.tsx
+++ b/apps/ton/src/components/Modals/RemoveLiquidityModal.tsx
@@ -1,11 +1,10 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency } from '@pancakeswap/ton-v2-sdk'
 import { AddIcon, Button, Flex, FlexGap, Grid, Text } from '@pancakeswap/uikit'
-import { settingsAtom } from 'atoms/settings/settingsAtom'
 import { LightGreyCard } from 'components/Card'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'components/widgets'
 import { NumberDisplay } from 'components/widgets/NumberDisplay'
-import { useAtomValue } from 'jotai'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 import styled from 'styled-components'
 import { Hr } from 'styles'
 
@@ -37,8 +36,7 @@ export const RemoveLiquidityModal = ({
   onConfirm,
 }: RemoveLiquidityModalProps) => {
   const { t } = useTranslation()
-  const settings = useAtomValue(settingsAtom)
-  const { slippage } = settings
+  const [slippage] = useUserSlippage()
 
   return (
     <StyledFlexGap gap="8px" maxWidth={[null, null, null, '400px']}>

--- a/apps/ton/src/components/TonSwap/SwapDetails/AdvancedSwapDetails.tsx
+++ b/apps/ton/src/components/TonSwap/SwapDetails/AdvancedSwapDetails.tsx
@@ -1,12 +1,12 @@
 import { styled } from 'styled-components'
 import { useTranslation } from '@pancakeswap/localization'
 import { Text, RowBetween, RowFixed, AutoColumn, Flex, QuestionHelperV2, SkeletonV2 } from '@pancakeswap/uikit'
-import { useUserSlippage } from '@pancakeswap/utils/user'
 import { TradeType } from '@pancakeswap/swap-sdk-core'
 import { Field } from 'types'
 import { BUYBACK_FEE, LP_HOLDERS_FEE, TOTAL_FEE, TREASURY_FEE } from 'config/constants/exchange'
 import { computeSlippageAdjustedAmounts, computeTradePriceBreakdown } from 'utils/exchange'
 import { SlippageButton } from 'components/Buttons/SlippageButton'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 import SwapRoute, { AdvancedSwapDetailsProps } from './SwapRoute'
 import FormattedPriceImpact from '../FormattedPriceImpact'
 

--- a/apps/ton/src/components/TonSwap/SwapDetails/PricingAndSlippage.tsx
+++ b/apps/ton/src/components/TonSwap/SwapDetails/PricingAndSlippage.tsx
@@ -1,8 +1,8 @@
 import { Currency, CurrencyAmount, Price } from '@pancakeswap/ton-v2-sdk'
 import { FlexGap, Text, useModal } from '@pancakeswap/uikit'
-import { useUserSlippage } from '@pancakeswap/utils/user'
 import { SwapUIV2 } from '@pancakeswap/widgets-internal'
 import { SettingsModal } from 'components/Modals/SettingsModal'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 import { memo, useMemo } from 'react'
 
 interface Props {

--- a/apps/ton/src/hooks/useUserSlippage.ts
+++ b/apps/ton/src/hooks/useUserSlippage.ts
@@ -1,0 +1,19 @@
+import { settingsAtom, userSlippagePercentAtom } from 'atoms/settings/settingsAtom'
+import { useAtom } from 'jotai'
+
+export const useUserSlippagePercent = () => {
+  return useAtom(userSlippagePercentAtom)
+}
+
+export const useUserSlippage = () => {
+  const [{ slippage }, setSettings] = useAtom(settingsAtom)
+
+  const setSlippage = (newSlippage: number) => {
+    setSettings((prev) => ({
+      ...prev,
+      slippage: newSlippage,
+    }))
+  }
+
+  return [slippage, setSlippage] as const
+}

--- a/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
+++ b/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
@@ -8,7 +8,6 @@ import {
   liquidityIndependentFieldAtom,
 } from 'atoms/liquidity/addLiquidityStateAtom'
 import { setAddLiquidityModalAtom } from 'atoms/modals/addLiquidityModalAtom'
-import { settingsAtom } from 'atoms/settings/settingsAtom'
 import { BigNumber as BN } from 'bignumber.js'
 import { ConnectWalletButton } from 'components/Buttons/ConnectWalletButton'
 import { SlippageButton } from 'components/Buttons/SlippageButton'
@@ -19,6 +18,7 @@ import { MAXIMUM_SIGNIFICANT_DIGITS } from 'config/constants/exchange'
 import { LP_TOKEN_DECIMALS } from 'config/constants/formatting'
 import { usePoolRates } from 'hooks/liquidity/usePoolRates'
 import { useCurrency } from 'hooks/tokens/useCurrency'
+import { useUserSlippage } from 'hooks/useUserSlippage'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
@@ -60,7 +60,7 @@ export const CardContent = (props: CardContentProps) => {
   const address = useAtomValue(addressAtom)
   const isWalletConnected = !!address
 
-  const { slippage } = useAtomValue(settingsAtom)
+  const [slippage] = useUserSlippage()
 
   const [currency0] = useCurrency(CurrencyField.ADD_LIQUIDITY_CURRENCY0, token0Address)
   const [currency1] = useCurrency(CurrencyField.ADD_LIQUIDITY_CURRENCY1, token1Address)

--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -24,7 +24,7 @@ import { computeTradePriceBreakdown } from 'utils/exchange'
 import { setConfirmSwapModalAtom } from 'atoms/modals/confirmSwapModalAtom'
 import { PricingAndSlippage } from 'components/TonSwap/SwapDetails/PricingAndSlippage'
 import { AdvancedSwapDetailsDropdown } from 'components/TonSwap/SwapDetails/AdvancedSwapDetailsDropdown'
-import { useUserSlippagePercent } from '@pancakeswap/utils/user'
+import { useUserSlippagePercent } from 'hooks/useUserSlippage'
 
 export const SwapForm = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the handling of user slippage by moving related hooks from `@pancakeswap/utils/user` to a local `hooks/useUserSlippage` implementation. It updates several components to use the new hooks, improving modularity and maintainability.

### Detailed summary
- Moved `useUserSlippage` and `useUserSlippagePercent` to `hooks/useUserSlippage`.
- Updated imports in various components to use the new hooks.
- Created `userSlippagePercentAtom` in `settingsAtom` for managing user slippage.
- Refactored components to access slippage using the new hooks instead of `settingsAtom`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->