### PR TITLE
fix: PAN-5217

### DIFF
--- a/apps/web/src/views/universalFarms/hooks/useBinAmountsFromUsdValue.ts
+++ b/apps/web/src/views/universalFarms/hooks/useBinAmountsFromUsdValue.ts
@@ -6,13 +6,15 @@ export const useBinAmountsFromUsdValue = ({ usdValue, currency0, currency1, curr
   const usdAmount = parseFloat(usdValue) / 2
 
   const amount0 = useMemo(() => {
-    const amount = new BN(usdAmount).times(10 ** currency0.decimals).div(currency0UsdPrice)
+    if (!currency0 || !currency0UsdPrice) return undefined
+    const amount = new BN(usdAmount).times(10 ** currency0.decimals).div(currency0UsdPrice ?? 1)
     const [n, d] = amount.isFinite() ? amount.toFraction() : [0, 1]
     return CurrencyAmount.fromFractionalAmount(currency0, n.toString(), d.toString())
   }, [usdAmount, currency0, currency0UsdPrice])
 
   const amount1 = useMemo(() => {
-    const amount = new BN(usdAmount).times(10 ** currency1.decimals).div(currency1UsdPrice)
+    if (!currency1 || !currency1UsdPrice) return undefined
+    const amount = new BN(usdAmount).times(10 ** currency1.decimals).div(currency1UsdPrice ?? 1)
     const [n, d] = amount.isFinite() ? amount.toFraction() : [0, 1]
     return CurrencyAmount.fromFractionalAmount(currency1, n.toString(), d.toString())
   }, [usdAmount, currency1, currency1UsdPrice])

--- a/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
+++ b/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
@@ -690,8 +690,8 @@ export const useInfinityBinDerivedApr = (poolInfo: InfinityBinPoolInfo) => {
       lowerBinId,
       upperBinId,
       binStep: pool?.binStep,
-      amount0: amountA.quotient,
-      amount1: amountB.quotient,
+      amount0: amountA?.quotient ?? 0n,
+      amount1: amountB?.quotient ?? 0n,
       activeBinId: pool?.activeId,
     })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of optional values in the `usePositionAPR` and `useBinAmountsFromUsdValue` hooks, ensuring that undefined values are safely managed and default values are provided.

### Detailed summary
- In `usePositionAPR.ts`, `amount0` and `amount1` now use optional chaining and provide a default value of `0n` if `amountA` or `amountB` are undefined.
- In `useBinAmountsFromUsdValue.ts`, checks for `currency0` and `currency1` as well as their respective USD prices are added to prevent calculation errors.
- The division by `currency0UsdPrice` and `currency1UsdPrice` now falls back to `1` if they are undefined, ensuring calculations do not fail.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->