### PR TITLE
fix: add bin liq crash

### DIFF
--- a/apps/web/src/views/universalFarms/hooks/useBinAmountsFromUsdValue.ts
+++ b/apps/web/src/views/universalFarms/hooks/useBinAmountsFromUsdValue.ts
@@ -7,13 +7,13 @@ export const useBinAmountsFromUsdValue = ({ usdValue, currency0, currency1, curr
 
   const amount0 = useMemo(() => {
     const amount = new BN(usdAmount).times(10 ** currency0.decimals).div(currency0UsdPrice)
-    const [n, d] = amount.toFraction()
+    const [n, d] = amount.isFinite() ? amount.toFraction() : [0, 1]
     return CurrencyAmount.fromFractionalAmount(currency0, n.toString(), d.toString())
   }, [usdAmount, currency0, currency0UsdPrice])
 
   const amount1 = useMemo(() => {
     const amount = new BN(usdAmount).times(10 ** currency1.decimals).div(currency1UsdPrice)
-    const [n, d] = amount.toFraction()
+    const [n, d] = amount.isFinite() ? amount.toFraction() : [0, 1]
     return CurrencyAmount.fromFractionalAmount(currency1, n.toString(), d.toString())
   }, [usdAmount, currency1, currency1UsdPrice])
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR improves the handling of potentially infinite values in the `useBinAmountsFromUsdValue` hook, ensuring that if the calculated amount is not finite, it defaults to a fraction of `[0, 1]`.

### Detailed summary
- Updated `amount0` calculation to check if `amount` is finite before calling `toFraction()`.
- Updated `amount1` calculation to check if `amount` is finite before calling `toFraction()`.
- In both cases, if `amount` is not finite, it assigns a default fraction of `[0, 1]`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->