### PR TITLE
chore: move Defiedge to history page

### DIFF
--- a/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
+++ b/apps/web/src/views/PositionManagers/components/AddLiquidity.tsx
@@ -75,7 +75,7 @@ interface Props {
   minDepositUSD?: number
   boosterMultiplier?: number
   isBooster?: boolean
-  onStake: (
+  onStake?: (
     amountA: CurrencyAmount<Currency>,
     amountB: CurrencyAmount<Currency>,
     allowDepositToken0: boolean,

--- a/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
@@ -15,7 +15,13 @@ import { StatusViewButtons } from 'views/Farms/components/YieldBooster/component
 import { useBCakeBoostLimitAndLockInfo } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info'
 import { useBoostStatusPM } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/useBoostStatus'
 import { useAccount } from 'wagmi'
-import { AprDataInfo, usePMV2SSMaxBoostMultiplier, useWrapperBooster } from '../hooks'
+import {
+  AprDataInfo,
+  PositionManagerStatus,
+  usePMV2SSMaxBoostMultiplier,
+  usePositionManagerStatus,
+  useWrapperBooster,
+} from '../hooks'
 import { useOnStake } from '../hooks/useOnStake'
 import { AddLiquidity } from './AddLiquidity'
 import { RemoveLiquidity } from './RemoveLiquidity'
@@ -153,6 +159,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
 
   const showRemoveLiquidityModal = useCallback(() => setRemoveLiquidityModalOpen(true), [])
   const hideRemoveLiquidityModal = useCallback(() => setRemoveLiquidityModalOpen(false), [])
+
   const { maxBoostMultiplier } = usePMV2SSMaxBoostMultiplier()
 
   const relevantTokenBalances = useCurrencyBalances(
@@ -172,8 +179,28 @@ export const LiquidityManagement = memo(function LiquidityManagement({
     boosterMultiplier ?? 1,
     bCakeWrapper,
   )
-  const { isTxLoading, onStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
+  const { isTxLoading, onStake: originalOnStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
   const { locked } = useBCakeBoostLimitAndLockInfo()
+  const { status: positionManagerStatus } = usePositionManagerStatus()
+
+  const isDisabled = positionManagerStatus === PositionManagerStatus.FINISHED
+
+  // Create a wrapper for onStake that does nothing when disabled
+  const onStake = useCallback(
+    (
+      amountA: CurrencyAmount<Currency>,
+      amountB: CurrencyAmount<Currency>,
+      allowDepositToken0Param: boolean,
+      allowDepositToken1Param: boolean,
+      onDone?: () => void,
+    ) => {
+      if (isDisabled) {
+        return undefined
+      }
+      return originalOnStake(amountA, amountB, allowDepositToken0Param, allowDepositToken1Param, onDone)
+    },
+    [isDisabled, originalOnStake],
+  )
 
   return (
     <>
@@ -185,12 +212,13 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               currencyB={currencyB}
               staked0Amount={staked0Amount}
               staked1Amount={staked1Amount}
-              onAdd={showAddLiquidityModal}
-              onRemove={showRemoveLiquidityModal}
               token0PriceUSD={token0PriceUSD}
               token1PriceUSD={token1PriceUSD}
               isSingleDepositToken={isSingleDepositToken}
               isSingleDepositToken0={isSingleDepositToken0}
+              onAdd={showAddLiquidityModal}
+              onRemove={showRemoveLiquidityModal}
+              isDisabled={isDisabled}
             />
             <AtomBox
               width={{
@@ -248,7 +276,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               {!account ? (
                 <ConnectWalletButton mt="4px" width="100%" />
               ) : (
-                <Button variant="primary" width="100%" onClick={showAddLiquidityModal}>
+                <Button variant="primary" width="100%" onClick={showAddLiquidityModal} disabled={isDisabled}>
                   {t('Add Liquidity')}
                 </Button>
               )}

--- a/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/LiquidityManagement.tsx
@@ -173,33 +173,19 @@ export const LiquidityManagement = memo(function LiquidityManagement({
   const dividerBorderStyle = useMemo(() => `1px solid ${colors.input}`, [colors.input])
   const isSingleDepositToken0 = isSingleDepositToken && allowDepositToken0
 
+  const { status: positionManagerStatus } = usePositionManagerStatus()
   const { status } = useBoostStatusPM(Boolean(bCakeWrapper), boosterMultiplier, refetch)
   const { shouldUpdate, veCakeUserMultiplierBeforeBoosted } = useWrapperBooster(
     boosterContractAddress ?? '0x',
     boosterMultiplier ?? 1,
     bCakeWrapper,
   )
-  const { isTxLoading, onStake: originalOnStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
   const { locked } = useBCakeBoostLimitAndLockInfo()
-  const { status: positionManagerStatus } = usePositionManagerStatus()
-
-  const isDisabled = positionManagerStatus === PositionManagerStatus.FINISHED
-
-  // Create a wrapper for onStake that does nothing when disabled
-  const onStake = useCallback(
-    (
-      amountA: CurrencyAmount<Currency>,
-      amountB: CurrencyAmount<Currency>,
-      allowDepositToken0Param: boolean,
-      allowDepositToken1Param: boolean,
-      onDone?: () => void,
-    ) => {
-      if (isDisabled) {
-        return undefined
-      }
-      return originalOnStake(amountA, amountB, allowDepositToken0Param, allowDepositToken1Param, onDone)
-    },
-    [isDisabled, originalOnStake],
+  const { isTxLoading, onStake, onUpdate } = useOnStake(
+    manager.id,
+    contractAddress,
+    bCakeWrapper,
+    positionManagerStatus === PositionManagerStatus.FINISHED,
   )
 
   return (
@@ -218,7 +204,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               isSingleDepositToken0={isSingleDepositToken0}
               onAdd={showAddLiquidityModal}
               onRemove={showRemoveLiquidityModal}
-              isDisabled={isDisabled}
+              isDisabled={positionManagerStatus === PositionManagerStatus.FINISHED}
             />
             <AtomBox
               width={{
@@ -276,7 +262,12 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               {!account ? (
                 <ConnectWalletButton mt="4px" width="100%" />
               ) : (
-                <Button variant="primary" width="100%" onClick={showAddLiquidityModal} disabled={isDisabled}>
+                <Button
+                  variant="primary"
+                  width="100%"
+                  onClick={showAddLiquidityModal}
+                  disabled={positionManagerStatus === PositionManagerStatus.FINISHED}
+                >
                   {t('Add Liquidity')}
                 </Button>
               )}

--- a/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
+++ b/apps/web/src/views/PositionManagers/components/StakedAssets.tsx
@@ -29,6 +29,7 @@ interface StakedAssetsProps {
   isSingleDepositToken0?: boolean
   onAdd?: () => void
   onRemove?: () => void
+  isDisabled?: boolean
 }
 
 export const StakedAssets = memo(function StakedAssets({
@@ -42,6 +43,7 @@ export const StakedAssets = memo(function StakedAssets({
   token1PriceUSD,
   isSingleDepositToken0,
   isSingleDepositToken,
+  isDisabled,
 }: StakedAssetsProps) {
   const { t } = useTranslation()
 
@@ -83,7 +85,7 @@ export const StakedAssets = memo(function StakedAssets({
           <ActionButton scale="md" onClick={onRemove} variant="secondary">
             <MinusIcon color="currentColor" width="1.5em" />
           </ActionButton>
-          <ActionButton scale="md" ml="0.5em" onClick={onAdd} variant="secondary">
+          <ActionButton scale="md" ml="0.5em" onClick={onAdd} variant="secondary" disabled={isDisabled}>
             <AddIcon color="currentColor" width="1.5em" />
           </ActionButton>
         </Flex>

--- a/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Currency, CurrencyAmount } from '@pancakeswap/sdk'
+import { memo, useCallback, useMemo, useState } from 'react'
+import { styled, useTheme } from 'styled-components'
 import { AtomBox, Button, Flex, RowBetween, useMatchBreakpoints } from '@pancakeswap/uikit'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import { memo, useCallback, useMemo, useState } from 'react'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { styled, useTheme } from 'styled-components'
 import { StatusView } from 'views/Farms/components/YieldBooster/components/bCakeV3/StatusView'
 import { StatusViewButtons } from 'views/Farms/components/YieldBooster/components/bCakeV3/StatusViewButtons'
 import { useBCakeBoostLimitAndLockInfo } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info'
@@ -112,34 +111,20 @@ export const LiquidityManagement = memo(function LiquidityManagement({
   const dividerBorderStyle = useMemo(() => `1px solid ${colors.input}`, [colors.input])
   const isSingleDepositToken0 = isSingleDepositToken && allowDepositToken0
 
+  const { status: positionManagerStatus } = usePositionManagerStatus()
   const { status } = useBoostStatusPM(Boolean(bCakeWrapper), boosterMultiplier, refetch)
   const { shouldUpdate, veCakeUserMultiplierBeforeBoosted } = useWrapperBooster(
     boosterContractAddress ?? '0x',
     boosterMultiplier ?? 1,
     bCakeWrapper,
   )
-  const { isTxLoading, onStake: originalOnStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
   const { locked } = useBCakeBoostLimitAndLockInfo()
   const { isDesktop } = useMatchBreakpoints()
-  const { status: positionManagerStatus } = usePositionManagerStatus()
-
-  const isDisabled = positionManagerStatus === PositionManagerStatus.FINISHED
-
-  // Create a wrapper for onStake that does nothing when disabled
-  const onStake = useCallback(
-    (
-      amountA: CurrencyAmount<Currency>,
-      amountB: CurrencyAmount<Currency>,
-      allowDepositToken0Param: boolean,
-      allowDepositToken1Param: boolean,
-      onDone?: () => void,
-    ) => {
-      if (isDisabled) {
-        return undefined
-      }
-      return originalOnStake(amountA, amountB, allowDepositToken0Param, allowDepositToken1Param, onDone)
-    },
-    [isDisabled, originalOnStake],
+  const { isTxLoading, onStake, onUpdate } = useOnStake(
+    manager.id,
+    contractAddress,
+    bCakeWrapper,
+    positionManagerStatus === PositionManagerStatus.FINISHED,
   )
 
   return (
@@ -162,7 +147,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
                 isSingleDepositToken0={isSingleDepositToken0}
                 onAdd={showAddLiquidityModal}
                 onRemove={showRemoveLiquidityModal}
-                isDisabled={isDisabled}
+                isDisabled={positionManagerStatus === PositionManagerStatus.FINISHED}
               />
               {!isDesktop && (
                 <AtomBox
@@ -245,7 +230,12 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               {!account ? (
                 <ConnectWalletButton mt="4px" width="100%" />
               ) : (
-                <Button variant="primary" width="100%" onClick={showAddLiquidityModal} disabled={isDisabled}>
+                <Button
+                  variant="primary"
+                  width="100%"
+                  onClick={showAddLiquidityModal}
+                  disabled={positionManagerStatus === PositionManagerStatus.FINISHED}
+                >
                   {t('Add Liquidity')}
                 </Button>
               )}

--- a/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
+++ b/apps/web/src/views/PositionManagers/components/TableView/LiquidityManagement.tsx
@@ -1,17 +1,21 @@
 import { useTranslation } from '@pancakeswap/localization'
-
+import { Currency, CurrencyAmount } from '@pancakeswap/sdk'
 import { AtomBox, Button, Flex, RowBetween, useMatchBreakpoints } from '@pancakeswap/uikit'
+import ConnectWalletButton from 'components/ConnectWalletButton'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-
-import ConnectWalletButton from 'components/ConnectWalletButton'
 import { styled, useTheme } from 'styled-components'
 import { StatusView } from 'views/Farms/components/YieldBooster/components/bCakeV3/StatusView'
 import { StatusViewButtons } from 'views/Farms/components/YieldBooster/components/bCakeV3/StatusViewButtons'
 import { useBCakeBoostLimitAndLockInfo } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/useBCakeV3Info'
 import { useBoostStatusPM } from 'views/Farms/components/YieldBooster/hooks/bCakeV3/useBoostStatus'
 import { useAccount } from 'wagmi'
-import { usePMV2SSMaxBoostMultiplier, useWrapperBooster } from '../../hooks'
+import {
+  PositionManagerStatus,
+  usePMV2SSMaxBoostMultiplier,
+  usePositionManagerStatus,
+  useWrapperBooster,
+} from '../../hooks'
 import { useOnStake } from '../../hooks/useOnStake'
 import { AddLiquidity } from '../AddLiquidity'
 import { LiquidityManagementProps } from '../LiquidityManagement'
@@ -114,9 +118,30 @@ export const LiquidityManagement = memo(function LiquidityManagement({
     boosterMultiplier ?? 1,
     bCakeWrapper,
   )
-  const { isTxLoading, onStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
+  const { isTxLoading, onStake: originalOnStake, onUpdate } = useOnStake(manager.id, contractAddress, bCakeWrapper)
   const { locked } = useBCakeBoostLimitAndLockInfo()
   const { isDesktop } = useMatchBreakpoints()
+  const { status: positionManagerStatus } = usePositionManagerStatus()
+
+  const isDisabled = positionManagerStatus === PositionManagerStatus.FINISHED
+
+  // Create a wrapper for onStake that does nothing when disabled
+  const onStake = useCallback(
+    (
+      amountA: CurrencyAmount<Currency>,
+      amountB: CurrencyAmount<Currency>,
+      allowDepositToken0Param: boolean,
+      allowDepositToken1Param: boolean,
+      onDone?: () => void,
+    ) => {
+      if (isDisabled) {
+        return undefined
+      }
+      return originalOnStake(amountA, amountB, allowDepositToken0Param, allowDepositToken1Param, onDone)
+    },
+    [isDisabled, originalOnStake],
+  )
+
   return (
     <>
       {hasStaked ? (
@@ -131,12 +156,13 @@ export const LiquidityManagement = memo(function LiquidityManagement({
                 currencyB={currencyB}
                 staked0Amount={staked0Amount}
                 staked1Amount={staked1Amount}
-                onAdd={showAddLiquidityModal}
-                onRemove={showRemoveLiquidityModal}
                 token0PriceUSD={token0PriceUSD}
                 token1PriceUSD={token1PriceUSD}
                 isSingleDepositToken={isSingleDepositToken}
                 isSingleDepositToken0={isSingleDepositToken0}
+                onAdd={showAddLiquidityModal}
+                onRemove={showRemoveLiquidityModal}
+                isDisabled={isDisabled}
               />
               {!isDesktop && (
                 <AtomBox
@@ -219,7 +245,7 @@ export const LiquidityManagement = memo(function LiquidityManagement({
               {!account ? (
                 <ConnectWalletButton mt="4px" width="100%" />
               ) : (
-                <Button variant="primary" width="100%" onClick={showAddLiquidityModal}>
+                <Button variant="primary" width="100%" onClick={showAddLiquidityModal} disabled={isDisabled}>
                   {t('Add Liquidity')}
                 </Button>
               )}

--- a/apps/web/src/views/PositionManagers/containers/VaultContent.tsx
+++ b/apps/web/src/views/PositionManagers/containers/VaultContent.tsx
@@ -2,6 +2,7 @@ import { isThirdPartyVaultConfig } from '@pancakeswap/position-managers'
 import { ViewMode } from '@pancakeswap/uikit'
 import { memo, useMemo } from 'react'
 import { useFarmsV3WithPositionsAndBooster } from 'state/farmsV3/hooks'
+import { MANAGER } from '@pancakeswap/position-managers/src/constants/managers'
 
 import { CardLayout } from '../components'
 import { TableRow } from '../components/TableView'
@@ -63,7 +64,12 @@ export const VaultContent = memo(function VaultContent() {
         }
         return true
       })
-      .filter(() => {
+      .filter((d) => {
+        // Move all DefiEdge pools to history page
+        if (d.manager === MANAGER.DEFIEDGE) {
+          return status === PositionManagerStatus.FINISHED // Only show in history
+        }
+
         if (status === PositionManagerStatus.FINISHED) {
           return false
           // return d.endTimestamp <= Date.now() / 1000

--- a/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
+++ b/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
@@ -104,8 +104,6 @@ export const useOnStake = (
 
   const onUpdate = useCallback(
     async (onDone?: () => void) => {
-      // If disabled, do nothing and return
-
       const receipt = await fetchWithCatchTxError(
         bCakeWrapperAddress
           ? async () =>

--- a/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
+++ b/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
@@ -11,7 +11,12 @@ import { useCallback } from 'react'
 import { Address } from 'viem'
 import { usePMSlippage } from './usePMSlippage'
 
-export const useOnStake = (managerId: MANAGER, contractAddress: Address, bCakeWrapperAddress?: Address) => {
+export const useOnStake = (
+  managerId: MANAGER,
+  contractAddress: Address,
+  bCakeWrapperAddress?: Address,
+  isDisabled?: boolean,
+) => {
   const positionManagerBCakeWrapperContract = usePositionManagerBCakeWrapperContract(bCakeWrapperAddress ?? '0x')
   const positionManagerWrapperContract = usePositionManagerWrapperContract(contractAddress)
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
@@ -58,7 +63,7 @@ export const useOnStake = (managerId: MANAGER, contractAddress: Address, bCakeWr
                 },
               )
             }
-          : () =>
+          : async () =>
               positionManagerWrapperContract.write.mintThenDeposit(
                 [
                   allowDepositToken0 ? amountA?.numerator ?? 0n : 0n,
@@ -99,14 +104,16 @@ export const useOnStake = (managerId: MANAGER, contractAddress: Address, bCakeWr
 
   const onUpdate = useCallback(
     async (onDone?: () => void) => {
+      // If disabled, do nothing and return
+
       const receipt = await fetchWithCatchTxError(
         bCakeWrapperAddress
-          ? () =>
+          ? async () =>
               positionManagerBCakeWrapperContract.write.deposit([0n, true], {
                 account: account ?? '0x',
                 chain,
               })
-          : () =>
+          : async () =>
               positionManagerWrapperContract.write.deposit([0n], {
                 account: account ?? '0x',
                 chain,
@@ -136,7 +143,7 @@ export const useOnStake = (managerId: MANAGER, contractAddress: Address, bCakeWr
   )
 
   return {
-    onStake: mintThenDeposit,
+    onStake: isDisabled ? undefined : mintThenDeposit,
     onUpdate,
     isTxLoading: pendingTx,
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the liquidity management features in the application by adding conditional checks and new properties to improve user experience, particularly regarding staking and adding liquidity based on the position manager's status.

### Detailed summary
- Updated `AddLiquidity` component to make `onStake` optional.
- Modified `VaultContent` to filter out DefiEdge pools based on their status.
- Added `isDisabled` prop to `StakedAssets` and updated button behaviors accordingly.
- Enhanced `useOnStake` hook to accept `isDisabled` parameter.
- Integrated `positionManagerStatus` checks in `LiquidityManagement` to disable actions when the status is finished.
- Updated button components to reflect the disabled state based on `positionManagerStatus`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->