### PR TITLE
feat(PAN-5304): add farm icon

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolAprButton/AprButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/AprButton.tsx
@@ -1,20 +1,21 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { FlexGap, Skeleton, Text, TooltipText, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { displayApr } from '@pancakeswap/utils/displayApr'
 import { FarmWidget } from '@pancakeswap/widgets-internal'
 import { forwardRef, MouseEvent, useCallback, useMemo } from 'react'
-import { displayApr } from '@pancakeswap/utils/displayApr'
 
 type ApyButtonProps = {
   showApyButton?: boolean
   loading?: boolean
   onClick?: () => void
+  hasFarm?: boolean
   onAPRTextClick?: () => void
   baseApr?: number
   boostApr?: number
 }
 
 export const AprButton = forwardRef<HTMLElement, ApyButtonProps>(
-  ({ showApyButton = true, loading, onClick, onAPRTextClick, baseApr, boostApr }, ref) => {
+  ({ showApyButton = true, loading, onClick, onAPRTextClick, baseApr, boostApr, hasFarm }, ref) => {
     const handleClick = useCallback(
       (e: MouseEvent) => {
         e.preventDefault()
@@ -33,17 +34,17 @@ export const AprButton = forwardRef<HTMLElement, ApyButtonProps>(
     return (
       <FlexGap alignItems="center">
         {showApyButton && <FarmWidget.FarmApyButton variant="text-and-button" handleClickButton={handleClick} />}
-        <AprButtonText baseApr={baseApr} boostApr={boostApr} ref={ref} onClick={onAPRTextClick} />
+        <AprButtonText hasFarm={hasFarm} baseApr={baseApr} boostApr={boostApr} ref={ref} onClick={onAPRTextClick} />
       </FlexGap>
     )
   },
 )
 
-type AprButtonTextProps = Pick<ApyButtonProps, 'baseApr' | 'boostApr'> & {
+type AprButtonTextProps = Pick<ApyButtonProps, 'baseApr' | 'boostApr' | 'hasFarm'> & {
   onClick?: () => void
 }
 
-const AprButtonText = forwardRef<HTMLElement, AprButtonTextProps>(({ baseApr, boostApr, onClick }, ref) => {
+const AprButtonText = forwardRef<HTMLElement, AprButtonTextProps>(({ baseApr, boostApr, hasFarm, onClick }, ref) => {
   const { t } = useTranslation()
   const isZeroApr = baseApr === 0
   const hasBoost = boostApr && boostApr > 0
@@ -99,9 +100,16 @@ const AprButtonText = forwardRef<HTMLElement, AprButtonTextProps>(({ baseApr, bo
 
   const commonApr = useMemo(
     () => (
-      <TooltipText ml="4px" fontSize="16px" color="text">
-        {baseApr ? displayApr(baseApr) : null}
-      </TooltipText>
+      <FlexGap>
+        {hasFarm ? (
+          <Text fontSize="16px" color="v2Primary50" bold>
+            🌿
+          </Text>
+        ) : null}
+        <TooltipText ml="4px" fontSize="16px" color="text">
+          {baseApr ? displayApr(baseApr) : null}
+        </TooltipText>
+      </FlexGap>
     ),
     [baseApr],
   )

--- a/apps/web/src/views/universalFarms/components/PoolAprButton/PoolAprButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/PoolAprButton.tsx
@@ -69,6 +69,7 @@ export const PoolAprButton: React.FC<PoolGlobalAprButtonProps> = ({
   return (
     <StopPropagation>
       <AprButton
+        hasFarm={Number(cakeApr?.value) > 0}
         ref={targetRef}
         baseApr={baseApr}
         boostApr={boostApr}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `hasFarm` prop to the `AprButton` and `AprButtonText` components, allowing them to conditionally display an icon based on whether a farm exists. This enhances the visual feedback for users regarding farm availability.

### Detailed summary
- Added `hasFarm` prop to `AprButton` and `AprButtonText`.
- Updated `AprButton` to pass `hasFarm` to `AprButtonText`.
- Modified `AprButtonText` to conditionally render a leaf icon (🌿) based on `hasFarm`.
- Adjusted the structure of the `commonApr` to include the icon within a `FlexGap`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->