### PR TITLE
fix: android broken

### DIFF
--- a/apps/ton/src/components/Header.tsx
+++ b/apps/ton/src/components/Header.tsx
@@ -59,7 +59,7 @@ export const Header = ({ showBridgeLink }: HeaderProps) => {
   )
 
   const handleShareClick = useCallback(() => {
-    if (navigator.canShare(shareData)) {
+    if (navigator.canShare?.(shareData)) {
       navigator.share(shareData)
     }
   }, [shareData])
@@ -89,7 +89,7 @@ export const Header = ({ showBridgeLink }: HeaderProps) => {
         <IconButton variant="text" scale="sm" onClick={() => setIsOpen(true)}>
           <CogIcon width={24} color="textSubtle" />
         </IconButton>
-        {navigator.canShare(shareData) && (
+        {navigator.canShare?.(shareData) && (
           <IconButton variant="text" scale="sm" onClick={handleShareClick}>
             <ShareIcon width={24} color="textSubtle" />
           </IconButton>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the safety of the `navigator.canShare` method calls by using optional chaining. This prevents potential errors if `navigator.canShare` is undefined.

### Detailed summary
- Changed `navigator.canShare(shareData)` to `navigator.canShare?.(shareData)` in `handleShareClick` function.
- Updated the conditional rendering of the share button to use optional chaining: `navigator.canShare?.(shareData)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->