### PR TITLE
chore: fix exact output issue ato slippage calculaiton

### DIFF
--- a/apps/web/src/hooks/useAutoSlippage.tsx
+++ b/apps/web/src/hooks/useAutoSlippage.tsx
@@ -140,6 +140,15 @@ export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade):
   const outputDollarValue =
     outputAmount && outputUSDPrice ? parseFloat(outputAmount) * parseFloat(outputUSDPrice.toSignificant(6)) : undefined
 
+  // Get USD price of input amount
+  const inputCurrency = trade?.inputAmount?.currency
+  const inputUSDPrice = useStablecoinPrice(inputCurrency)
+  const inputAmountValue = trade?.inputAmount?.toSignificant(6)
+  const inputDollarValue =
+    inputAmountValue && inputUSDPrice
+      ? parseFloat(inputAmountValue) * parseFloat(inputUSDPrice.toSignificant(6))
+      : undefined
+
   // Gas estimation
   const supportsGasEstimate = useMemo(() => chainId && chainSupportsGasEstimates(chainId), [chainId])
 
@@ -187,6 +196,8 @@ export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade):
       const calculatedSlippage = calculateSlippageFromDollarValues(dollarCostToUse, outputDollarValue)
 
       console.info('Auto Slippage: Calculated result', {
+        gasCostUSDValue,
+        gasEstimateUSD,
         dollarCostToUse,
         outputDollarValue,
         fraction: dollarCostToUse / outputDollarValue,
@@ -194,7 +205,11 @@ export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade):
         result: calculatedSlippage.toFixed(2),
       })
 
-      return calculatedSlippage.lessThan(inputBasedSlippage)
+      console.log({ calculatedSlippage, inputBasedSlippage }, 'autoSlippage')
+
+      return calculatedSlippage.lessThan(inputBasedSlippage) &&
+        inputDollarValue &&
+        (inputDollarValue * 1.1 > outputDollarValue || inputDollarValue * 0.9 < outputDollarValue)
         ? inputBasedSlippage
         : applySlippageLimits(calculatedSlippage)
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useClassicAutoSlippageTolerance` hook by adding calculations for the input amount's USD value and incorporating it into the slippage calculation logic.

### Detailed summary
- Introduced calculation for `inputDollarValue` based on `inputAmount` and its USD price.
- Added logging for `calculatedSlippage` and `inputBasedSlippage`.
- Updated the return statement to include conditions using `inputDollarValue` for slippage comparison.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->