### PR TITLE
chore: Add userIsPayer option to swap calldata encoding

### DIFF
--- a/.changeset/nice-students-promise.md
+++ b/.changeset/nice-students-promise.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/universal-router-sdk': minor
+---
+
+Add payerIsUser option to erc20 swap calldata encoding

--- a/packages/universal-router-sdk/src/entities/Command.ts
+++ b/packages/universal-router-sdk/src/entities/Command.ts
@@ -1,14 +1,7 @@
 import { RoutePlanner } from '../utils/routerCommands'
+import { PaymentOptions } from './types'
 
-export interface UniversalRouterOptions {
-  /**
-   * Whether the payer of the trade is the user. Defaults to true.
-   * NOTE: This option is ignored in WETH case. Because WETH is now owned by the router, the router pays for inputs.
-   */
-  payerIsUser?: boolean
-}
-
-export interface TradeConfig extends UniversalRouterOptions {
+export type TradeConfig = PaymentOptions & {
   allowRevert: boolean
 }
 
@@ -21,5 +14,5 @@ export enum RouterTradeType {
 // interface for entities that can be encoded as a Universal Router command
 export interface Command {
   tradeType: RouterTradeType
-  encode(planner: RoutePlanner, config: UniversalRouterOptions): void
+  encode(planner: RoutePlanner, config: PaymentOptions): void
 }

--- a/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/pancakeswap.ts
@@ -13,8 +13,8 @@ import { Address } from 'viem'
 import { CONTRACT_BALANCE, ROUTER_AS_RECIPIENT, SENDER_AS_RECIPIENT } from '../../constants'
 import { encodeFeeBips } from '../../utils/numbers'
 import { ABIParametersType, CommandType, RoutePlanner } from '../../utils/routerCommands'
-import { Command, RouterTradeType, UniversalRouterOptions } from '../Command'
-import { PancakeSwapOptions } from '../types'
+import { Command, RouterTradeType } from '../Command'
+import { PancakeSwapOptions, PaymentOptions } from '../types'
 
 // Wrapper for pancakeswap router-sdk trade entity to encode swaps for Universal Router
 export class PancakeSwapTrade implements Command {
@@ -29,7 +29,7 @@ export class PancakeSwapTrade implements Command {
     }
   }
 
-  encode(planner: RoutePlanner, options?: UniversalRouterOptions): void {
+  encode(planner: RoutePlanner, options?: PaymentOptions): void {
     let payerIsUser = options?.payerIsUser ?? true
     const { trade } = this
     const numberOfTrades = trade.routes.length

--- a/packages/universal-router-sdk/src/entities/types.ts
+++ b/packages/universal-router-sdk/src/entities/types.ts
@@ -17,7 +17,14 @@ export type FlatFeeOptions = {
   recipient: Address
 }
 
+export type PaymentOptions = {
+  /**
+   * Whether the payer of the trade is the user. Defaults to true.
+   */
+  payerIsUser?: boolean
+}
+
 export type PancakeSwapOptions = Omit<SwapOptions, 'inputTokenPermit'> & {
   inputTokenPermit?: Permit2Signature
   flatFee?: FlatFeeOptions
-}
+} & PaymentOptions


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new option, `payerIsUser`, to the ERC20 swap calldata encoding in the `universal-router-sdk`. This allows the user to specify whether the payer of the trade is the user themselves, enhancing flexibility in trade configurations.

### Detailed summary
- Added `payerIsUser` option to `PaymentOptions` type.
- Updated `TradeConfig` to extend `PaymentOptions`.
- Modified `encode` method in `Command` to accept `PaymentOptions`.
- Adjusted `PancakeSwapTrade` to use `PaymentOptions` in the `encode` method.
- Updated `swapERC20CallParameters` to destructure `payerIsUser` from `PancakeSwapOptions`.
- Incorporated logic to handle `payerIsUser` in trade execution and validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->