### PR TITLE
chore: Remove merl competition ad

### DIFF
--- a/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
+++ b/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
@@ -15,6 +15,7 @@ const tradingCompetitionConfig: {
     learnMoreUrl: string
     reward: string
     unit: string
+    endTimestamp: number
   }
 } = {}
 
@@ -43,14 +44,17 @@ export const AdTradingCompetition = (props: AdPlayerProps & { token: string }) =
 }
 
 export const useTradingCompetitionAds = () => {
-  return useMemo(
-    () =>
-      Object.keys(tradingCompetitionConfig)
-        .reverse()
-        .map((token) => ({
-          id: `ad-${token}-tc`,
-          component: <AdTradingCompetition key={token} token={token} />,
-        })),
-    [],
-  )
+  return useMemo(() => {
+    const currentTime = Math.floor(Date.now() / 1000)
+    return Object.keys(tradingCompetitionConfig)
+      .filter((token) => {
+        const { endTimestamp } = tradingCompetitionConfig[token]
+        return currentTime <= endTimestamp
+      })
+      .reverse()
+      .map((token) => ({
+        id: `ad-${token}-tc`,
+        component: <AdTradingCompetition key={token} token={token} />,
+      }))
+  }, [])
 }

--- a/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
+++ b/apps/web/src/components/AdPanel/Ads/AdTradingCompetition.tsx
@@ -8,19 +8,17 @@ import { AdCard } from '../Card'
 import { AdPlayerProps } from '../types'
 import { getImageUrl } from '../utils'
 
-const tradingCompetitionConfig = {
-  merl: {
-    imgUrl: 'merl_competition',
-    swapUrl:
-      'https://pancakeswap.finance/swap?inputCurrency=BNB&outputCurrency=0xa0c56a8c0692bD10B3fA8f8bA79Cf5332B7107F9&utm_source=Website&utm_medium=banner&utm_campaign=MERL&utm_id=TradingCompetition',
-    learnMoreUrl:
-      'https://blog.pancakeswap.finance/articles/pancake-swap-x-merl-trading-competition-50-000-in-rewards?utm_source=Website&utm_medium=banner&utm_campaign=MERL&utm_id=TradingCompetition',
-    reward: '50,000',
-    unit: '$',
-  },
-}
+const tradingCompetitionConfig: {
+  [key: string]: {
+    imgUrl: string
+    swapUrl: string
+    learnMoreUrl: string
+    reward: string
+    unit: string
+  }
+} = {}
 
-export const AdTradingCompetition = (props: AdPlayerProps & { token: keyof typeof tradingCompetitionConfig }) => {
+export const AdTradingCompetition = (props: AdPlayerProps & { token: string }) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
   const { token, ...rest } = props
@@ -51,7 +49,7 @@ export const useTradingCompetitionAds = () => {
         .reverse()
         .map((token) => ({
           id: `ad-${token}-tc`,
-          component: <AdTradingCompetition key={token} token={token as keyof typeof tradingCompetitionConfig} />,
+          component: <AdTradingCompetition key={token} token={token} />,
         })),
     [],
   )


### PR DESCRIPTION
Should be merged 15th april when merl competition ends

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `tradingCompetitionConfig` object in the `AdTradingCompetition` component to improve type safety and functionality by adding an `endTimestamp` property. It also updates the type for the `token` prop and modifies the logic for filtering active trading competitions.

### Detailed summary
- Changed `tradingCompetitionConfig` from a hardcoded object to a typed object with dynamic keys.
- Added `endTimestamp` to the `tradingCompetitionConfig` type definition.
- Updated the `token` prop type in `AdTradingCompetition` from `keyof typeof tradingCompetitionConfig` to `string`.
- Enhanced the `useTradingCompetitionAds` function to filter competitions based on the current timestamp using `endTimestamp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->