### PR TITLE
perf: auto slippage improvements

### DIFF
--- a/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
@@ -147,7 +147,7 @@ const useSizeAdaption = (value: string, currencySymbol?: string, otherCurrencySy
 }
 
 interface CurrencyInputPanelProps {
-  value: string | undefined
+  defaultValue: string | undefined
   onUserInput: (value: string) => void
   onInputBlur?: () => void
   onPercentInput?: (percent: number) => void
@@ -168,6 +168,7 @@ interface CurrencyInputPanelProps {
   commonBasesType?: string
   showSearchInput?: boolean
   beforeButton?: React.ReactNode
+  isDependent?: boolean
   disabled?: boolean
   error?: boolean | string
   showUSDPrice?: boolean
@@ -183,7 +184,7 @@ interface CurrencyInputPanelProps {
   isUserInsufficientBalance?: boolean
 }
 const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
-  value,
+  defaultValue,
   onUserInput,
   onInputBlur,
   onPercentInput,
@@ -213,6 +214,8 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
   isUserInsufficientBalance,
 }: CurrencyInputPanelProps) {
   const { address: account } = useAccount()
+  // const value = useRef<string | undefined>(defaultValue)
+  const [value, setValue] = useState<string | undefined>(defaultValue)
 
   const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
   const { t } = useTranslation()
@@ -223,6 +226,7 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
 
   const amountInDollar = useStablecoinPriceAmount(
     showUSDPrice ? currency ?? undefined : undefined,
+
     value !== undefined && Number.isFinite(+value) ? +value : undefined,
     {
       hideIfPriceImpactTooHigh: true,
@@ -250,12 +254,22 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
     otherCurrency?.symbol,
   )
 
-  const handleUserInput = useCallback(
-    (val: string) => {
-      onUserInput(val)
-    },
-    [onUserInput],
-  )
+  useEffect(() => {
+    if (isInputFocus) {
+      return
+    }
+    setValue(defaultValue)
+  }, [defaultValue, isInputFocus])
+
+  useEffect(() => {
+    if (isInputFocus) {
+      onUserInput(value ?? '')
+    }
+  }, [value, defaultValue, isInputFocus])
+
+  const handleUserInput = useCallback((val: string) => {
+    setValue(val)
+  }, [])
   const handleUserInputBlur = useCallback(() => {
     onInputBlur?.()
     setTimeout(() => setIsInputFocus(false), 300)

--- a/apps/web/src/hooks/useAutoSlippage.tsx
+++ b/apps/web/src/hooks/useAutoSlippage.tsx
@@ -13,11 +13,11 @@ import { useGasPrice } from 'state/user/hooks'
 import useNativeCurrency from './useNativeCurrency'
 import { useStablecoinPrice, useStablecoinPriceAmount } from './useStablecoinPrice'
 
-const MIN_SLIPPAGE_NUMERATOR = 50
-const MAX_SLIPPAGE_NUMERATOR = 500
-const DEFAULT_AUTO_SLIPPAGE = new Percent(50, 10_000) // 0.5%
-const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(MIN_SLIPPAGE_NUMERATOR, 10_000) // 0.5%
-const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(MAX_SLIPPAGE_NUMERATOR, 10_000) // 5%
+export const MIN_DEFAULT_SLIPPAGE_NUMERATOR = 50
+export const MAX_SLIPPAGE_NUMERATOR = 500
+export const DEFAULT_AUTO_SLIPPAGE = new Percent(MIN_DEFAULT_SLIPPAGE_NUMERATOR, 10_000) // 0.5%
+export const MIN_AUTO_SLIPPAGE_TOLERANCE = new Percent(MIN_DEFAULT_SLIPPAGE_NUMERATOR, 10_000) // 0.5%
+export const MAX_AUTO_SLIPPAGE_TOLERANCE = new Percent(MAX_SLIPPAGE_NUMERATOR, 10_000) // 5%
 
 // Helper functions
 const isL2ChainId = (chainId?: number): boolean => {
@@ -113,7 +113,7 @@ const calculateSlippageFromDollarValues = (dollarCostToUse: number, outputDollar
 // Apply slippage tolerance limits
 const applySlippageLimits = (
   calculatedSlippage: Percent,
-  min = MIN_SLIPPAGE_NUMERATOR,
+  min = MIN_DEFAULT_SLIPPAGE_NUMERATOR,
   max = MAX_SLIPPAGE_NUMERATOR,
 ) => {
   if (calculatedSlippage.greaterThan(new Percent(max, 10_000))) {

--- a/apps/web/src/hooks/useAutoSlippage.tsx
+++ b/apps/web/src/hooks/useAutoSlippage.tsx
@@ -138,7 +138,7 @@ type SupportedTrade =
 export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade): Percent {
   const { chainId } = useActiveChainId()
   const onL2 = isL2ChainId(chainId)
-  const inputBasedSlippage = useInputBasedAutoSlippage(trade?.inputAmount)
+  const { inputBasedSlippage, inputDollarValue } = useInputBasedAutoSlippage(trade?.inputAmount)
 
   // Get USD price of output amount
   const outputCurrency = trade?.outputAmount?.currency
@@ -190,18 +190,28 @@ export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade):
 
       if (outputDollarValue && dollarCostToUse) {
         const calculatedSlippage = calculateSlippageFromDollarValues(dollarCostToUse, outputDollarValue)
+        const outputBaseSlippage = applySlippageLimits(calculatedSlippage)
+        // input usd has value and the usd value difference is 5% up, this is for some edge case
+        const shouldUseInputBase =
+          inputDollarValue &&
+          Math.abs(inputDollarValue - outputDollarValue) > outputDollarValue * 0.05 &&
+          outputBaseSlippage.lessThan(inputBasedSlippage)
+
+        const finalSlippage = shouldUseInputBase ? inputBasedSlippage : outputBaseSlippage
 
         console.info('Auto Slippage: Calculated result', {
+          shouldUseInputBase,
+          inputBasedSlippage,
+          outputBaseSlippage,
           dollarCostToUse,
+          inputDollarValue,
           outputDollarValue,
           fraction: dollarCostToUse / outputDollarValue,
           resultBasisPoints: Math.floor((dollarCostToUse / outputDollarValue) * 10000),
-          result: calculatedSlippage.toFixed(2),
+          result: finalSlippage.toFixed(2),
         })
 
-        return calculatedSlippage.lessThan(inputBasedSlippage)
-          ? inputBasedSlippage
-          : applySlippageLimits(calculatedSlippage)
+        return finalSlippage
       }
 
       console.log('Auto Slippage: Using DEFAULT_AUTO_SLIPPAGE because missing outputDollarValue or dollarCostToUse')
@@ -216,7 +226,10 @@ export default function useClassicAutoSlippageTolerance(trade?: SupportedTrade):
 }
 
 // Calculate slippage based on input dollar value
-export function useInputBasedAutoSlippage(inputAmount?: CurrencyAmount<Currency>): Percent {
+export function useInputBasedAutoSlippage(inputAmount?: CurrencyAmount<Currency>): {
+  inputBasedSlippage: Percent
+  inputDollarValue: number | undefined
+} {
   const { chainId } = useActiveChainId()
   const onL2 = isL2ChainId(chainId)
 
@@ -242,7 +255,7 @@ export function useInputBasedAutoSlippage(inputAmount?: CurrencyAmount<Currency>
     ],
     queryFn: () => {
       // If no input amount or on L2 chain, use default
-      if (!inputAmount || onL2) return DEFAULT_AUTO_SLIPPAGE
+      if (!inputAmount || onL2) return { inputBasedSlippage: DEFAULT_AUTO_SLIPPAGE, inputDollarValue: undefined }
 
       const inputAmountValue = inputAmount?.toSignificant(6)
       const inputDollarValue =
@@ -255,14 +268,14 @@ export function useInputBasedAutoSlippage(inputAmount?: CurrencyAmount<Currency>
         // For input-based calculation, we use a different formula
         // We want to ensure the slippage covers the gas cost relative to the input amount
         const calculatedSlippage = calculateSlippageFromDollarValues(gasCostUSDValue, inputDollarValue)
-        return applySlippageLimits(calculatedSlippage)
+        return { inputBasedSlippage: applySlippageLimits(calculatedSlippage), inputDollarValue }
       }
 
-      return DEFAULT_AUTO_SLIPPAGE
+      return { inputBasedSlippage: DEFAULT_AUTO_SLIPPAGE, inputDollarValue: undefined }
     },
     placeholderData: keepPreviousData,
     staleTime: Infinity,
     gcTime: 0, // Remove data from cache immediately after unmount
   })
-  return data ?? DEFAULT_AUTO_SLIPPAGE
+  return data ?? { inputBasedSlippage: DEFAULT_AUTO_SLIPPAGE, inputDollarValue: undefined }
 }

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -4,11 +4,20 @@ import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/swap-sdk-core'
 import { useUserSlippage } from '@pancakeswap/utils/user'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
-import { useMemo } from 'react'
-import useClassicAutoSlippageTolerance, { useInputBasedAutoSlippage } from './useAutoSlippage'
+import { useEffect, useMemo } from 'react'
+import { useAllTypeBestTrade } from 'views/Swap/V3Swap/hooks/useAllTypeBestTrade'
+import useClassicAutoSlippageTolerance, {
+  MIN_DEFAULT_SLIPPAGE_NUMERATOR,
+  useInputBasedAutoSlippage,
+} from './useAutoSlippage'
 
 // Atom to store the user's preference for auto slippage
 const autoSlippageEnabledAtom = atomWithStorage('pcs:auto-slippage-enabled-2', true)
+const autoSlippageAtom = atomWithStorage('pcs:auto-slippage-value', MIN_DEFAULT_SLIPPAGE_NUMERATOR)
+
+export const useAutoSlippageAtom = () => {
+  return useAtom(autoSlippageAtom)
+}
 
 export const useAutoSlippageEnabled = () => {
   return useAtom(autoSlippageEnabledAtom)
@@ -24,19 +33,19 @@ type SupportedTrade =
  * If auto slippage is enabled, it will use the auto-calculated value
  * Otherwise, it will use the user's manually set slippage
  */
-export function useAutoSlippageWithFallback(trade?: SupportedTrade): {
+export function useAutoSlippageWithFallback(): {
   slippageTolerance: number
   isAuto: boolean
 } {
   const [isAutoSlippageEnabled] = useAutoSlippageEnabled()
   const [userSlippageTolerance] = useUserSlippage()
-  const autoSlippageTolerance = useClassicAutoSlippageTolerance(trade)
-  const isXOrder = Boolean((trade as ExclusiveDutchOrderTrade<Currency, Currency>)?.orderInfo)
+  const [autoSlippageTolerance] = useAutoSlippageAtom()
+  const hasTrade = Boolean(useAllTypeBestTrade()?.bestOrder?.trade)
 
   return useMemo(() => {
-    if (isAutoSlippageEnabled && trade && !isXOrder) {
+    if (isAutoSlippageEnabled && hasTrade) {
       return {
-        slippageTolerance: Number(autoSlippageTolerance.numerator),
+        slippageTolerance: autoSlippageTolerance,
         isAuto: true,
       }
     }
@@ -48,7 +57,7 @@ export function useAutoSlippageWithFallback(trade?: SupportedTrade): {
       slippageTolerance: userSlippageTolerancePercent,
       isAuto: false,
     }
-  }, [isAutoSlippageEnabled, trade, autoSlippageTolerance, userSlippageTolerance])
+  }, [isAutoSlippageEnabled, hasTrade, autoSlippageTolerance, userSlippageTolerance])
 }
 
 export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmount<Currency>) => {
@@ -69,4 +78,24 @@ export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmou
       isAuto: false,
     }
   }, [isAutoSlippageEnabled, inputAmount, autoSlippageTolerance, userSlippageTolerance])
+}
+
+export const AutoSlippageProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <>
+      {children}
+      <Sync />
+    </>
+  )
+}
+export const Sync = () => {
+  const result = useAllTypeBestTrade()
+  const autoSlippage = useClassicAutoSlippageTolerance(result?.bestOrder?.trade)
+  const [, setAutoSlippageValue] = useAutoSlippageAtom()
+  useEffect(() => {
+    if (result?.bestOrder?.trade && autoSlippage) {
+      setAutoSlippageValue(Number(autoSlippage.numerator))
+    }
+  }, [result, autoSlippage])
+  return null
 }

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -50,11 +50,8 @@ export function useAutoSlippageWithFallback(): {
       }
     }
 
