### PR TITLE
fix: Swap crash when currency decimals and balance is 0

### DIFF
--- a/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
@@ -19,6 +19,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { styled } from 'styled-components'
 
 import { formatNumber } from '@pancakeswap/utils/formatBalance'
+import isUndefinedOrNull from '@pancakeswap/utils/isUndefinedOrNull'
 import { useStablecoinPriceAmount } from 'hooks/useStablecoinPrice'
 import { StablePair } from 'views/AddLiquidity/AddStableLiquidity/hooks/useStableLPDerivedMintInfo'
 
@@ -272,8 +273,11 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
 
   const balance = useMemo(
     () =>
-      !hideBalance && !!currency && selectedCurrencyBalance
-        ? formatAmount(selectedCurrencyBalance, selectedCurrencyBalance?.currency?.decimals || 6)
+      !hideBalance &&
+      !!currency &&
+      selectedCurrencyBalance &&
+      !isUndefinedOrNull(selectedCurrencyBalance?.currency?.decimals)
+        ? formatAmount(selectedCurrencyBalance, selectedCurrencyBalance?.currency?.decimals)
         : undefined,
     [selectedCurrencyBalance, currency, hideBalance],
   )

--- a/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
@@ -270,10 +270,13 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
     }
   }, [onPresentCurrencyModal, disableCurrencySelect])
 
-  const balance =
-    !hideBalance && !!currency
-      ? formatAmount(selectedCurrencyBalance, selectedCurrencyBalance?.currency.decimals)
-      : undefined
+  const balance = useMemo(
+    () =>
+      !hideBalance && !!currency && selectedCurrencyBalance
+        ? formatAmount(selectedCurrencyBalance, selectedCurrencyBalance?.currency?.decimals || 6)
+        : undefined,
+    [selectedCurrencyBalance, currency, hideBalance],
+  )
 
   return (
     <SwapUIV2.CurrencyInputPanelSimplify

--- a/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
+++ b/packages/uikit/src/hooks/useTooltip/useTooltip.tsx
@@ -105,7 +105,10 @@ const useTooltip = (content: React.ReactNode, options?: TooltipOptions): Tooltip
 
   const toggleTooltip = useCallback(
     (e: Event) => {
-      if (!avoidToStopPropagation) e.stopPropagation();
+      if (!avoidToStopPropagation) {
+        e.stopPropagation();
+        e.preventDefault();
+      }
       setVisible(!visible);
     },
     [visible, avoidToStopPropagation]

--- a/packages/utils/formatFractions.ts
+++ b/packages/utils/formatFractions.ts
@@ -12,7 +12,7 @@ export function formatFraction(
   if (!fraction || fraction.denominator === 0n) {
     return undefined
   }
-  if (fraction.greaterThan(10n ** BigInt(precision))) {
+  if (precision === 0 || fraction.greaterThan(10n ** BigInt(precision))) {
     return fraction.toFixed(0)
   }
   return fraction.toSignificant(precision, undefined, rounding)

--- a/packages/widgets-internal/swap-v2/WalletAssetDisplay.tsx
+++ b/packages/widgets-internal/swap-v2/WalletAssetDisplay.tsx
@@ -32,7 +32,10 @@ export const WalletAssetDisplay: React.FC<{
   balance?: string;
   isUserInsufficientBalance?: boolean;
 }> = memo(({ balance, onMax, isUserInsufficientBalance }) => {
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(balance || "", { placement: "right" });
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(balance || "", {
+    placement: "right",
+    avoidToStopPropagation: true,
+  });
 
   return (
     <Wrapper


### PR DESCRIPTION
Page crashes if currency decimals and balance is 0: 

https://pancakeswap.finance/swap?inputCurrency=0x55d398326f99059fF775485246999027B3197955&outputCurrency=0x649a2DA7B28E0D54c13D5eFf95d3A660652742cC

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving utility functions and enhancing the tooltip functionality in the UI components. It includes better handling of precision in fraction formatting, event handling for tooltips, and more robust balance calculations in the currency input panel.

### Detailed summary
- In `packages/utils/formatFractions.ts`, added a check for `precision === 0` when formatting fractions.
- In `packages/uikit/src/hooks/useTooltip/useTooltip.tsx`, modified the tooltip toggle to also call `e.preventDefault()`.
- In `packages/widgets-internal/swap-v2/WalletAssetDisplay.tsx`, added `avoidToStopPropagation: true` to the tooltip options.
- In `apps/web/src/components/CurrencyInputPanelSimplify/index.tsx`, refactored balance calculation using `useMemo` for better performance and added a check using `isUndefinedOrNull`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->