### PR TITLE
fix: disabled the output currency input

### DIFF
--- a/apps/ton/src/views/TONSwap/SwapForm.tsx
+++ b/apps/ton/src/views/TONSwap/SwapForm.tsx
@@ -166,7 +166,7 @@ export const SwapForm = () => {
               currency={outputCurrency}
               otherCurrency={inputCurrency}
               commonBasesType={undefined}
-              onUserInput={(val) => onUserInput(Field.OUTPUT, val)}
+              onUserInput={noop}
               onPercentInput={noop}
               onMax={noop}
               onCurrencySelect={(currency) => onCurrencySelection(Field.OUTPUT, currency)}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the event handlers in the `SwapForm.tsx` component by replacing the `onUserInput` function with a `noop` (no operation) function, indicating that user input handling is being disabled for the output field.

### Detailed summary
- Changed `onUserInput` prop from `(val) => onUserInput(Field.OUTPUT, val)` to `noop`.
- Set `onPercentInput` to `noop`.
- Set `onMax` to `noop`.
- Retained `onCurrencySelect` function to handle currency selection for the output field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->