### PR TITLE
fix: ton swap native TON amount incorrect

### DIFF
--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -103,7 +103,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade }: SwapArgs) =>
           address: token0.isNative ? routerJettonWallet0.toString() : userJettonWallet0!.toString(),
           // Attached TON for fees, not the amount of jettons to transfer!
           // todo:@eric add estimate logic
-          amount: GAS.toString(),
+          amount: token0.isNative ? (parseUnits(amount0, token0.decimals) + FORWARD_GAS).toString() : GAS.toString(),
           payload: payload.toBoc().toString('base64'),
         },
       ],


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the logic for calculating the `amount` in the `useSwap` function within the `apps/ton/src/ton/logic/swap/useSwap.ts` file to account for whether `token0` is a native token or not.

### Detailed summary
- Changed the calculation of `amount`:
  - If `token0` is native, it now computes `amount` as the sum of `parseUnits(amount0, token0.decimals)` and `FORWARD_GAS`.
  - Otherwise, it retains the original `GAS.toString()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->