### PR TITLE
chore: remove old gtag ID 

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,4 +1,1 @@
-NEXT_PUBLIC_GTAG = "GTM-TLF66T4"
-
 NEXT_PUBLIC_SNAPSHOT_BASE_URL = "https://hub.snapshot.org"
-

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/iframe-has-title */
 import { FARMS_API } from 'config/constants/endpoints'
-import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document'
+import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
 class MyDocument extends Document {
@@ -50,7 +50,7 @@ class MyDocument extends Document {
         <body>
           <noscript>
             <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTAG}`}
+              src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_NEW_GTAG}`}
               height="0"
               width="0"
               style={{ display: 'none', visibility: 'hidden' }}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

1. The environment variable `NEXT_PUBLIC_GTAG` is not needed in `.env.production` file.
2. Update to use new GTAG

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the configuration for a production environment and modifies the Google Tag Manager ID used in the `_document.tsx` file.

### Detailed summary
- Updated the value of `NEXT_PUBLIC_SNAPSHOT_BASE_URL` in the `.env.production` file.
- Changed the import order in the `MyDocument` class from `next/document`.
- Replaced the Google Tag Manager ID from `NEXT_PUBLIC_GTAG` to `NEXT_PUBLIC_NEW_GTAG`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->