### PR TITLE
fix: Switch needs reload on some wallets

### DIFF
--- a/apps/web/src/hooks/useSwitchNetwork.ts
+++ b/apps/web/src/hooks/useSwitchNetwork.ts
@@ -6,12 +6,32 @@ import { ExtendEthereum } from 'global'
 import { useCallback, useMemo } from 'react'
 import { useAppDispatch } from 'state'
 import { clearUserStates } from 'utils/clearUserStates'
-import { useAccount, useSwitchChain } from 'wagmi'
+import { Connector, useAccount, useSwitchChain } from 'wagmi'
 import { useAtom } from 'jotai/index'
 import { queryChainIdAtom } from 'hooks/useActiveChainId'
 import { EXCHANGE_PAGE_PATHS } from 'config/constants/exchange'
 import { getHashFromRouter } from 'utils/getHashFromRouter'
 import { useSwitchNetworkLoading } from './useSwitchNetworkLoading'
+
+const checkSwitchReloadNeeded = async (connector: Connector, chainId: number, address: `0x${string}` | undefined) => {
+  try {
+    if (typeof connector.getProvider !== 'function') return false
+
+    const provider = (await connector.getProvider()) as any
+
+    return Boolean(
+      provider &&
+        (provider.isTokenPocket ||
+          (Array.isArray(provider.session?.namespaces?.eip155?.accounts) &&
+            !provider.session.namespaces.eip155.accounts.some((account: string) =>
+              account?.includes(`${chainId}:${address}`),
+            ))),
+    )
+  } catch (error) {
+    console.error(error, 'Error detecting provider')
+    return false
+  }
+}
 
 export function useSwitchNetworkLocal() {
   const [, setQueryChainId] = useAtom(queryChainIdAtom)
@@ -79,7 +99,7 @@ export function useSwitchNetwork() {
   const { t } = useTranslation()
 
   const { toastError } = useToast()
-  const { isConnected } = useAccount()
+  const { isConnected, connector, address } = useAccount()
 
   const switchNetworkLocal = useSwitchNetworkLocal()
 
@@ -87,14 +107,13 @@ export function useSwitchNetwork() {
 
   const switchNetworkAsync = useCallback(
     async (chainId: number) => {
-      if (isConnected && typeof _switchNetworkAsync === 'function') {
+      if (isConnected && connector && typeof _switchNetworkAsync === 'function') {
         if (isLoading) return undefined
         setLoading(true)
         return _switchNetworkAsync({ chainId })
-          .then((c) => {
+          .then(async (c) => {
             switchNetworkLocal(chainId)
-            // well token pocket
-            if (window.ethereum?.isTokenPocket === true) {
+            if (await checkSwitchReloadNeeded(connector, chainId, address)) {
               window.location.reload()
             }
             return c
@@ -109,7 +128,7 @@ export function useSwitchNetwork() {
         switchNetworkLocal(chainId)
       })
     },
-    [isConnected, _switchNetworkAsync, isLoading, setLoading, switchNetworkLocal, toastError, t],
+    [isConnected, _switchNetworkAsync, isLoading, setLoading, switchNetworkLocal, toastError, t, connector, address],
   )
 
   const switchNetwork = useCallback(


### PR DESCRIPTION
Fixes #11325

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useSwitchNetwork` hook by adding functionality to check if a reload is needed when switching networks, particularly for the TokenPocket wallet. It introduces the `checkSwitchReloadNeeded` function and updates the logic for network switching to incorporate this check.

### Detailed summary
- Added `Connector` import from `wagmi`.
- Introduced `checkSwitchReloadNeeded` function to determine if a reload is necessary based on the wallet provider.
- Updated `useAccount` to destructure `connector` and `address`.
- Modified `switchNetworkAsync` to include the reload check using `checkSwitchReloadNeeded`.
- Adjusted dependency array in `useCallback` to include `connector` and `address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->