### PR TITLE
fix: reward calc amount incorrect

### DIFF
--- a/apps/web/src/hooks/infinity/useInfinityCakeAPR.ts
+++ b/apps/web/src/hooks/infinity/useInfinityCakeAPR.ts
@@ -81,6 +81,7 @@ export const useInfinityCLPositionCakeAPR = ({
     const positionRewardPerEpoch = rewardsPerEpoch?.[position.tokenId.toString()]
     const rewardForPositionPerYear = positionRewardPerEpoch
       ? positionRewardPerEpoch
+          .dividedBy(1e18)
           .times(3)
           .times(365)
           .times(cakePrice ?? 1)
@@ -143,6 +144,7 @@ export const useInfinityBinPositionCakeAPR = ({
 
     const rewardForPositionPerYear = positionRewardPerEpoch
       ? positionRewardPerEpoch
+          .dividedBy(1e18)
           .times(3)
           .times(365)
           .times(cakePrice ?? 1)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the calculation of `rewardForPositionPerYear` in the `useInfinityCakeAPR` hook to ensure it properly computes the reward based on `positionRewardPerEpoch`, factoring in `cakePrice`.

### Detailed summary
- Added a new line to calculate `rewardForPositionPerYear` based on `positionRewardPerEpoch`.
- The calculation includes converting `positionRewardPerEpoch` to a usable format and multiplying by constants for yearly reward estimation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->