### PR TITLE
fix: add minOut for multihops

### DIFF
--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -12,8 +12,9 @@ import { ActionType } from 'components/Modals/ActionModal'
 import { ALLOWED_PRICE_IMPACT_HIGH, PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN } from 'config/constants/exchange'
 import { useLatestTxReceipt } from 'hooks/useLatestTxReceipt'
 import { useUserAddress } from 'hooks/useUserAddress'
+import { useUserSlippagePercent } from 'hooks/useUserSlippage'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { routerContractAtom } from 'ton/atom/contracts/routerContractAtom'
 import { gasConstantsAtom } from 'ton/atom/gasConstantsAtom'
 
@@ -31,14 +32,14 @@ interface SwapArgs {
   token0?: Currency
   token1?: Currency
   amount0: string
-  minOut?: string
 }
 
-export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }: SwapArgs) => {
+export const useSwap = ({ amount0, token0, token1, trade, refreshTrade }: SwapArgs) => {
   const { t } = useTranslation()
   const [tonUI] = useTonConnectUI()
 
   const userAddress = useUserAddress()
+  const [allowedSlippage] = useUserSlippagePercent()
 
   const GAS_CONSTANTS = useAtomValue(gasConstantsAtom)
   const routerAddress = useAtomValue(routerContractAtom).address
@@ -51,6 +52,8 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
   const setErrorMsgModal = useSetAtom(setErrorMsgModalAtom)
 
   const [, setLatestTxReceipt] = useLatestTxReceipt()
+
+  const destMinOut = useMemo(() => trade?.minimumAmountOut(allowedSlippage).toExact(), [allowedSlippage, trade])
 
   const getTxRequest = useCallback(async () => {
     const queryId = generateQueryId()
@@ -69,11 +72,12 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
       const path = trade?.route.path
       for (let idx = path.length - 1; idx >= 2; idx--) {
         const currency = path[idx]
+        const minOut = trade?.minimumAmountOut(allowedSlippage, trade.tokenAmounts[idx]).toExact()
         // eslint-disable-next-line no-await-in-loop
         const routerJettonWalletOut = await getJettonWalletAddress(routerAddress, currency.wrapped.address)
         const next = {
           tokenAddress: routerJettonWalletOut,
-          minOut: idx === path.length - 1 && minOut ? parseUnits(minOut, currency?.decimals) : 1n,
+          minOut: minOut ? parseUnits(minOut, currency?.decimals) : 1n,
           next: lastSwapNext,
         }
         lastSwapNext = next
@@ -85,10 +89,14 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
         storeSwap({
           fromRealUser: userAddress,
           fromUserAddress: userAddress,
-
           // If it is NOT a Multihop trade, set minOut for token0 => token1
-          minOut: !lastSwapNext && minOut ? parseUnits(minOut, token1?.decimals) : 1n,
-
+          minOut:
+            !lastSwapNext && destMinOut
+              ? parseUnits(destMinOut, token1?.decimals)
+              : parseUnits(
+                  trade?.minimumAmountOut(allowedSlippage, trade.tokenAmounts[0]).toExact(),
+                  trade.tokenAmounts[0].currency.decimals,
+                ),
           refAddress: null,
           refMessageValue: 0n,
           tokenWallet: routerJettonWallet1,
@@ -128,13 +136,15 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
       ],
     }
   }, [
+    destMinOut,
+    token1?.decimals,
+    allowedSlippage,
     routerJettonWallet1,
     routerJettonWallet0,
     trade,
     token0,
     userJettonWallet0,
     userAddress,
-    minOut,
     amount0,
     routerAddress,
     GAS_CONSTANTS.swapTonToJetton.forwardGasAmount,
@@ -151,7 +161,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
         currency0: token0,
         currency1: token1,
         amount0,
-        amount1: minOut,
+        amount1: destMinOut,
       })
 
       const txRequest: SendTransactionRequest | undefined = await getTxRequest()
@@ -167,7 +177,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
           currency0: token0,
           currency1: token1,
           amount0,
-          amount1: minOut,
+          amount1: destMinOut,
         })
       }
 
@@ -179,7 +189,7 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
           currency0: token0,
           currency1: token1,
           amount0,
-          amount1: minOut,
+          amount1: destMinOut,
           hash,
         })
         // dont await, just let it go
