### PR TITLE
chore: Update opbnb block time

### DIFF
--- a/.changeset/selfish-rice-raise.md
+++ b/.changeset/selfish-rice-raise.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/chains': patch
+---
+
+chore: Update opbnb block time

--- a/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
+++ b/apps/web/src/hooks/usePublicNodeWaitForTransaction.ts
@@ -106,11 +106,13 @@ export function usePublicNodeWaitForTransaction() {
           throw error
         }
       }
+      const bufferedAvgBlockTime =
+        (selectedChain ? AVERAGE_CHAIN_BLOCK_TIMES[selectedChain] : BSC_BLOCK_TIME) * 1000 + 1000
       return retry(getTransaction, {
         n: 10,
-        minWait: 5000,
-        maxWait: 10000,
-        delay: (selectedChain ? AVERAGE_CHAIN_BLOCK_TIMES[selectedChain] : BSC_BLOCK_TIME) * 1000 + 1000,
+        minWait: bufferedAvgBlockTime,
+        maxWait: bufferedAvgBlockTime * 1.1,
+        delay: bufferedAvgBlockTime,
       }).promise as Promise<TransactionReceipt>
     },
     [chainId, provider, refetchBlockData, w3WConfig],

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -3,7 +3,7 @@ import { ChainId } from './chainId'
 export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
   [ChainId.BSC_TESTNET]: 1.5,
-  [ChainId.OPBNB]: 1,
+  [ChainId.OPBNB]: 0.5,
   [ChainId.OPBNB_TESTNET]: 0.5,
   [ChainId.ETHEREUM]: 12,
   [ChainId.GOERLI]: 3,

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -2,9 +2,9 @@ import { ChainId } from './chainId'
 
 export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
-  [ChainId.BSC_TESTNET]: 3,
+  [ChainId.BSC_TESTNET]: 0.5,
   [ChainId.OPBNB]: 0.5,
-  [ChainId.OPBNB_TESTNET]: 1,
+  [ChainId.OPBNB_TESTNET]: 0.5,
   [ChainId.ETHEREUM]: 12,
   [ChainId.GOERLI]: 3,
   [ChainId.POLYGON_ZKEVM]: 3,

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -2,7 +2,7 @@ import { ChainId } from './chainId'
 
 export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
-  [ChainId.BSC_TESTNET]: 1.5,
+  [ChainId.BSC_TESTNET]: 3,
   [ChainId.OPBNB]: 0.5,
   [ChainId.OPBNB_TESTNET]: 0.5,
   [ChainId.ETHEREUM]: 12,

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -4,7 +4,7 @@ export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
   [ChainId.BSC_TESTNET]: 3,
   [ChainId.OPBNB]: 0.5,
-  [ChainId.OPBNB_TESTNET]: 0.5,
+  [ChainId.OPBNB_TESTNET]: 1,
   [ChainId.ETHEREUM]: 12,
   [ChainId.GOERLI]: 3,
   [ChainId.POLYGON_ZKEVM]: 3,

--- a/packages/chains/src/averageChainBlockTimes.ts
+++ b/packages/chains/src/averageChainBlockTimes.ts
@@ -2,7 +2,7 @@ import { ChainId } from './chainId'
 
 export const AVERAGE_CHAIN_BLOCK_TIMES: Record<ChainId, number> = {
   [ChainId.BSC]: 3,
-  [ChainId.BSC_TESTNET]: 0.5,
+  [ChainId.BSC_TESTNET]: 1.5,
   [ChainId.OPBNB]: 0.5,
   [ChainId.OPBNB_TESTNET]: 0.5,
   [ChainId.ETHEREUM]: 12,


### PR DESCRIPTION
Should be merged 21st april

https://x.com/BNBCHAIN/status/1910384574938423424

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the average block time for the `OPBNB` chain and adjusting the transaction waiting logic in the `usePublicNodeWaitForTransaction` hook accordingly.

### Detailed summary
- Updated average block time for `ChainId.OPBNB` from `1` to `0.5`.
- Introduced `bufferedAvgBlockTime` to calculate transaction wait times based on the selected chain.
- Adjusted `minWait`, `maxWait`, and `delay` parameters in the `retry` function to use `bufferedAvgBlockTime`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->