### PR TITLE
fix: homepage swap url

### DIFF
--- a/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButtonForHomepage.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButtonForHomepage.tsx
@@ -249,12 +249,11 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   )
 
   const handleSwap = useCallback(() => {
-    let [input, output] = [inputCurrency, outputCurrency].map((currency) => currencyId(currency))
-    if (independentField === Field.OUTPUT) {
-      ;[input, output] = [output, input]
-    }
+    const [input, output] = [inputCurrency, outputCurrency].map((currency) => currencyId(currency))
 
-    router.push(`/swap?inputCurrency=${input}&outputCurrency=${output}&exactAmount=${typedValue}`)
+    router.push(
+      `/swap?inputCurrency=${input}&outputCurrency=${output}&exactAmount=${typedValue}&exactField=${independentField}`,
+    )
   }, [inputCurrency, outputCurrency, typedValue])
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `handleSwap` function in `SwapCommitButtonForHomepage.tsx` to improve the handling of input and output currencies and includes the `exactField` parameter in the routing URL.

### Detailed summary
- Changed variable declaration from `let` to `const` for `input` and `output`.
- Removed unnecessary re-assignment of `input` and `output` based on `independentField`.
- Added `exactField` parameter to the URL in the `router.push` call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->