### PR TITLE
chore: add limit decimal in swap

### DIFF
--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -3,6 +3,7 @@ import { SwapCSS } from "@pancakeswap/uikit";
 import { escapeRegExp } from "@pancakeswap/utils/escapeRegExp";
 import clsx from "clsx";
 import { memo } from "react";
+import { truncateDecimals } from "../utils/numbers";
 
 const inputRegex = RegExp(`^\\d*(?:\\\\[.])?\\d*$`); // match escaped "." characters via in a non-capturing group
 
@@ -25,7 +26,7 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      onUserInput(truncateDecimals(nextUserInput));
     }
   };
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a utility function to truncate decimal values in the `NumericalInput` component, ensuring that user input is properly formatted before being processed.

### Detailed summary
- Added import for the `truncateDecimals` function from `../utils/numbers`.
- Modified the `onUserInput` call to use `truncateDecimals(nextUserInput)` instead of passing `nextUserInput` directly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->