### PR TITLE
chore: whitelist pTON-PAN

### DIFF
--- a/apps/ton/src/config/presetPools.ts
+++ b/apps/ton/src/config/presetPools.ts
@@ -5,6 +5,9 @@ export const PRESET_POOLS = {
   [TonNetworks.Mainnet]: [],
   [TonNetworks.Testnet]: {
     // ...testnetPools,
+    // TON-PAN
+    'kQABtdKCYuAAIrEAD4LbONdybLTYsYleyYhsy6CfsXkkP0tg<>kQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffAw5':
+      'EQD_Lx2fpT3CDX16OzHWu4utvHkMqk4cww65uN53js4WY5Au',
     // TON-USDC
     'kQCM3B12QK1e4yZSf8GtBRT0aLMNyEsBc_DhVfRRtOEffAw5<>kQBN6HSn7GmAB30K_YmL3vhS2ms5LMm9aPW0PGzvUZASRzng':
       'kQDINV8OA01yK-fmAECxCXwskiQI_A5GAZYRBDnPhvrmzISS',

--- a/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
+++ b/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
@@ -83,8 +83,8 @@ export const CardContent = (props: CardContentProps) => {
   // TODO: Handle native token
   const { data: lpBalance, isLoading: isLpBalanceLoading } = useAtomValue(
     lpBalanceQueryAtom({
-      token0Address: currency0?.isNative ? address : currency0?.address,
-      token1Address: currency1?.isNative ? address : currency1?.address,
+      token0Address: currency0?.wrapped.address,
+      token1Address: currency1?.wrapped.address,
     }),
   )
 

--- a/apps/ton/src/views/TONRemoveLiquidity/RemoveLiquidityCard/CardContent.tsx
+++ b/apps/ton/src/views/TONRemoveLiquidity/RemoveLiquidityCard/CardContent.tsx
@@ -88,8 +88,8 @@ export const CardContent = (props: CardContentProps) => {
 
   const { data: lpBalance, isLoading: isLpBalanceLoading } = useAtomValue(
     lpBalanceQueryAtom({
-      token0Address: currency0?.isNative ? userAddress : currency0?.address,
-      token1Address: currency1?.isNative ? userAddress : currency1?.address,
+      token0Address: currency0?.wrapped.address,
+      token1Address: currency1?.wrapped.address,
     }),
   )
   const { data: poolData, isLoading: isPoolDataLoading } = useAtomValue(


### PR DESCRIPTION
- **fix: ton swap impact confirm modal**
- **chore: whitelist pTON-PAN**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the way liquidity pool addresses are handled in the `AddLiquidityCard` and `RemoveLiquidityCard` components, ensuring that wrapped addresses are used instead of native or original addresses. It also adds new pool configurations.

### Detailed summary
- In `AddLiquidityCard/CardContent.tsx`, changed `token0Address` and `token1Address` to use `currency0?.wrapped.address` and `currency1?.wrapped.address`.
- In `presetPools.ts`, added new pool configurations for TON-PAN and TON-USDC.
- In `RemoveLiquidityCard/CardContent.tsx`, updated `token0Address` and `token1Address` similarly to `AddLiquidityCard`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->