### PR TITLE
chore: Limit 6 decimals in Swap Input

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
@@ -270,7 +270,10 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
     }
   }, [onPresentCurrencyModal, disableCurrencySelect])
 
-  const balance = !hideBalance && !!currency ? formatAmount(selectedCurrencyBalance, 6) : undefined
+  const balance =
+    !hideBalance && !!currency
+      ? formatAmount(selectedCurrencyBalance, selectedCurrencyBalance?.currency.decimals)
+      : undefined
 
   return (
     <SwapUIV2.CurrencyInputPanelSimplify

--- a/packages/widgets-internal/swap-v2/NumericalInput.tsx
+++ b/packages/widgets-internal/swap-v2/NumericalInput.tsx
@@ -2,8 +2,9 @@ import { useTranslation } from "@pancakeswap/localization";
 import { SwapCSS } from "@pancakeswap/uikit";
 import { escapeRegExp } from "@pancakeswap/utils/escapeRegExp";
 import clsx from "clsx";
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { styled } from "styled-components";
+import { truncateDecimals } from "../utils/numbers";
 
 const StyledInput = styled.input`
   /* will-change: font-size;
@@ -36,11 +37,13 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      onUserInput(truncateDecimals(nextUserInput));
     }
   };
 
   const { t } = useTranslation();
+
+  const truncatedValue = useMemo(() => (typeof value === "string" ? truncateDecimals(value) : value), [value]);
 
   return (
     <StyledInput
@@ -53,7 +56,7 @@ export const NumericalInput = memo(function InnerInput({
         })
       )}
       {...rest}
-      value={value}
+      value={truncatedValue}
       onChange={(event) => {
         // replace commas with periods, because we exclusively uses period as the decimal separator
         enforcer(event.target.value.replace(/,/g, "."));

--- a/packages/widgets-internal/swap-v2/WalletAssetDisplay.tsx
+++ b/packages/widgets-internal/swap-v2/WalletAssetDisplay.tsx
@@ -1,8 +1,9 @@
-import { MotionBox, Text, WalletFilledV2Icon } from "@pancakeswap/uikit";
+import { MotionBox, TooltipText, useTooltip, WalletFilledV2Icon } from "@pancakeswap/uikit";
 import { memo } from "react";
 import { styled } from "styled-components";
+import { truncateDecimals } from "../utils/numbers";
 
-const StyledText = styled(Text)`
+const StyledText = styled(TooltipText)`
   font-size: 12px;
   font-weight: 600;
 `;
@@ -31,6 +32,8 @@ export const WalletAssetDisplay: React.FC<{
   balance?: string;
   isUserInsufficientBalance?: boolean;
 }> = memo(({ balance, onMax, isUserInsufficientBalance }) => {
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(balance || "", { placement: "right" });
+
   return (
     <Wrapper
       key="WalletAssetDisplay"
@@ -41,7 +44,10 @@ export const WalletAssetDisplay: React.FC<{
       onClick={onMax}
     >
       <WalletFilledV2Icon color={isUserInsufficientBalance ? "#D14293" : "textSubtle"} width="16px" />
-      <StyledText color={isUserInsufficientBalance ? "#D14293" : "textSubtle"}>{balance}</StyledText>
+      <StyledText ref={targetRef} color={isUserInsufficientBalance ? "#D14293" : "textSubtle"}>
+        {truncateDecimals(balance)}
+      </StyledText>
+      {tooltipVisible && tooltip}
     </Wrapper>
   );
 });

--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -3,6 +3,7 @@ import { SwapCSS } from "@pancakeswap/uikit";
 import { escapeRegExp } from "@pancakeswap/utils/escapeRegExp";
 import clsx from "clsx";
 import { memo } from "react";
+import { truncateDecimals } from "../utils/numbers";
 
 const inputRegex = RegExp(`^\\d*(?:\\\\[.])?\\d*$`); // match escaped "." characters via in a non-capturing group
 
@@ -25,7 +26,7 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      onUserInput(truncateDecimals(nextUserInput));
     }
   };
 

--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -43,7 +43,7 @@ export const NumericalInput = memo(function InnerInput({
         })
       )}
       {...rest}
-      value={value}
+      value={truncateDecimals(value?.toString())}
       onChange={(event) => {
         // replace commas with periods, because we exclusively uses period as the decimal separator
         enforcer(event.target.value.replace(/,/g, "."));

--- a/packages/widgets-internal/utils/numbers.ts
+++ b/packages/widgets-internal/utils/numbers.ts
@@ -1,0 +1,24 @@
+export const MAX_DECIMALS_DISPLAY = 6;
+
+/**
+ * Truncates a decimal string to a specified number of decimal places
+ * @param value - The string value containing a decimal number
+ * @param maxDecimals - The maximum number of decimal places to keep
+ * @returns The truncated decimal string
+ */
+export function truncateDecimals(value?: string): string {
+  if (!value) {
+    return "";
+  }
+
+  if (!value.includes(".")) {
+    return value;
+  }
+
+  const [wholeNumber, decimal] = value.split(".");
+  if (!decimal || decimal.length <= MAX_DECIMALS_DISPLAY) {
+    return value;
+  }
+
+  return `${wholeNumber}.${decimal.slice(0, MAX_DECIMALS_DISPLAY)}`;
+}


### PR DESCRIPTION
…tility

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of decimal values across various components by introducing a `truncateDecimals` function to ensure consistent formatting. It also updates the `balance` calculation to use the currency's decimal precision.

### Detailed summary
- Updated `balance` calculation in `CurrencyInputPanelSimplify` to use dynamic decimal precision.
- Added `MAX_DECIMALS_DISPLAY` constant and `truncateDecimals` function in `numbers.ts` for decimal truncation.
- Integrated `truncateDecimals` in `NumericalInput` component for user input and value display.
- Used `truncateDecimals` in `WalletAssetDisplay` to format balance display.
- Adjusted `StyledText` to use `TooltipText` in `WalletAssetDisplay`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->