### PR TITLE
fix: pool state non exist

### DIFF
--- a/apps/web/src/hooks/v3/usePools.ts
+++ b/apps/web/src/hooks/v3/usePools.ts
@@ -141,16 +141,16 @@ export function usePools(
         | { result: [bigint, number, number, number, number, number, boolean]; status: 'success' | 'error' }
         | undefined
 
-      if (!slot0Result) return [PoolState.INVALID, null]
+      if (!slot0Result) return [PoolState.NOT_EXISTS, null]
       const { result: slot0 } = slot0Result
 
       const liquidityResult = liquidities?.[index]
 
-      if (!liquidityResult) return [PoolState.INVALID, null]
+      if (!liquidityResult) return [PoolState.NOT_EXISTS, null]
       const { result: liquidity } = liquidityResult as { result: bigint; status: 'success' | 'error' }
 
       if (!tokens || slot0Result.status !== 'success' || liquidityResult.status !== 'success')
-        return [PoolState.INVALID, null]
+        return [PoolState.NOT_EXISTS, null]
       if (!slot0 || typeof liquidity === 'undefined') return [PoolState.NOT_EXISTS, null]
 
       const [sqrtPriceX96, tick, , , , feeProtocol] = slot0


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `usePools` hook to change the handling of certain states from `PoolState.INVALID` to `PoolState.NOT_EXISTS`, improving clarity in scenarios where data is missing.

### Detailed summary
- Changed return value from `[PoolState.INVALID, null]` to `[PoolState.NOT_EXISTS, null]` for missing `slot0Result`.
- Changed return value from `[PoolState.INVALID, null]` to `[PoolState.NOT_EXISTS, null]` for missing `liquidityResult`.
- Updated the final return condition to return `[PoolState.NOT_EXISTS, null]` if any required data is missing.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->