### PR TITLE
fix: pool has no active campaign but showing cake apr

### DIFF
--- a/apps/web/src/hooks/infinity/useInfinityCakeAPR.ts
+++ b/apps/web/src/hooks/infinity/useInfinityCakeAPR.ts
@@ -8,6 +8,7 @@ import { InfinityPoolInfo } from 'state/farmsV4/state/type'
 import { Address } from 'viem/accounts'
 import { useCampaignsByChainId } from './useCampaigns'
 import { useFarmRewardsByPoolId } from './useFarmReward'
+import { usePositionIsFarming } from './useIsFarming'
 
 interface InfinityCakeAPRProps {
   chainId?: number
@@ -70,9 +71,10 @@ export const useInfinityCLPositionCakeAPR = ({
   const { cakePerYear, poolWeight } = useInfinityCakeAPR({ chainId, poolId, tvlUSD, cakePrice })
   const { address } = useAccount()
   const rewardsPerEpoch = useFarmRewardsByPoolId({ chainId, address, poolId })
+  const isFarming = usePositionIsFarming({ chainId, poolId })
 
   return useMemo(() => {
-    if (!cakePerYear || !tvlUSD) {
+    if (!cakePerYear || !tvlUSD || !isFarming) {
       return {
         value: '0' as `${number}`,
       }
@@ -94,6 +96,7 @@ export const useInfinityCLPositionCakeAPR = ({
       value: rewardForPositionPerYear.div(tvlUSD).toString() as `${number}`,
     }
   }, [
+    isFarming,
     position.tokenId,
     rewardsPerEpoch,
     cakePerYear,
@@ -112,6 +115,7 @@ export const useInfinityBinPositionCakeAPR = ({
   pool,
 }: InfinityPositionCakeAPR<InfinityBinPositionDetail>) => {
   const { chainId, poolId } = pool
+  const isFarming = usePositionIsFarming({ chainId, poolId })
   const activeTVLUsd = useMemo(() => {
     if (!tvlUSD || !position.liquidity || (!position.poolLiquidity && !pool.liquidity)) {
       return '0' as `${number}`
@@ -128,7 +132,7 @@ export const useInfinityBinPositionCakeAPR = ({
   const rewardsPerEpoch = useFarmRewardsByPoolId({ chainId, address, poolId })
 
   return useMemo(() => {
-    if (!cakePerYear || !tvlUSD) {
+    if (!cakePerYear || !tvlUSD || !isFarming) {
       return {
         value: '0' as `${number}`,
       }
@@ -157,6 +161,7 @@ export const useInfinityBinPositionCakeAPR = ({
       value: rewardForPositionPerYear.div(tvlUSD).toString() as `${number}`,
     }
   }, [
+    isFarming,
     rewardsPerEpoch,
     cakePerYear,
     tvlUSD,

--- a/apps/web/src/hooks/infinity/useIsFarming.ts
+++ b/apps/web/src/hooks/infinity/useIsFarming.ts
@@ -63,28 +63,24 @@ export const useMultiChainPoolsFarmingStatus = (pools: UniversalFarmConfig[]) =>
   )
 }
 
-export const usePositionIsFarming = ({
-  chainId,
-  poolId,
-  tokenId,
-}: {
-  chainId?: number
-  poolId?: Address
-  tokenId?: bigint
-}) => {
-  const { address } = useAccount()
-  const { data: rewards } = usePoolFarmRewardsFormAPI({
-    address,
-    chainId,
-    poolId,
-    timestamp: dayjs().startOf('hour').unix(),
+export const usePositionIsFarming = ({ chainId, poolId }: { chainId?: number; poolId?: Address }) => {
+  const { data: campaignsByPoolId } = useQuery({
+    queryKey: ['CampaignsByPoolId', poolId, chainId],
+    queryFn: async () =>
+      fetchCampaignsByPoolIds({ chainId: Number(chainId), poolIds: [poolId!], fetchAll: true, includeInactive: false }),
+    enabled: !!poolId,
+    retry: false,
   })
-  return useMemo(() => {
-    if (!tokenId) {
-      return !!rewards?.find((r) => r.poolId === poolId)
-    }
-    return !!rewards?.find((r) => r.tokenIds.includes(tokenId.toString()))
-  }, [rewards, tokenId, poolId])
+  return useMemo(
+    () =>
+      campaignsByPoolId?.some(
+        (camp) =>
+          camp.poolId === poolId &&
+          Number(camp.startTime) <= Number(dayjs().unix()) &&
+          Number(camp.startTime) + Number(camp.duration) >= Number(dayjs().unix()),
+      ),
+    [campaignsByPoolId, poolId],
+  )
 }
 
 export const usePositionsWithFarming = <T extends InfinityBinPositionDetail | InfinityCLPositionDetail>({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the `usePositionIsFarming` hook to simplify its parameters and improve its functionality by fetching campaigns based on `poolId` and `chainId`. It also updates the `useInfinityCLPositionCakeAPR` and `useInfinityBinPositionCakeAPR` hooks to incorporate the new logic.

### Detailed summary
- Refactored `usePositionIsFarming` to accept only `chainId` and `poolId`.
- Changed data fetching in `usePositionIsFarming` to use `useQuery` for campaigns.
- Updated return logic in `usePositionIsFarming` to check for active campaigns.
- Modified `useInfinityCLPositionCakeAPR` to include `isFarming` check.
- Altered `useInfinityBinPositionCakeAPR` to incorporate `isFarming` in conditional logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->