### PR TITLE
feat: getTimePeriods rounding

### DIFF
--- a/apps/web/src/views/Idos/hooks/ido/useIDODuration.tsx
+++ b/apps/web/src/views/Idos/hooks/ido/useIDODuration.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@pancakeswap/localization'
 import getTimePeriods from '@pancakeswap/utils/getTimePeriods'
 
 export const useIDODuration = (duration: number) => {
-  const { days, hours } = getTimePeriods(duration)
+  const { days, hours } = getTimePeriods(duration, 'ceil')
   const { t } = useTranslation()
 
   if (days > 1) {

--- a/packages/utils/getTimePeriods.ts
+++ b/packages/utils/getTimePeriods.ts
@@ -9,7 +9,8 @@ export const YEAR_IN_SECONDS = 31557600
  *
  * @param seconds
  */
-const getTimePeriods = (seconds: number) => {
+const getTimePeriods = (seconds: number, _rounding: 'floor' | 'ceil' = 'floor') => {
+  const rounding = _rounding === 'floor' ? Math.floor : Math.ceil
   let delta = Math.abs(seconds)
   const timeLeft = {
     years: 0,
@@ -22,31 +23,31 @@ const getTimePeriods = (seconds: number) => {
   }
 
   if (delta >= DAY_IN_SECONDS) {
-    timeLeft.totalDays = Math.floor(delta / DAY_IN_SECONDS)
+    timeLeft.totalDays = rounding(delta / DAY_IN_SECONDS)
   }
 
   if (delta >= YEAR_IN_SECONDS) {
-    timeLeft.years = Math.floor(delta / YEAR_IN_SECONDS)
+    timeLeft.years = rounding(delta / YEAR_IN_SECONDS)
     delta -= timeLeft.years * YEAR_IN_SECONDS
   }
 
   if (delta >= MONTH_IN_SECONDS) {
-    timeLeft.months = Math.floor(delta / MONTH_IN_SECONDS)
+    timeLeft.months = rounding(delta / MONTH_IN_SECONDS)
     delta -= timeLeft.months * MONTH_IN_SECONDS
   }
 
   if (delta >= DAY_IN_SECONDS) {
-    timeLeft.days = Math.floor(delta / DAY_IN_SECONDS)
+    timeLeft.days = rounding(delta / DAY_IN_SECONDS)
     delta -= timeLeft.days * DAY_IN_SECONDS
   }
 
   if (delta >= HOUR_IN_SECONDS) {
-    timeLeft.hours = Math.floor(delta / HOUR_IN_SECONDS)
+    timeLeft.hours = rounding(delta / HOUR_IN_SECONDS)
     delta -= timeLeft.hours * HOUR_IN_SECONDS
   }
 
   if (delta >= MINUTE_IN_SECONDS) {
-    timeLeft.minutes = Math.floor(delta / MINUTE_IN_SECONDS)
+    timeLeft.minutes = rounding(delta / MINUTE_IN_SECONDS)
     delta -= timeLeft.minutes * MINUTE_IN_SECONDS
   }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a rounding option to the `getTimePeriods` function, allowing for either ceiling or floor calculations of time periods based on the provided duration. This change impacts how time periods are calculated in the `useIDODuration` hook.

### Detailed summary
- Updated `getTimePeriods` to accept a second parameter `_rounding` for specifying rounding type ('floor' or 'ceil').
- Adjusted calculations within `getTimePeriods` to use the specified rounding method.
- Modified `useIDODuration` to call `getTimePeriods` with 'ceil' as the rounding option.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->