### PR TITLE
chore: remove debug info for QA

### DIFF
--- a/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
@@ -265,11 +265,6 @@ export const InfinityCLPosition = () => {
     [],
   )
 
-  useEffect(() => {
-    // todo:@eric for QA, remove before launch
-    console.log('poolId', poolId)
-  }, [poolId])
-
   return (
     <>
       {!isLoading && (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes a `useEffect` hook from the `InfinityCLPosition.tsx` file, which logged the `poolId` for QA purposes.

### Detailed summary
- Deleted the `useEffect` hook that logged `poolId`.
- Removed the accompanying comment indicating it was for QA and should be removed before launch.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->