### PR TITLE
chore(universal-router-sdk): PAN-5319 add payerIsUser option

### DIFF
--- a/.changeset/shy-moons-pretend.md
+++ b/.changeset/shy-moons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/universal-router-sdk': minor
+---
+
+Add payerIsUser option

--- a/packages/universal-router-sdk/src/entities/Command.ts
+++ b/packages/universal-router-sdk/src/entities/Command.ts
@@ -1,6 +1,14 @@
 import { RoutePlanner } from '../utils/routerCommands'
 
-export type TradeConfig = {
+export interface UniversalRouterOptions {
+  /**
+   * Whether the payer of the trade is the user. Defaults to true.
+   * NOTE: This option is ignored in WETH case. Because WETH is now owned by the router, the router pays for inputs.
+   */
+  payerIsUser?: boolean
+}
+
+export interface TradeConfig extends UniversalRouterOptions {
   allowRevert: boolean
 }
 
@@ -13,5 +21,5 @@ export enum RouterTradeType {
 // interface for entities that can be encoded as a Universal Router command
 export interface Command {
   tradeType: RouterTradeType
-  encode(planner: RoutePlanner, config: TradeConfig): void
+  encode(planner: RoutePlanner, config: UniversalRouterOptions): void
 }

--- a/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
@@ -14,7 +14,7 @@ import { CONTRACT_BALANCE, ROUTER_AS_RECIPIENT, SENDER_AS_RECIPIENT } from '../.
 import { encodeFeeBips } from '../../utils/numbers'
 import { ABIParametersType, CommandType, RoutePlanner } from '../../utils/routerCommands'
 import { Command, RouterTradeType } from '../Command'
-import { PancakeSwapOptions } from '../types'
+import { PancakeSwapOptions, UniversalRouterOptions } from '../types'
 
 // Wrapper for pancakeswap router-sdk trade entity to encode swaps for Universal Router
 export class PancakeSwapTrade implements Command {
@@ -29,8 +29,8 @@ export class PancakeSwapTrade implements Command {
     }
   }
 
-  encode(planner: RoutePlanner): void {
-    let payerIsUser = true
+  encode(planner: RoutePlanner, options?: UniversalRouterOptions): void {
+    let payerIsUser = options?.payerIsUser ?? true
     const { trade } = this
     const numberOfTrades = trade.routes.length
 

--- a/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
@@ -13,8 +13,8 @@ import { Address } from 'viem'
 import { CONTRACT_BALANCE, ROUTER_AS_RECIPIENT, SENDER_AS_RECIPIENT } from '../../constants'
 import { encodeFeeBips } from '../../utils/numbers'
 import { ABIParametersType, CommandType, RoutePlanner } from '../../utils/routerCommands'
-import { Command, RouterTradeType } from '../Command'
-import { PancakeSwapOptions, UniversalRouterOptions } from '../types'
+import { Command, RouterTradeType, UniversalRouterOptions } from '../Command'
+import { PancakeSwapOptions } from '../types'
 
 // Wrapper for pancakeswap router-sdk trade entity to encode swaps for Universal Router
 export class PancakeSwapTrade implements Command {

--- a/packages/universal-router-sdk/src/entities/types.ts
+++ b/packages/universal-router-sdk/src/entities/types.ts
@@ -21,11 +21,3 @@ export type PancakeSwapOptions = Omit<SwapOptions, 'inputTokenPermit'> & {
   inputTokenPermit?: Permit2Signature
   flatFee?: FlatFeeOptions
 }
-
-export interface UniversalRouterOptions {
-  /**
-   * Whether the payer of the trade is the user. Defaults to true.
-   * NOTE: This option is ignored in WETH case. Because WETH is now owned by the router, the router pays for inputs.
-   */
-  payerIsUser?: boolean
-}

--- a/packages/universal-router-sdk/src/entities/types.ts
+++ b/packages/universal-router-sdk/src/entities/types.ts
@@ -21,3 +21,11 @@ export type PancakeSwapOptions = Omit<SwapOptions, 'inputTokenPermit'> & {
   inputTokenPermit?: Permit2Signature
   flatFee?: FlatFeeOptions
 }
+
+export interface UniversalRouterOptions {
+  /**
+   * Whether the payer of the trade is the user. Defaults to true.
+   * NOTE: This option is ignored in WETH case. Because WETH is now owned by the router, the router pays for inputs.
+   */
+  payerIsUser?: boolean
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new option `payerIsUser` to the `UniversalRouterOptions` interface, affecting how trades are configured in the `universal-router-sdk`. It modifies the `Command` interface and the `PancakeSwapTrade` class to incorporate this new option.

### Detailed summary
- Added `payerIsUser` option to `UniversalRouterOptions` interface.
- Updated `TradeConfig` to extend `UniversalRouterOptions`.
- Changed `encode` method in `Command` interface to accept `UniversalRouterOptions`.
- Modified `encode` method in `PancakeSwapTrade` to utilize `payerIsUser` from options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->