### PR TITLE
chore: remove okx wallet from mev whitelist

### DIFF
--- a/apps/web/src/views/Mev/constant.ts
+++ b/apps/web/src/views/Mev/constant.ts
@@ -33,6 +33,7 @@ export const walletPretendToMetamask = [
   'isSafePal',
   'isBybit',
   'isCoinbaseWallet',
+  'isOkxWallet',
 ]
 // wallet support mev on bsc default, but it not using PCS RPC
 

--- a/apps/web/src/views/Mev/constant.ts
+++ b/apps/web/src/views/Mev/constant.ts
@@ -4,7 +4,7 @@ export const walletSupportDefaultMevOnBSC = ['isTrustWallet', 'isTrust', 'isBina
 export const walletConnectSupportDefaultMevOnBSC = ['Binance Wallet', 'Trust Wallet']
 // wallet connect wallets that support mev on bsc default
 
-export const walletSupportCustomRPCNative = ['isOkxWallet', 'isMetaMask']
+export const walletSupportCustomRPCNative = ['isMetaMask'] // isOkxWallet okx can't support EIP-3085 on wallet app
 // wallet support wallet_addEthereumChain native
 
 export const walletSupportManualRPCConfig = ['isRabby']


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the list of wallets that support MEV (Maximal Extractable Value) on BSC (Binance Smart Chain) by removing `isOkxWallet` and adding comments for clarity.

### Detailed summary
- Removed `isOkxWallet` from `walletSupportCustomRPCNative` due to its inability to support EIP-3085.
- Added `isOkxWallet` to `walletPretendToMetamask` list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->