### PR TITLE
fix: cake apr use estimate value when compaign start

### DIFF
--- a/apps/web/src/hooks/infinity/useFarmReward.ts
+++ b/apps/web/src/hooks/infinity/useFarmReward.ts
@@ -458,7 +458,7 @@ export const useFarmRewardsByPoolId = ({ chainId, address, poolId }: PoolFarmRew
   const rewardsMap = useMemo(() => formatRewardsMap(rewards), [rewards])
   const previousRewardsMap = useMemo(() => formatRewardsMap(previousRewards), [previousRewards])
   return useMemo(() => {
-    if (!rewardsMap) {
+    if (!(rewardsMap && Object.keys(rewardsMap).length)) {
       return undefined
     }
     return Object.keys(rewardsMap).reduce<{ [k: string]: BigNumber }>((acc, k) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the condition for checking `rewardsMap` in the `useFarmReward` hook, ensuring that it not only exists but also contains keys before proceeding.

### Detailed summary
- Updated the condition from `if (!rewardsMap)` to `if (!(rewardsMap && Object.keys(rewardsMap).length))` to ensure `rewardsMap` is both defined and not empty before returning `undefined`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->