### PR TITLE
revert: "fix: Dont show warning when slippage auto"

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
@@ -14,7 +14,7 @@ import {
 import GlobalSettings from 'components/Menu/GlobalSettings'
 import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 import { useAutoSlippageWithFallback } from 'hooks/useAutoSlippageWithFallback'
-import { ReactElement, useMemo } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 import { basisPointsToPercent } from 'utils/exchange'
 
@@ -52,24 +52,19 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
   const isRiskyVeryHigh = slippageTolerance > 2000
 
   const { targetRef, tooltip, tooltipVisible } = useTooltip(
-    !isAuto
-      ? isRiskyLow
-        ? t('Your transaction may fail. Reset settings to avoid potential loss')
-        : isRiskyHigh
-        ? t('Your transaction may be frontrun. Reset settings to avoid potential loss')
-        : ''
+    isRiskyLow
+      ? t('Your transaction may fail. Reset settings to avoid potential loss')
+      : isRiskyHigh
+      ? t('Your transaction may be frontrun. Reset settings to avoid potential loss')
       : '',
     { placement: 'top' },
   )
 
-  const color = useMemo(() => {
-    if (isAuto) return theme.colors.primary60
-    return isRiskyVeryHigh
-      ? theme.colors.failure
-      : isRiskyLow || isRiskyHigh
-      ? theme.colors.yellow
-      : theme.colors.primary60
-  }, [theme, isRiskyVeryHigh, isRiskyLow, isRiskyHigh, isAuto])
+  const color = isRiskyVeryHigh
+    ? theme.colors.failure
+    : isRiskyLow || isRiskyHigh
+    ? theme.colors.yellow
+    : theme.colors.primary60
 
   return (
     <>
@@ -83,13 +78,11 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
               <TertiaryButton
                 $color={color}
                 startIcon={
-                  !isAuto ? (
-                    isRiskyVeryHigh ? (
-                      <RiskAlertIcon color={color} width={16} />
-                    ) : isRiskyLow || isRiskyHigh ? (
-                      <WarningIcon color={color} width={16} />
-                    ) : null
-                  ) : null
+                  isRiskyVeryHigh ? (
+                    <RiskAlertIcon color={color} width={16} />
+                  ) : isRiskyLow || isRiskyHigh ? (
+                    <WarningIcon color={color} width={16} />
+                  ) : undefined
                 }
                 endIcon={<PencilIcon color={color} width={12} />}
                 onClick={onClick}
@@ -102,7 +95,7 @@ export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
               </TertiaryButton>
             </div>
 
-            {!isAuto && (isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
+            {(isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
           </div>
         )}
       />

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -48,7 +48,7 @@ export function V4SwapForm() {
   } = useAllTypeBestTrade()
 
   const isWrapping = useIsWrapping()
-  const { chainId: activeChainId } = useActiveChainId()
+  const { chainId: activeChianId } = useActiveChainId()
   const isUserInsufficientBalance = useUserInsufficientBalance(bestOrder)
   const { shouldShowBuyCrypto, buyCryptoLink } = useBuyCryptoInfo(bestOrder)
 
@@ -119,8 +119,8 @@ export function V4SwapForm() {
   const inputCurrency = useCurrency(inputCurrencyId)
   const outputCurrency = useCurrency(outputCurrencyId)
 
-  const { slippageTolerance: userSlippageTolerance, isAuto } = useAutoSlippageWithFallback(bestOrder?.trade)
-  const isSlippageTooHigh = useMemo(() => !isAuto && userSlippageTolerance > 500, [isAuto, userSlippageTolerance])
+  const { slippageTolerance: userSlippageTolerance } = useAutoSlippageWithFallback(bestOrder?.trade)
+  const isSlippageTooHigh = useMemo(() => userSlippageTolerance > 500, [userSlippageTolerance])
   const shouldRiskPanelDisplay = useShouldRiskPanelDisplay(inputCurrency?.wrapped, outputCurrency?.wrapped)
   const token0Risk = useTokenRisk(inputCurrency?.wrapped)
   const token1Risk = useTokenRisk(outputCurrency?.wrapped)
@@ -175,7 +175,7 @@ export function V4SwapForm() {
               <RefreshButton
                 onRefresh={refreshOrder}
                 refreshDisabled={refreshDisabled}
-                chainId={activeChainId}
+                chainId={activeChianId}
                 loading={!tradeLoaded}
               />
               <PricingAndSlippage


### PR DESCRIPTION
Reverts pancakeswap/pancake-frontend#11431

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code clarity and functionality in the `V4SwapForm` and `SlippageButton` components by correcting variable names, simplifying conditions, and enhancing readability.

### Detailed summary
- Fixed typo in variable name from `activeChainId` to `activeChianId`.
- Removed `isAuto` from slippage calculations and conditions in `V4SwapForm`.
- Simplified tooltip logic in `SlippageButton`.
- Improved readability of color determination logic in `SlippageButton`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->