### PR TITLE
fix: add/remove liquidity events

### DIFF
--- a/apps/ton/src/hooks/swap/useAllCommonPairs.ts
+++ b/apps/ton/src/hooks/swap/useAllCommonPairs.ts
@@ -97,41 +97,15 @@ export function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): U
 }
 
 const usePairs = (pairs: [Token, Token][]) => {
-  // const pairsAddress = useMemo(
-  //   () =>
-  //     pairs.map(([token0, token1]) =>
-  //       token0.sortsBefore(token1)
-  //         ? {
-  //             token0Address: token0.wrapped.address,
-  //             token1Address: token1.wrapped.address,
-  //           }
-  //         : {
-  //             token1Address: token0.wrapped.address,
-  //             token0Address: token1.wrapped.address,
-  //           },
-  //     ),
-  //   [pairs],
-  // )
+  const pairsAddress = useMemo(
+    () =>
+      pairs.map(([token0, token1]) => ({
+        token0Address: token0.wrapped.address,
+        token1Address: token1.wrapped.address,
+      })),
+    [pairs],
+  )
 
-  const { data: pairsAddress } = useQuery({
-    queryKey: ['pairs', pairs],
-    queryFn: async () => {
-      return Promise.all(
-        pairs.map(async ([token0, token1]) =>
-          (await getCurrencyOrder(token0, token1)).isFlipped
-            ? {
-                token1Address: token0.wrapped.address,
-                token0Address: token1.wrapped.address,
-              }
-            : {
-                token0Address: token0.wrapped.address,
-                token1Address: token1.wrapped.address,
-              },
-        ),
-      )
-    },
-    initialData: [],
-  })
   const result = useAtomValue(poolDataQueriesAtom(pairsAddress))
   const { refresh } = useRefreshPoolData(pairsAddress)
   return useMemo(() => {

--- a/apps/ton/src/pages/_app.tsx
+++ b/apps/ton/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import Script from 'next/script'
 import { FloatingNavigation } from 'components/FloatingNavigation'
 import { Providers } from 'components/Providers'
 import type { AppProps } from 'next/app'
@@ -5,11 +6,26 @@ import '../styles/globals.css' // Import global CSS
 
 const MyApp = ({ Component, pageProps }: AppProps<{ dehydratedState?: any }>) => {
   return (
-    <Providers dehydratedState={pageProps.dehydratedState}>
-      <Component {...pageProps} />
+    <>
+      <Providers dehydratedState={pageProps.dehydratedState}>
+        <Component {...pageProps} />
 
-      <FloatingNavigation />
-    </Providers>
+        <FloatingNavigation />
+      </Providers>
+      <Script
+        strategy="afterInteractive"
+        id="google-tag"
+        dangerouslySetInnerHTML={{
+          __html: `
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_NEW_GTAG}');
+        `,
+        }}
+      />
+    </>
   )
 }
 

--- a/apps/ton/src/ton/logic/liquidity/useAddLiquidity.ts
+++ b/apps/ton/src/ton/logic/liquidity/useAddLiquidity.ts
@@ -14,6 +14,7 @@ import { formatBalance } from 'ton/utils/formatting'
 import { generateQueryId } from 'ton/utils/generateQueryId'
 import { getCurrencyOrder } from 'ton/utils/tokenOrder'
 import { getTransactionByBOC } from 'ton/utils/transaction'
+import { logGTMAddLiquidityTxSentEvent } from 'utils/customGTMEventTracking'
 
 interface AddLiquidityArgs {
   token0: Currency
@@ -139,6 +140,7 @@ export const useAddLiquidity = () => {
         }
         const hash = await getTransactionByBOC(userAddress, boc)
         if (hash) {
+          logGTMAddLiquidityTxSentEvent()
           setTxnModal({
             type: ActionType.TransactionComplete,
             currency0,

--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -1,12 +1,15 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { TradeType } from '@pancakeswap/swap-sdk-core'
 import { Contracts, Currency, TonContractNames, Trade, storeSwap } from '@pancakeswap/ton-v2-sdk'
+import { useAsyncConfirmPriceImpactWithoutFee } from '@pancakeswap/widgets-internal'
 import { storeJettonTransferMessage } from '@ton-community/assets-sdk'
 import { beginCell, toNano } from '@ton/core'
 import { SendTransactionRequest, TonConnectUIError, UserRejectsError, useTonConnectUI } from '@tonconnect/ui-react'
+import { setConfirmSwapModalAtom } from 'atoms/modals/confirmSwapModalAtom'
 import { setErrorMsgModalAtom } from 'atoms/modals/errorMsgModalAtom'
 import { setTransactionModalAtom } from 'atoms/modals/transactionModalAtom'
 import { ActionType } from 'components/Modals/ActionModal'
+import { ALLOWED_PRICE_IMPACT_HIGH, PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN } from 'config/constants/exchange'
 import { useUserAddress } from 'hooks/useUserAddress'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useCallback } from 'react'
@@ -16,19 +19,22 @@ import { parseAddress } from 'ton/utils/address'
 import { parseUnits } from 'ton/utils/formatting'
 import { generateQueryId } from 'ton/utils/generateQueryId'
 import { getTransactionByBOC } from 'ton/utils/transaction'
+import { logGTMClickSwapConfirmEvent, logGTMClickSwapEvent, logGTMSwapTxSentEvent } from 'utils/customGTMEventTracking'
+import { computeTradePriceBreakdown } from 'utils/exchange'
 
 const GAS = toNano('0.6')
 const FORWARD_GAS = toNano('0.5')
 
 interface SwapArgs {
   trade?: Trade<Currency, Currency, TradeType> | null
+  refreshTrade: () => void
   token0?: Currency
   token1?: Currency
   amount0: string
   minOut?: string
 }
 
-export const useSwap = ({ amount0, minOut, token0, token1, trade }: SwapArgs) => {
+export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }: SwapArgs) => {
   const { t } = useTranslation()
   const [tonUI] = useTonConnectUI()
   const userAddress = useUserAddress()
@@ -121,6 +127,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade }: SwapArgs) =>
   ])
 
   const swap = useCallback(async () => {
+    logGTMClickSwapConfirmEvent()
     try {
       setTransactionModal({
         type: ActionType.ConfirmSwap,
@@ -150,6 +157,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade }: SwapArgs) =>
 
       const hash = await getTransactionByBOC(userAddress, boc)
       if (hash) {
+        logGTMSwapTxSentEvent()
         setTransactionModal({
           type: ActionType.SwapCompleted,
           currency0: token0,
@@ -171,5 +179,40 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade }: SwapArgs) =>
     }
   }, [amount0, minOut, token0, token1, setErrorMsgModal, t, userAddress, tonUI, getTxRequest, setTransactionModal])
 
-  return { swap }
+  const setSwapConfirmModal = useSetAtom(setConfirmSwapModalAtom)
+  const { priceImpactWithoutFee } = computeTradePriceBreakdown(trade)
+  const confirmPriceImpactWithoutFee = useAsyncConfirmPriceImpactWithoutFee(
+    priceImpactWithoutFee,
+    PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN,
+    ALLOWED_PRICE_IMPACT_HIGH,
+  )
+  const swapPreflightCheck = useCallback(async () => {
+    if (priceImpactWithoutFee) {
+      const confirmed = await confirmPriceImpactWithoutFee()
+      if (!confirmed) {
+        return false
+      }
+    }
+    return true
+  }, [confirmPriceImpactWithoutFee, priceImpactWithoutFee])
+
+  const confirmSwap = useCallback(async () => {
+    if (!token0 || !token1) {
+      return
+    }
+    if (!(await swapPreflightCheck())) {
+      return
+    }
+    logGTMClickSwapEvent()
+    setSwapConfirmModal({
+      isOpen: true,
+      inputCurrency: token0,
+      outputCurrency: token1,
+      trade,
+      refreshTrade,
+      onConfirm: swap,
+    })
+  }, [token0, token1, setSwapConfirmModal, trade, refreshTrade, swap, swapPreflightCheck])
+
+  return { swap, confirmSwap }
 }

--- a/apps/ton/src/utils/customGTMEventTracking.ts
+++ b/apps/ton/src/utils/customGTMEventTracking.ts
@@ -61,3 +61,39 @@ export const logGTMSwapTxSentEvent = () => {
     category: GTMCategory.Swap,
   })
 }
