### PR TITLE
chore: fix monad position display issue

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
@@ -3,7 +3,7 @@ import { NFT_POSITION_MANAGER_ADDRESSES, nonfungiblePositionManagerABI } from '@
 import BigNumber from 'bignumber.js'
 import { getMasterChefV3Contract } from 'utils/contractHelpers'
 import { publicClient } from 'utils/viem'
-import { Address } from 'viem'
+import { Address, isAddress } from 'viem'
 import { PositionDetail } from '../../type'
 import { getAccountV3TokenIds } from './getAccountV3TokenIds'
 
@@ -25,7 +25,7 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
     } as const
   })
   const farmingCalls =
-    masterChefV3 && masterChefV3?.address !== '0x'
+    masterChefV3 && isAddress(masterChefV3.address)
       ? tokenIds.map((tokenId) => {
           return {
             abi: masterChefV3.abi,
@@ -41,7 +41,7 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
       contracts: positionCalls,
       allowFailure: false,
     }),
-    masterChefV3 && masterChefV3?.address !== '0x'
+    masterChefV3 && isAddress(masterChefV3.address)
       ? client.multicall({
           contracts: farmingCalls,
           allowFailure: false,

--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
@@ -12,7 +12,7 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
   const client = publicClient({ chainId })
   const masterChefV3 = getMasterChefV3Contract(undefined, chainId)
 
-  if (!client || !nftPositionManagerAddress || !tokenIds.length || !masterChefV3) {
+  if (!client || !nftPositionManagerAddress || !tokenIds.length) {
     return []
   }
 
@@ -24,24 +24,29 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
       args: [tokenId] as const,
     } as const
   })
-  const farmingCalls = tokenIds.map((tokenId) => {
-    return {
-      abi: masterChefV3.abi,
-      address: masterChefV3.address,
-      functionName: 'userPositionInfos',
-      args: [tokenId] as const,
-    } as const
-  })
+  const farmingCalls =
+    masterChefV3 && masterChefV3?.address !== '0x'
+      ? tokenIds.map((tokenId) => {
+          return {
+            abi: masterChefV3.abi,
+            address: masterChefV3.address,
+            functionName: 'userPositionInfos',
+            args: [tokenId] as const,
+          } as const
+        })
+      : []
 
   const [positions, farmingPosition] = await Promise.all([
     client.multicall({
       contracts: positionCalls,
       allowFailure: false,
     }),
-    client.multicall({
-      contracts: farmingCalls,
-      allowFailure: false,
-    }),
+    masterChefV3 && masterChefV3?.address !== '0x'
+      ? client.multicall({
+          contracts: farmingCalls,
+          allowFailure: false,
+        })
+      : [],
   ])
 
   return positions.map((position, index) => {
@@ -59,7 +64,8 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
       tokensOwed0,
       tokensOwed1,
     ] = position
-    const [farmingLiquidity, , , , , , , , boostMultiplier] = farmingPosition[index]
+    const farmingLiquidity = farmingPosition?.[index]?.[0] ?? 0n
+    const boostMultiplier = farmingPosition?.[index]?.[8] ?? 0n
     return {
       tokenId: tokenIds[index],
       nonce,

--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3TokenIds.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3TokenIds.ts
@@ -1,7 +1,7 @@
 import { masterChefV3ABI, NFT_POSITION_MANAGER_ADDRESSES } from '@pancakeswap/v3-sdk'
 import { getMasterChefV3Address } from 'utils/addressHelpers'
 import { publicClient } from 'utils/viem'
-import { Address } from 'viem'
+import { Address, isAddress } from 'viem'
 
 /**
  * Get all token ids of a given account
@@ -19,7 +19,9 @@ export const getAccountV3TokenIds = async (
   const nftPositionManagerAddress = NFT_POSITION_MANAGER_ADDRESSES[chainId]
 
   const [farmingTokenIds, nonFarmTokenIds] = await Promise.all([
-    masterChefV3Address === '0x' ? [] : getAccountV3TokenIdsFromContract(chainId, account, masterChefV3Address),
+    masterChefV3Address && isAddress(masterChefV3Address)
+      ? getAccountV3TokenIdsFromContract(chainId, account, masterChefV3Address)
+      : [],
     getAccountV3TokenIdsFromContract(chainId, account, nftPositionManagerAddress),
   ])
 

--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3TokenIds.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3TokenIds.ts
@@ -11,12 +11,15 @@ import { Address } from 'viem'
  * @param account target account address
  * @returns
  */
-export const getAccountV3TokenIds = async (chainId: number, account: Address) => {
+export const getAccountV3TokenIds = async (
+  chainId: number,
+  account: Address,
+): Promise<{ farmingTokenIds: bigint[]; nonFarmTokenIds: bigint[] }> => {
   const masterChefV3Address = getMasterChefV3Address(chainId)
   const nftPositionManagerAddress = NFT_POSITION_MANAGER_ADDRESSES[chainId]
 
   const [farmingTokenIds, nonFarmTokenIds] = await Promise.all([
-    getAccountV3TokenIdsFromContract(chainId, account, masterChefV3Address),
+    masterChefV3Address === '0x' ? [] : getAccountV3TokenIdsFromContract(chainId, account, masterChefV3Address),
     getAccountV3TokenIdsFromContract(chainId, account, nftPositionManagerAddress),
   ])
 

--- a/apps/web/src/views/universalFarms/hooks/useMultiChains.ts
+++ b/apps/web/src/views/universalFarms/hooks/useMultiChains.ts
@@ -1,9 +1,10 @@
+import { ChainId } from '@pancakeswap/chains'
 import { CHAINS } from 'config/chains'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useMemo } from 'react'
 
 export const MAINNET_CHAINS = CHAINS.filter((chain) => {
-  if ('testnet' in chain && chain.testnet) {
+  if ('testnet' in chain && chain.testnet && chain.id !== ChainId.MONAD_TESTNET) {
     return false
   }
   return true


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing type safety and improving the handling of blockchain addresses in the `getAccountV3TokenIds` and `readPositions` functions. It adds checks for valid addresses and refines the logic for fetching token IDs and positions.

### Detailed summary
- Updated `MAINNET_CHAINS` filtering to exclude `MONAD_TESTNET`.
- Added `isAddress` check when retrieving `masterChefV3Address` in `getAccountV3TokenIds`.
- Modified return type of `getAccountV3TokenIds` to specify the structure of the returned object.
- Removed redundant checks for `masterChefV3` in `readPositions`.
- Added `isAddress` check for `masterChefV3.address` in `farmingCalls` mapping.
- Updated destructuring of `farmingPosition` to provide default values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->