### PR TITLE
fix(PAN-5002): update the liquidity after tx

### DIFF
--- a/apps/web/src/hooks/infinity/getPool.ts
+++ b/apps/web/src/hooks/infinity/getPool.ts
@@ -37,7 +37,13 @@ export const getClPoolWithCache = ({
 }): CLPool => {
   const cacheKey = `${chainId}:${poolId}`
   const cachedPool = clPoolCache.get(cacheKey)
-  if (cachedPool) return cachedPool
+  if (cachedPool) {
+    cachedPool.sqrtRatioX96 = BigInt(sqrtRatioX96)
+    cachedPool.liquidity = BigInt(liquidity)
+    cachedPool.tickCurrent = tick
+    clPoolCache.set(cacheKey, cachedPool)
+    return cachedPool
+  }
 
   const pool = new CLPool({
     poolType,
@@ -71,7 +77,11 @@ export const getBinPoolWithCache = ({
 }): BinPool => {
   const cacheKey = `${chainId}:${poolId}`
   const cachedPool = binPoolCache.get(cacheKey)
-  if (cachedPool) return cachedPool
+  if (cachedPool) {
+    cachedPool.activeId = rawPoolInfo.activeId
+    binPoolCache.set(cacheKey, cachedPool)
+    return cachedPool
+  }
 
   const [currency0, currency1] = sortCurrencies([currencyA, currencyB])
 

--- a/apps/web/src/hooks/infinity/usePool.ts
+++ b/apps/web/src/hooks/infinity/usePool.ts
@@ -8,6 +8,7 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { PoolState } from 'hooks/v3/types'
 import { useMemo } from 'react'
 import { fetchPoolInfo } from 'state/farmsV4/state/accountPositions/fetcher/infinity/getPoolInfo'
+import { useLatestTxReceipt } from 'state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt'
 import { Address } from 'viem'
 import { getBinPoolWithCache, getClPoolWithCache } from './getPool'
 import { isPoolId } from './utils/pool'
@@ -21,9 +22,10 @@ export const usePoolById = <
 ): [PoolState, TPool | null] => {
   const { chainId: activeChainId } = useActiveChainId()
   const chainId = overrideChainId || activeChainId
+  const [latestTxReceipt] = useLatestTxReceipt()
 
   const { data } = useQuery({
-    queryKey: ['poolInfo', poolId, chainId],
+    queryKey: ['poolInfo', poolId, chainId, latestTxReceipt?.blockHash],
     queryFn: () => fetchPoolInfo(poolId!, chainId),
     enabled: isPoolId(poolId) && !!chainId,
     retry: false,

--- a/packages/infinity-sdk/src/entities/pool.ts
+++ b/packages/infinity-sdk/src/entities/pool.ts
@@ -48,11 +48,11 @@ export class Pool {
 
   public readonly protocolFee: number
 
-  public readonly sqrtRatioX96: bigint
+  public sqrtRatioX96: bigint
 
-  public readonly liquidity: bigint
+  public liquidity: bigint
 
-  public readonly tickCurrent: number
+  public tickCurrent: number
 
   public readonly tickDataProvider: TickDataProvider
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `pool` entity properties to remove the `readonly` modifier, allowing for mutable state. Additionally, it updates caching logic in the `getPool` and `getBinPoolWithCache` functions to store modified pool properties and incorporates the latest transaction receipt in the query key.

### Detailed summary
- Removed `readonly` modifier from properties: `sqrtRatioX96`, `liquidity`, and `tickCurrent` in `packages/infinity-sdk/src/entities/pool.ts`.
- Updated caching logic in `apps/web/src/hooks/infinity/getPool.ts` to set `sqrtRatioX96`, `liquidity`, and `tickCurrent` in `cachedPool`.
- Updated `cachedPool` to include `activeId` in `getBinPoolWithCache`.
- Added `latestTxReceipt` to the query key in `apps/web/src/hooks/infinity/usePool.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->