### PR TITLE
fix(PAN-5002): derived cake apr liquidity

### DIFF
--- a/apps/web/src/hooks/infinity/getPool.ts
+++ b/apps/web/src/hooks/infinity/getPool.ts
@@ -37,7 +37,13 @@ export const getClPoolWithCache = ({
 }): CLPool => {
   const cacheKey = `${chainId}:${poolId}`
   const cachedPool = clPoolCache.get(cacheKey)
-  if (cachedPool) return cachedPool
+  if (cachedPool) {
+    cachedPool.sqrtRatioX96 = BigInt(sqrtRatioX96)
+    cachedPool.liquidity = BigInt(liquidity)
+    cachedPool.tickCurrent = tick
+    clPoolCache.set(cacheKey, cachedPool)
+    return cachedPool
+  }
 
   const pool = new CLPool({
     poolType,
@@ -71,7 +77,11 @@ export const getBinPoolWithCache = ({
 }): BinPool => {
   const cacheKey = `${chainId}:${poolId}`
   const cachedPool = binPoolCache.get(cacheKey)
-  if (cachedPool) return cachedPool
+  if (cachedPool) {
+    cachedPool.activeId = rawPoolInfo.activeId
+    binPoolCache.set(cacheKey, cachedPool)
+    return cachedPool
+  }
 
   const [currency0, currency1] = sortCurrencies([currencyA, currencyB])
 

--- a/apps/web/src/hooks/infinity/usePool.ts
+++ b/apps/web/src/hooks/infinity/usePool.ts
@@ -8,6 +8,7 @@ import { useActiveChainId } from 'hooks/useActiveChainId'
 import { PoolState } from 'hooks/v3/types'
 import { useMemo } from 'react'
 import { fetchPoolInfo } from 'state/farmsV4/state/accountPositions/fetcher/infinity/getPoolInfo'
+import { useLatestTxReceipt } from 'state/farmsV4/state/accountPositions/hooks/useLatestTxReceipt'
 import { Address } from 'viem'
 import { getBinPoolWithCache, getClPoolWithCache } from './getPool'
 import { isPoolId } from './utils/pool'
@@ -21,9 +22,10 @@ export const usePoolById = <
 ): [PoolState, TPool | null] => {
   const { chainId: activeChainId } = useActiveChainId()
   const chainId = overrideChainId || activeChainId
+  const [latestTxReceipt] = useLatestTxReceipt()
 
   const { data } = useQuery({
-    queryKey: ['poolInfo', poolId, chainId],
+    queryKey: ['poolInfo', poolId, chainId, latestTxReceipt?.blockHash],
     queryFn: () => fetchPoolInfo(poolId!, chainId),
     enabled: isPoolId(poolId) && !!chainId,
     retry: false,

--- a/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
+++ b/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
@@ -257,15 +257,19 @@ export const useInfinityCLPositionApr = (pool: InfinityPoolInfo, position: Infin
     amount0,
     amount1,
   })
-  const cakeApr = useInfinityCLPositionCakeAPR({ pool, position, cakePrice, tvlUSD: TVLUsd })
-  console.debug('debug', { pool, position, TVLUsd, cakeApr })
-  return useInfinityPositionApr({
-    pool: {
+  const poolWithOnChainLiquidity = useMemo(() => {
+    if (!onChainPoolInfo) return pool
+    return {
       ...pool,
       // @notice: backend returns liquidity not 100% on time
       // it will cause the derived apr not same as the position apr after created
-      liquidity: onChainPoolInfo?.liquidity ?? pool.liquidity,
-    },
+      liquidity: onChainPoolInfo.liquidity ?? pool.liquidity,
+    }
+  }, [onChainPoolInfo, pool])
+  const cakeApr = useInfinityCLPositionCakeAPR({ pool: poolWithOnChainLiquidity, position, cakePrice, tvlUSD: TVLUsd })
+  console.debug('debug', { pool, position, TVLUsd, cakeApr })
+  return useInfinityPositionApr({
+    pool: poolWithOnChainLiquidity,
     position,
     positionLiquidity: position.liquidity,
     removed,

--- a/packages/infinity-sdk/src/entities/pool.ts
+++ b/packages/infinity-sdk/src/entities/pool.ts
@@ -48,11 +48,11 @@ export class Pool {
 
   public readonly protocolFee: number
 
-  public readonly sqrtRatioX96: bigint
+  public sqrtRatioX96: bigint
 
-  public readonly liquidity: bigint
+  public liquidity: bigint
 
-  public readonly tickCurrent: number
+  public tickCurrent: number
 
   public readonly tickDataProvider: TickDataProvider
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying the `pool` entity in the `infinity-sdk` to allow for mutable properties and updating the caching logic in the hooks to accommodate these changes. It also enhances the handling of on-chain liquidity in the `usePositionAPR` calculation.

### Detailed summary
- Changed properties in `pool.ts` from `readonly` to mutable: `sqrtRatioX96`, `liquidity`, and `tickCurrent`.
- Updated caching logic in `getPool.ts` to set updated values for `sqrtRatioX96`, `liquidity`, and `tickCurrent` when a pool is cached.
- Enhanced caching in `getBinPoolWithCache` to include `activeId`.
- Modified `usePoolById` to include `latestTxReceipt` in the query key.
- Adjusted `usePositionAPR` to include on-chain liquidity when calculating APR.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->