-    // Convert basis points to percent
-    const userSlippageTolerancePercent = userSlippageTolerance
-
     return {
-      slippageTolerance: userSlippageTolerancePercent,
+      slippageTolerance: userSlippageTolerance,
       isAuto: false,
     }
   }, [isAutoSlippageEnabled, hasTrade, autoSlippageTolerance, userSlippageTolerance])

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -2,7 +2,7 @@ import { ExclusiveDutchOrderTrade } from '@pancakeswap/pcsx-sdk'
 import { SmartRouterTrade, V4Router } from '@pancakeswap/smart-router'
 import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/swap-sdk-core'
 import { useUserSlippage } from '@pancakeswap/utils/user'
-import { useAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useAllTypeBestTrade } from 'views/Swap/V3Swap/hooks/useAllTypeBestTrade'
@@ -13,10 +13,9 @@ import useClassicAutoSlippageTolerance, {
 
 // Atom to store the user's preference for auto slippage
 const autoSlippageEnabledAtom = atomWithStorage('pcs:auto-slippage-enabled-2', true)
-const autoSlippageAtom = atomWithStorage('pcs:auto-slippage-value', MIN_DEFAULT_SLIPPAGE_NUMERATOR)
 
 export const useAutoSlippageAtom = () => {
-  return useAtom(autoSlippageAtom)
+  return useAtom(atom(MIN_DEFAULT_SLIPPAGE_NUMERATOR))
 }
 
 export const useAutoSlippageEnabled = () => {

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -59,12 +59,12 @@ export function useAutoSlippageWithFallback(): {
 export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmount<Currency>) => {
   const [isAutoSlippageEnabled] = useAutoSlippageEnabled()
   const [userSlippageTolerance] = useUserSlippage()
-  const autoSlippageTolerance = useInputBasedAutoSlippage(inputAmount)
+  const { inputBasedSlippage } = useInputBasedAutoSlippage(inputAmount)
 
   return useMemo(() => {
-    if (isAutoSlippageEnabled && inputAmount && autoSlippageTolerance) {
+    if (isAutoSlippageEnabled && inputAmount && inputBasedSlippage) {
       return {
-        slippageTolerance: Number(autoSlippageTolerance.numerator),
+        slippageTolerance: Number(inputBasedSlippage.numerator),
         isAuto: true,
       }
     }
@@ -73,7 +73,7 @@ export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmou
       slippageTolerance: userSlippageTolerance,
       isAuto: false,
     }
-  }, [isAutoSlippageEnabled, inputAmount, autoSlippageTolerance, userSlippageTolerance])
+  }, [isAutoSlippageEnabled, inputAmount, inputBasedSlippage, userSlippageTolerance])
 }
 
 export const AutoSlippageProvider = ({ children }: { children?: React.ReactNode }) => {

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -97,6 +97,7 @@ export const Sync = () => {
       tradeRef.current?.outputAmount?.equalTo(result?.bestOrder?.trade?.outputAmount)
     )
   }, [result?.bestOrder])
