### PR TITLE
fix: minOut for first step of swap

### DIFF
--- a/apps/ton/src/ton/logic/swap/useSwap.ts
+++ b/apps/ton/src/ton/logic/swap/useSwap.ts
@@ -94,7 +94,7 @@ export const useSwap = ({ amount0, token0, token1, trade, refreshTrade }: SwapAr
             !lastSwapNext && destMinOut
               ? parseUnits(destMinOut, token1?.decimals)
               : parseUnits(
-                  trade?.minimumAmountOut(allowedSlippage, trade.tokenAmounts[0]).toExact(),
+                  trade?.minimumAmountOut(allowedSlippage, trade.tokenAmounts[1]).toExact(),
                   trade.tokenAmounts[0].currency.decimals,
                 ),
           refAddress: null,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the index used to retrieve the `minimumAmountOut` from the `tokenAmounts` array in the `useSwap.ts` file, ensuring the correct token amount is considered for the swap logic.

### Detailed summary
- Changed the index from `0` to `1` in the call to `trade?.minimumAmountOut(allowedSlippage, trade.tokenAmounts[1]).toExact()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->