### PR TITLE
fix(PAN-5239): xs create lp ui

### DIFF
--- a/apps/web/src/views/CreateLiquidityPool/components/FieldSelectCurrencies.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/components/FieldSelectCurrencies.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { AddIcon, Box, BoxProps, Flex, FlexGap, PreTitle, Text } from '@pancakeswap/uikit'
+import { AddIcon, Box, BoxProps, Flex, FlexGap, PreTitle, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { CurrencySelectV2 } from 'components/CurrencySelectV2'
 import { ChainLogo } from 'components/Logo/ChainLogo'
 import { CommonBasesType } from 'components/SearchModal/types'
@@ -17,6 +17,7 @@ export const FieldSelectCurrencies: React.FC<FieldSelectCurrenciesProps> = ({ ..
   const chainName = chainId ? getChainFullName(chainId) : undefined
   const { baseCurrency, quoteCurrency } = useCurrencies()
   const { handleBaseCurrencySelect, handleQuoteCurrencySelect } = useFieldSelectCurrencies()
+  const { isXs } = useMatchBreakpoints()
 
   return (
     <Box {...boxProps}>
@@ -31,7 +32,7 @@ export const FieldSelectCurrencies: React.FC<FieldSelectCurrenciesProps> = ({ ..
           </Flex>
         ) : null}
       </Flex>
-      <FlexGap gap="4px" width="100%" mb="8px" alignItems="center">
+      <FlexGap gap="4px" width="100%" mb="8px" alignItems="center" flexDirection={isXs ? 'column' : 'row'}>
         <CurrencySelectV2
           id="infinity-form-select-base-currency"
           chainId={chainId}

--- a/apps/web/src/views/HookSettings/HookSettings.tsx
+++ b/apps/web/src/views/HookSettings/HookSettings.tsx
@@ -10,6 +10,7 @@ import {
   Radio,
   Text,
   Toggle,
+  useMatchBreakpoints,
 } from '@pancakeswap/uikit'
 import { GreyCard } from '@pancakeswap/widgets-internal'
 import Divider from 'components/Divider'
@@ -26,6 +27,7 @@ type FieldHookSettingsProps = BoxProps & {
 
 export const HookSettings: React.FC<FieldHookSettingsProps> = ({ onHookChange, onHookEnabledChange, ...boxProps }) => {
   const { t } = useTranslation()
+  const { isXs } = useMatchBreakpoints()
 
   const [hookEnabled, setHookEnabled] = useHookEnabledQueryState()
   const [selectionType, setSelectionType] = useHookSelectTypeQueryState()
@@ -46,7 +48,7 @@ export const HookSettings: React.FC<FieldHookSettingsProps> = ({ onHookChange, o
       <DynamicSection mt="12px" disabled={!hookEnabled}>
         <GreyCard padding="16px">
           <AutoColumn gap="8px">
-            <FlexGap gap="24px">
+            <FlexGap gap="24px" flexDirection={isXs ? 'column' : 'row'}>
               <Flex alignItems="center">
                 <label htmlFor="radio-hook-selection-1">
                   <Text mr="8px" style={{ whiteSpace: 'nowrap' }}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces responsive design adjustments to the `HookSettings` and `FieldSelectCurrencies` components by utilizing the `useMatchBreakpoints` hook to modify the layout based on screen size.

### Detailed summary
- Added `useMatchBreakpoints` to `HookSettings` and `FieldSelectCurrencies`.
- Updated `FlexGap` in `HookSettings` to use a column layout for small screens.
- Updated `FlexGap` in `FieldSelectCurrencies` to use a column layout for small screens.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->