### PR TITLE
fix(PinnedFAQButton): add invertedContrast in HelpIcon

### DIFF
--- a/apps/web/src/components/PinnedFAQButton/index.tsx
+++ b/apps/web/src/components/PinnedFAQButton/index.tsx
@@ -97,7 +97,7 @@ const PinnedFAQButton: React.FC<PinnedFAQButtonProps> = ({ faqConfig, docLink })
       variant="subtle"
       onClick={handleOpenModal}
     >
-      <HelpIcon ml="0" color="white" width="24px" />
+      <HelpIcon ml="0" color="invertedContrast" width="24px" />
     </Button>
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the color of the `HelpIcon` component used within the `PinnedFAQButton`. The color change enhances the visual consistency of the button.

### Detailed summary
- Changed the `color` property of the `HelpIcon` from `white` to `invertedContrast`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->