### PR TITLE
feat: add Route Card

### DIFF
--- a/apps/web/src/components/NetworkSwitcher.tsx
+++ b/apps/web/src/components/NetworkSwitcher.tsx
@@ -12,7 +12,7 @@ import { chainNameConverter } from 'utils/chainNameConverter'
 import { chains as evmChains } from 'utils/wagmi'
 import { NetworkSwitcherModal, networkSwitcherModalAtom } from './NetworkSwitcherModal'
 
-const SHORT_SYMBOL = {
+export const SHORT_SYMBOL = {
   [ChainId.ETHEREUM]: 'ETH',
   [ChainId.BSC]: 'BNB',
   [ChainId.BSC_TESTNET]: 'tBNB',

--- a/apps/web/src/state/swap/actions.ts
+++ b/apps/web/src/state/swap/actions.ts
@@ -10,6 +10,7 @@ export enum Field {
 export const selectCurrency = createAction<{ field: Field; currencyId: string; chainId: number | undefined }>(
   'swap/selectCurrency',
 )
+
 export const switchCurrencies = createAction<void>('swap/switchCurrencies')
 export const typeInput = createAction<{ field: Field; typedValue: string }>('swap/typeInput')
 export const replaceSwapState = createAction<{

--- a/apps/web/src/state/swap/reducer.test.tsx
+++ b/apps/web/src/state/swap/reducer.test.tsx
@@ -1,6 +1,6 @@
-import { StrictMode } from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { useAtom } from 'jotai'
+import { StrictMode } from 'react'
 import { Field, selectCurrency } from './actions'
 import { swapReducerAtom } from './reducer'
 
@@ -23,6 +23,7 @@ describe('swap reducer', () => {
                   selectCurrency({
                     field: Field.OUTPUT,
                     currencyId: '0x0000',
+                    chainId: 1,
                   }),
                 )
               }

--- a/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency } from '@pancakeswap/sdk'
-import { Route, SmartRouter } from '@pancakeswap/smart-router'
+import { Route, RouteType, SmartRouter } from '@pancakeswap/smart-router'
 import {
   AtomBox,
   AutoColumn,
@@ -16,12 +16,13 @@ import { CurrencyLogo } from '@pancakeswap/widgets-internal'
 import { memo, useMemo } from 'react'
 
 import { RoutingSettingsButton } from 'components/Menu/GlobalSettings/SettingsModalV2'
+import { SHORT_SYMBOL } from 'components/NetworkSwitcher'
 import { CurrencyLogoWrapper, RouterBox, RouterPoolBox, RouterTypeText } from 'views/Swap/components/RouterViewer'
 import { v3FeeToPercent } from '../utils/exchange'
 
 type Pair = [Currency, Currency]
 
-export type RouteDisplayEssentials = Pick<Route, 'path' | 'pools' | 'inputAmount' | 'outputAmount' | 'percent'>
+export type RouteDisplayEssentials = Pick<Route, 'path' | 'pools' | 'inputAmount' | 'outputAmount' | 'percent' | 'type'>
 
 interface Props extends UseModalV2Props {
   routes: RouteDisplayEssentials[]
@@ -89,6 +90,41 @@ export const RouteDisplay = memo(function RouteDisplay({ route }: RouteDisplayPr
     }
     return currencyPairs
   }, [path])
+
+  if (route.type === RouteType.BRIDGE) {
+    return (
+      <AutoColumn gap="24px">
+        <RouterBox justifyContent="space-between" alignItems="center">
+          <CurrencyLogoWrapper
+            size={{
+              xs: '32px',
+              md: '48px',
+            }}
+            ref={targetRef}
+          >
+            <CurrencyLogo showChainLogo size="44px" currency={inputCurrency} />
+          </CurrencyLogoWrapper>
+          {tooltipVisible && tooltip}
+          <PairNode
+            pair={[inputCurrency, outputCurrency]}
+            text={`${SHORT_SYMBOL[inputCurrency.chainId]} → ${SHORT_SYMBOL[outputCurrency.chainId]}`}
+            className=""
+            tooltipText="hello text"
+          />
+          <CurrencyLogoWrapper
+            size={{
+              xs: '32px',
+              md: '48px',
+            }}
+            ref={outputTargetRef}
+          >
+            <CurrencyLogo showChainLogo size="44px" currency={outputCurrency} />
+          </CurrencyLogoWrapper>
+          {outputTooltipVisible && outputTooltip}
+        </RouterBox>
+      </AutoColumn>
+    )
+  }
 
   const pairNodes =
     pairs.length > 0

--- a/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContent.tsx
@@ -3,7 +3,7 @@ import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 import { memo, useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import SwapModalHeader from '../../components/SwapModalHeader'
 import {
   computeSlippageAdjustedAmounts as computeSlippageAdjustedAmountsWithSmartRouter,
@@ -61,7 +61,8 @@ export const TransactionConfirmSwapContent = memo<TransactionConfirmSwapContentP
       [order, allowedSlippage],
     )
     const { priceImpactWithoutFee, lpFeeAmount } = useMemo(
-      () => computeTradePriceBreakdownWithSmartRouter(isXOrder(order) ? undefined : order?.trade),
+      () =>
+        computeTradePriceBreakdownWithSmartRouter(isXOrder(order) || isBridgeOrder(order) ? undefined : order?.trade),
       [order],
     )
 

--- a/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContentV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/TransactionConfirmSwapContentV2.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 import SwapModalHeaderV2 from 'views/Swap/components/SwapModalHeaderV2'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import {
   computeSlippageAdjustedAmounts as computeSlippageAdjustedAmountsWithSmartRouter,
   computeTradePriceBreakdown as computeTradePriceBreakdownWithSmartRouter,
@@ -61,7 +61,8 @@ export const TransactionConfirmSwapContentV2 = memo<TransactionConfirmSwapConten
       [order, allowedSlippage],
     )
     const { priceImpactWithoutFee, lpFeeAmount } = useMemo(
-      () => computeTradePriceBreakdownWithSmartRouter(isXOrder(order) ? undefined : order?.trade),
+      () =>
+        computeTradePriceBreakdownWithSmartRouter(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
       [order],
     )
 

--- a/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/SwapCommitButton.tsx
@@ -23,7 +23,7 @@ import { useRoutingSettingChanged } from 'state/user/smartRouter'
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { logGTMClickSwapConfirmEvent, logGTMClickSwapEvent } from 'utils/customGTMEventTracking'
 import { warningSeverity } from 'utils/exchange'
-import { isClassicOrder, isXOrder } from 'views/Swap/utils'
+import { isBridgeOrder, isClassicOrder, isXOrder } from 'views/Swap/utils'
 import { useAccount, useChainId } from 'wagmi'
 import { useParsedAmounts, useSlippageAdjustedAmounts, useSwapInputError } from '../hooks'
 import { useConfirmModalState } from '../hooks/useConfirmModalState'
@@ -132,7 +132,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const { isExpertMode } = useSwapConfig()
 
   const tradePriceBreakdown = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(order) ? undefined : order?.trade),
+    () => computeTradePriceBreakdown(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
     [order],
   )
 

--- a/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
+++ b/apps/web/src/views/Swap/V3Swap/containers/TradeDetails.tsx
@@ -8,8 +8,8 @@ import { AdvancedDetailsFooter } from 'views/Swap/components/AdvancedSwapDetails
 import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { GasTokenSelector } from 'components/Paymaster/GasTokenSelector'
 import { usePaymaster } from 'hooks/usePaymaster'
-import { isClassicOrder, isXOrder } from 'views/Swap/utils'
-import { RoutesBreakdown, XRoutesBreakdown } from '../components'
+import { isBridgeOrder, isClassicOrder, isXOrder } from 'views/Swap/utils'
+import { RouteDisplayEssentials, RoutesBreakdown, XRoutesBreakdown } from '../components'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../hooks'
 import { computeTradePriceBreakdown } from '../utils/exchange'
 
@@ -22,7 +22,7 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
   const slippageAdjustedAmounts = useSlippageAdjustedAmounts(order)
   const isWrapping = useIsWrapping()
   const { priceImpactWithoutFee, lpFeeAmount } = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade),
+    () => computeTradePriceBreakdown(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
     [order],
   )
   const hasStablePool = useMemo(
@@ -57,7 +57,16 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
             isPaymasterAvailable && inputAmount && <GasTokenSelector inputCurrency={inputAmount.currency} />
           }
         />
-        {isXOrder(order) ? <XRoutesBreakdown /> : <RoutesBreakdown routes={order?.trade?.routes} />}
+        {isXOrder(order) ? (
+          <XRoutesBreakdown />
+        ) : (
+          <RoutesBreakdown
+            routes={
+              // TODO: remove when bridge is implemented
+              order?.trade?.routes as RouteDisplayEssentials[]
+            }
+          />
+        )}
       </AutoColumn>
     </AdvancedDetailsFooter>
   )

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapBestTrade.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapBestTrade.ts
@@ -46,8 +46,12 @@ export function useSwapBestOrder({ maxHops }: Options = {}) {
     return stableSwap && isExactIn
   }, [stableSwap, isExactIn])
 
+  const isBridge = useMemo(() => {
+    return inputCurrency && outputCurrency && inputCurrency?.chainId !== outputCurrency?.chainId
+  }, [inputCurrency, outputCurrency])
+
   const bestTradeOptions = {
-    enabled,
+    enabled: isBridge ? false : enabled,
     amount,
     currency: dependentCurrency,
     baseCurrency: independentCurrency,
@@ -63,10 +67,6 @@ export function useSwapBestOrder({ maxHops }: Options = {}) {
   const { fetchStatus, data: swapData, isStale, error, refetch } = useBestTradeFromApi(bestTradeOptions)
   useBestTradeFromApiShadow(bestTradeOptions, 'quote-api-ori')
   useBestTradeFromApiShadow(bestTradeOptions, 'quote-api-opt')
-
-  const isBridge = useMemo(() => {
-    return inputCurrency && outputCurrency && inputCurrency?.chainId !== outputCurrency?.chainId
-  }, [inputCurrency, outputCurrency])
 
   // if bridge, return bridege trade
 

--- a/apps/web/src/views/Swap/components/SwapRoute.tsx
+++ b/apps/web/src/views/Swap/components/SwapRoute.tsx
@@ -1,9 +1,11 @@
 import { Currency } from '@pancakeswap/sdk'
+import { RouteType } from '@pancakeswap/smart-router'
 import { ChevronRightIcon, Flex, Text } from '@pancakeswap/uikit'
+import { SHORT_SYMBOL } from 'components/NetworkSwitcher'
 import { Fragment, memo } from 'react'
 import { unwrappedToken } from 'utils/wrappedCurrency'
 
-export default memo(function SwapRoute({ path }: { path?: Currency[] }) {
+export default memo(function SwapRoute({ path, type }: { path?: Currency[]; type?: RouteType }) {
   return (
     <Flex flexWrap="wrap" width="100%" justifyContent="flex-end" alignItems="center">
       {path?.map((token, i) => {
@@ -15,7 +17,7 @@ export default memo(function SwapRoute({ path }: { path?: Currency[] }) {
           <Fragment key={`${currency?.symbol}_${i}`}>
             <Flex alignItems="end">
               <Text fontSize="14px" ml="0.125rem" mr="0.125rem">
-                {currency?.symbol}
+                {currency?.symbol} {type === RouteType.BRIDGE ? `(${SHORT_SYMBOL[currency?.chainId]})` : ''}
               </Text>
             </Flex>
             {!isLastItem && <ChevronRightIcon color="textSubtle" width="20px" />}

--- a/apps/web/src/views/Swap/utils.ts
+++ b/apps/web/src/views/Swap/utils.ts
@@ -15,9 +15,7 @@ export const isClassicOrder = (order: InterfaceOrder | undefined | null): order 
   order?.type === OrderType.PCS_CLASSIC
 
 export const isBridgeOrder = (order: InterfaceOrder | undefined | null): order is BridgeOrder =>
-  // TODO: Remove "true" value after testing
-  true
-// order?.type === OrderType.PCS_BRIDGE
+  order?.type === OrderType.PCS_BRIDGE
 
 export type InterfaceOrder<
   input extends Currency = Currency,

--- a/apps/web/src/views/SwapSimplify/V4Swap/CrossChainConfirmSwapModal/OrderStatus/OrderDetailsPanel.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/CrossChainConfirmSwapModal/OrderStatus/OrderDetailsPanel.tsx
@@ -20,7 +20,7 @@ import { useAtom, useAtomValue } from 'jotai'
 import { useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import styled from 'styled-components'
-import { isXOrder } from 'views/Swap/utils'
+import { isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import {
   computeSlippageAdjustedAmounts as computeSlippageAdjustedAmountsWithSmartRouter,
   computeTradePriceBreakdown as computeTradePriceBreakdownWithSmartRouter,
@@ -53,7 +53,7 @@ export const OrderDetailsPanel = ({ ...props }: OrderDetailsPanelProps) => {
   )
 
   const { lpFeeAmount } = useMemo(
-    () => computeTradePriceBreakdownWithSmartRouter(isXOrder(order) ? undefined : order?.trade),
+    () => computeTradePriceBreakdownWithSmartRouter(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
     [order],
   )
 

--- a/apps/web/src/views/SwapSimplify/V4Swap/CrossChainConfirmSwapModal/TransactionConfirmSwapContentV3.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/CrossChainConfirmSwapModal/TransactionConfirmSwapContentV3.tsx
@@ -3,7 +3,7 @@ import { ConfirmationModalContent } from '@pancakeswap/widgets-internal'
 import { memo, useCallback, useMemo } from 'react'
 import { Field } from 'state/swap/actions'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import {
   computeSlippageAdjustedAmounts as computeSlippageAdjustedAmountsWithSmartRouter,
   computeTradePriceBreakdown as computeTradePriceBreakdownWithSmartRouter,
@@ -61,7 +61,8 @@ export const TransactionConfirmSwapContentV3 = memo<TransactionConfirmSwapConten
       [order, allowedSlippage],
     )
     const { priceImpactWithoutFee, lpFeeAmount } = useMemo(
-      () => computeTradePriceBreakdownWithSmartRouter(isXOrder(order) ? undefined : order?.trade),
+      () =>
+        computeTradePriceBreakdownWithSmartRouter(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
       [order],
     )
 

--- a/apps/web/src/views/SwapSimplify/V4Swap/RoutesBreakdown.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/RoutesBreakdown.tsx
@@ -106,15 +106,15 @@ export const XRoutesBreakdown = memo(function XRoutesBreakdown({ wrapperStyle, l
 })
 
 interface RouteProps {
-  route: Pick<Route, 'path'>
+  route: Pick<Route, 'path' | 'type'>
 }
 
 function RouteComp({ route }: RouteProps) {
-  const { path } = route
+  const { path, type } = route
 
   return (
     <RowBetween mt="4px">
-      <SwapRoute path={path} />
+      <SwapRoute path={path} type={type} />
     </RowBetween>
   )
 }

--- a/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/SwapCommitButton.tsx
@@ -145,7 +145,7 @@ const SwapCommitButtonInner = memo(function SwapCommitButtonInner({
   const { isRecipientEmpty, isRecipientError } = useIsRecipientError()
 
   const tradePriceBreakdown = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(order) ? undefined : order?.trade),
+    () => computeTradePriceBreakdown(isBridgeOrder(order) || isXOrder(order) ? undefined : order?.trade),
     [order],
   )
 

--- a/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/TradeDetails.tsx
@@ -5,7 +5,8 @@ import { memo, useMemo } from 'react'
 import { styled } from 'styled-components'
 
 import { PriceOrder } from '@pancakeswap/price-api-sdk'
-import { isClassicOrder, isXOrder } from 'views/Swap/utils'
+import { isBridgeOrder, isClassicOrder, isXOrder } from 'views/Swap/utils'
+import { RouteDisplayEssentials } from 'views/Swap/V3Swap/components'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
 import { TradeSummary } from './AdvancedSwapDetails'
@@ -31,7 +32,7 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
   const slippageAdjustedAmounts = useSlippageAdjustedAmounts(order)
   const isWrapping = useIsWrapping()
   const { priceImpactWithoutFee, lpFeeAmount } = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade),
+    () => (isBridgeOrder(order) ? {} : computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade)),
     [order],
   )
   const hasStablePool = useMemo(
@@ -66,7 +67,14 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           {isXOrder(order) ? (
             <XRoutesBreakdown wrapperStyle={{ padding: 0 }} loading={!loaded} />
           ) : (
-            <RoutesBreakdown routes={order?.trade?.routes} wrapperStyle={{ padding: 0 }} loading={!loaded} />
+            <RoutesBreakdown
+              routes={
+                // TODO: remove when bridge is implemented
+                order?.trade?.routes as RouteDisplayEssentials[]
+              }
+              wrapperStyle={{ padding: 0 }}
+              loading={!loaded}
+            />
           )}
         </Box>
       </AutoColumn>

--- a/apps/web/src/views/SwapSimplify/V4Swap/TradingFee.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/TradingFee.tsx
@@ -3,7 +3,7 @@ import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { FlexGap, SkeletonV2, Text } from '@pancakeswap/uikit'
 import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { memo, useMemo } from 'react'
-import { isXOrder } from 'views/Swap/utils'
+import { isBridgeOrder, isXOrder } from 'views/Swap/utils'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
 
@@ -16,7 +16,7 @@ export const TradingFee: React.FC<TradingFeeProps> = memo(({ order, loaded }) =>
   const { t } = useTranslation()
   const slippageAdjustedAmounts = useSlippageAdjustedAmounts(order)
   const { lpFeeAmount } = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade),
+    () => (isBridgeOrder(order) ? {} : computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade)),
     [order],
   )
   const isWrapping = useIsWrapping()

--- a/apps/web/src/views/SwapSimplify/hooks/useIsPriceImpactTooHigh.ts
+++ b/apps/web/src/views/SwapSimplify/hooks/useIsPriceImpactTooHigh.ts
@@ -1,7 +1,7 @@
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useMemo, useRef } from 'react'
 import { warningSeverity } from 'utils/exchange'
-import { InterfaceOrder, isXOrder } from 'views/Swap/utils'
+import { InterfaceOrder, isBridgeOrder, isXOrder } from 'views/Swap/utils'
 
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
 
@@ -10,7 +10,11 @@ export const useIsPriceImpactTooHigh = (bestOrder: InterfaceOrder | undefined, i
   const chainIdRef = useRef(chainId)
 
   const { priceImpactWithoutFee } = useMemo(
-    () => computeTradePriceBreakdown(isXOrder(bestOrder) ? bestOrder?.ammTrade : bestOrder?.trade),
+    () =>
+      // TODO: remove when bridge is implemented
+      isBridgeOrder(bestOrder)
+        ? { priceImpactWithoutFee: null }
+        : computeTradePriceBreakdown(isXOrder(bestOrder) ? bestOrder?.ammTrade : bestOrder?.trade),
     [bestOrder],
   )
   const isPriceImpactTooHigh = useMemo(() => {

--- a/packages/price-api-sdk/src/orderPriceApiParsers.ts
+++ b/packages/price-api-sdk/src/orderPriceApiParsers.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { ExclusiveDutchOrder, createExclusiveDutchOrderTrade } from '@pancakeswap/pcsx-sdk'
-import { PoolType, V4Router } from '@pancakeswap/smart-router'
+import { PoolType, RouteType, V4Router } from '@pancakeswap/smart-router'
 import { Currency, CurrencyAmount, Percent, TradeType, type BigintIsh } from '@pancakeswap/swap-sdk-core'
 import { zeroAddress } from './getCurrencyPrice'
 import { getPoolTypeKey } from './getPoolType'
@@ -101,7 +101,14 @@ export function parseBridgeQuoteResponse<
     trade: {
       inputAmount: amountIn,
       outputAmount: CurrencyAmount.fromRawAmount(currencyOut, amountIn.quotient.toString()),
-      routes: [],
+      routes: [
+        {
+          path: [amountIn.currency, currencyOut],
+          inputAmount: amountIn,
+          outputAmount: CurrencyAmount.fromRawAmount(currencyOut, amountIn.quotient.toString()),
+          type: RouteType.BRIDGE,
+        },
+      ],
       tradeType,
     },
   }

--- a/packages/price-api-sdk/src/types/order.ts
+++ b/packages/price-api-sdk/src/types/order.ts
@@ -43,7 +43,12 @@ export type ClassicOrder<tradeType extends TradeType = TradeType> = {
 export interface BridgeTrade<tradeType extends TradeType = TradeType> {
   inputAmount: CurrencyAmount<Currency>
   outputAmount: CurrencyAmount<Currency>
-  routes: []
+  routes: {
+    path: [Currency, Currency]
+    inputAmount: CurrencyAmount<Currency>
+    outputAmount: CurrencyAmount<Currency>
+    type: 'PCS_BRIDGE'
+  }[]
   tradeType: tradeType
 }
 

--- a/packages/smart-router/evm/v3-router/types/route.ts
+++ b/packages/smart-router/evm/v3-router/types/route.ts
@@ -11,6 +11,7 @@ export enum RouteType {
   MM,
   V4CL,
   V4BIN,
+  BRIDGE,
 }
 
 export interface BaseRoute {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of bridge orders within the swap functionality. It introduces a new `BRIDGE` type for routes and modifies various components and utilities to account for this new order type.

### Detailed summary
- Added `BRIDGE` to route types.
- Exported `SHORT_SYMBOL` in `NetworkSwitcher`.
- Updated logic to handle `BridgeOrder` in price breakdown computations.
- Modified route props to include `type`.
- Enhanced various components to support `BridgeOrder` checks.
- Adjusted tests to include `chainId` in actions.
- Updated `TransactionConfirmSwapContent` to handle bridge-specific logic.
- Introduced conditional rendering for bridge routes in UI components.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->