### PR TITLE
chore: Remove eos ad and make tc components dynamic

### DIFF
--- a/apps/web/src/components/AdPanel/AdSlidesRender.tsx
+++ b/apps/web/src/components/AdPanel/AdSlidesRender.tsx
@@ -54,7 +54,7 @@ export const AdSlidesRender = ({
   const handleSlideChange = useCallback((event: any) => {
     if (swiperRef.current) {
       const activeIndex = swiperRef.current.swiper.realIndex
-      const bullets = swiperRef.current.swiper.pagination.bullets
+      const { bullets } = swiperRef.current.swiper.pagination
 
       bullets.forEach((bullet: HTMLElement) => {
         bullet.classList.remove('played')

--- a/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
+++ b/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Link, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { useMemo } from 'react'
 import { BodyText } from '../BodyText'
 import { AdButton } from '../Button'
 import { AdCard } from '../Card'
@@ -8,15 +9,6 @@ import { AdPlayerProps } from '../types'
 import { getImageUrl } from '../utils'
 
 const tradingCompetitionConfig = {
-  eos: {
-    imgUrl: 'eos_competition',
-    swapUrl:
-      'https://pancakeswap.finance/swap?outputCurrency=0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6&utm_source=Website&utm_medium=banner&utm_campaign=EOS&utm_id=TradingCompetition',
-    learnMoreUrl:
-      'https://blog.pancakeswap.finance/articles/pancake-swap-x-eos-network-trading-competition-75-000-in-rewards?utm_source=Website&utm_medium=banner&utm_campaign=EOS&utm_id=TradingCompetition',
-    reward: '75,000',
-    unit: '$',
-  },
   merl: {
     imgUrl: 'merl_competition',
     swapUrl:
@@ -32,36 +24,35 @@ export const AdTradingCompetition = (props: AdPlayerProps & { token: keyof typeo
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
   const { token, ...rest } = props
-  const { unit, reward } = tradingCompetitionConfig[token]
+  const { unit, reward, imgUrl, swapUrl, learnMoreUrl } = tradingCompetitionConfig[token]
 
   return (
-    <AdCard imageUrl={getImageUrl(tradingCompetitionConfig[token].imgUrl)} {...rest}>
+    <AdCard imageUrl={getImageUrl(imgUrl)} {...rest}>
       <BodyText mb="0">
         {isMobile
           ? t('Swap %token% to win a share of', { token: token.toUpperCase() })
           : t('Join %token% Trading Competition to share of', { token: token.toUpperCase() })}{' '}
         {unit === '$' ? `$${reward}` : `${reward} ${unit}`}.{' '}
-        <Link
-          style={!isMobile ? { display: 'inline' } : {}}
-          fontSize="inherit"
-          href={tradingCompetitionConfig[token].swapUrl}
-          color="secondary"
-          bold
-        >
+        <Link style={!isMobile ? { display: 'inline' } : {}} fontSize="inherit" href={swapUrl} color="secondary" bold>
           {t('Swap Now')}
         </Link>
       </BodyText>
-      <AdButton mt="16px" href={tradingCompetitionConfig[token].learnMoreUrl} externalIcon isExternalLink>
+      <AdButton mt="16px" href={learnMoreUrl} externalIcon isExternalLink>
         {t('Learn More')}
       </AdButton>
     </AdCard>
   )
 }
 
-export const AdTradingCompetitionEos = (props: AdPlayerProps) => {
-  return <AdTradingCompetition token="eos" {...props} />
-}
-
-export const AdTradingCompetitionMerl = (props: AdPlayerProps) => {
-  return <AdTradingCompetition token="merl" {...props} />
+export const useTradingCompetitionAds = () => {
+  return useMemo(
+    () =>
+      Object.keys(tradingCompetitionConfig)
+        .reverse()
+        .map((token) => ({
+          id: `ad-${token}-tc`,
+          component: <AdTradingCompetition key={token} token={token as keyof typeof tradingCompetitionConfig} />,
+        })),
+    [],
+  )
 }

--- a/apps/web/src/components/AdPanel/config.tsx
+++ b/apps/web/src/components/AdPanel/config.tsx
@@ -1,5 +1,5 @@
 import { useMatchBreakpoints } from '@pancakeswap/uikit'
-import { AdTradingCompetitionEos, AdTradingCompetitionMerl } from 'components/AdPanel/Ads/AdTradingCompetition'
+import { useTradingCompetitionAds } from 'components/AdPanel/Ads/AdTradingCompetition'
 import { AdsIds, useAdsConfigs } from 'components/AdPanel/hooks/useAdsConfig'
 import { useMemo } from 'react'
 import { AdCakeStaking } from './Ads/AdCakeStaking'
@@ -29,6 +29,7 @@ export const useAdConfig = () => {
   const MAX_ADS = isDesktop ? 6 : 4
   const shouldRenderAdIfo = useShouldRenderAdIfo()
   const configs = useAdsConfigs()
+  const tradingCompetitionAds = useTradingCompetitionAds()
   const commonAdConfigs = useMemo(() => {
     return Object.entries(configs)
       .map(([key, value]) => {
@@ -60,14 +61,7 @@ export const useAdConfig = () => {
         id: 'ad-springboard',
         component: <AdSpringboard />,
       },
-      {
-        id: 'ad-merl-tc',
-        component: <AdTradingCompetitionMerl />,
-      },
-      {
-        id: 'ad-eos-tc',
-        component: <AdTradingCompetitionEos />,
-      },
+      ...tradingCompetitionAds,
       {
         id: 'ad-ifo',
         component: <AdIfo />,
@@ -82,7 +76,7 @@ export const useAdConfig = () => {
         component: <AdCakeStaking />,
       },
     ],
-    [shouldRenderOnPage, shouldRenderAdIfo, commonAdConfigs],
+    [shouldRenderOnPage, shouldRenderAdIfo, commonAdConfigs, tradingCompetitionAds],
   )
 
   return useMemo(


### PR DESCRIPTION
Eos tc ends April 7, 2025, 23:59 UTC

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `AdTradingCompetition` component and its related configurations to improve code structure and enhance the use of hooks for managing trading competition ads.

### Detailed summary
- Updated `AdSlidesRender.tsx` to destructure `bullets` from `swiper.pagination`.
- Changed imports in `config.tsx` to use `useTradingCompetitionAds` hook.
- Removed direct references to `AdTradingCompetitionEos` and `AdTradingCompetitionMerl`.
- Integrated `tradingCompetitionAds` into the ad configuration.
- Refactored `AdTradingCompetition.tsx` to utilize properties directly from `tradingCompetitionConfig`.
- Created a `useTradingCompetitionAds` hook to generate ad components dynamically.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->