### PR TITLE
chore: [PAN-5078] ads module quick fix

### DIFF
--- a/apps/web/src/components/AdPanel/DesktopCard.tsx
+++ b/apps/web/src/components/AdPanel/DesktopCard.tsx
@@ -1,5 +1,4 @@
-import { Box, getPortalRoot, useMatchBreakpoints } from '@pancakeswap/uikit'
-import { createPortal } from 'react-dom'
+import { Box, useMatchBreakpoints } from '@pancakeswap/uikit'
 import styled from 'styled-components'
 import { AdPlayer } from './AdPlayer'
 import { AdPlayerProps } from './types'
@@ -17,22 +16,18 @@ export const DesktopCard = ({
   forceMobile = false,
   ...props
 }: DesktopCardProps) => {
-  const portalRoot = getPortalRoot()
   const { isDesktop } = useMatchBreakpoints()
   const [show] = useShowAdPanel()
 
-  return portalRoot && shouldRender && isDesktop && show
-    ? createPortal(
-        <FloatingContainer>
-          <AdPlayer isDismissible={isDismissible} forceMobile={forceMobile} {...props} />
-        </FloatingContainer>,
-        portalRoot,
-      )
-    : null
+  return shouldRender && isDesktop && show ? (
+    <FloatingContainer>
+      <AdPlayer isDismissible={isDismissible} forceMobile={forceMobile} {...props} />
+    </FloatingContainer>
+  ) : null
 }
 
 const FloatingContainer = styled(Box)`
-  position: fixed;
+  position: absolute;
   right: 30px;
   bottom: 30px;
 `

--- a/apps/web/src/components/AdPanel/DesktopCard.tsx
+++ b/apps/web/src/components/AdPanel/DesktopCard.tsx
@@ -30,4 +30,5 @@ const FloatingContainer = styled(Box)`
   position: absolute;
   right: 30px;
   bottom: 30px;
+  z-index: 10000;
 `


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `DesktopCard` component in `DesktopCard.tsx` by modifying the rendering logic and styling. It replaces the use of `createPortal` with direct rendering and changes the positioning of the `FloatingContainer`.

### Detailed summary
- Removed the `createPortal` function and simplified the return statement for rendering the `AdPlayer`.
- Changed the `position` property of `FloatingContainer` from `fixed` to `absolute`.
- Added a `z-index` of `10000` to the `FloatingContainer`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->