### PR TITLE
feat(swap): preserve input currency and remove URL updates

### DIFF
--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -263,7 +263,8 @@ export function useDefaultsFromURLSearch():
   >()
 
   const {
-    [Field.INPUT]: { currencyId: inputCurrencyId },
+    [Field.INPUT]: { currencyId: inputCurrencyId, chainId: inputChainId },
+    [Field.OUTPUT]: { currencyId: outputCurrencyId, chainId: outputChainId },
   } = useSwapState()
 
   useEffect(() => {
@@ -279,7 +280,9 @@ export function useDefaultsFromURLSearch():
         typedValue: parsed.typedValue,
         field: parsed.independentField,
         inputCurrencyId: inputCurrencyId || parsed[Field.INPUT].currencyId,
-        outputCurrencyId: parsed[Field.OUTPUT].currencyId,
+        outputCurrencyId: outputCurrencyId || parsed[Field.OUTPUT].currencyId,
+        inputChainId,
+        outputChainId,
         recipient: null,
       }),
     )

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -262,6 +262,10 @@ export function useDefaultsFromURLSearch():
     { inputCurrencyId: string | undefined; outputCurrencyId: string | undefined } | undefined
   >()
 
+  const {
+    [Field.INPUT]: { currencyId: inputCurrencyId },
+  } = useSwapState()
+
   useEffect(() => {
     if (!chainId || !native || !isReady) return
     const parsed = queryParametersToSwapState(
@@ -274,7 +278,7 @@ export function useDefaultsFromURLSearch():
       replaceSwapState({
         typedValue: parsed.typedValue,
         field: parsed.independentField,
-        inputCurrencyId: parsed[Field.INPUT].currencyId,
+        inputCurrencyId: inputCurrencyId || parsed[Field.INPUT].currencyId,
         outputCurrencyId: parsed[Field.OUTPUT].currencyId,
         recipient: null,
       }),

--- a/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4.tsx
+++ b/apps/web/src/views/SwapSimplify/V4Swap/FormMainV4.tsx
@@ -11,7 +11,6 @@ import { Field } from 'state/swap/actions'
 import { useDefaultsFromURLSearch, useSwapState } from 'state/swap/hooks'
 import { useSwapActionHandlers } from 'state/swap/useSwapActionHandlers'
 import { useCurrencyBalances } from 'state/wallet/hooks'
-import { currencyId } from 'utils/currencyId'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 
 import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
@@ -82,18 +81,20 @@ export function FormMain({ inputAmount, outputAmount, tradeLoading, isUserInsuff
       warningSwapHandler(newCurrency)
 
       const isInput = field === Field.INPUT
-      const oldCurrencyId = isInput ? currentInputCurrencyId : currentOutputCurrencyId
-      const otherCurrencyId = isInput ? currentOutputCurrencyId : currentInputCurrencyId
-      const newCurrencyId = currencyId(newCurrency)
 
-      if (isInput && canSwitch) {
-        switchNetwork(newCurrency.chainId)
-      }
+      // TODO: Handle URL update currencyId??? Uniswap stops supporting it.
+      // const oldCurrencyId = isInput ? currentInputCurrencyId : currentOutputCurrencyId
+      // const otherCurrencyId = isInput ? currentOutputCurrencyId : currentInputCurrencyId
+      // const newCurrencyId = currencyId(newCurrency)
 
       // replaceBrowserHistoryMultiple({
       //   ...(newCurrencyId === otherCurrencyId && { [isInput ? 'outputCurrency' : 'inputCurrency']: oldCurrencyId }),
       //   [isInput ? 'inputCurrency' : 'outputCurrency']: newCurrencyId,
       // })
+
+      if (isInput && canSwitch) {
+        switchNetwork(newCurrency.chainId)
+      }
     },
     [onCurrencySelection, warningSwapHandler, canSwitch, switchNetwork],
   )


### PR DESCRIPTION
- Preserve input currency ID when parsing URL parameters\n- Remove URL history updates for currency changes in V4 swap form\n- Reorder network switching logic

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of currency and chain IDs in the `useSwapState` and `FormMain` components, particularly when parsing and updating swap states.

### Detailed summary
- Extracted `inputCurrencyId`, `inputChainId`, `outputCurrencyId`, and `outputChainId` from `useSwapState`.
- Updated `replaceSwapState` to use extracted currency and chain IDs with fallbacks.
- Commented out old currency ID handling logic in `FormMain`.
- Retained the network switching logic for input currencies.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->