+
+export const logGTMClickAddLiquidityEvent = () => {
+  console.info('---AddLiquidity---')
+  window?.dataLayer?.push({
+    event: GTMEvent.AddLiquidity,
+    action: GTMAction.ClickAddLiquidityButton,
+    category: GTMCategory.AddLiquidity,
+  })
+}
+
+export const logGTMClickAddLiquidityConfirmEvent = () => {
+  console.info('---AddLiquidityConfirmed---')
+  window?.dataLayer?.push({
+    event: GTMEvent.AddLiquidityConfirmed,
+    action: GTMAction.ClickAddLiquidityConfirmButton,
+    category: GTMCategory.AddLiquidity,
+  })
+}
+
+export const logGTMAddLiquidityTxSentEvent = () => {
+  console.info('---AddLiquidityTxSent---')
+  window?.dataLayer?.push({
+    event: GTMEvent.AddLiquidityTxSent,
+    action: GTMAction.AddLiquidityTransactionSent,
+    category: GTMCategory.AddLiquidity,
+  })
+}
+
+export const logGTMClickRemoveLiquidityEvent = () => {
+  console.info('---RemoveLiquidity---')
+  window?.dataLayer?.push({
+    event: GTMEvent.RemoveLiquidity,
+    action: GTMAction.ClickRemoveLiquidityButton,
+    category: GTMCategory.RemoveLiquidity,
+  })
+}

