### PR TITLE
fix(PAN-5210): uniq farm pools

### DIFF
--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -21,6 +21,7 @@ import { isInfinityProtocol } from 'utils/protocols'
 import { publicClient } from 'utils/viem'
 import { type Address } from 'viem'
 
+import uniqWith from 'lodash/uniqWith'
 import { InfinityPoolInfo, PoolInfo } from '../type'
 import { parseFarmPools } from '../utils'
 
@@ -207,12 +208,15 @@ export const fetchFarmPools = async (
   }
 
   const fetchFarmConfig = await fetchAllUniversalFarms()
-  const localPools = fetchFarmConfig.filter((farm) => {
-    return (
-      args.protocols?.includes(farm.protocol) &&
-      (Array.isArray(args.chainId) ? args.chainId.includes(farm.chainId) : farm.chainId === args.chainId)
-    )
-  })
+  const localPools = uniqWith(
+    fetchFarmConfig.filter((farm) => {
+      return (
+        args.protocols?.includes(farm.protocol) &&
+        (Array.isArray(args.chainId) ? args.chainId.includes(farm.chainId) : farm.chainId === args.chainId)
+      )
+    }),
+    (a, b) => a.chainId === b.chainId && a.lpAddress === b.lpAddress && a.protocol === b.protocol,
+  )
   const remoteMissedPoolsIndex: number[] = []
 
   const finalPools = await Promise.all(


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the filtering of farm pools by removing duplicates using `uniqWith` from `lodash`. This improves the efficiency of the `fetchFarmPools` function by ensuring that only unique farm pools are processed.

### Detailed summary
- Added import of `uniqWith` from `lodash`.
- Replaced the existing filtering logic for `localPools` with a call to `uniqWith`.
- The new logic maintains the same filtering criteria while ensuring uniqueness based on `chainId`, `lpAddress`, and `protocol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->