### PR TITLE
fix: native TON trade compare

### DIFF
--- a/apps/ton/src/config/constants/exchange.ts
+++ b/apps/ton/src/config/constants/exchange.ts
@@ -33,9 +33,9 @@ export const BETTER_TRADE_LESS_HOPS_THRESHOLD = new Percent(50n, BIPS_BASE)
 // max hops for swap
 export const MAX_HOPS = 3
 
-export const ADDITIONAL_BASES: { [chainId in TonChainId]?: { [tokenAddress: string]: Token[] } } = {}
+export const ADDITIONAL_BASES: { [chainId: number]: { [tokenAddress: string]: Token[] } } = {}
 
-export const CUSTOM_BASES: { [chainId in TonChainId]?: { [tokenAddress: string]: Token[] } } = {}
+export const CUSTOM_BASES: { [chainId: number]: { [tokenAddress: string]: Token[] } } = {}
 // todo:@eric mock bases to test multihops
 const USDC = tokenList.tokens.find((t) => t.symbol === 'USDC')!
 export const BASES_TO_CHECK_TRADES_AGAINST: { [chainId: number]: Currency[] } = {

--- a/apps/ton/src/hooks/swap/useAllCommonPairs.ts
+++ b/apps/ton/src/hooks/swap/useAllCommonPairs.ts
@@ -1,5 +1,4 @@
 import { Currency, CurrencyAmount, Pair, Token } from '@pancakeswap/ton-v2-sdk'
-import { useQuery } from '@tanstack/react-query'
 import { ADDITIONAL_BASES, BASES_TO_CHECK_TRADES_AGAINST, CUSTOM_BASES } from 'config/constants/exchange'
 import { useAtomValue } from 'jotai'
 import flatMap from 'lodash/flatMap'
@@ -7,7 +6,6 @@ import uniqBy from 'lodash/uniqBy'
 import uniqWith from 'lodash/uniqWith'
 import { useMemo } from 'react'
 import { poolDataQueriesAtom, useRefreshPoolData } from 'ton/atom/liquidity/poolDataQueriesAtom'
-import { getCurrencyOrder } from 'ton/utils/tokenOrder'
 
 interface UseAllCommonPairsReturnType {
   isLoading: boolean
@@ -27,7 +25,7 @@ export function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): U
     const additionalA = tokenA ? ADDITIONAL_BASES[chainId]?.[tokenA.address] ?? [] : []
     const additionalB = tokenB ? ADDITIONAL_BASES[chainId]?.[tokenB.address] ?? [] : []
 
-    return [...common, ...additionalA, ...additionalB]
+    return [...common, ...additionalA, ...additionalB].map((c) => c.wrapped)
   }, [chainId, tokenA, tokenB])
 
   const basePairs: [Token, Token][] = useMemo(

--- a/packages/ton-v2-sdk/src/utils/trade.ts
+++ b/packages/ton-v2-sdk/src/utils/trade.ts
@@ -210,7 +210,7 @@ export const bestTradeExactOut = <TInput extends Currency, TOutput extends Curre
   for (let i = 0; i < pairs.length; i++) {
     const pair = pairs[i]
     // pair irrelevant
-    if (!pair.token0.equals(amountOut.currency) && !pair.token1.equals(amountOut.currency)) continue
+    if (!pair.token0.wrapped.equals(amountOut.currency) && !pair.token1.wrapped.equals(amountOut.currency)) continue
     if (pair.reserve0.equalTo(ZERO) || pair.reserve1.equalTo(ZERO)) continue
 
     let amountIn: CurrencyAmount<Currency>
@@ -225,7 +225,7 @@ export const bestTradeExactOut = <TInput extends Currency, TOutput extends Curre
       throw error
     }
     // we have arrived at the input token, so this is the first trade of one of the paths
-    if (amountIn.currency.equals(tokenIn)) {
+    if (amountIn.currency.wrapped.equals(tokenIn)) {
       sortedInsert(
         bestTrades,
         new Trade(
@@ -276,7 +276,7 @@ export const bestTradeExactIn = <TInput extends Currency, TOutput extends Curren
   for (let i = 0; i < pairs.length; i++) {
     const pair = pairs[i]
     // pair irrelevant
-    if (!pair.token0.equals(amountIn.currency) && !pair.token1.equals(amountIn.currency)) continue
+    if (!pair.token0.wrapped.equals(amountIn.currency) && !pair.token1.wrapped.equals(amountIn.currency)) continue
     if (pair.reserve0.equalTo(ZERO) || pair.reserve1.equalTo(ZERO)) continue
 
     let amountOut: CurrencyAmount<Currency>
@@ -291,7 +291,7 @@ export const bestTradeExactIn = <TInput extends Currency, TOutput extends Curren
       throw error
     }
     // we have arrived at the output token, so this is the final trade of one of the paths
-    if (amountOut.currency.equals(tokenOut)) {
+    if (amountOut.currency.wrapped.equals(tokenOut)) {
       sortedInsert(
         bestTrades,
         new Trade(
@@ -336,8 +336,8 @@ export const isTradeBetter = (
 
   if (
     tradeA.tradeType !== tradeB.tradeType ||
-    !tradeA.inputAmount.currency.equals(tradeB.inputAmount.currency) ||
-    !tradeA.outputAmount.currency.equals(tradeB.outputAmount.currency)
+    !tradeA.inputAmount.currency.wrapped.equals(tradeB.inputAmount.currency.wrapped) ||
+    !tradeA.outputAmount.currency.wrapped.equals(tradeB.outputAmount.currency.wrapped)
   ) {
     throw new Error('Trades are not comparable')
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on updating type definitions for `ADDITIONAL_BASES` and `CUSTOM_BASES` in `exchange.ts` to use `number` instead of `TonChainId`. Additionally, it modifies various comparisons in the `trade.ts` file to use the `wrapped` property of tokens.

### Detailed summary
- Changed type of `chainId` in `ADDITIONAL_BASES` and `CUSTOM_BASES` from `TonChainId` to `number`.
- Updated token comparisons in `useAllCommonPairs` to use `wrapped` property.
- Updated token comparisons in `bestTradeExactOut` and `bestTradeExactIn` to use `wrapped` property.
- Adjusted trade comparison logic in `isTradeBetter` to use `wrapped` property for input and output amounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->