### PR TITLE
chore: [PAN-4848] Remove BETA from Prediction

### DIFF
--- a/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
+++ b/apps/web/src/components/AdPanel/FAQ/config/prediction.ts
@@ -2,7 +2,7 @@ import { getImageUrl } from 'components/AdPanel/utils'
 import { FAQConfig } from '../types'
 
 export const predictionFAQConfig: FAQConfig = (t) => ({
-  title: t('Quick start to Prediction (BETA)'),
+  title: t('Quick start to Prediction'),
   imageUrl: getImageUrl('prediction_telegram_bot'),
   alt: 'Prediction Telegram bot',
   docsUrl: 'https://docs.pancakeswap.finance/products/prediction',

--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -169,7 +169,7 @@ const config: (
           type: DropdownMenuItemType.EXTERNAL_LINK,
         },
         {
-          label: t('Prediction (BETA)'),
+          label: t('Prediction'),
           href: '/prediction',
           image: '/images/decorations/prediction.png',
           supportChainIds: PREDICTION_SUPPORTED_CHAINS,

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -568,7 +568,6 @@
   "Register": "Register",
   "Contribute %symbol%": "Contribute %symbol%",
   "Volume": "Volume",
-  "Prediction (BETA)": "Prediction (BETA)",
   "You can now start prediction": "You can now start prediction",
   "Leaderboard": "Leaderboard",
   "Tokens": "Tokens",
@@ -3400,7 +3399,6 @@
   "PancakeSwap Prediction Telegram Bot is now live!": "PancakeSwap Prediction Telegram Bot is now live!",
   "Quick start to Buy Crypto": "Quick start to Buy Crypto",
   "Need Help?": "Need Help?",
-  "Quick start to Prediction (BETA)": "Quick start to Prediction (BETA)",
   "What is the Prediction Feature?": "What is the Prediction Feature?",
   "How Do I Participate in Prediction?": "How Do I Participate in Prediction?",
   "What Are the Risks in Prediction?": "What Are the Risks in Prediction?",
@@ -3637,7 +3635,6 @@
   "Please upgrade your wallet app": "Please upgrade your wallet app",
   "Account Already Participated": "Account Already Participated",
   "You have already participated in this TGE": "You have already participated in this TGE",
-
   "Quick start": "Quick start",
   "View details in Docs": "View details in Docs",
   "What is CAKE staking?": "What is CAKE staking?",
@@ -3691,5 +3688,6 @@
   "I still have CAKE staked in the old Auto or Manual CAKE Pools. What should I do?": "I still have CAKE staked in the old Auto or Manual CAKE Pools. What should I do?",
   "Auto CAKE and Manual CAKE Pools": "Auto CAKE and Manual CAKE Pools",
   "migrate to veCAKE": "migrate to veCAKE",
-  "Learn how to migrate here": "Learn how to migrate here"
+  "Learn how to migrate here": "Learn how to migrate here",
+  "Quick start to Prediction": "Quick start to Prediction"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -568,6 +568,7 @@
   "Register": "Register",
   "Contribute %symbol%": "Contribute %symbol%",
   "Volume": "Volume",
+  "Prediction (BETA)": "Prediction (BETA)",
   "You can now start prediction": "You can now start prediction",
   "Leaderboard": "Leaderboard",
   "Tokens": "Tokens",
@@ -3399,6 +3400,7 @@
   "PancakeSwap Prediction Telegram Bot is now live!": "PancakeSwap Prediction Telegram Bot is now live!",
   "Quick start to Buy Crypto": "Quick start to Buy Crypto",
   "Need Help?": "Need Help?",
+  "Quick start to Prediction (BETA)": "Quick start to Prediction (BETA)",
   "What is the Prediction Feature?": "What is the Prediction Feature?",
   "How Do I Participate in Prediction?": "How Do I Participate in Prediction?",
   "What Are the Risks in Prediction?": "What Are the Risks in Prediction?",
@@ -3635,6 +3637,7 @@
   "Please upgrade your wallet app": "Please upgrade your wallet app",
   "Account Already Participated": "Account Already Participated",
   "You have already participated in this TGE": "You have already participated in this TGE",
+
   "Quick start": "Quick start",
   "View details in Docs": "View details in Docs",
   "What is CAKE staking?": "What is CAKE staking?",
@@ -3688,6 +3691,5 @@
   "I still have CAKE staked in the old Auto or Manual CAKE Pools. What should I do?": "I still have CAKE staked in the old Auto or Manual CAKE Pools. What should I do?",
   "Auto CAKE and Manual CAKE Pools": "Auto CAKE and Manual CAKE Pools",
   "migrate to veCAKE": "migrate to veCAKE",
-  "Learn how to migrate here": "Learn how to migrate here",
-  "Quick start to Prediction": "Quick start to Prediction"
+  "Learn how to migrate here": "Learn how to migrate here"
 }

--- a/scripts/translationManager.ts
+++ b/scripts/translationManager.ts
@@ -10,9 +10,9 @@ type TaggedKeys = [string[], Tag]
 const TRANSLATIONS_FILE = path.resolve(__dirname, '../packages/localization/src/config/translations.json')
 
 /**
- * Updates the translations.json file by adding or removing specified keys
- * @param keysToProcess Object containing keys to add or remove in format { "key1": "key1", "key2": "key2" }
- * @param taggedKeys Array of tagged keys: [["key1", "key2"], "unused"] or [["key3"], "missing"]
+ * Manages the translations.json file by adding missing keys or removing unused ones
+ * @param keysToProcess Object containing keys in format { "key1": "key1", "key2": "key2" }
+ * @param taggedKeys Array of tagged keys with format [["key1", "key2"], "unused"] or [["key3"], "missing"]
  */
 async function updateTranslationsFile(keysToProcess: TranslationKeys, taggedKeys: TaggedKeys) {
   const [keys, tag] = taggedKeys
@@ -20,7 +20,7 @@ async function updateTranslationsFile(keysToProcess: TranslationKeys, taggedKeys
 }
 
 /**
- * Process a single translation file by adding or removing keys
+ * Process a translation file by adding missing keys or removing unused ones
  */
 function processFile(filePath: string, keysToProcess: TranslationKeys, targetKeys: string[], tag: Tag) {
   try {
@@ -101,7 +101,7 @@ function processFile(filePath: string, keysToProcess: TranslationKeys, targetKey
 }
 
 /**
- * Main function to run the script
+ * Main function that handles CLI arguments and runs the translation management
  */
 async function main() {
   const args = process.argv.slice(2)
@@ -110,14 +110,14 @@ async function main() {
     // eslint-disable-next-line no-console
     console.log(`
 Usage: 
-  pnpm tsx scripts/updateTranslation.ts <keys_json_string> -tag <tag>
+  pnpm tsx scripts/translationManager.ts <keys_json_string> -tag <tag>
 
 Examples:
-  // Remove unused keys from translations.json
-  pnpm tsx scripts/updateTranslation.ts '{"key1":"key1","key2":"key2"}' -tag unused
+  # Remove unused keys from translations file
+  pnpm tsx scripts/translationManager.ts '{"key1":"key1","key2":"key2"}' -tag unused
   
-  // Add missing keys to translations.json
-  pnpm tsx scripts/updateTranslation.ts '{"key3":"key3"}' -tag missing
+  # Add missing keys to translations file
+  pnpm tsx scripts/translationManager.ts '{"key3":"key3"}' -tag missing
     `)
     process.exit(1)
   }

--- a/scripts/updateTranslation.ts
+++ b/scripts/updateTranslation.ts
@@ -1,0 +1,168 @@
+import fs from 'fs'
+import path from 'path'
+
+// Define types
+type TranslationKey = string
+type TranslationKeys = Record<TranslationKey, TranslationKey>
+type Tag = 'unused' | 'missing'
+type TaggedKeys = [string[], Tag]
+
+const TRANSLATIONS_FILE = path.resolve(__dirname, '../packages/localization/src/config/translations.json')
+
+/**
+ * Updates the translations.json file by adding or removing specified keys
+ * @param keysToProcess Object containing keys to add or remove in format { "key1": "key1", "key2": "key2" }
+ * @param taggedKeys Array of tagged keys: [["key1", "key2"], "unused"] or [["key3"], "missing"]
+ */
+async function updateTranslationsFile(keysToProcess: TranslationKeys, taggedKeys: TaggedKeys) {
+  const [keys, tag] = taggedKeys
+  processFile(TRANSLATIONS_FILE, keysToProcess, keys, tag)
+}
+
+/**
+ * Process a single translation file by adding or removing keys
+ */
+function processFile(filePath: string, keysToProcess: TranslationKeys, targetKeys: string[], tag: Tag) {
+  try {
+    const fileContent = fs.readFileSync(filePath, 'utf8')
+    const translations = JSON.parse(fileContent)
+    let modified = false
+
+    if (tag === 'unused') {
+      // Remove keys tagged as unused
+      for (const key of targetKeys) {
+        if (key in translations) {
+          delete translations[key]
+          modified = true
+          console.log(`Removed key "${key}" from ${path.basename(filePath)}`)
+        }
+      }
+
+      if (modified) {
+        // For removals, we need to rewrite the entire file
+        fs.writeFileSync(filePath, JSON.stringify(translations, null, 2))
+        // eslint-disable-next-line no-console
+        console.log(`Updated ${path.basename(filePath)}`)
+      }
+    } else if (tag === 'missing') {
+      // For missing keys, we'll manually append to the end of the file
+      const keysToAdd: Record<string, string> = {}
+      let hasKeysToAdd = false
+
+      for (const key of targetKeys) {
+        if (!(key in translations) && key in keysToProcess) {
+          keysToAdd[key] = keysToProcess[key]
+          hasKeysToAdd = true
+          // eslint-disable-next-line no-console
+          console.log(`Added key "${key}" to ${path.basename(filePath)}`)
+        }
+      }
+
+      if (hasKeysToAdd) {
+        // Read the file line by line
+        const lines = fileContent.split('\n')
+
+        // Find the last line with the closing brace
+        let lastContentLineIdx = -1
+        for (let i = lines.length - 1; i >= 0; i--) {
+          if (lines[i].trim() === '}') {
+            lastContentLineIdx = i
+            break
+          }
+        }
+
+        if (lastContentLineIdx !== -1) {
+          // Check if the line before the closing brace has a comma
+          const lastKeyLineIdx = lastContentLineIdx - 1
+          if (lastKeyLineIdx >= 0 && !lines[lastKeyLineIdx].trim().endsWith(',')) {
+            lines[lastKeyLineIdx] += ','
+          }
+
+          // Add each new key before the closing brace
+          const keyLines = Object.entries(keysToAdd).map(
+            ([key, value], idx, arr) => `  "${key}": "${value}"${idx < arr.length - 1 ? ',' : ''}`,
+          )
+
+          // Insert the new key lines before the closing brace
+          lines.splice(lastContentLineIdx, 0, ...keyLines)
+
+          // Write the modified content back to the file
+          fs.writeFileSync(filePath, lines.join('\n'))
+          // eslint-disable-next-line no-console
+          console.log(`Updated ${path.basename(filePath)}`)
+        } else {
+          console.error(`Could not find the closing brace in ${filePath}`)
+        }
+      }
+    }
+  } catch (error) {
+    console.error(`Error processing ${filePath}:`, error)
+  }
+}
+
+/**
+ * Main function to run the script
+ */
+async function main() {
+  const args = process.argv.slice(2)
+
+  if (args.length < 2) {
+    // eslint-disable-next-line no-console
+    console.log(`
+Usage: 
+  pnpm tsx scripts/updateTranslation.ts <keys_json_string> -tag <tag>
+
+Examples:
+  // Remove unused keys from translations.json
+  pnpm tsx scripts/updateTranslation.ts '{"key1":"key1","key2":"key2"}' -tag unused
+  
+  // Add missing keys to translations.json
+  pnpm tsx scripts/updateTranslation.ts '{"key3":"key3"}' -tag missing
+    `)
+    process.exit(1)
+  }
+
+  // Check for -tag argument
+  const tagIndex = args.indexOf('-tag')
+  if (tagIndex === -1 || tagIndex === args.length - 1) {
+    console.error('Missing or invalid -tag parameter')
+    process.exit(1)
+  }
+
+  const tagValue = args[tagIndex + 1]
+  if (tagValue !== 'unused' && tagValue !== 'missing') {
+    console.error('Tag must be either "unused" or "missing"')
+    process.exit(1)
+  }
+  const tag = tagValue as Tag
+
+  // Remove the -tag and its value from args for further processing
+  const processArgs = [...args]
+  processArgs.splice(tagIndex, 2)
+
+  // Parse remaining arguments
+  if (processArgs.length !== 1) {
+    console.error('Invalid number of arguments')
+    process.exit(1)
+  }
+
+  const keysString = processArgs[0]
+
+  // Parse keys object
+  let keysToProcess: TranslationKeys
+  try {
+    keysToProcess = JSON.parse(keysString)
+  } catch (error) {
+    console.error('Invalid JSON format for keys:', error)
+    process.exit(1)
+  }
+
+  // Extract keys from the keys object
+  const keys = Object.keys(keysToProcess)
+
+  // Run the update
+  await updateTranslationsFile(keysToProcess, [keys, tag])
+}
+
+// Run the script
+main().catch(console.error)


### PR DESCRIPTION
Closes PAN-4848

## Description
Removed the BETA label from Prediction feature in menu and FAQ title as requested in Linear ticket.

### Changes
- Removed "(BETA)" from Prediction label in menu dropdown
- Removed "(BETA)" from Quick start to Prediction title in FAQ

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the "BETA" label from the `Prediction` feature across various files and enhancing the translation management script for better handling of unused and missing translation keys.

### Detailed summary
- Updated `label` in `apps/web/src/components/Menu/config/config.ts` to remove "BETA".
- Changed `title` in `apps/web/src/components/AdPanel/FAQ/config/prediction.ts` to remove "BETA".
- Removed "Prediction (BETA)" from `packages/localization/src/config/translations.json`.
- Added "Quick start to Prediction" to `translations.json`.
- Enhanced `scripts/translationManager.ts` to manage translation keys more effectively, including adding/removing keys based on tags.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->