### PR TITLE
feat: remove andy banner

### DIFF
--- a/apps/web/src/components/AdPanel/InfoStripes/TradingCompetition.tsx
+++ b/apps/web/src/components/AdPanel/InfoStripes/TradingCompetition.tsx
@@ -38,15 +38,6 @@ export const tradingCompetitionConfig = {
     reward: '100,000',
     unit: '$',
   },
-  andy: {
-    imgUrl: 'andy_competition',
-    swapUrl:
-      'https://pancakeswap.finance/?outputCurrency=0x01CA78a2B5F1a9152D8A3A625bd7dF5765eeE1D8&utm_source=Website&utm_medium=banner&utm_campaign=ANDY&utm_id=TradingCompetition',
-    learnMoreUrl:
-      'https://blog.pancakeswap.finance/articles/pancake-swap-x-andy-trading-competition-50-000-in-rewards?utm_source=Website&utm_medium=banner&utm_campaign=ANDY&utm_id=TradingCompetition',
-    reward: '50,000',
-    unit: '$',
-  },
 }
 
 export const TradingCompetition: React.FC<{ token: 'aitech' | 'bfg' | 'apt' | 'vinu' | 'andy' }> = ({ token }) => {
@@ -104,8 +95,4 @@ export const TradingCompetition: React.FC<{ token: 'aitech' | 'bfg' | 'apt' | 'v
       </Link>
     </Box>
   )
-}
-
-export const TradingCompetitionInfoStripeAndy = () => {
-  return <TradingCompetition token="andy" />
 }

--- a/apps/web/src/components/AdPanel/InfoStripes/index.tsx
+++ b/apps/web/src/components/AdPanel/InfoStripes/index.tsx
@@ -13,7 +13,6 @@ import { useGetInfoStripeConfig } from './InfoStripeCommon'
 import { Step1 } from './Step1'
 import { Step2 } from './Step2'
 import { Step3 } from './Step3'
-import { TradingCompetitionInfoStripeAndy } from './TradingCompetition'
 
 const Container = styled(Flex).withConfig({ shouldForwardProp: (prop) => !['$background'].includes(prop) })<{
   $background?: string
@@ -103,12 +102,6 @@ type BannerConfig = {
 const useBannerConfigs = () => {
   const perpConfig = useGetInfoStripeConfig(AdsIds.TST_PERP)
   const CONFIG: BannerConfig[] = [
-    {
-      component: <TradingCompetitionInfoStripeAndy />,
-      stripeImage: `${ASSET_CDN}/web/phishing-warning/andy.png`,
-      stripeImageWidth: '92px',
-      stripeImageAlt: 'ANDY',
-    },
     {
       ...perpConfig,
     },

--- a/apps/web/src/components/AdPanel/config.tsx
+++ b/apps/web/src/components/AdPanel/config.tsx
@@ -5,7 +5,6 @@ import { AdCommon } from './Ads/AdCommon'
 import { AdIfo } from './Ads/AdIfo'
 import { AdPCSX } from './Ads/AdPCSX'
 import { AdSpringboard } from './Ads/AdSpringboard'
-import { AdTradingCompetitionAndy } from './Ads/AdTradingCompetition'
 import { ExpandableAd } from './Expandable/ExpandableAd'
 import { AdsIds } from './hooks/useAdsConfig'
 import { shouldRenderOnPages } from './renderConditions'
@@ -46,10 +45,6 @@ export const useAdConfig = () => {
       {
         id: 'ad-springboard',
         component: <AdSpringboard />,
-      },
-      {
-        id: 'ad-andy-tc',
-        component: <AdTradingCompetitionAndy />,
       },
       {
         id: 'ad-ifo',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes references to the `AdTradingCompetitionAndy` and the `TradingCompetitionInfoStripeAndy` components from the `AdPanel` and `InfoStripes` sections, streamlining the ad configuration and related components.

### Detailed summary
- Removed `AdTradingCompetitionAndy` from `useAdConfig`.
- Deleted `TradingCompetitionInfoStripeAndy` component and its related configuration in `InfoStripes`.
- Eliminated `andy` configuration from `TradingCompetition` in `InfoStripes`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->