### PR TITLE
fix: solana link update

### DIFF
--- a/apps/solana/components/Menu.tsx
+++ b/apps/solana/components/Menu.tsx
@@ -108,7 +108,7 @@ export const Menu = (props) => {
       {isClient ? (
         <MenuWrapper>
           <UIMenu
-            logoComponent={<Logo href="/swap" />}
+            logoComponent={<Logo href="https://pancakeswap.finance/home" />}
             linkComponent={LinkComponent}
             chainId={chainId}
             links={menuItems}

--- a/apps/solana/config/adBanner/ads/AdPCSxSolana.tsx
+++ b/apps/solana/config/adBanner/ads/AdPCSxSolana.tsx
@@ -9,7 +9,6 @@ import { AdCard } from '../Card'
 import { getImageUrl } from '../utils'
 
 const learnMoreLink = 'https://blog.pancakeswap.finance/articles/expanding-solana-s-accessibility'
-const actionLink = '/swap'
 
 export const AdPCSxSolana = (props: Omit<AdPlayerProps, 'config'>) => {
   const { t } = useTranslation()
@@ -21,10 +20,6 @@ export const AdPCSxSolana = (props: Omit<AdPlayerProps, 'config'>) => {
           {t('Swap Solana Tokens on PancakeSwap.')}
         </Text>
       </BodyText>
-
-      <AdButton variant="text" href={actionLink}>
-        {t('Swap Now!')}
-      </AdButton>
 
       <AdButton mt="16px" href={learnMoreLink} externalIcon isExternalLink>
         {t('Learn More')}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the links in the `Menu` and `AdPCSxSolana` components to point to external resources, specifically changing the logo link and removing the action link for a button.

### Detailed summary
- In `Menu.tsx`, changed `logoComponent` href from `/swap` to `https://pancakeswap.finance/home`.
- In `AdPCSxSolana.tsx`, removed the `actionLink` constant that pointed to `/swap`.
- Updated the button to only link to the `learnMoreLink`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->