### PR TITLE
feat: Make common ads generation by config and remove trade ads

### DIFF
--- a/apps/web/src/components/AdPanel/InfoStripes/InfoStripeCommon.tsx
+++ b/apps/web/src/components/AdPanel/InfoStripes/InfoStripeCommon.tsx
@@ -1,19 +1,9 @@
 import { Box, Link } from '@pancakeswap/uikit'
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
-import { ASSET_CDN } from 'config/constants/endpoints'
 import { AdsIds, useAdsConfig } from '../hooks/useAdsConfig'
 import { AdTextConfig } from '../types'
 import { TextHighlight } from './TextHighlight'
 
-export const useGetInfoStripeConfig = (id: AdsIds) => {
-  const config = useAdsConfig(id).infoStripe
-  return {
-    component: <InfoStripeCommon id={id} />,
-    stripeImage: `${ASSET_CDN}/web/phishing-warning/${config.img}.png`,
-    stripeImageWidth: '92px',
-    stripeImageAlt: id,
-  }
-}
 export const InfoStripeCommon = (props: { id: AdsIds }) => {
   const config = useAdsConfig(props.id).infoStripe
   return (

--- a/apps/web/src/components/AdPanel/InfoStripes/index.tsx
+++ b/apps/web/src/components/AdPanel/InfoStripes/index.tsx
@@ -8,8 +8,8 @@ import 'swiper/css/effect-fade'
 import { ASSET_CDN } from 'config/constants/endpoints'
 import { Countdown } from './Countdown'
 
-import { AdsIds } from '../hooks/useAdsConfig'
-import { useGetInfoStripeConfig } from './InfoStripeCommon'
+import { AdsIds, useAdsConfigs } from '../hooks/useAdsConfig'
+import { InfoStripeCommon } from './InfoStripeCommon'
 import { Step1 } from './Step1'
 import { Step2 } from './Step2'
 import { Step3 } from './Step3'
@@ -100,11 +100,24 @@ type BannerConfig = {
 }
 
 const useBannerConfigs = () => {
-  const perpConfig = useGetInfoStripeConfig(AdsIds.TST_PERP)
+  const configs = useAdsConfigs()
+  const commonAdConfigs = useMemo(() => {
+    return Object.entries(configs)
+      .map(([key, value]) => {
+        if (value.infoStripe) {
+          return {
+            component: <InfoStripeCommon id={key as AdsIds} />,
+            stripeImage: `${ASSET_CDN}/web/phishing-warning/${value.infoStripe.img}.png`,
+            stripeImageWidth: '92px',
+            stripeImageAlt: value.id,
+          }
+        }
+        return undefined
+      })
+      .filter(Boolean) as BannerConfig[]
+  }, [configs])
   const CONFIG: BannerConfig[] = [
-    {
-      ...perpConfig,
-    },
+    ...commonAdConfigs,
     {
       component: <Step1 />,
       stripeImage: `${ASSET_CDN}/web/phishing-warning/phishing-warning-bunny-1.png`,

--- a/apps/web/src/components/AdPanel/InfoStripes/index.tsx
+++ b/apps/web/src/components/AdPanel/InfoStripes/index.tsx
@@ -116,27 +116,30 @@ const useBannerConfigs = () => {
       })
       .filter(Boolean) as BannerConfig[]
   }, [configs])
-  const CONFIG: BannerConfig[] = [
-    ...commonAdConfigs,
-    {
-      component: <Step1 />,
-      stripeImage: `${ASSET_CDN}/web/phishing-warning/phishing-warning-bunny-1.png`,
-      stripeImageWidth: '92px',
-      stripeImageAlt: 'Phishing Warning',
-    },
-    {
-      component: <Step2 />,
-      stripeImage: `${ASSET_CDN}/web/phishing-warning/phishing-warning-bunny-2.png`,
-      stripeImageWidth: '92px',
-      stripeImageAlt: 'Phishing Warning',
-    },
-    {
-      component: <Step3 />,
-      stripeImage: `${ASSET_CDN}/web/banners/pcsx/pcsx-bg-medium.png`,
-      stripeImageWidth: '92px',
-      stripeImageAlt: 'PCSX',
-    },
-  ]
+  const CONFIG: BannerConfig[] = useMemo(
+    () => [
+      ...commonAdConfigs,
+      {
+        component: <Step1 />,
+        stripeImage: `${ASSET_CDN}/web/phishing-warning/phishing-warning-bunny-1.png`,
+        stripeImageWidth: '92px',
+        stripeImageAlt: 'Phishing Warning',
+      },
+      {
+        component: <Step2 />,
+        stripeImage: `${ASSET_CDN}/web/phishing-warning/phishing-warning-bunny-2.png`,
+        stripeImageWidth: '92px',
+        stripeImageAlt: 'Phishing Warning',
+      },
+      {
+        component: <Step3 />,
+        stripeImage: `${ASSET_CDN}/web/banners/pcsx/pcsx-bg-medium.png`,
+        stripeImageWidth: '92px',
+        stripeImageAlt: 'PCSX',
+      },
+    ],
+    [commonAdConfigs],
+  )
   return CONFIG
 }
 
@@ -149,7 +152,7 @@ const InfoStripes: React.FC<React.PropsWithChildren> = () => {
   const CONFIG = useBannerConfigs()
   const banner = CONFIG[step]
 
-  const nextItem = useMemo(() => (step < CONFIG.length - 1 ? step + 1 : 0), [step])
+  const nextItem = useMemo(() => (step < CONFIG.length - 1 ? step + 1 : 0), [step, CONFIG.length])
 
   const handleClickNext = useCallback(() => {
     setStep(nextItem)

--- a/apps/web/src/components/AdPanel/config.tsx
+++ b/apps/web/src/components/AdPanel/config.tsx
@@ -71,7 +71,7 @@ export const useAdConfig = () => {
         component: <AdCakeStaking />,
       },
     ],
-    [shouldRenderOnPage, shouldRenderAdIfo],
+    [shouldRenderOnPage, shouldRenderAdIfo, commonAdConfigs],
   )
 
   return useMemo(

--- a/apps/web/src/components/AdPanel/config.tsx
+++ b/apps/web/src/components/AdPanel/config.tsx
@@ -1,14 +1,14 @@
 import { useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useMemo } from 'react'
+import { AdsIds, useAdsConfigs } from 'components/AdPanel/hooks/useAdsConfig'
 import { AdCakeStaking } from './Ads/AdCakeStaking'
-import { AdCommon } from './Ads/AdCommon'
 import { AdIfo } from './Ads/AdIfo'
 import { AdPCSX } from './Ads/AdPCSX'
 import { AdSpringboard } from './Ads/AdSpringboard'
 import { ExpandableAd } from './Expandable/ExpandableAd'
-import { AdsIds } from './hooks/useAdsConfig'
 import { shouldRenderOnPages } from './renderConditions'
 import { useShouldRenderAdIfo } from './useShouldRenderAdIfo'
+import { AdCommon } from './Ads/AdCommon'
 
 enum Priority {
   FIRST_AD = 6,
@@ -24,6 +24,20 @@ export const useAdConfig = () => {
   const shouldRenderOnPage = shouldRenderOnPages(['/buy-crypto', '/', '/prediction'])
   const MAX_ADS = isDesktop ? 6 : 4
   const shouldRenderAdIfo = useShouldRenderAdIfo()
+  const configs = useAdsConfigs()
+  const commonAdConfigs = useMemo(() => {
+    return Object.entries(configs)
+      .map(([key, value]) => {
+        if (value.ad) {
+          return {
+            id: value.id,
+            component: <AdCommon id={key as AdsIds} />,
+          }
+        }
+        return undefined
+      })
+      .filter(Boolean) as { id: string; component: JSX.Element }[]
+  }, [configs])
 
   const adList: Array<{
     id: string
@@ -38,10 +52,7 @@ export const useAdConfig = () => {
         priority: Priority.FIRST_AD,
         shouldRender: [shouldRenderOnPage],
       },
-      {
-        id: 'tst-perp',
-        component: <AdCommon id={AdsIds.TST_PERP} />,
-      },
+      ...commonAdConfigs,
       {
         id: 'ad-springboard',
         component: <AdSpringboard />,

--- a/apps/web/src/components/AdPanel/hooks/useAdsConfig.ts
+++ b/apps/web/src/components/AdPanel/hooks/useAdsConfig.ts
@@ -1,4 +1,5 @@
 import { ContextApi, useTranslation } from '@pancakeswap/localization'
+import { useMemo } from 'react'
 import { AdsCampaignConfig } from '../types'
 
 export enum AdsIds {
@@ -56,11 +57,15 @@ const getPerpConfigs = (t: ContextApi['t']): AdsCampaignConfig[] => {
 export const useAdsConfigs = (): AdsConfigMap => {
   const { t } = useTranslation()
 
-  const AdsConfigs: AdsConfigMap = getPerpConfigs(t).reduce((acc, config) => {
-    // eslint-disable-next-line no-param-reassign
-    acc[config.id] = config
-    return acc
-  }, {} as AdsConfigMap)
+  const AdsConfigs: AdsConfigMap = useMemo(
+    () =>
+      getPerpConfigs(t).reduce((acc, config) => {
+        // eslint-disable-next-line no-param-reassign
+        acc[config.id] = config
+        return acc
+      }, {} as AdsConfigMap),
+    [t],
+  )
 
   return AdsConfigs
 }

--- a/apps/web/src/components/AdPanel/hooks/useAdsConfig.ts
+++ b/apps/web/src/components/AdPanel/hooks/useAdsConfig.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from '@pancakeswap/localization'
+import { ContextApi, useTranslation } from '@pancakeswap/localization'
 import { AdsCampaignConfig } from '../types'
 
 export enum AdsIds {
@@ -8,54 +8,60 @@ export enum AdsIds {
 type AdsConfigMap = {
   [key in AdsIds]: AdsCampaignConfig
 }
+const getPerpConfigs = (t: ContextApi['t']): AdsCampaignConfig[] => {
+  return [
+    // {
+    //   id: AdsIds.TST_PERP,
+    //   ad: {
+    //     img: 'perp',
+    //     texts: [
+    //       {
+    //         text: t('Trade Perpetual v2 to Win $10,000.'),
+    //       },
+    //       {
+    //         text: t('Trade Now'),
+    //         link: 'https://perp.pancakeswap.finance/en/futures/v2/BTCUSD',
+    //       },
+    //     ],
+    //     btn: {
+    //       text: t('Learn More'),
+    //       link: 'https://blog.pancakeswap.finance/articles/trade-tst-trump-pepe-and-more-tokens-on-pancake-swap-perpetual-v2-on-chain-and-share-a-10-000-prize-pool?utm_source=Website&utm_medium=SwapPage&utm_campaign=Perps&utm_id=PerpsCampaign',
+    //     },
+    //     options: {
+    //       imagePadding: '20px',
+    //     },
+    //   },
+    //   infoStripe: {
+    //     img: 'perp',
+    //     texts: [
+    //       {
+    //         text: t('Trade $TST, $PEPE, and More on Perpetual V2 to Win $10,000.'),
+    //       },
+    //     ],
+    //     btns: [
+    //       {
+    //         text: t('Trade Now'),
+    //         link: 'https://perp.pancakeswap.finance/en/futures/v2/BTCUSD',
+    //       },
+    //       {
+    //         text: t('Learn More'),
+    //         link: 'https://blog.pancakeswap.finance/articles/trade-tst-trump-pepe-and-more-tokens-on-pancake-swap-perpetual-v2-on-chain-and-share-a-10-000-prize-pool?utm_source=Website&utm_medium=SwapPage&utm_campaign=Perps&utm_id=PerpsCampaign',
+    //       },
+    //     ],
+    //   },
+    // },
+  ]
+}
 
-const useAdsConfigs = (): AdsConfigMap => {
+export const useAdsConfigs = (): AdsConfigMap => {
   const { t } = useTranslation()
 
-  const configPerp: AdsCampaignConfig = {
-    id: AdsIds.TST_PERP,
-    ad: {
-      img: 'perp',
-      texts: [
-        {
-          text: t('Trade Perpetual v2 to Win $10,000.'),
-        },
-        {
-          text: t('Trade Now'),
-          link: 'https://perp.pancakeswap.finance/en/futures/v2/BTCUSD',
-        },
-      ],
-      btn: {
-        text: t('Learn More'),
-        link: 'https://blog.pancakeswap.finance/articles/trade-tst-trump-pepe-and-more-tokens-on-pancake-swap-perpetual-v2-on-chain-and-share-a-10-000-prize-pool?utm_source=Website&utm_medium=SwapPage&utm_campaign=Perps&utm_id=PerpsCampaign',
-      },
-      options: {
-        imagePadding: '20px',
-      },
-    },
-    infoStripe: {
-      img: 'perp',
-      texts: [
-        {
-          text: t('Trade $TST, $PEPE, and More on Perpetual V2 to Win $10,000.'),
-        },
-      ],
-      btns: [
-        {
-          text: t('Trade Now'),
-          link: 'https://perp.pancakeswap.finance/en/futures/v2/BTCUSD',
-        },
-        {
-          text: t('Learn More'),
-          link: 'https://blog.pancakeswap.finance/articles/trade-tst-trump-pepe-and-more-tokens-on-pancake-swap-perpetual-v2-on-chain-and-share-a-10-000-prize-pool?utm_source=Website&utm_medium=SwapPage&utm_campaign=Perps&utm_id=PerpsCampaign',
-        },
-      ],
-    },
-  }
+  const AdsConfigs: AdsConfigMap = getPerpConfigs(t).reduce((acc, config) => {
+    // eslint-disable-next-line no-param-reassign
+    acc[config.id] = config
+    return acc
+  }, {} as AdsConfigMap)
 
-  const AdsConfigs: AdsConfigMap = {
-    [AdsIds.TST_PERP]: configPerp,
-  }
   return AdsConfigs
 }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the advertisement configuration and rendering logic in the `AdPanel` component. It consolidates ad configurations and modifies how info stripes are generated, improving the modularity and maintainability of the code.

### Detailed summary
- Removed `useGetInfoStripeConfig` and its usage in favor of direct configuration extraction.
- Introduced `useAdsConfigs` to fetch ad configurations.
- Created `commonAdConfigs` to streamline ad rendering logic.
- Updated `useBannerConfigs` to integrate common ad configurations.
- Modified the `CONFIG` array to include common ad configurations.
- Changed the structure of `AdsConfigs` to use a memoized function for better performance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->