### PR TITLE
perf: Cache slippage tolerance calculation per trade

### DIFF
--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -115,10 +115,12 @@ export const useStablecoinPriceAmount = (
 ): number | undefined => {
   const stablePrice = useStablecoinPrice(currency, { enabled: !!currency, ...config })
 
-  if (amount) {
-    if (stablePrice) {
-      return multiplyPriceByAmount(stablePrice, amount)
+  return useMemo(() => {
+    if (amount) {
+      if (stablePrice) {
+        return multiplyPriceByAmount(stablePrice, amount)
+      }
     }
-  }
-  return undefined
+    return undefined
+  }, [amount, stablePrice])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the hooks `useStablecoinPrice` and `useAutoSlippage` by introducing `useMemo` for better performance and readability, and adjusting how gas estimates and dollar values are calculated for trades.

### Detailed summary
- Refactored `useStablecoinPrice` to use `useMemo` for improved performance.
- Updated `useAutoSlippage` to use `useQuery` for fetching slippage data.
- Simplified gas cost calculations using `useMemo`.
- Adjusted handling of `trade` and `inputAmount` checks for better clarity and efficiency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->