### PR TITLE
fix: allow close modal when clicking outside

### DIFF
--- a/apps/web/src/components/PinnedFAQButton/index.tsx
+++ b/apps/web/src/components/PinnedFAQButton/index.tsx
@@ -114,7 +114,7 @@ const PinnedFAQButton: React.FC<PinnedFAQButtonProps> = ({ faqConfig, docLink })
           portal,
         )}
 
-      <ModalV2 isOpen={showModal} onDismiss={handleCloseModal}>
+      <ModalV2 isOpen={showModal} onDismiss={handleCloseModal} closeOnOverlayClick>
         <FaqModal onDismiss={handleCloseModal} title={t('Quick start')}>
           <Box
             border="2px solid"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new prop to the `ModalV2` component, enhancing its functionality by allowing it to close when the overlay is clicked.

### Detailed summary
- Added `closeOnOverlayClick` prop to the `ModalV2` component in `apps/web/src/components/PinnedFAQButton/index.tsx`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->