### PR TITLE
chore: Update opbnb bsc testnet block times

### DIFF
--- a/.changeset/flat-seals-sniff.md
+++ b/.changeset/flat-seals-sniff.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/chains': patch
+---
+
+chore: Change opbnb bnb testnet block times

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -2,9 +2,9 @@ import { ChainId } from './chainId'
 
 export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
-  [ChainId.BSC_TESTNET]: 3,
+  [ChainId.BSC_TESTNET]: 1.5,
   [ChainId.OPBNB]: 1,
-  [ChainId.OPBNB_TESTNET]: 1,
+  [ChainId.OPBNB_TESTNET]: 0.5,
   [ChainId.ETHEREUM]: 12,
   [ChainId.GOERLI]: 3,
   [ChainId.POLYGON_ZKEVM]: 3,


### PR DESCRIPTION
Should be merged now

https://x.com/BNBCHAIN/status/1910384574938423424

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the average block times for specific testnets in the `AVERAGE_CHAIN_BLOCK_TIMES` object within the `averageChainBlockTimes.ts` file.

### Detailed summary
- Updated the average block time for `ChainId.BSC_TESTNET` from 3 to 1.5 seconds.
- Updated the average block time for `ChainId.OPBNB_TESTNET` from 1 to 0.5 seconds.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->