### PR TITLE
fix: Crash info token pages

### DIFF
--- a/apps/web/src/views/Info/components/InfoTables/PoolsTable.tsx
+++ b/apps/web/src/views/Info/components/InfoTables/PoolsTable.tsx
@@ -119,7 +119,7 @@ const DataRow = ({ poolData, index }: { poolData: PoolData; index: number }) => 
 }
 
 interface PoolTableProps {
-  poolDatas: (PoolData | undefined)[]
+  poolDatas: PoolData[] | undefined
   loading?: boolean // If true shows indication that SOME pools are loading, but the ones already fetched will be shown
 }
 

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -31,7 +31,7 @@ import { formatAmount } from 'utils/formatInfoNumbers'
 
 import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import truncateHash from '@pancakeswap/utils/truncateHash'
-import { atom, useAtomValue } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import isEqual from 'lodash/isEqual'
 import { ChainLinkSupportChains, multiChainId, multiChainScan } from 'state/info/constant'
@@ -42,6 +42,7 @@ import { getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import useCMCLink from 'views/Info/hooks/useCMCLink'
 import { chainNames } from '@pancakeswap/chains'
+import { atomWithAsyncRetry } from 'utils/atomWithAsyncRetry'
 import BarChart from '../components/BarChart/alt'
 import { LocalLoader } from '../components/Loader'
 import Percent from '../components/Percent'
@@ -92,10 +93,13 @@ interface TokenQueryResponse {
 }
 
 const tokenPageDataAtom = atomFamily((params: TokenPageParams) => {
-  return atom(async () => {
-    const resp = await fetch(`/api/token/v3/${params.chain || 'bsc'}/${params.address}`)
-    const json = await resp.json()
-    return json as TokenQueryResponse
+  return atomWithAsyncRetry({
+    asyncFn: async () => {
+      const resp = await fetch(`/api/token/v3/${params.chain || 'bsc'}/${params.address}`)
+      if (!resp.ok) throw new Error('Fetch error')
+      const json = await resp.json()
+      return json as TokenQueryResponse
+    },
   })
 }, isEqual)
 

--- a/apps/web/src/views/V3Info/views/TokenPage.tsx
+++ b/apps/web/src/views/V3Info/views/TokenPage.tsx
@@ -86,10 +86,10 @@ interface TokenPageParams {
 }
 
 interface TokenQueryResponse {
-  token: TokenDataForView
-  pool: PoolDataForView[]
-  transactions: Transaction[]
-  charts: TokenChartEntry[]
+  token: TokenDataForView | undefined
+  pool: PoolDataForView[] | undefined
+  transactions: Transaction[] | undefined
+  charts: TokenChartEntry[] | undefined
 }
 
 const tokenPageDataAtom = atomFamily((params: TokenPageParams) => {
@@ -100,6 +100,7 @@ const tokenPageDataAtom = atomFamily((params: TokenPageParams) => {
       const json = await resp.json()
       return json as TokenQueryResponse
     },
+    fallbackValue: { token: undefined, pool: undefined, transactions: undefined, charts: undefined },
   })
 }, isEqual)
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving type safety and error handling in the `TokenPage` and `PoolsTable` components by refining the types of certain properties and implementing asynchronous data fetching with retry logic.

### Detailed summary
- Updated `poolDatas` type in `PoolTableProps` to `PoolData[] | undefined`.
- Changed `TokenQueryResponse` structure in `TokenPage.tsx` to use `undefined` for `token` and `pool`.
- Introduced `atomWithAsyncRetry` for fetching token data with error handling in both `TokenPage.tsx` and `V3Info/TokenPage.tsx`.
- Updated fallback values for `token`, `pool`, `transactions`, and charts in the new async logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->