### PR TITLE
fix: ton swap url reflect

### DIFF
--- a/apps/ton/src/atoms/swap/swapStateAtom.ts
+++ b/apps/ton/src/atoms/swap/swapStateAtom.ts
@@ -1,11 +1,8 @@
 import { useQueryState, parseAsString } from 'nuqs'
-import { atom, useSetAtom } from 'jotai'
+import { atom } from 'jotai'
 import { Field } from 'types'
 import { Currency } from '@pancakeswap/ton-v2-sdk'
 import { useCurrency } from 'hooks/tokens/useCurrency'
-import { CurrencyField } from 'types/currency'
-import { currencyFamily } from 'atoms/currencyAtoms'
-import { useEffect } from 'react'
 
 // TODO: Refactor to use the global CurrencyField enum
 export const independentFieldAtom = atom(Field.INPUT)
@@ -20,11 +17,6 @@ export const useInputCurrencyQueryState = (defaultAddress: string = '') => {
     }),
   )
   const currency = useCurrency(address)
-  const setCurrency = useSetAtom(currencyFamily(CurrencyField.SWAP_INPUT))
-
-  useEffect(() => {
-    setCurrency(currency)
-  }, [setCurrency, currency])
 
   return [
     currency,
@@ -42,11 +34,6 @@ export const useOutputCurrencyQueryState = (defaultAddress: string = '') => {
     }),
   )
   const currency = useCurrency(address)
-  const setCurrency = useSetAtom(currencyFamily(CurrencyField.SWAP_OUTPUT))
-
-  useEffect(() => {
-    setCurrency(currency)
-  }, [setCurrency, currency])
 
   return [
     currency,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the state management in the `swapStateAtom.ts` file by removing unnecessary imports and the use of `useSetAtom` and `useEffect` hooks for setting currency states.

### Detailed summary
- Removed the import of `useSetAtom` from `jotai`.
- Eliminated the `CurrencyField` and `currencyFamily` imports.
- Removed `useEffect` hooks that set the currency for both input and output states.
- Simplified the state management related to currency selection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->