### PR TITLE
chore: add Vote Now

### DIFF
--- a/apps/web/src/views/GaugesVoting/components/GaguesVotingMobileView.tsx
+++ b/apps/web/src/views/GaugesVoting/components/GaguesVotingMobileView.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Box, Card, Flex, Grid, Tab, TabMenu, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Box, Button, Card, Flex, Grid, Tab, TabMenu, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import Divider from 'components/Divider'
 import PinnedFAQButton from 'components/PinnedFAQButton'
 import { useEffect, useState } from 'react'
@@ -103,6 +103,21 @@ const GaugesVotingMobileView = () => {
               isLoading={isLoading}
               totalGaugesWeight={Number(totalGaugesWeight)}
             />
+
+            <Box width="100%" p="16px">
+              <Button
+                width="100%"
+                onClick={() => {
+                  setActiveTab(1)
+                  window.scrollTo({
+                    top: 0,
+                    behavior: 'smooth',
+                  })
+                }}
+              >
+                {t('Vote now')}
+              </Button>
+            </Box>
           </Card>
         ) : (
           <VoteTable />


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `Button` component to the `GaugesVotingMobileView` that allows users to quickly navigate to the voting section by clicking "Vote now." This enhances user interaction by providing a clear call-to-action.

### Detailed summary
- Added a `Button` component to `GaugesVotingMobileView`.
- The button is styled to take full width and has padding.
- On click, it sets the active tab to `1` and scrolls the window to the top smoothly.
- The button displays the text "Vote now."

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->