### PR TITLE
fix: ton token sortsBefore logic

### DIFF
--- a/apps/ton/public/lists/testnet.json
+++ b/apps/ton/public/lists/testnet.json
@@ -5,14 +5,6 @@
   "tokens": [
     {
       "chainId": -3,
-      "address": "kQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffAw5",
-      "name": "Proxy TON",
-      "symbol": "pTON",
-      "decimals": 9,
-      "logoURI": "https://cache.tonapi.io/imgproxy/X7T-fLahBBVIxXacXAqrsCHIgFgTQE3Jt2HAdnc5_Mc/rs:fill:200:200:1/g:no/aHR0cHM6Ly9zdGF0aWMuc3Rvbi5maS9sb2dvL3Rvbl9zeW1ib2wucG5n.webp"
-    },
-    {
-      "chainId": -3,
       "address": "kQA8oT-HRBY-9-yFymg17hD5FE07--Z1gYc_sZTbzqpOZr1t",
       "name": "Pancake Token",
       "symbol": "CAKE",

--- a/packages/ton-v2-sdk/src/currency/AgnosticToken.ts
+++ b/packages/ton-v2-sdk/src/currency/AgnosticToken.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant'
-import { Address } from '@ton/core'
 
 import { AgnosticBaseCurrency } from './AgnosticBaseCurrency'
+import { getAddressCellHash } from '../utils/address'
 
 export interface SerializedToken {
   chainId: number
@@ -61,7 +61,7 @@ export class AgnosticToken extends AgnosticBaseCurrency {
   public sortsBefore(other: AgnosticToken): boolean {
     invariant(this.chainId === other.chainId, 'CHAIN_IDS')
     invariant(this.address !== other.address, 'ADDRESSES')
-    return other.isNative ? false : Address.parse(this.address).hash < Address.parse(other.address).hash
+    return other.isNative ? true : getAddressCellHash(this.address) > getAddressCellHash(other.address)
   }
 
   /**

--- a/packages/ton-v2-sdk/src/index.test.ts
+++ b/packages/ton-v2-sdk/src/index.test.ts
@@ -18,7 +18,6 @@ test('exports', () => {
       "NATIVE",
       "WNATIVE",
       "priceOf",
-      "getPairAddress",
       "getOutputAmount",
       "getInputAmount",
       "Trade",

--- a/packages/ton-v2-sdk/src/index.ts
+++ b/packages/ton-v2-sdk/src/index.ts
@@ -20,7 +20,6 @@ export { CurrencyAmount } from './fractions/CurrencyAmount'
 
 export {
   priceOf,
-  getPairAddress,
   getOutputAmount,
   getInputAmount,
   Trade,

--- a/packages/ton-v2-sdk/src/utils/address.ts
+++ b/packages/ton-v2-sdk/src/utils/address.ts
@@ -1,0 +1,3 @@
+import { Address, beginCell } from '@ton/core'
+
+export const getAddressCellHash = (address: string) => beginCell().storeAddress(Address.parse(address)).endCell().hash()

--- a/packages/ton-v2-sdk/src/utils/getAddress.ts
+++ b/packages/ton-v2-sdk/src/utils/getAddress.ts
@@ -1,7 +1,0 @@
-import { Address } from '@ton/core'
-import { Currency } from '../currency'
-
-// todo:@eric wait for ton's currency type implemented
-export const getPairAddress = (tokenA: Currency, tokenB: Currency): Address => {
-  return Address.parse(tokenA.wrapped.address)
-}

--- a/packages/ton-v2-sdk/src/utils/index.ts
+++ b/packages/ton-v2-sdk/src/utils/index.ts
@@ -1,6 +1,6 @@
 export * from './amount'
 export * from './price'
-export * from './getAddress'
+export * from './address'
 export * from './trade'
 export * from './swap'
 export * from './liquidity'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `ton-v2-sdk` by removing the `getPairAddress` utility, replacing it with an updated `getAddressCellHash` function, and revising the token list in the testnet configuration.

### Detailed summary
- Deleted `getAddress.tsp` file.
- Removed `getPairAddress` from exports in `index.ts` and test files.
- Replaced `getAddress` export with `address` in `index.ts`.
- Added `getAddressCellHash` function in `address.ts`.
- Updated the testnet JSON by removing a token entry.
- Modified `AgnosticToken` to use `getAddressCellHash` instead of `Address.parse`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->