### PR TITLE
fix(PAN-5213): force chianId with pool

### DIFF
--- a/apps/web/src/views/PoolDetail/components/MyPositions.tsx
+++ b/apps/web/src/views/PoolDetail/components/MyPositions.tsx
@@ -276,9 +276,11 @@ const MyPositionsInner: React.FC<{ poolInfo: PoolInfo }> = ({ poolInfo }) => {
   const { isMobile } = useMatchBreakpoints()
 
   const currency0 =
-    useCurrencyByChainId(poolInfo?.token0.isNative ? zeroAddress : (poolInfo?.token0 as Token)?.address, chainId) ??
-    undefined
-  const currency1 = useCurrencyByChainId(poolInfo?.token1.address, chainId) ?? undefined
+    useCurrencyByChainId(
+      poolInfo?.token0.isNative ? zeroAddress : (poolInfo?.token0 as Token)?.address,
+      poolInfo?.chainId,
+    ) ?? undefined
+  const currency1 = useCurrencyByChainId(poolInfo?.token1.address, poolInfo?.chainId) ?? undefined
 
   const key = useMemo(() => `${chainId}:${lpAddress}` as const, [chainId, lpAddress])
   const { cakeApr, merklApr } = usePoolApr(key, poolInfo)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the way `currency0` and `currency1` are defined in the `MyPositions` component to use `poolInfo?.chainId` consistently.

### Detailed summary
- Updated the definition of `currency0` to use `poolInfo?.chainId` instead of `chainId`.
- Ensured `currency1` also uses `poolInfo?.chainId` for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->