### PR TITLE
chore: Limit NumericalInput to 18 decimal places

### DIFF
--- a/packages/widgets-internal/swap-v2/NumericalInput.tsx
+++ b/packages/widgets-internal/swap-v2/NumericalInput.tsx
@@ -36,7 +36,13 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      // Limit to 18 decimal places
+      const [integer, decimal] = nextUserInput.split(".");
+      if (decimal && decimal.length > 18) {
+        onUserInput(`${integer}.${decimal.substring(0, 18)}`);
+      } else {
+        onUserInput(nextUserInput);
+      }
     }
   };
 
@@ -65,7 +71,7 @@ export const NumericalInput = memo(function InnerInput({
       autoCorrect="off"
       // text-specific options
       type="text"
-      pattern="^[0-9]*[.,]?[0-9]*$"
+      pattern="^[0-9]*[.,]?[0-9]{0,18}$"
       placeholder={placeholder || "0.00"}
       minLength={1}
       maxLength={79}

--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -25,7 +25,13 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      // Limit to 18 decimal places
+      const [integer, decimal] = nextUserInput.split(".");
+      if (decimal && decimal.length > 18) {
+        onUserInput(`${integer}.${decimal.substring(0, 18)}`);
+      } else {
+        onUserInput(nextUserInput);
+      }
     }
   };
 
@@ -54,7 +60,7 @@ export const NumericalInput = memo(function InnerInput({
       autoCorrect="off"
       // text-specific options
       type="text"
-      pattern="^[0-9]*[.,]?[0-9]*$"
+      pattern="^[0-9]*[.,]?[0-9]{0,18}$"
       placeholder={placeholder || "0.0"}
       minLength={1}
       maxLength={79}


### PR DESCRIPTION
This PR addresses PAN-4953 by limiting the number of decimal places in swap input to 18 digits.

### Changes:
- Modified the NumericalInput component in swap-v2 to limit decimal input to 18 places
- Updated the pattern attribute for validation to match the 18 decimal limit
- Applied the same changes to the NumericalInput in the swap directory for consistency

Closes PAN-4953

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enforcing a limit of 18 decimal places for user input in the `NumericalInput` component across two files: `packages/widgets-internal/swap/NumericalInput.tsx` and `packages/widgets-internal/swap-v2/NumericalInput.tsx`.

### Detailed summary
- Added logic to limit decimal places to 18 in the `enforcer` function.
- Updated the `pattern` attribute to restrict input to a maximum of 18 decimal places in both `NumericalInput.tsx` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->