### PR TITLE
fix: Dont show warning when slippage auto

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
@@ -14,7 +14,7 @@ import {
 import GlobalSettings from 'components/Menu/GlobalSettings'
 import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 import { useAutoSlippageWithFallback } from 'hooks/useAutoSlippageWithFallback'
-import { ReactElement } from 'react'
+import { ReactElement, useMemo } from 'react'
 import styled from 'styled-components'
 import { basisPointsToPercent } from 'utils/exchange'
 
@@ -52,19 +52,24 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
   const isRiskyVeryHigh = slippageTolerance > 2000
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
-    isRiskyLow
-      ? t('Your transaction may fail. Reset settings to avoid potential loss')
-      : isRiskyHigh
-      ? t('Your transaction may be frontrun. Reset settings to avoid potential loss')
+    !isAuto
+      ? isRiskyLow
+        ? t('Your transaction may fail. Reset settings to avoid potential loss')
+        : isRiskyHigh
+        ? t('Your transaction may be frontrun. Reset settings to avoid potential loss')
+        : ''
       : '',
     { placement: 'top' },
   )
 
-  const color = isRiskyVeryHigh
-    ? theme.colors.failure
-    : isRiskyLow || isRiskyHigh
-    ? theme.colors.yellow
-    : theme.colors.primary60
+  const color = useMemo(() => {
+    if (isAuto) return theme.colors.primary60
+    return isRiskyVeryHigh
+      ? theme.colors.failure
+      : isRiskyLow || isRiskyHigh
+      ? theme.colors.yellow
+      : theme.colors.primary60
+  }, [theme, isRiskyVeryHigh, isRiskyLow, isRiskyHigh, isAuto])
 
   return (
     <>
@@ -78,11 +83,13 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
               <TertiaryButton
                 $color={color}
                 startIcon={
-                  isRiskyVeryHigh ? (
-                    <RiskAlertIcon color={color} width={16} />
-                  ) : isRiskyLow || isRiskyHigh ? (
-                    <WarningIcon color={color} width={16} />
-                  ) : undefined
+                  !isAuto ? (
+                    isRiskyVeryHigh ? (
+                      <RiskAlertIcon color={color} width={16} />
+                    ) : isRiskyLow || isRiskyHigh ? (
+                      <WarningIcon color={color} width={16} />
+                    ) : null
+                  ) : null
                 }
                 endIcon={<PencilIcon color={color} width={12} />}
                 onClick={onClick}
@@ -95,7 +102,7 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
               </TertiaryButton>
             </div>
 
-            {(isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
+            {!isAuto && (isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
           </div>
         )}
       />

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -48,7 +48,7 @@ export function V4SwapForm() {
   } = useAllTypeBestTrade()
 
   const isWrapping = useIsWrapping()
-  const { chainId: activeChianId } = useActiveChainId()
+  const { chainId: activeChainId } = useActiveChainId()
   const isUserInsufficientBalance = useUserInsufficientBalance(bestOrder)
   const { shouldShowBuyCrypto, buyCryptoLink } = useBuyCryptoInfo(bestOrder)
 
@@ -119,8 +119,8 @@ export function V4SwapForm() {
   const inputCurrency = useCurrency(inputCurrencyId)
   const outputCurrency = useCurrency(outputCurrencyId)
 
-  const { slippageTolerance: userSlippageTolerance } = useAutoSlippageWithFallback(bestOrder?.trade)
-  const isSlippageTooHigh = useMemo(() => userSlippageTolerance > 500, [userSlippageTolerance])
+  const { slippageTolerance: userSlippageTolerance, isAuto } = useAutoSlippageWithFallback(bestOrder?.trade)
+  const isSlippageTooHigh = useMemo(() => !isAuto && userSlippageTolerance > 500, [isAuto, userSlippageTolerance])
   const shouldRiskPanelDisplay = useShouldRiskPanelDisplay(inputCurrency?.wrapped, outputCurrency?.wrapped)
   const token0Risk = useTokenRisk(inputCurrency?.wrapped)
   const token1Risk = useTokenRisk(outputCurrency?.wrapped)
@@ -175,7 +175,7 @@ export function V4SwapForm() {
               <RefreshButton
                 onRefresh={refreshOrder}
                 refreshDisabled={refreshDisabled}
-                chainId={activeChianId}
+                chainId={activeChainId}
                 loading={!tradeLoaded}
               />
               <PricingAndSlippage


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of slippage tolerance in the `V4SwapForm` and `SlippageButton` components, including better management of risky transaction notifications based on automatic slippage settings.

### Detailed summary
- Renamed `activeChianId` to `activeChainId`.
- Added `isAuto` to the slippage tolerance logic.
- Updated slippage risk checks to consider `isAuto`.
- Adjusted tooltip visibility based on `isAuto`.
- Enhanced color logic for the `SlippageButton` based on `isAuto`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->