### PR TITLE
fix: Options causing state infinite

### DIFF
--- a/apps/web/src/state/multicall/hooks.ts
+++ b/apps/web/src/state/multicall/hooks.ts
@@ -45,17 +45,20 @@ function useCallsData(calls: (Call | undefined)[], options?: ListenerOptions): C
     [calls],
   )
 
+  const serializedOptions: string = useMemo(() => JSON.stringify(options ?? {}), [options])
+
   // update listeners when there is an actual change that persists for at least 100ms
   useEffect(() => {
     const callKeys: string[] = JSON.parse(serializedCallKeys)
     if (!chainId || callKeys.length === 0) return undefined
+    const objectOptions: ListenerOptions = JSON.parse(serializedOptions)
     // eslint-disable-next-line @typescript-eslint/no-shadow
     const calls = callKeys.map((key) => parseCallKey(key))
     dispatch(
       addMulticallListeners({
         chainId,
         calls,
-        options,
+        options: objectOptions,
       }),
     )
 
@@ -64,11 +67,11 @@ function useCallsData(calls: (Call | undefined)[], options?: ListenerOptions): C
         removeMulticallListeners({
           chainId,
           calls,
-          options,
+          options: objectOptions,
         }),
       )
     }
-  }, [chainId, dispatch, options, serializedCallKeys])
+  }, [chainId, dispatch, serializedOptions, serializedCallKeys])
 
   return useMemo(
     () =>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the handling of `options` in the `useCallsData` hook by serializing them and ensuring that the correct object is used when adding and removing multicall listeners.

### Detailed summary
- Introduced `serializedOptions` to store a stringified version of `options`.
- Changed the listener addition to use `objectOptions`, which is derived from `serializedOptions`.
- Updated the listener removal to also use `objectOptions`.
- Modified the dependency array in `useEffect` to include `serializedOptions` instead of `options`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->