### PR TITLE
fix: disabled harvest when there no unclaimed previous epoch reward

### DIFF
--- a/apps/web/src/views/universalFarms/components/PositionActions/InfinityPositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/InfinityPositionActions.tsx
@@ -37,6 +37,7 @@ export const InfinityPositionActions = ({ pos, positionList = [] }: ActionPanelP
     attemptingTx: harvestAttemptingTxn,
     isMerkleRootMismatch,
     hasRewards,
+    hasUnclaimedRewards,
   } = useFarmInfinityActions({
     chainId,
     onDone: (resp) => setLatestTxReceipt(resp),
@@ -88,7 +89,7 @@ export const InfinityPositionActions = ({ pos, positionList = [] }: ActionPanelP
         <Button
           width={['100px']}
           scale="md"
-          disabled={isAttemptingTx || isMerkleRootMismatch || !hasRewards}
+          disabled={isAttemptingTx || isMerkleRootMismatch || !hasRewards || !hasUnclaimedRewards}
           onClick={modalState.onOpen}
         >
           {isAttemptingTx ? t('Harvesting') : t('Harvest')}

--- a/apps/web/src/views/universalFarms/hooks/useFarmInfinityActions.tsx
+++ b/apps/web/src/views/universalFarms/hooks/useFarmInfinityActions.tsx
@@ -18,6 +18,7 @@ import { useCheckShouldSwitchNetwork } from './useCheckShouldSwitchNetwork'
 
 interface FarmInfinityActionReturnType {
   hasRewards: boolean
+  hasUnclaimedRewards: boolean
   isMerkleRootMismatch: boolean
   attemptingTx: boolean
   onHarvest: () => Promise<void>
@@ -133,6 +134,7 @@ const useFarmInfinityActions = ({
 
   return {
     hasRewards: Boolean(allRewards?.length),
+    hasUnclaimedRewards: totalUnclaimedRewards?.some((r) => Number(r.totalReward) > 0),
     isMerkleRootMismatch: Boolean(merkleRootMismatch),
     attemptingTx: loading || isSwitchingNetwork,
     onHarvest,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new feature to track unclaimed rewards in the `FarmInfinityActionReturnType` interface and updates the `InfinityPositionActions` component to utilize this information, enhancing user interaction with reward harvesting.

### Detailed summary
- Added `hasUnclaimedRewards` boolean to `FarmInfinityActionReturnType` interface.
- Updated the return object in `useFarmInfinityActions` to compute `hasUnclaimedRewards` based on `totalUnclaimedRewards`.
- Modified the `InfinityPositionActions` component to include `hasUnclaimedRewards` in destructuring.
- Adjusted the `disabled` state of the `Button` to include the condition for `hasUnclaimedRewards`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->