@@ -201,9 +211,9 @@ export const useSwap = ({ amount0, minOut, token0, token1, trade, refreshTrade }
       return Promise.reject()
     }
   }, [
+    destMinOut,
     amount0,
     setLatestTxReceipt,
-    minOut,
     token0,
     token1,
     setErrorMsgModal,

--- a/packages/ton-v2-sdk/src/utils/trade.ts
+++ b/packages/ton-v2-sdk/src/utils/trade.ts
@@ -108,6 +108,8 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
    */
   public readonly priceImpact: Percent
 
+  public readonly tokenAmounts: CurrencyAmount<Currency>[]
+
   constructor(
     route: Route<TInput, TOutput>,
     amount: TTradeType extends TradeType.EXACT_INPUT ? CurrencyAmount<TInput> : CurrencyAmount<TOutput>,
@@ -116,33 +118,33 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
     this.route = route
     this.tradeType = tradeType
 
-    const tokenAmounts: CurrencyAmount<Currency>[] = new Array(route.path.length)
+    this.tokenAmounts = new Array(route.path.length)
     if (tradeType === TradeType.EXACT_INPUT) {
       invariant(amount.currency.equals(route.input), 'INPUT')
-      tokenAmounts[0] = amount.wrapped
+      this.tokenAmounts[0] = amount.wrapped
       for (let i = 0; i < route.path.length - 1; i++) {
         const pair = route.pairs[i]
-        const [outputAmount] = getOutputAmount(tokenAmounts[i], pair)
-        tokenAmounts[i + 1] = outputAmount
+        const [outputAmount] = getOutputAmount(this.tokenAmounts[i], pair)
+        this.tokenAmounts[i + 1] = outputAmount
       }
       this.inputAmount = CurrencyAmount.fromFractionalAmount(route.input, amount.numerator, amount.denominator)
       this.outputAmount = CurrencyAmount.fromFractionalAmount(
         route.output,
-        tokenAmounts[tokenAmounts.length - 1].numerator,
-        tokenAmounts[tokenAmounts.length - 1].denominator,
+        this.tokenAmounts[this.tokenAmounts.length - 1].numerator,
+        this.tokenAmounts[this.tokenAmounts.length - 1].denominator,
       )
     } else {
       invariant(amount.currency.equals(route.output), 'OUTPUT')
-      tokenAmounts[tokenAmounts.length - 1] = amount.wrapped
+      this.tokenAmounts[this.tokenAmounts.length - 1] = amount.wrapped
       for (let i = route.path.length - 1; i > 0; i--) {
         const pair = route.pairs[i - 1]
-        const [inputAmount] = getOutputAmount(tokenAmounts[i], pair)
-        tokenAmounts[i - 1] = inputAmount
+        const [inputAmount] = getOutputAmount(this.tokenAmounts[i], pair)
+        this.tokenAmounts[i - 1] = inputAmount
       }
       this.inputAmount = CurrencyAmount.fromFractionalAmount(
         route.input,
-        tokenAmounts[0].numerator,
-        tokenAmounts[0].denominator,
+        this.tokenAmounts[0].numerator,
+        this.tokenAmounts[0].denominator,
       )
       this.outputAmount = CurrencyAmount.fromFractionalAmount(route.output, amount.numerator, amount.denominator)
     }
@@ -163,16 +165,19 @@ export class Trade<TInput extends Currency, TOutput extends Currency, TTradeType
    * Get the minimum amount that must be received from this trade for the given slippage tolerance
    * @param slippageTolerance tolerance of unfavorable slippage from the execution price of this trade
    */
-  public minimumAmountOut(slippageTolerance: Percent): CurrencyAmount<TOutput> {
+  public minimumAmountOut(
+    slippageTolerance: Percent,
+    amount: CurrencyAmount<Currency> = this.outputAmount,
+  ): CurrencyAmount<Currency> {
     invariant(!slippageTolerance.lessThan(ZERO), 'SLIPPAGE_TOLERANCE')
     if (this.tradeType === TradeType.EXACT_OUTPUT) {
-      return this.outputAmount
+      return amount
     }
     const slippageAdjustedAmountOut = new Fraction(ONE)
       .add(slippageTolerance)
       .invert()
-      .multiply(this.outputAmount.quotient).quotient
-    return CurrencyAmount.fromRawAmount(this.outputAmount.currency, slippageAdjustedAmountOut)
+      .multiply(amount.quotient).quotient
+    return CurrencyAmount.fromRawAmount(amount.currency, slippageAdjustedAmountOut)
   }
 
   /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements to the `Trade` class and the `useSwap` hook, improving the handling of token amounts and minimum output calculations, including slippage tolerance adjustments.

### Detailed summary
- Added `tokenAmounts` property to the `Trade` class.
- Updated constructor to initialize `this.tokenAmounts`.
- Modified `minimumAmountOut` method to accept an optional `amount` parameter.
- Enhanced `useSwap` to utilize `allowedSlippage` and calculate `destMinOut`.
- Adjusted logic for `minOut` calculations in `useSwap`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->