### PR TITLE
fix: fix cb1 text

### DIFF
--- a/apps/web/src/components/Cb1/Cb1Membership.tsx
+++ b/apps/web/src/components/Cb1/Cb1Membership.tsx
@@ -41,7 +41,7 @@ const Cb1Inner = () => {
             marginTop: '24px',
           }}
         >
-          $8.453 {t('to be earned!')}
+          $8,453 {t('to be earned!')}
         </Text>
         <Text
           style={{
@@ -50,7 +50,7 @@ const Cb1Inner = () => {
         >
           <b>Coinbase One </b>
           {t(
-            'members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.',
+            'members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8,453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.',
           )}
         </Text>
         <Button

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3732,6 +3732,6 @@
   "PancakeSwap Options will officially be retired on March 11th, 2025, at 08:00 UTC, please withdraw liquidity by the deadline or migrate to PancakeSwap V3 pools.": "PancakeSwap Options will officially be retired on March 11th, 2025, at 08:00 UTC, please withdraw liquidity by the deadline or migrate to PancakeSwap V3 pools.",
   "You are Eligible!": "You are Eligible!",
   "to be earned!": "to be earned!",
-  "members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.": "members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.",
+  "members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8,453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.": "members who trade on PancakeSwap on Base, BNB, or Arbitrum are eligible to earn a portion of $8,453 airdropped to their wallet biweekly! Must trade a minimum of $100 to qualify.",
   "Trade now to participate!": "Trade now to participate!"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the currency formatting in the `Cb1Membership` component and its associated translation strings to include a comma in the dollar amount for better readability.

### Detailed summary
- Changed the display of the dollar amount from `$8453` to `$8,453` in `Cb1Membership.tsx`.
- Updated the corresponding translation string in `translations.json` to reflect the new format of `$8,453`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->