### PR TITLE
fix: Route is disappear if token name is too long

### DIFF
--- a/apps/ton/src/components/TonSwap/SwapDetails/SwapRoute.tsx
+++ b/apps/ton/src/components/TonSwap/SwapDetails/SwapRoute.tsx
@@ -3,7 +3,12 @@ import { TradeType } from '@pancakeswap/swap-sdk-core'
 import { Currency, Trade } from '@pancakeswap/ton-v2-sdk'
 import { ChevronRightIcon, Flex, QuestionHelper, Text } from '@pancakeswap/uikit'
 import { Fragment } from 'react'
+import styled from 'styled-components'
 import { unwrappedToken } from 'utils/tokens/unwrappedToken'
+
+export const TruncatedText = styled(Text).attrs({ ellipsis: true })`
+  max-width: 46px;
+`
 
 export interface AdvancedSwapDetailsProps {
   trade?: Trade<Currency, Currency, TradeType> | null
@@ -20,9 +25,9 @@ export const SwapRoute = ({ trade }: AdvancedSwapDetailsProps) => {
         return (
           <Fragment key={token.wrapped.address}>
             <Flex alignItems="end">
-              <Text fontSize="14px" ml="0.125rem" mr="0.125rem">
+              <TruncatedText title={symbol} fontSize="14px" ml="0.125rem" mr="0.125rem">
                 {symbol}
-              </Text>
+              </TruncatedText>
             </Flex>
             {!isLastItem && <ChevronRightIcon width="12px" />}
           </Fragment>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `SwapRoute` component by introducing a new styled component, `TruncatedText`, to improve text handling and visual presentation.

### Detailed summary
- Added a new styled component `TruncatedText` that truncates text with a maximum width of 46px.
- Replaced the `Text` component with `TruncatedText` in the `SwapRoute` component for better text management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->