### PR TITLE
fix: remove pnp as a warning token

### DIFF
--- a/apps/web/src/config/constants/swapWarningTokens.ts
+++ b/apps/web/src/config/constants/swapWarningTokens.ts
@@ -7,7 +7,7 @@ import { bscWarningTokens } from 'config/constants/warningTokens/bscWarningToken
 
 const { alETH } = ethereumTokens
 const { bondly, itam, ccar, bttold, abnbc, metis } = bscTokens
-const { pokemoney, free, safemoon, gala, xcad, lusd, nfp, pnp } = bscWarningTokens
+const { pokemoney, free, safemoon, gala, xcad, lusd, nfp } = bscWarningTokens
 const { mPendle } = arbitrumWarningTokens
 const { usdPlus } = zksyncTokens
 const { ath } = baseWarningTokens
@@ -36,7 +36,6 @@ const SwapWarningTokens = <WarningTokenList>{
     metis,
     lusd,
     nfp,
-    pnp,
   },
   [ChainId.ZKSYNC]: {
     usdPlus,

--- a/apps/web/src/config/constants/warningTokens/bscWarningTokens.ts
+++ b/apps/web/src/config/constants/warningTokens/bscWarningTokens.ts
@@ -52,6 +52,5 @@ export const bscWarningTokens = {
     'https://nfprompt.io/',
   ),
   nmt: new ERC20Token(ChainId.BSC, '0x03AA6298F1370642642415EDC0db8b957783e8D6', 18, 'NMT', 'NetMind Token'),
-  pnp: new ERC20Token(ChainId.BSC, '0x5012c90F14d190607662CA8344120812Aaa2639D', 18, 'PNP', 'Penpie Token'),
   uniBTC: new ERC20Token(ChainId.BSC, '0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a', 8, 'uniBTC', 'uniBTC'),
 }

--- a/apps/web/src/views/Swap/components/SwapWarningModal/bsc/index.tsx
+++ b/apps/web/src/views/Swap/components/SwapWarningModal/bsc/index.tsx
@@ -14,7 +14,7 @@ import RugPullWarning from './RugPullWarning'
 import SafemoonWarning from './SafemoonWarning'
 import XCADWarning from './XCADWarning'
 
-const { safemoon, bondly, itam, ccar, bttold, pokemoney, free, gala, abnbc, xcad, metis, lusd, nfp, pnp } =
+const { safemoon, bondly, itam, ccar, bttold, pokemoney, free, gala, abnbc, xcad, metis, lusd, nfp } =
   SwapWarningTokensConfig[ChainId.BSC]
 
 const BSC_WARNING_LIST = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the warning tokens configuration for the BSC chain by removing the `pnp` token from the `SwapWarningTokensConfig` and related lists.

### Detailed summary
- Removed `pnp` from the destructuring assignment in `apps/web/src/views/Swap/components/SwapWarningModal/bsc/index.tsx`.
- Removed `pnp` from the `BSC_WARNING_LIST` in `apps/web/src/config/constants/warningTokens/bscWarningTokens.ts`.
- Updated destructuring in `apps/web/src/config/constants/swapWarningTokens.ts` to exclude `pnp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->