--- a/apps/ton/src/utils/customGTMEventTracking.ts
+++ b/apps/ton/src/utils/customGTMEventTracking.ts
@@ -1,0 +1,63 @@
+export enum GTMEvent {
+  Swap = 'swap',
+  SwapTxSent = 'swapTxSent',
+  SwapConfirmed = 'swapConfirmed',
+  AddLiquidity = 'addLiquidity',
+  AddLiquidityConfirmed = 'addLiquidityConfirmed',
+  AddLiquidityTxSent = 'addLiquidityTxSent',
+  RemoveLiquidity = 'removeLiquidity',
+}
+
+export enum GTMCategory {
+  Swap = 'Swap',
+  AddLiquidity = 'AddLiquidity',
+  RemoveLiquidity = 'RemoveLiquidity',
+}
+
+export enum GTMAction {
+  ClickSwapButton = 'Click Swap Button',
+  ClickSwapConfirmButton = 'Click Swap Confirm Button',
+  SwapTransactionSent = 'Swap Transaction Sent',
+  ClickAddLiquidityConfirmButton = 'Click Add Liquidity Confirm Button',
+  AddLiquidityTransactionSent = 'Add Liquidity Transaction Sent',
+  ClickAddLiquidityButton = 'Click Add Liquidity Button',
+  ClickRemoveLiquidityButton = 'Click Remove Liquidity Button',
+}
+
+interface CustomGTMDataLayer {
+  event: GTMEvent
+  category?: GTMCategory
+  action?: GTMAction
+  label?: string
+}
+type WindowWithDataLayer = Window & {
+  dataLayer: CustomGTMDataLayer[] | undefined
+}
+declare const window: WindowWithDataLayer
+
+export const logGTMClickSwapEvent = () => {
+  console.info('---Swap---')
+  window?.dataLayer?.push({
+    event: GTMEvent.Swap,
+    action: GTMAction.ClickSwapButton,
+    category: GTMCategory.Swap,
+  })
+}
+
+export const logGTMClickSwapConfirmEvent = () => {
+  console.info('---SwapClickConfirm---')
+  window?.dataLayer?.push({
+    event: GTMEvent.SwapConfirmed,
+    action: GTMAction.ClickSwapConfirmButton,
+    category: GTMCategory.Swap,
+  })
+}
+
+export const logGTMSwapTxSentEvent = () => {
+  console.info('---SwapTxSent---')
+  window?.dataLayer?.push({
+    event: GTMEvent.SwapTxSent,
+    action: GTMAction.SwapTransactionSent,
+    category: GTMCategory.Swap,
+  })
+}

