### PR TITLE
feat: Update graph health api and implement api check

### DIFF
--- a/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator.tsx
@@ -9,5 +9,7 @@ const SubgraphHealthIndicator = dynamic(() => import('components/SubgraphHealthI
 export const FixedSubgraphHealthIndicator = () => {
   const { pathname } = useRouter()
   const isOnNftPages = pathname.includes('nfts')
-  return isOnNftPages ? <SubgraphHealthIndicator chainId={ChainId.BSC} subgraph={GRAPH_API_NFTMARKET} /> : null
+  return isOnNftPages ? (
+    <SubgraphHealthIndicator chainId={ChainId.BSC} subgraph={GRAPH_API_NFTMARKET} checkApiInstead />
+  ) : null
 }

--- a/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/FloatingSubgraphHealthIndicators.tsx
@@ -4,18 +4,19 @@ import { createPortal } from 'react-dom'
 
 import { GRAPH_API_PREDICTION_BNB } from '@pancakeswap/prediction'
 import { getPortalRoot } from '@pancakeswap/uikit'
-import { GRAPH_API_LOTTERY } from 'config/constants/endpoints'
+import { GRAPH_API_LOTTERY, GRAPH_API_NFTMARKET } from 'config/constants/endpoints'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { SubgraphHealthIndicator, SubgraphHealthIndicatorProps } from './SubgraphHealthIndicator'
 
 interface FactoryParams {
   getSubgraph: (chainId: ChainId) => string
+  checkApiInstead?: boolean
 }
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
-export function subgraphHealthIndicatorFactory({ getSubgraph }: FactoryParams) {
+export function subgraphHealthIndicatorFactory({ getSubgraph, checkApiInstead }: FactoryParams) {
   return function Indicator(props: PartialBy<SubgraphHealthIndicatorProps, 'subgraph' | 'chainId'>) {
     const { chainId } = useActiveChainId()
 
@@ -36,7 +37,15 @@ export function subgraphHealthIndicatorFactory({ getSubgraph }: FactoryParams) {
     const portalRoot = getPortalRoot()
 
     return portalRoot
-      ? createPortal(<SubgraphHealthIndicator chainId={chainId} subgraph={subgraph} {...props} />, portalRoot)
+      ? createPortal(
+          <SubgraphHealthIndicator
+            chainId={chainId}
+            subgraph={subgraph}
+            checkApiInstead={checkApiInstead}
+            {...props}
+          />,
+          portalRoot,
+        )
       : null
   }
 }
@@ -47,4 +56,5 @@ export const LotterySubgraphHealthIndicator = subgraphHealthIndicatorFactory({
 
 export const PredictionSubgraphHealthIndicator = subgraphHealthIndicatorFactory({
   getSubgraph: (chainId) => GRAPH_API_PREDICTION_BNB?.[chainId],
+  checkApiInstead: true,
 })

--- a/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
+++ b/apps/web/src/components/SubgraphHealthIndicator/SubgraphHealthIndicator.tsx
@@ -98,6 +98,7 @@ export type SubgraphHealthIndicatorProps = React.PropsWithChildren<{
   inline?: boolean
   customDescriptions?: CustomDescriptions
   obeyGlobalSetting?: boolean
+  checkApiInstead?: boolean
 }>
 
 export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = ({
@@ -106,9 +107,14 @@ export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = (
   inline,
   customDescriptions,
   obeyGlobalSetting = true,
+  checkApiInstead,
 }) => {
   const { t } = useTranslation()
-  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth({ chainId, subgraph })
+  const { status, currentBlock, blockDifference, latestBlock } = useSubgraphHealth({
+    chainId,
+    subgraph,
+    checkApiInstead,
+  })
   const [alwaysShowIndicator] = useSubgraphHealthIndicatorManager()
   const forceIndicatorDisplay =
     status === SubgraphStatus.WARNING || status === SubgraphStatus.NOT_OK || status === SubgraphStatus.DOWN
@@ -133,7 +139,7 @@ export const SubgraphHealthIndicator: React.FC<SubgraphHealthIndicatorProps> = (
       currentBlock={currentBlock}
       secondRemainingBlockSync={secondRemainingBlockSync}
       blockNumberFromSubgraph={latestBlock}
-      showBlockInfo={status !== SubgraphStatus.DOWN}
+      showBlockInfo={status !== SubgraphStatus.DOWN && (currentBlock !== -1 || latestBlock !== -1)}
       {...current}
     />,
     {

--- a/apps/web/src/config/constants/endpoints.ts
+++ b/apps/web/src/config/constants/endpoints.ts
@@ -31,7 +31,7 @@ const BLOCKS_SUBGRAPH_URLS = {
 }
 
 export const GRAPH_API_NFTMARKET = `${THE_GRAPH_PROXY_API}/nft-marketplace-bsc`
-export const GRAPH_HEALTH = 'https://api.thegraph.com/index-node/graphql'
+export const GRAPH_HEALTH = 'https://indexer.upgrade.thegraph.com/status'
 
 export const TC_MOBOX_SUBGRAPH = `${THE_GRAPH_PROXY_API}/trading-competition-v3`
 export const TC_MOD_SUBGRAPH = `${THE_GRAPH_PROXY_API}/trading-competition-v4`


### PR DESCRIPTION
Prediction leaderboard and lottery pages show subgraph as down but infact only the status api not accessible

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `SubgraphHealthIndicator` component by adding a new `checkApiInstead` prop, modifying API endpoints, and improving the health-check logic to handle indexing errors. It also updates the rendering logic based on the current page context.

### Detailed summary
- Added `checkApiInstead` prop to `SubgraphHealthIndicator` and related components.
- Modified `GRAPH_HEALTH` endpoint to point to a new URL.
- Updated `useSubgraphHealth` to handle `checkApiInstead` and indexing errors.
- Adjusted rendering logic in `FixedSubgraphHealthIndicator` based on `checkApiInstead`.
- Enhanced health-check logic to set status based on indexing errors.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->