### PR TITLE
chore: wording adjustments

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooter.tsx
@@ -24,8 +24,8 @@ import { warningSeverity } from 'utils/exchange'
 
 import { paymasterInfo } from 'config/paymaster'
 import { usePaymaster } from 'hooks/usePaymaster'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
 import { isAddressEqual } from 'utils'
+import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
 import FormattedPriceImpact from '../../components/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from '../../components/styleds'
 import { SlippageAdjustedAmounts, formatExecutionPrice } from '../utils/exchange'
@@ -185,7 +185,7 @@ export const SwapModalFooter = memo(function SwapModalFooter({
                 <>
                   <Text>
                     {t(
-                      'Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
+                      'Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
                     )}
                   </Text>
                   <Text mt="12px">

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -215,7 +215,7 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
                 <>
                   <Text>
                     {t(
-                      'Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
+                      'Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
                     )}
                   </Text>
                   <Text mt="12px">

--- a/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/Swap/components/AdvancedSwapDetails.tsx
@@ -145,7 +145,7 @@ export const TradeSummary = memo(function TradeSummary({
                     </Text>
                     :{' '}
                     {t(
-                      'Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
+                      'Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
                     )}
                   </Text>
                   <Text mt="12px">

--- a/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
@@ -194,7 +194,7 @@ export const TradeSummary = memo(function TradeSummary({
                     </Text>
                     :{' '}
                     {t(
-                      'Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
+                      'Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.',
                     )}
                   </Text>
                   <Text mt="12px">

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -2216,7 +2216,7 @@
   "Split routing enables token swaps to be broken into multiple routes to achieve the best deal.": "Split routing enables token swaps to be broken into multiple routes to achieve the best deal.",
   "Turning this off will only allow a single route, which may result in low efficiency or higher slippage.": "Turning this off will only allow a single route, which may result in low efficiency or higher slippage.",
   "Route is automatically calculated based on your routing preference to achieve the best price for your trade.": "Route is automatically calculated based on your routing preference to achieve the best price for your trade.",
-  "Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.": "Fee ranging from 0.1% to 0.01% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.",
+  "Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.": "Fee ranging from 0.01% to 1% depending on the pool fee tier. You can check the fee tier by clicking the magnifier icon under the “Route” section.",
   "Fee Breakdown and Tokenomics": "Fee Breakdown and Tokenomics",
   "Harvest All": "Harvest All",
   "Avg": "Avg",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the fee range displayed in multiple components and localization files from "0.1% to 0.01%" to "0.01% to 1%," ensuring consistency in the user interface regarding pool fee tiers.

### Detailed summary
- Updated fee range text in:
  - `AdvancedSwapDetails.tsx` (two instances)
  - `SwapModalFooterV2.tsx`
  - `SwapModalFooter.tsx`
- Changed localization entry for fee range in `translations.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->