--- a/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
+++ b/apps/ton/src/views/TONAddLiquidity/AddLiquidityCard/CardContent.tsx
@@ -31,6 +31,7 @@ import { useAddLiquidity } from 'ton/logic/liquidity/useAddLiquidity'
 import { formatBalance, parseUnits } from 'ton/utils/formatting'
 import { getExpectedPoolTokens, getNewPoolShare } from 'ton/utils/pool'
 import { CurrencyField } from 'types/currency'
+import { logGTMClickAddLiquidityConfirmEvent, logGTMClickAddLiquidityEvent } from 'utils/customGTMEventTracking'
 import { currencyKey } from 'utils/tokens/currency'
 
 const ContentContainer = styled(Box)<{ $isBottomRounded?: boolean }>`
@@ -259,7 +260,7 @@ export const CardContent = (props: CardContentProps) => {
 
   const handleAddLiquidity = useCallback(async () => {
     if (isDisabled || !currency0?.wrapped.address || !currency1?.wrapped.address) return
-
+    logGTMClickAddLiquidityConfirmEvent()
     try {
       const expectedTokens = getExpectedPoolTokens({
         amount0: parseUnits(currencyAmounts[CurrencyField.ADD_LIQUIDITY_CURRENCY0], currency0.decimals),
@@ -290,7 +291,7 @@ export const CardContent = (props: CardContentProps) => {
 
   const openConfirmationModal = useCallback(() => {
     // TODO: Determine data directly in modal
-
+    logGTMClickAddLiquidityEvent()
     setAddLiquidityModal({
       isOpen: true,
       currency0,

--- a/apps/ton/src/views/TONRemoveLiquidity/RemoveLiquidityCard/CardContent.tsx
+++ b/apps/ton/src/views/TONRemoveLiquidity/RemoveLiquidityCard/CardContent.tsx
@@ -22,6 +22,7 @@ import { poolDataQueryAtom } from 'ton/atom/liquidity/poolDataQueryAtom'
 import { useRemoveLiquidity } from 'ton/logic/liquidity/useRemoveLiquidity'
 import { formatBalance } from 'ton/utils/formatting'
 import { getCurrencyOrder } from 'ton/utils/tokenOrder'
+import { logGTMClickRemoveLiquidityEvent } from 'utils/customGTMEventTracking'
 
 const ContentContainer = styled(Box)<{ $isBottomRounded?: boolean }>`
   padding: 24px;
