### PR TITLE
chore: ignore eslint in build

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -46,6 +46,9 @@ const workerDeps = Object.keys(smartRouterPkgs.dependencies)
 
 /** @type {import('next').NextConfig} */
 const config = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   typescript: {
     tsconfigPath: 'tsconfig.json',
   },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a configuration change in the `next.config.mjs` file to adjust ESLint behavior during the build process.

### Detailed summary
- Added an `eslint` property to the configuration object.
- Set `ignoreDuringBuilds` to `true`, allowing the build to proceed even if there are ESLint errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->