### PR TITLE
chore: add tTON as swap bases

### DIFF
--- a/apps/ton/src/config/constants/exchange.ts
+++ b/apps/ton/src/config/constants/exchange.ts
@@ -38,10 +38,12 @@ export const ADDITIONAL_BASES: { [chainId: number]: { [tokenAddress: string]: To
 export const CUSTOM_BASES: { [chainId: number]: { [tokenAddress: string]: Token[] } } = {}
 // todo:@eric mock bases to test multihops
 const USDC = tokenList.tokens.find((t) => t.symbol === 'USDC')!
+const tTON = tokenList.tokens.find((t) => t.symbol === 'tTON')!
 export const BASES_TO_CHECK_TRADES_AGAINST: { [chainId: number]: Currency[] } = {
   [TonChainId.Testnet]: [
     new Native(NATIVE[TonChainId.Testnet]),
     new Token(USDC.chainId, USDC.address, USDC.decimals, USDC.name, USDC.symbol, USDC.logoURI),
+    new Token(tTON.chainId, tTON.address, tTON.decimals, tTON.name, tTON.symbol, tTON.logoURI),
   ] satisfies Currency[],
   [TonChainId.Mainnet]: [],
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for a new token, `tTON`, in the trading configuration for the `TonChainId.Testnet`, enhancing the token list used for multi-hop trading.

### Detailed summary
- Added a new constant `tTON` to find the token with the symbol `tTON` in `tokenList.tokens`.
- Updated `BASES_TO_CHECK_TRADES_AGAINST` for `TonChainId.Testnet` to include a new `Token` instance for `tTON`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->