### PR TITLE
fix: update TON swap error modal

### DIFF
--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -182,14 +182,13 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
       }
       return Promise.resolve()
     } catch (e) {
-      let msg = typeof e === 'string' ? e : (e as Error)?.message
-      if (e instanceof UserRejectsError || e instanceof TonConnectUIError) {
-        msg = t('Transaction rejected')
+      const msg = typeof e === 'string' ? e : (e as Error)?.message
+      if (e instanceof UserRejectsError || e instanceof TonConnectUIError || msg.includes('Reject request')) {
+        setErrorMsgModal({
+          isOpen: true,
+          msg: t('Transaction rejected'),
+        })
       }
-      setErrorMsgModal({
-        isOpen: true,
-        msg,
-      })
       return Promise.reject()
     }
   }, [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies error handling in the `useSwap` function to provide more specific feedback when certain errors occur, particularly around user rejections. It enhances the error message logic and updates the modal display settings.

### Detailed summary
- Changed `let msg` to `const msg` for better variable scoping.
- Added a condition to check if `msg` includes 'Reject request' alongside existing error checks.
- Updated `setErrorMsgModal` to display a fixed message 'Transaction rejected' instead of the generic error message.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->