+
   const autoSlippage = useClassicAutoSlippageTolerance(result?.bestOrder?.trade)
   const [, setAutoSlippageValue] = useAutoSlippageAtom()
   const updateAutoSlippage = useCallback(() => {
@@ -106,6 +107,7 @@ export const Sync = () => {
   }, [autoSlippage])
   useEffect(() => {
     if (!isSameOrder) {
+      tradeRef.current = result?.bestOrder?.trade
       updateAutoSlippage()
     }
   }, [isSameOrder, updateAutoSlippage])

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -13,9 +13,10 @@ import useClassicAutoSlippageTolerance, {
 
 // Atom to store the user's preference for auto slippage
 const autoSlippageEnabledAtom = atomWithStorage('pcs:auto-slippage-enabled-2', true)
+const autoSlippageValueAtom = atom(MIN_DEFAULT_SLIPPAGE_NUMERATOR)
 
 export const useAutoSlippageAtom = () => {
-  return useAtom(atom(MIN_DEFAULT_SLIPPAGE_NUMERATOR))
+  return useAtom(autoSlippageValueAtom)
 }
 
 export const useAutoSlippageEnabled = () => {

--- a/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
+++ b/apps/web/src/hooks/useAutoSlippageWithFallback.tsx
@@ -4,7 +4,7 @@ import { Currency, CurrencyAmount, TradeType } from '@pancakeswap/swap-sdk-core'
 import { useUserSlippage } from '@pancakeswap/utils/user'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useAllTypeBestTrade } from 'views/Swap/V3Swap/hooks/useAllTypeBestTrade'
 import useClassicAutoSlippageTolerance, {
   MIN_DEFAULT_SLIPPAGE_NUMERATOR,
@@ -40,10 +40,9 @@ export function useAutoSlippageWithFallback(): {
   const [isAutoSlippageEnabled] = useAutoSlippageEnabled()
   const [userSlippageTolerance] = useUserSlippage()
   const [autoSlippageTolerance] = useAutoSlippageAtom()
-  const hasTrade = Boolean(useAllTypeBestTrade()?.bestOrder?.trade)
 
   return useMemo(() => {
-    if (isAutoSlippageEnabled && hasTrade) {
+    if (isAutoSlippageEnabled) {
       return {
         slippageTolerance: autoSlippageTolerance,
         isAuto: true,
@@ -54,7 +53,7 @@ export function useAutoSlippageWithFallback(): {
       slippageTolerance: userSlippageTolerance,
       isAuto: false,
     }
-  }, [isAutoSlippageEnabled, hasTrade, autoSlippageTolerance, userSlippageTolerance])
+  }, [isAutoSlippageEnabled, autoSlippageTolerance, userSlippageTolerance])
 }
 
 export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmount<Currency>) => {
@@ -63,7 +62,7 @@ export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmou
   const autoSlippageTolerance = useInputBasedAutoSlippage(inputAmount)
 
   return useMemo(() => {
-    if (isAutoSlippageEnabled && inputAmount) {
+    if (isAutoSlippageEnabled && inputAmount && autoSlippageTolerance) {
       return {
         slippageTolerance: Number(autoSlippageTolerance.numerator),
         isAuto: true,
@@ -77,7 +76,7 @@ export const useInputBasedAutoSlippageWithFallback = (inputAmount?: CurrencyAmou
   }, [isAutoSlippageEnabled, inputAmount, autoSlippageTolerance, userSlippageTolerance])
 }
 
-export const AutoSlippageProvider = ({ children }: { children: React.ReactNode }) => {
+export const AutoSlippageProvider = ({ children }: { children?: React.ReactNode }) => {
   return (
     <>
       {children}
@@ -87,12 +86,28 @@ export const AutoSlippageProvider = ({ children }: { children: React.ReactNode }
 }
 export const Sync = () => {
   const result = useAllTypeBestTrade()
+  const tradeRef = useRef(result?.bestOrder?.trade)
+  const isSameOrder = useMemo(() => {
+    if (!tradeRef.current || !result?.bestOrder?.trade) return false
+    return (
+      tradeRef.current?.inputAmount?.currency?.equals(result?.bestOrder?.trade?.inputAmount?.currency) &&
+      tradeRef.current?.outputAmount?.currency?.equals(result?.bestOrder?.trade?.outputAmount?.currency) &&
+      tradeRef.current?.tradeType === result?.bestOrder?.trade?.tradeType &&
+      tradeRef.current?.inputAmount?.equalTo(result?.bestOrder?.trade?.inputAmount) &&
+      tradeRef.current?.outputAmount?.equalTo(result?.bestOrder?.trade?.outputAmount)
+    )
+  }, [result?.bestOrder])
   const autoSlippage = useClassicAutoSlippageTolerance(result?.bestOrder?.trade)
   const [, setAutoSlippageValue] = useAutoSlippageAtom()
-  useEffect(() => {
-    if (result?.bestOrder?.trade && autoSlippage) {
+  const updateAutoSlippage = useCallback(() => {
+    if (autoSlippage) {
       setAutoSlippageValue(Number(autoSlippage.numerator))
     }
-  }, [result, autoSlippage])
+  }, [autoSlippage])
+  useEffect(() => {
+    if (!isSameOrder) {
+      updateAutoSlippage()
+    }
+  }, [isSameOrder, updateAutoSlippage])
   return null
 }

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -169,7 +169,7 @@ export function useDerivedSwapInfo(
     inputError = inputError ?? t('Invalid recipient')
   }
   // @ts-ignore
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(v2Trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
 
   const slippageAdjustedAmounts = v2Trade && allowedSlippage && computeSlippageAdjustedAmounts(v2Trade, allowedSlippage)
 

--- a/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
+++ b/apps/web/src/views/CakeStaking/components/LockCakeForm.tsx
@@ -35,7 +35,7 @@ const CakeInput: React.FC<{
       showUSDPrice
       showCommonBases
       showMaxButton={false}
-      value={value?.toString()}
+      defaultValue={value?.toString()}
       onUserInput={onInput}
       title={
         <Text color="textSubtle" fontSize={12} bold>

--- a/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SlippageButton.tsx
@@ -1,7 +1,5 @@
 import { useTheme } from '@pancakeswap/hooks'
 import { useTranslation } from '@pancakeswap/localization'
-import { TradeType } from '@pancakeswap/sdk'
-import { SmartRouterTrade, V4Router } from '@pancakeswap/smart-router'
 import {
   Button,
   PencilIcon,
@@ -35,16 +33,15 @@ const AutoSlippageText = styled(Text)`
 
 interface SlippageButtonProps {
   slippage?: number | ReactElement
-  trade?: SmartRouterTrade<TradeType> | V4Router.V4TradeWithoutGraph<TradeType>
 }
 
-export const SlippageButton = ({ slippage, trade }: SlippageButtonProps) => {
+export const SlippageButton = ({ slippage }: SlippageButtonProps) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
   const { isMobile } = useMatchBreakpoints()
 
   // Calculate auto slippage
-  const { slippageTolerance, isAuto } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance, isAuto } = useAutoSlippageWithFallback()
 
   const isRiskyLow = slippageTolerance < 50
 

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -177,7 +177,7 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
                 <DottedHelpText fontSize="14px">{t('Slippage Tolerance')}</DottedHelpText>
               </QuestionHelperV2>
             </RowFixed>
-            <SlippageButton slippage={allowedSlippage} trade={order?.trade} />
+            <SlippageButton slippage={allowedSlippage} />
           </RowBetween>
         )}
         <RowBetween mb="8px">

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModal.tsx
@@ -78,7 +78,7 @@ export const ConfirmSwapModal: React.FC<ConfirmSwapModalProps> = ({
 }) => {
   const { t } = useTranslation()
   const { chainId } = useActiveChainId()
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(originalOrder?.trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
   const slippageAdjustedAmounts = useSlippageAdjustedAmounts(originalOrder)
   const { recipient } = useSwapState()
   const loadingAnimationVisible = useMemo(() => {

--- a/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/ConfirmSwapModalV2.tsx
@@ -79,7 +79,7 @@ export const ConfirmSwapModalV2: React.FC<ConfirmSwapModalV2Props> = ({
   const { t } = useTranslation()
   const { chainId } = useActiveChainId()
   // @ts-ignore
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(originalOrder?.trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
 
   const slippageAdjustedAmounts = useSlippageAdjustedAmounts(originalOrder)
   const { recipient } = useSwapState()

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSendSwapTransaction.ts
@@ -68,7 +68,7 @@ export default function useSendSwapTransaction(
   const { sendTransactionAsync } = useSendTransaction()
   const publicClient = viemClients[chainId as ChainId]
   // @ts-ignore
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
   const { recipient } = useSwapState()
   const recipientAddress = recipient === null ? account : recipient
 

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSlippageAdjustedAmounts.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSlippageAdjustedAmounts.ts
@@ -4,6 +4,6 @@ import { InterfaceOrder } from 'views/Swap/utils'
 import { computeSlippageAdjustedAmounts } from '../utils/exchange'
 
 export function useSlippageAdjustedAmounts(order: InterfaceOrder | undefined | null) {
-  const { slippageTolerance } = useAutoSlippageWithFallback(order?.trade)
+  const { slippageTolerance } = useAutoSlippageWithFallback()
   return useMemo(() => computeSlippageAdjustedAmounts(order, slippageTolerance), [slippageTolerance, order])
 }

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallback.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallback.ts
@@ -48,7 +48,6 @@ export function useSwapCallback({
 }: UseSwapCallbackArgs): UseSwapCallbackReturns {
   const { t } = useTranslation()
   const { account, chainId } = useAccountActiveChain()
-  // @ts-ignore
   const { slippageTolerance: allowedSlippageRaw } = useAutoSlippageWithFallback()
   const { recipient: recipientAddress } = useSwapState()
   const recipient = recipientAddress === null ? account : recipientAddress

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallback.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapCallback.ts
@@ -49,7 +49,7 @@ export function useSwapCallback({
   const { t } = useTranslation()
   const { account, chainId } = useAccountActiveChain()
   // @ts-ignore
-  const { slippageTolerance: allowedSlippageRaw } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance: allowedSlippageRaw } = useAutoSlippageWithFallback()
   const { recipient: recipientAddress } = useSwapState()
   const recipient = recipientAddress === null ? account : recipientAddress
 

--- a/apps/web/src/views/Swap/V3Swap/hooks/useWallchain.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useWallchain.ts
@@ -131,7 +131,7 @@ export function useWallchainApi(
   const { data: walletClient } = useWalletClient()
   const { account } = useAccountActiveChain()
 
-  const { slippageTolerance: allowedSlippageRaw } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance: allowedSlippageRaw } = useAutoSlippageWithFallback()
   const allowedSlippage = useMemo(() => basisPointsToPercent(allowedSlippageRaw), [allowedSlippageRaw])
   const [lastUpdate, setLastUpdate] = useState(0)
   const useUniversalRouter = true

--- a/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/AdvancedSwapDetails.tsx
@@ -46,7 +46,6 @@ export const TradeSummary = memo(function TradeSummary({
   realizedLPFee,
   isX = false,
   loading = false,
-  trade,
 }: {
   hasStablePair?: boolean
   inputAmount?: CurrencyAmount<Currency>
@@ -57,12 +56,11 @@ export const TradeSummary = memo(function TradeSummary({
   realizedLPFee?: CurrencyAmount<Currency> | null
   isX?: boolean
   loading?: boolean
-  trade?: any
 }) {
   const { t } = useTranslation()
   const isExactIn = tradeType === TradeType.EXACT_INPUT
   const { feeSavedAmount, feeSavedUsdValue } = useFeeSaved(inputAmount, outputAmount)
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
 
   return (
     <AutoColumn px="4px">
@@ -181,7 +179,7 @@ export const TradeSummary = memo(function TradeSummary({
             <DetailsTitle>{t('Slippage Tolerance')}</DetailsTitle>
           </QuestionHelperV2>
         </RowFixed>
-        <SlippageButton slippage={allowedSlippage} trade={trade} />
+        <SlippageButton slippage={allowedSlippage} />
       </RowBetween>
 
       {(realizedLPFee || isX) && (

--- a/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4.tsx
@@ -121,7 +121,7 @@ export function FormMain({ inputAmount, outputAmount, tradeLoading, isUserInsuff
         inputLoading={!isWrapping && inputLoading}
         currencyLoading={!loadedUrlParams}
         label={!isTypingInput && !isWrapping ? t('From (estimated)') : t('From')}
-        value={isWrapping ? typedValue : inputValue}
+        defaultValue={isWrapping ? typedValue : inputValue}
         maxAmount={maxAmountInput}
         showQuickInputButton
         currency={inputCurrency}
@@ -147,7 +147,7 @@ export function FormMain({ inputAmount, outputAmount, tradeLoading, isUserInsuff
         inputLoading={!isWrapping && outputLoading}
         currencyLoading={!loadedUrlParams}
         label={isTypingInput && !isWrapping ? t('To (estimated)') : t('To')}
-        value={isWrapping ? typedValue : outputValue}
+        defaultValue={isWrapping ? typedValue : outputValue}
         currency={outputCurrency}
         onUserInput={handleTypeOutput}
         onCurrencySelect={handleOutputSelect}

--- a/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4ForHomePage.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4ForHomePage.tsx
@@ -133,7 +133,7 @@ export function FormMainForHomePage({ inputAmount, outputAmount, tradeLoading, i
           inputLoading={!isWrapping && inputLoading}
           currencyLoading={!loadedUrlParams}
           label={!isTypingInput && !isWrapping ? t('From (estimated)') : t('From')}
-          value={isWrapping ? typedValue : inputValue}
+          defaultValue={isWrapping ? typedValue : inputValue}
           maxAmount={maxAmountInput}
           showQuickInputButton
           currency={inputCurrency}
@@ -159,7 +159,7 @@ export function FormMainForHomePage({ inputAmount, outputAmount, tradeLoading, i
           inputLoading={!isWrapping && outputLoading}
           currencyLoading={!loadedUrlParams}
           label={isTypingInput && !isWrapping ? t('To (estimated)') : t('To')}
-          value={isWrapping ? typedValue : outputValue}
+          defaultValue={isWrapping ? typedValue : outputValue}
           currency={outputCurrency}
           onUserInput={handleTypeOutput}
           onCurrencySelect={handleOutputSelect}

--- a/apps/web/src/views/SwapSimplify/V4Swap/PricingAndSlippage.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/PricingAndSlippage.tsx
@@ -13,16 +13,14 @@ interface Props {
   showSlippage?: boolean
   priceLoading?: boolean
   price?: Price<Currency, Currency>
-  trade?: any // Accept any trade type
 }
 
 export const PricingAndSlippage = memo(function PricingAndSlippage({
   priceLoading,
   price,
   showSlippage = true,
-  trade,
 }: Props) {
-  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback(trade)
+  const { slippageTolerance: allowedSlippage } = useAutoSlippageWithFallback()
 
   const isWrapping = useIsWrapping()
   const [onPresentSettingsModal] = useModal(<SettingsModal mode={SettingsMode.SWAP_LIQUIDITY} />)

--- a/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
@@ -61,7 +61,6 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           realizedLPFee={lpFeeAmount ?? undefined}
           hasStablePair={hasStablePool}
           loading={!loaded}
-          trade={isXOrder(order) ? order.ammTrade : order?.trade}
         />
         <Box mt="10px" pl="4px">
           {isXOrder(order) ? (

--- a/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/index.tsx
@@ -119,7 +119,7 @@ export function V4SwapForm() {
   const inputCurrency = useCurrency(inputCurrencyId)
   const outputCurrency = useCurrency(outputCurrencyId)
 
-  const { slippageTolerance: userSlippageTolerance } = useAutoSlippageWithFallback(bestOrder?.trade)
+  const { slippageTolerance: userSlippageTolerance } = useAutoSlippageWithFallback()
   const isSlippageTooHigh = useMemo(() => userSlippageTolerance > 500, [userSlippageTolerance])
   const shouldRiskPanelDisplay = useShouldRiskPanelDisplay(inputCurrency?.wrapped, outputCurrency?.wrapped)
   const token0Risk = useTokenRisk(inputCurrency?.wrapped)
@@ -182,7 +182,6 @@ export function V4SwapForm() {
                 priceLoading={!tradeLoaded}
                 price={executionPrice ?? undefined}
                 showSlippage={false}
-                trade={bestOrder?.trade}
               />
             </FlexGap>
             <TradingFee loaded={tradeLoaded} order={bestOrder} />

--- a/apps/web/src/views/SwapSimplify/index.tsx
+++ b/apps/web/src/views/SwapSimplify/index.tsx
@@ -72,72 +72,72 @@ export default function V4Swap() {
   )
 
   return (
-    <AutoSlippageProvider>
-      <Page removePadding hideFooterOnDesktop={isChartExpanded || false} showExternalLink={false} showHelpLink={false}>
+    <Page removePadding hideFooterOnDesktop={isChartExpanded || false} showExternalLink={false} showHelpLink={false}>
+      <Flex
+        width="100%"
+        height="100%"
+        justifyContent="center"
+        position="relative"
+        mt={isChartExpanded ? undefined : isMobile ? '18px' : '42px'}
+        p={isChartExpanded ? undefined : isMobile ? '16px' : '24px'}
+      >
+        {isDesktop && isChartSupported && (
+          <PriceChartContainer
+            inputCurrencyId={inputCurrencyId}
+            inputCurrency={currencies[Field.INPUT]}
+            outputCurrencyId={outputCurrencyId}
+            outputCurrency={currencies[Field.OUTPUT]}
+            isChartExpanded={isChartExpanded}
+            setIsChartExpanded={setIsChartExpanded}
+            isChartDisplayed={isChartDisplayed}
+            currentSwapPrice={singleTokenPrice}
+          />
+        )}
+        {!isDesktop && isChartSupported && (
+          <BottomDrawer
+            content={
+              <PriceChartContainer
+                inputCurrencyId={inputCurrencyId}
+                inputCurrency={currencies[Field.INPUT]}
+                outputCurrencyId={outputCurrencyId}
+                outputCurrency={currencies[Field.OUTPUT]}
+                isChartExpanded={isChartExpanded}
+                setIsChartExpanded={setIsChartExpanded}
+                isChartDisplayed={isChartDisplayed}
+                currentSwapPrice={singleTokenPrice}
+                isFullWidthContainer
+                isMobile
+              />
+            }
+            isOpen={isChartDisplayed}
+            setIsOpen={(isOpen) => setIsChartDisplayed?.(isOpen)}
+          />
+        )}
         <Flex
-          width="100%"
+          flexDirection="column"
+          alignItems="center"
           height="100%"
-          justifyContent="center"
+          width={isChartDisplayed && !isMobile ? 'auto' : '100%'}
+          mt={isChartExpanded && !isMobile ? '42px' : undefined}
           position="relative"
-          mt={isChartExpanded ? undefined : isMobile ? '18px' : '42px'}
-          p={isChartExpanded ? undefined : isMobile ? '16px' : '24px'}
+          zIndex={1}
         >
-          {isDesktop && isChartSupported && (
-            <PriceChartContainer
-              inputCurrencyId={inputCurrencyId}
-              inputCurrency={currencies[Field.INPUT]}
-              outputCurrencyId={outputCurrencyId}
-              outputCurrency={currencies[Field.OUTPUT]}
-              isChartExpanded={isChartExpanded}
-              setIsChartExpanded={setIsChartExpanded}
-              isChartDisplayed={isChartDisplayed}
-              currentSwapPrice={singleTokenPrice}
-            />
-          )}
-          {!isDesktop && isChartSupported && (
-            <BottomDrawer
-              content={
-                <PriceChartContainer
-                  inputCurrencyId={inputCurrencyId}
-                  inputCurrency={currencies[Field.INPUT]}
-                  outputCurrencyId={outputCurrencyId}
-                  outputCurrency={currencies[Field.OUTPUT]}
-                  isChartExpanded={isChartExpanded}
-                  setIsChartExpanded={setIsChartExpanded}
-                  isChartDisplayed={isChartDisplayed}
-                  currentSwapPrice={singleTokenPrice}
-                  isFullWidthContainer
-                  isMobile
-                />
-              }
-              isOpen={isChartDisplayed}
-              setIsOpen={(isOpen) => setIsChartDisplayed?.(isOpen)}
-            />
-          )}
-          <Flex
-            flexDirection="column"
-            alignItems="center"
-            height="100%"
-            width={isChartDisplayed && !isMobile ? 'auto' : '100%'}
-            mt={isChartExpanded && !isMobile ? '42px' : undefined}
-            position="relative"
-            zIndex={1}
+          <StyledSwapContainer
+            justifyContent="center"
+            width="100%"
+            style={{ height: '100%' }}
+            $isChartExpanded={isChartExpanded}
           >
-            <StyledSwapContainer
-              justifyContent="center"
-              width="100%"
-              style={{ height: '100%' }}
-              $isChartExpanded={isChartExpanded}
-            >
+            <AutoSlippageProvider>
               <Wrapper height="100%">
                 <V4SwapForm />
               </Wrapper>
-            </StyledSwapContainer>
-          </Flex>
+            </AutoSlippageProvider>
+          </StyledSwapContainer>
         </Flex>
+      </Flex>
 
-        <MobileCard />
-      </Page>
-    </AutoSlippageProvider>
+      <MobileCard />
+    </Page>
   )
 }

--- a/apps/web/src/views/SwapSimplify/index.tsx
+++ b/apps/web/src/views/SwapSimplify/index.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect, useState } from 'react'
 
 import { MobileCard } from 'components/AdPanel/MobileCard'
 import { useCurrency } from 'hooks/Tokens'
+import { AutoSlippageProvider } from 'hooks/useAutoSlippageWithFallback'
 import { useSwapHotTokenDisplay } from 'hooks/useSwapHotTokenDisplay'
 import { Field } from 'state/swap/actions'
 import { useSingleTokenSwapInfo, useSwapState } from 'state/swap/hooks'
@@ -71,70 +72,72 @@ export default function V4Swap() {
   )
 
   return (
-    <Page removePadding hideFooterOnDesktop={isChartExpanded || false} showExternalLink={false} showHelpLink={false}>
-      <Flex
-        width="100%"
-        height="100%"
-        justifyContent="center"
-        position="relative"
-        mt={isChartExpanded ? undefined : isMobile ? '18px' : '42px'}
-        p={isChartExpanded ? undefined : isMobile ? '16px' : '24px'}
-      >
-        {isDesktop && isChartSupported && (
-          <PriceChartContainer
-            inputCurrencyId={inputCurrencyId}
-            inputCurrency={currencies[Field.INPUT]}
-            outputCurrencyId={outputCurrencyId}
-            outputCurrency={currencies[Field.OUTPUT]}
-            isChartExpanded={isChartExpanded}
-            setIsChartExpanded={setIsChartExpanded}
-            isChartDisplayed={isChartDisplayed}
-            currentSwapPrice={singleTokenPrice}
-          />
-        )}
-        {!isDesktop && isChartSupported && (
-          <BottomDrawer
-            content={
-              <PriceChartContainer
-                inputCurrencyId={inputCurrencyId}
-                inputCurrency={currencies[Field.INPUT]}
-                outputCurrencyId={outputCurrencyId}
-                outputCurrency={currencies[Field.OUTPUT]}
-                isChartExpanded={isChartExpanded}
-                setIsChartExpanded={setIsChartExpanded}
-                isChartDisplayed={isChartDisplayed}
-                currentSwapPrice={singleTokenPrice}
-                isFullWidthContainer
-                isMobile
-              />
-            }
-            isOpen={isChartDisplayed}
-            setIsOpen={(isOpen) => setIsChartDisplayed?.(isOpen)}
-          />
-        )}
+    <AutoSlippageProvider>
+      <Page removePadding hideFooterOnDesktop={isChartExpanded || false} showExternalLink={false} showHelpLink={false}>
         <Flex
-          flexDirection="column"
-          alignItems="center"
+          width="100%"
           height="100%"
-          width={isChartDisplayed && !isMobile ? 'auto' : '100%'}
-          mt={isChartExpanded && !isMobile ? '42px' : undefined}
+          justifyContent="center"
           position="relative"
-          zIndex={1}
+          mt={isChartExpanded ? undefined : isMobile ? '18px' : '42px'}
+          p={isChartExpanded ? undefined : isMobile ? '16px' : '24px'}
         >
-          <StyledSwapContainer
-            justifyContent="center"
-            width="100%"
-            style={{ height: '100%' }}
-            $isChartExpanded={isChartExpanded}
+          {isDesktop && isChartSupported && (
+            <PriceChartContainer
+              inputCurrencyId={inputCurrencyId}
+              inputCurrency={currencies[Field.INPUT]}
+              outputCurrencyId={outputCurrencyId}
+              outputCurrency={currencies[Field.OUTPUT]}
+              isChartExpanded={isChartExpanded}
+              setIsChartExpanded={setIsChartExpanded}
+              isChartDisplayed={isChartDisplayed}
+              currentSwapPrice={singleTokenPrice}
+            />
+          )}
+          {!isDesktop && isChartSupported && (
+            <BottomDrawer
+              content={
+                <PriceChartContainer
+                  inputCurrencyId={inputCurrencyId}
+                  inputCurrency={currencies[Field.INPUT]}
+                  outputCurrencyId={outputCurrencyId}
+                  outputCurrency={currencies[Field.OUTPUT]}
+                  isChartExpanded={isChartExpanded}
+                  setIsChartExpanded={setIsChartExpanded}
+                  isChartDisplayed={isChartDisplayed}
+                  currentSwapPrice={singleTokenPrice}
+                  isFullWidthContainer
+                  isMobile
+                />
+              }
+              isOpen={isChartDisplayed}
+              setIsOpen={(isOpen) => setIsChartDisplayed?.(isOpen)}
+            />
+          )}
+          <Flex
+            flexDirection="column"
+            alignItems="center"
+            height="100%"
+            width={isChartDisplayed && !isMobile ? 'auto' : '100%'}
+            mt={isChartExpanded && !isMobile ? '42px' : undefined}
+            position="relative"
+            zIndex={1}
           >
-            <Wrapper height="100%">
-              <V4SwapForm />
-            </Wrapper>
-          </StyledSwapContainer>
+            <StyledSwapContainer
+              justifyContent="center"
+              width="100%"
+              style={{ height: '100%' }}
+              $isChartExpanded={isChartExpanded}
+            >
+              <Wrapper height="100%">
+                <V4SwapForm />
+              </Wrapper>
+            </StyledSwapContainer>
+          </Flex>
         </Flex>
-      </Flex>
 
-      <MobileCard />
-    </Page>
+        <MobileCard />
+      </Page>
+    </AutoSlippageProvider>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the handling of slippage tolerance in various components of the swap functionality, streamlining the use of the `useAutoSlippageWithFallback` hook, and enhancing the overall slippage management system.

### Detailed summary
- Updated `useAutoSlippageWithFallback` to no longer take `trade` as an argument.
- Modified components to use the new slippage handling, removing `trade` dependencies.
- Introduced `AutoSlippageProvider` to encapsulate slippage logic.
- Adjusted several components to use `defaultValue` instead of `value` for inputs.
- Refactored `SlippageButton` to remove `trade` prop.
- Enhanced slippage calculations and default values in `useClassicAutoSlippageTolerance`.
- Updated `useInputBasedAutoSlippage` to return both `inputBasedSlippage` and `inputDollarValue`.
- Improved state management for slippage across multiple components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->