### PR TITLE
feat(PAN-5299): add snapshot link to eligible card

### DIFF
--- a/apps/web/src/views/Idos/components/IdoCards/IdoStakeActionCard.tsx
+++ b/apps/web/src/views/Idos/components/IdoCards/IdoStakeActionCard.tsx
@@ -73,7 +73,7 @@ export const IdoStakeActionCard: React.FC<{
                 {account && !isPendingVerify ? (
                   status === 'coming_soon' ? (
                     verifyStatus === VerifyStatus.eligible ? (
-                      <PreSaleEligibleCard />
+                      <PreSaleEligibleCard projectId={id} />
                     ) : verifyStatus === VerifyStatus.restricted ? (
                       <ComplianceCard />
                     ) : verifyStatus === VerifyStatus.snapshotNotPass ? (

--- a/apps/web/src/views/Idos/components/IdoCards/PreSaleInfoCard.tsx
+++ b/apps/web/src/views/Idos/components/IdoCards/PreSaleInfoCard.tsx
@@ -43,8 +43,11 @@ export const PreSaleInfoCard: React.FC = () => {
   )
 }
 
-export const PreSaleEligibleCard: React.FC = () => {
+export const PreSaleEligibleCard: React.FC<{ projectId: string | undefined }> = ({ projectId }) => {
   const { t } = useTranslation()
+  const link = useMemo(() => {
+    return getSnapshotDeepLink(projectId ?? '')
+  }, [projectId])
 
   return (
     <CardWrapper>
@@ -52,7 +55,15 @@ export const PreSaleEligibleCard: React.FC = () => {
         <FlexGap>
           <CheckmarkCircleIcon color="success" width="24px" />
         </FlexGap>
-        <Text>{t('You are eligible to join this sale when TGE goes live!')}</Text>
+        <FlexGap flexDirection="column">
+          <Text>{t('You are eligible to join this sale when TGE goes live!')}</Text>
+          <Flex onClick={() => window.open(link)}>
+            <Text color="positive60" bold>
+              {t('View Snapshots')}
+            </Text>
+            <ChevronRightIcon color="positive60" width="24px" ml="2px" />
+          </Flex>
+        </FlexGap>
       </FlexGap>
     </CardWrapper>
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `PreSaleEligibleCard` component by adding a `projectId` prop, which allows for the generation of a snapshot link. It also modifies the card's UI to include a clickable link for viewing snapshots, improving user interaction.

### Detailed summary
- Added `projectId` prop to `PreSaleEligibleCard`.
- Introduced a `link` variable using `useMemo` to generate a snapshot link.
- Updated the component's UI to include a clickable area that opens the snapshot link.
- Wrapped eligibility message and link in a new `FlexGap` for better layout.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->