### PR TITLE
fix: replace unpkg w/ jsdelivr

### DIFF
--- a/apps/bridge/components/layerZero/config.ts
+++ b/apps/bridge/components/layerZero/config.ts
@@ -1,10 +1,10 @@
 const VERSION = '0.0.30'
-// https://unpkg.com/@layerzerolabs/x-pancakeswap-widget@0.0.21/element.mjs.sha384
+// https://cdn.jsdelivr.net/npm/@layerzerolabs/x-pancakeswap-widget@0.0.21/element.mjs.sha384
 const SHA384 = 'gP8PH+BkL5mqD+BLlxDPi0+AZSLhKloxzEBENzAOXXe6r/Y/bD0vlULkhh3ryjxY'
 
 export const LAYER_ZERO_JS = {
-  src: `https://unpkg.com/@layerzerolabs/x-pancakeswap-widget@${VERSION}/element.mjs`,
-  css: `https://unpkg.com/@layerzerolabs/x-pancakeswap-widget@${VERSION}/element.css`,
+  src: `https://cdn.jsdelivr.net/npm/@layerzerolabs/x-pancakeswap-widget@${VERSION}/element.mjs`,
+  css: `https://cdn.jsdelivr.net/npm/@layerzerolabs/x-pancakeswap-widget@${VERSION}/element.css`,
   integrity: `sha384-${SHA384}`,
 }
 


### PR DESCRIPTION
UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

The PR replaces UNPKG usage with jsDelivr. The test cases are **not touched**.