### PR TITLE
fix: debug picks

### DIFF
--- a/apps/web/src/components/AdPanel/index.ts
+++ b/apps/web/src/components/AdPanel/index.ts
@@ -1,7 +1,7 @@
 import { BodyText } from './BodyText'
 import { AdButton as Button } from './Button' // Ensure correct import of AdButton
 import { AdCard as Card } from './Card' // Ensure correct import of AdCard
-import { AdPlayer, AdSlides as AdsSlides, DesktopCard, MobileCard, PickAdSlides as PicksAdsSlides } from './CardLayouts'
+import { AdPlayer, AdSlides as AdsSlides, DesktopCard, MobileCard } from './CardLayouts'
 
 export const AdPanel = {
   DesktopCard,
@@ -11,5 +11,4 @@ export const AdPanel = {
   BodyText,
   Button,
   AdsSlides,
-  PicksAdsSlides,
 }

--- a/apps/web/src/components/AdPanel/index.ts
+++ b/apps/web/src/components/AdPanel/index.ts
@@ -1,14 +1,7 @@
-import dynamic from 'next/dynamic'
-
-// Dynamically import components
-const BodyText = dynamic(() => import('./BodyText').then((mod) => mod.BodyText))
-const Button = dynamic(() => import('./Button').then((mod) => mod.AdButton)) // Ensure to reference AdButton correctly
-const Card = dynamic(() => import('./Card').then((mod) => mod.AdCard)) // Ensure to reference AdCard correctly
-const AdPlayer = dynamic(() => import('./CardLayouts').then((mod) => mod.AdPlayer))
-const DesktopCard = dynamic(() => import('./CardLayouts').then((mod) => mod.DesktopCard))
-const MobileCard = dynamic(() => import('./CardLayouts').then((mod) => mod.MobileCard))
-const AdsSlides = dynamic(() => import('./CardLayouts').then((mod) => mod.AdSlides))
-const PicksAdsSlides = dynamic(() => import('./CardLayouts').then((mod) => mod.PickAdSlides))
+import { BodyText } from './BodyText'
+import { AdButton as Button } from './Button' // Ensure correct import of AdButton
+import { AdCard as Card } from './Card' // Ensure correct import of AdCard
+import { AdPlayer, AdSlides as AdsSlides, DesktopCard, MobileCard, PickAdSlides as PicksAdsSlides } from './CardLayouts'
 
 export const AdPanel = {
   DesktopCard,

--- a/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
@@ -2,8 +2,6 @@ import { useTheme } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, Button, Column, LinkExternal, PageHeader, Row, Text } from '@pancakeswap/uikit'
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
-import { AdPanel } from 'components/AdPanel'
-import { Suspense } from 'react'
 import { FarmFlexWrapper, FarmH1, FarmH2 } from 'views/Farms/styled'
 
 export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }) => {
@@ -39,11 +37,6 @@ export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }
                 </>
               )}
             </Row>
-          </Box>
-          <Box>
-            <Suspense>
-              <AdPanel.PicksAdsSlides isDismissible={false} />
-            </Suspense>
           </Box>
         </FarmFlexWrapper>
       </Column>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `PoolsBanner` component by removing the `AdPanel` usage and improving the import statements in the `AdPanel` component for clarity and efficiency.

### Detailed summary
- Removed the `AdPanel.PicksAdsSlides` usage from `PoolsBanner`.
- Eliminated the `Suspense` wrapper around the `AdPanel` in `PoolsBanner`.
- Changed dynamic imports in `AdPanel` to standard imports for several components, enhancing readability.
- Removed `PicksAdsSlides` from the `AdPanel` exports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->