### PR TITLE
fix: Currency input percentage button in swap

### DIFF
--- a/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
+++ b/apps/web/src/components/CurrencyInputPanelSimplify/index.tsx
@@ -265,7 +265,17 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
     if (isInputFocus) {
       onUserInput(value ?? '')
     }
-  }, [value, defaultValue, isInputFocus])
+  }, [value, defaultValue, isInputFocus, onUserInput])
+
+  const handlePercentInput = useCallback(
+    (percent: number) => {
+      if (onPercentInput) {
+        setIsInputFocus(false)
+        onPercentInput(percent)
+      }
+    },
+    [onPercentInput],
+  )
 
   const handleUserInput = useCallback((val: string) => {
     setValue(val)
@@ -322,7 +332,7 @@ const CurrencyInputPanelSimplify = memo(function CurrencyInputPanel({
                       onMax={onMax}
                     />
                   ) : (
-                    <SwapUIV2.AssetSettingButtonList onPercentInput={onPercentInput} />
+                    <SwapUIV2.AssetSettingButtonList onPercentInput={handlePercentInput} />
                   )
                 ) : null}
               </LazyAnimatePresence>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c611665e-edb9-4295-b97e-9e25ca2ecb3d)

Buttons above not working right now

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `CurrencyInputPanelSimplify` component by adding a new `handlePercentInput` function, which handles percent input from the user. It also updates the dependency array for the `useCallback` hooks to include `onUserInput` and `onPercentInput`.

### Detailed summary
- Added `handlePercentInput` function to manage percent input.
- Updated `useCallback` for `handleUserInput` to include `onUserInput`.
- Changed the `onPercentInput` prop in `SwapUIV2.AssetSettingButtonList` to use the new `handlePercentInput` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->