### PR TITLE
fix(PAN-5321): validate address before swap output currency assignment

### DIFF
--- a/apps/web/src/views/InfinityInfo/components/Tokens/TokenInfo.tsx
+++ b/apps/web/src/views/InfinityInfo/components/Tokens/TokenInfo.tsx
@@ -44,7 +44,7 @@ import {
 } from 'state/info/hooks'
 import { styled } from 'styled-components'
 import { getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
-import { zeroAddress } from 'viem'
+import { isAddress, zeroAddress } from 'viem'
 import { isAddressEqual } from 'viem/utils'
 import { CurrencyLogo } from 'views/Info/components/CurrencyLogo'
 import useCMCLink from 'views/Info/hooks/useCMCLink'
@@ -165,6 +165,8 @@ const TokenInfo: React.FC<{ address: string }> = ({ address }) => {
 
   const tokenSymbol = getTokenSymbolAlias(address, chainId, tokenData?.symbol)
   const tokenName = getTokenNameAlias(address, chainId, tokenData?.name)
+  const swapOutputCurrency =
+    isAddress(address) && isAddressEqual(address, zeroAddress) ? CAKE[multiChainId[chainName]].address : address
   const addLiquidityUrl = useMemo(() => {
     const addr = safeGetAddress(address)
     return getSelectInfinityLiquidityURL({
@@ -264,7 +266,7 @@ const TokenInfo: React.FC<{ address: string }> = ({ address }) => {
                     </NextLinkFromReactRouter>
                   ) : null}
                   <NextLinkFromReactRouter
-                    to={`/swap?outputCurrency=${address}&chain=${CHAIN_QUERY_NAME[multiChainId[chainName]]}`}
+                    to={`/swap?outputCurrency=${swapOutputCurrency}&chain=${CHAIN_QUERY_NAME[multiChainId[chainName]]}`}
                   >
                     <Button>{t('Trade')}</Button>
                   </NextLinkFromReactRouter>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `TokenInfo` component by adding address validation and modifying the swap output currency logic.

### Detailed summary
- Imported `isAddress` from `viem`.
- Added a new constant `swapOutputCurrency` that checks if the `address` is valid and equals `zeroAddress`, otherwise defaults to `address`.
- Updated the swap link to use `swapOutputCurrency` instead of `address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->