### PR TITLE
fix: add liquidity native TON order

### DIFF
--- a/apps/ton/src/ton/logic/liquidity/useAddLiquidity.ts
+++ b/apps/ton/src/ton/logic/liquidity/useAddLiquidity.ts
@@ -126,8 +126,8 @@ export const useAddLiquidity = () => {
               payload: payload0.toBoc().toString('base64'),
             },
             {
-              address: userJettonWallet1.toString(),
-              amount: GAS.toString(),
+              address: currency1.isNative ? routerJettonWallet1.toString() : userJettonWallet1.toString(),
+              amount: (GAS + (currency1.isNative ? amount1 : 0n)).toString(),
               payload: payload1.toBoc().toString('base64'),
             },
           ],

--- a/apps/ton/src/ton/utils/tokenOrder.ts
+++ b/apps/ton/src/ton/utils/tokenOrder.ts
@@ -1,17 +1,7 @@
-import { Contracts, Currency, getAddressCellHash, Native, TonChainId, TonContractNames } from '@pancakeswap/ton-v2-sdk'
-import { isAddressEqual } from './address'
+import { Contracts, Currency, getAddressCellHash, TonChainId, TonContractNames } from '@pancakeswap/ton-v2-sdk'
 import { getJettonWalletAddress } from './jettonWalletAddress'
 
 export async function getTokenOrder(chainId: TonChainId, token0Address: string, token1Address: string) {
-  // Native token is always first
-  if (isAddressEqual(token0Address, Native.onChain(chainId).wrapped.address)) {
-    return { token0: token0Address, token1: token1Address, isFlipped: false }
-  }
-
-  if (isAddressEqual(token1Address, Native.onChain(chainId).wrapped.address)) {
-    return { token0: token1Address, token1: token0Address, isFlipped: true }
-  }
-
   const [routerJettonWallet0, routerJettonWallet1] = await Promise.all([
     getJettonWalletAddress(Contracts[TonContractNames.PCSRouter][chainId].address, token0Address),
     getJettonWalletAddress(Contracts[TonContractNames.PCSRouter][chainId].address, token1Address),
@@ -29,9 +19,6 @@ export async function getTokenOrder(chainId: TonChainId, token0Address: string, 
 
 export async function getCurrencyOrder(currency0: Currency, currency1: Currency) {
   if (!currency0 || !currency1) return { currency0, currency1, isFlipped: false }
-
-  if (currency0.isNative) return { currency0, currency1, isFlipped: false }
-  if (currency1.isNative) return { currency0: currency1, currency1: currency0, isFlipped: true }
 
   const { isFlipped } = await getTokenOrder(currency0.chainId, currency0.wrapped.address, currency1.wrapped.address)
 


### PR DESCRIPTION
- **fix: add liquidity native TON order**
- **Revert "fix: native-first token order"**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the logic for adding liquidity and updating the token order management in the `useAddLiquidity` and `getTokenOrder` functions, respectively. It introduces new conditions for handling native tokens and adjusts how addresses and amounts are calculated.

### Detailed summary
- In `useAddLiquidity.ts`:
  - Updated `address` to use `routerJettonWallet1` if `currency1` is native.
  - Adjusted `amount` calculation to include `amount1` when `currency1` is native.

- In `tokenOrder.ts`:
  - Removed import of `isAddressEqual`.
  - Added imports from `@pancakeswap/ton-v2-sdk`.
  - Simplified logic in `getTokenOrder` to remove checks for native token addresses.
  - Removed checks for native tokens in `getCurrencyOrder`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->