### PR TITLE
chore: enforce limit decimals rule when clicking max

### DIFF
--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -3,6 +3,7 @@ import { SwapCSS } from "@pancakeswap/uikit";
 import { escapeRegExp } from "@pancakeswap/utils/escapeRegExp";
 import clsx from "clsx";
 import { memo } from "react";
+import { truncateDecimals } from "../utils/numbers";
 
 const inputRegex = RegExp(`^\\d*(?:\\\\[.])?\\d*$`); // match escaped "." characters via in a non-capturing group
 
@@ -25,7 +26,7 @@ export const NumericalInput = memo(function InnerInput({
 }: NumericalInputProps) {
   const enforcer = (nextUserInput: string) => {
     if (nextUserInput === "" || inputRegex.test(escapeRegExp(nextUserInput))) {
-      onUserInput(nextUserInput);
+      onUserInput(truncateDecimals(nextUserInput));
     }
   };
 

--- a/packages/widgets-internal/swap/NumericalInput.tsx
+++ b/packages/widgets-internal/swap/NumericalInput.tsx
@@ -43,7 +43,7 @@ export const NumericalInput = memo(function InnerInput({
         })
       )}
       {...rest}
-      value={value}
+      value={truncateDecimals(value?.toString())}
       onChange={(event) => {
         // replace commas with periods, because we exclusively uses period as the decimal separator
         enforcer(event.target.value.replace(/,/g, "."));


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `NumericalInput` component by integrating the `truncateDecimals` utility function to ensure that user input and displayed values are properly truncated to a specified decimal format.

### Detailed summary
- Added import for `truncateDecimals` from `../utils/numbers`.
- Updated the `onUserInput` call to use `truncateDecimals(nextUserInput)`.
- Changed the `value` prop to use `truncateDecimals(value?.toString())`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->