@@ -189,6 +190,7 @@ export const CardContent = (props: CardContentProps) => {
   }, [removeLiquidity, lpTokensToBurn])
 
   const openConfirmationModal = useCallback(() => {
+    logGTMClickRemoveLiquidityEvent()
     setRemoveLiquidityModal({
       amount0: formatBalance(outputAmounts?.amount0 ?? 0n, currency0?.decimals),
       amount1: formatBalance(outputAmounts?.amount1 ?? 0n, currency1?.decimals),

--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -1,3 +1,7 @@
+import { useAtomValue } from 'jotai'
+import noop from 'lodash/noop'
+import { useEffect, useMemo } from 'react'
+
 import { useTranslation } from '@pancakeswap/localization'
 import { Rounding } from '@pancakeswap/swap-sdk-core'
 import { Native, TonNetworks } from '@pancakeswap/ton-v2-sdk'
@@ -12,21 +16,15 @@ import { SwapCommitButton } from 'components/TonSwap/SwapCommitButton'
 import { SwapUIV2 } from 'components/widgets/swap-v2'
 import { useBestTrade } from 'hooks/swap/useBestTrade'
 import { useSwapActionHandlers } from 'hooks/swap/useSwapActionHandlers'
-import { useAtomValue, useSetAtom } from 'jotai'
-import noop from 'lodash/noop'
-import { useCallback, useEffect, useMemo } from 'react'
 import { balanceAtom } from 'ton/logic/balanceAtom'
 import { useSwap } from 'ton/logic/swap/useSwap'
 import { Field } from 'types'
 import { tryParseAmount } from 'utils/tryParseAmount'
 import { useIsSwapDetailPanelOpen } from 'hooks/swap/useIsSwapDetailPanelOpen'
 import { computeTradePriceBreakdown } from 'utils/exchange'
-import { setConfirmSwapModalAtom } from 'atoms/modals/confirmSwapModalAtom'
 import { PricingAndSlippage } from 'components/TonSwap/SwapDetails/PricingAndSlippage'
 import { AdvancedSwapDetailsDropdown } from 'components/TonSwap/SwapDetails/AdvancedSwapDetailsDropdown'
 import { useUserSlippagePercent } from 'hooks/useUserSlippage'
-import { useAsyncConfirmPriceImpactWithoutFee } from '@pancakeswap/widgets-internal'
-import { ALLOWED_PRICE_IMPACT_HIGH, PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN } from 'config/constants/exchange'
 
 export const SwapForm = () => {
   const { t } = useTranslation()
@@ -74,7 +72,7 @@ export const SwapForm = () => {
   const { data: balance0 } = useAtomValue(balanceAtom(inputCurrency))
   const [allowedSlippage] = useUserSlippagePercent()
   const [isSwapDetailPanelOpen] = useIsSwapDetailPanelOpen()
-  const { realizedLPFee, priceImpactWithoutFee } = computeTradePriceBreakdown(trade)
+  const { realizedLPFee } = computeTradePriceBreakdown(trade)
   const { onUserInput, onCurrencySelection } = useSwapActionHandlers()
   const { data: activeList, isFetched } = useAtomValue(fetchListAtom)
 
@@ -85,23 +83,10 @@ export const SwapForm = () => {
     ],
     [balance0, parsedAmounts, isTradeLoading, trade?.route.path.length],
   )
-  const confirmPriceImpactWithoutFee = useAsyncConfirmPriceImpactWithoutFee(
-    priceImpactWithoutFee,
-    PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN,
-    ALLOWED_PRICE_IMPACT_HIGH,
-  )
-  const swapPreflightCheck = useCallback(async () => {
-    if (priceImpactWithoutFee) {
-      const confirmed = await confirmPriceImpactWithoutFee()
-      if (!confirmed) {
-        return false
-      }
-    }
-    return true
-  }, [confirmPriceImpactWithoutFee, priceImpactWithoutFee])
 
-  const { swap } = useSwap({
+  const { confirmSwap } = useSwap({
     trade,
+    refreshTrade,
     minOut: isExactIn
       ? trade?.minimumAmountOut(allowedSlippage).toExact()
       : trade?.maximumAmountIn(allowedSlippage).toExact(),
@@ -109,24 +94,6 @@ export const SwapForm = () => {
     token0: inputCurrency,
     token1: outputCurrency,
   })
-
-  const setSwapConfirmModal = useSetAtom(setConfirmSwapModalAtom)
-  const confirmSwap = useCallback(async () => {
-    if (!inputCurrency || !outputCurrency) {
-      return
-    }
-    if (!(await swapPreflightCheck())) {
-      return
-    }
-    setSwapConfirmModal({
-      isOpen: true,
-      inputCurrency,
-      outputCurrency,
-      trade,
-      refreshTrade,
-      onConfirm: swap,
-    })
-  }, [inputCurrency, outputCurrency, setSwapConfirmModal, trade, refreshTrade, swap, swapPreflightCheck])
 
   // Set default currencies on load
   useEffect(() => {


### PR DESCRIPTION
- **fix: update tTON to TON as bases tokens for swap**
- **fix: add swap events**
- **fix: add/remove liquidity events**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing Google Tag Manager (GTM) event tracking for liquidity and swap actions within the application. It introduces new event logging for add and remove liquidity actions, as well as swap transactions, to improve analytics.

### Detailed summary
- Added GTM event logging for:
  - `AddLiquidity` transaction sent in `useAddLiquidity.ts`
  - `RemoveLiquidity` click in `RemoveLiquidityCard/CardContent.tsx`
  - `AddLiquidity` confirm and click events in `AddLiquidityCard/CardContent.tsx`
  - `Swap` confirm and transaction sent events in `useSwap.ts`
- Introduced new enums and logging functions in `customGTMEventTracking.ts`
- Updated the application structure in `_app.tsx` to include GTM script loading. 
- Refactored `useAllCommonPairs.ts` for better readability and efficiency.
- Enhanced `useSwap` to include price impact checks before confirming swaps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->