### PR TITLE
fix: picks using config's link to support v2 pools  

### DIFF
--- a/apps/web/src/components/AdPanel/Ads/AdPicks.tsx
+++ b/apps/web/src/components/AdPanel/Ads/AdPicks.tsx
@@ -2,10 +2,11 @@ import { useTranslation } from '@pancakeswap/localization'
 import { Box, LinkExternal, Text, useTooltip } from '@pancakeswap/uikit'
 import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { formatAmount } from '@pancakeswap/utils/formatInfoNumbers'
+import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import BigNumber from 'bignumber.js'
 import { getChainId } from 'config/chains'
 import { ASSET_CDN } from 'config/constants/endpoints'
-import { atom, useAtomValue } from 'jotai'
+import { atom } from 'jotai'
 import { atomFamily } from 'jotai/utils'
 import { useEffect, useMemo } from 'react'
 import { usePoolApr, usePoolInfo } from 'state/farmsV4/hooks'
@@ -15,12 +16,11 @@ import styled from 'styled-components'
 import { useMyPositions } from 'views/PoolDetail/components/MyPositionsContext'
 import { getPoolDetailPageLink } from 'views/universalFarms/components'
 import { sumApr } from 'views/universalFarms/utils/sumApr'
-import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
+import { AdTag } from '../AdTag'
 import { BodyText } from '../BodyText'
 import { AdCard } from '../Card'
 import { PickBaseCoin } from '../PickBaseCoin'
 import { PickConfig } from '../types'
-import { AdTag } from '../AdTag'
 
 const usePicksData = (poolId: `0x{string}`, chain: string) => {
   const chainId = getChainId(chain)!
@@ -82,7 +82,6 @@ export const AdPicks = ({ config, index }: { config: PickConfig; index: number }
   const { poolId, chain, token0, token1 } = config
   const { t } = useTranslation()
   const data = usePicksData(poolId, chain)
-  const link = useAtomValue(poolLinkAtom(data?.pool))
   const { tooltip, targetRef, tooltipVisible } = useTooltip(<AdPicksTooltip />)
   const chainId = getChainId(chain)
   if (!data) {
@@ -136,7 +135,7 @@ export const AdPicks = ({ config, index }: { config: PickConfig; index: number }
             marginTop: '14.5px',
           }}
         >
-          <NextLinkFromReactRouter to={link}>
+          <NextLinkFromReactRouter to={config.url}>
             <Text color="primary60">
               {token0.symbol}/{token1.symbol}
             </Text>

--- a/apps/web/src/components/AdPanel/types.ts
+++ b/apps/web/src/components/AdPanel/types.ts
@@ -65,6 +65,7 @@ export type PickConfig = {
   poolId: `0x{string}`
   token0: Token
   token1: Token
+  url: string
 }
 
 export type PicksConfig = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `url` property to the `PicksConfig` type and updates the `AdPicks` component to utilize this property for linking. It also removes an unused import and modifies the way the link is constructed in the rendered output.

### Detailed summary
- Added `url: string` to `PicksConfig` in `types.ts`.
- Updated `AdPicks` component in `AdPicks.tsx` to use `config.url` instead of `link`.
- Removed the unused import of `useAtomValue` from `jotai`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->