### PR TITLE
fix: remove button disabled when isSwaping

### DIFF
--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -1,7 +1,6 @@
 import { useAtomValue } from 'jotai'
 import noop from 'lodash/noop'
-import debounce from 'lodash/debounce'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useTranslation } from '@pancakeswap/localization'
 import { Rounding } from '@pancakeswap/swap-sdk-core'
@@ -37,7 +36,6 @@ export const SwapForm = () => {
   const address = useAtomValue(addressAtom)
   const isWalletConnected = !!address
 
-  const [isSwaping, setIsSwaping] = useState(false)
   const [inputCurrency] = useInputCurrencyQueryState()
   const [outputCurrency] = useOutputCurrencyQueryState()
   const typedValue = useAtomValue(typedValueAtom)
@@ -103,22 +101,14 @@ export const SwapForm = () => {
     token1: outputCurrency,
   })
 
-  const resetSwapingState = debounce(() => {
-    setIsSwaping(false)
-    refreshTrade()
-  }, 20000)
-
   const handleSwap = useCallback(async () => {
     try {
-      setIsSwaping(true)
-      resetSwapingState()
       await confirmSwap()
       onUserInput(Field.INPUT, '')
     } finally {
-      setIsSwaping(false)
       refreshTrade()
     }
-  }, [onUserInput, confirmSwap, refreshTrade, resetSwapingState])
+  }, [onUserInput, confirmSwap, refreshTrade])
 
   const handlePercentInput = useCallback(() => {}, [])
 
@@ -189,9 +179,7 @@ export const SwapForm = () => {
       ) : (
         <ButtonAndDetailsPanel
           shouldRenderDetails={Boolean(typedValue) && !isInsufficientLiquidity}
-          swapCommitButton={
-            <SwapCommitButton trade={trade} isSwaping={isSwaping} isLoading={isTradeLoading} onClick={handleSwap} />
-          }
+          swapCommitButton={<SwapCommitButton trade={trade} isLoading={isTradeLoading} onClick={handleSwap} />}
           pricingAndSlippage={
             <PricingAndSlippage
               isLoading={isTradeLoading}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on simplifying the `SwapForm` component by removing unnecessary state management and optimizing the swap handling logic.

### Detailed summary
- Removed the unused `debounce` import and `isSwaping` state.
- Eliminated the `resetSwapingState` function, which was responsible for resetting the swap state.
- Updated the `handleSwap` function to directly manage the swap without the `isSwaping` state.
- Adjusted the `swapCommitButton` to omit the `isSwaping` prop.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->