### PR TITLE
feat(PAN-5400): add defaultFee to whitelist hook

### DIFF
--- a/apps/web/src/views/SwapSimplify/InfinitySwap/AdvancedSwapDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/AdvancedSwapDetails.tsx
@@ -46,6 +46,7 @@ export const TradeSummary = memo(function TradeSummary({
   realizedLPFee,
   isX = false,
   loading = false,
+  hasDynamicHook,
 }: {
   hasStablePair?: boolean
   inputAmount?: CurrencyAmount<Currency>
@@ -56,6 +57,7 @@ export const TradeSummary = memo(function TradeSummary({
   realizedLPFee?: CurrencyAmount<Currency> | null
   isX?: boolean
   loading?: boolean
+  hasDynamicHook?: boolean
 }) {
   const { t } = useTranslation()
   const isExactIn = tradeType === TradeType.EXACT_INPUT
@@ -224,6 +226,13 @@ export const TradeSummary = memo(function TradeSummary({
               <Text color="primary" fontSize="14px">
                 0 {inputAmount?.currency?.symbol}
               </Text>
+            ) : hasDynamicHook ? (
+              <QuestionHelperV2 text={t('This route uses a dynamic fee pool; actual fees may vary.')}>
+                <Text fontSize="14px" style={{ textDecoration: 'underline dotted', cursor: 'help' }}>{`~${formatAmount(
+                  realizedLPFee,
+                  4,
+                )} ${inputAmount?.currency?.symbol}`}</Text>
+              </QuestionHelperV2>
             ) : (
               <Text fontSize="14px">{`${formatAmount(realizedLPFee, 4)} ${inputAmount?.currency?.symbol}`}</Text>
             )}

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/TradeDetails.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/TradeDetails.tsx
@@ -8,6 +8,7 @@ import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { isClassicOrder, isXOrder } from 'views/Swap/utils'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
+import { useHasDynamicHook } from '../hooks/useHasDynamicHook'
 import { TradeSummary } from './AdvancedSwapDetails'
 import { RoutesBreakdown, XRoutesBreakdown } from './RoutesBreakdown'
 
@@ -43,6 +44,7 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
         : undefined,
     [order],
   )
+  const hasDynamicHook = useHasDynamicHook(order)
 
   if (isWrapping || !order || !slippageAdjustedAmounts || !order.trade) {
     return null
@@ -62,6 +64,7 @@ export const TradeDetails = memo(function TradeDetails({ loaded, order }: Props)
           priceImpactWithoutFee={priceImpactWithoutFee ?? undefined}
           realizedLPFee={lpFeeAmount ?? undefined}
           hasStablePair={hasStablePool}
+          hasDynamicHook={hasDynamicHook}
           loading={!loaded}
         />
         <Box mt="10px" pl="4px">

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/TradingFee.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/TradingFee.tsx
@@ -1,15 +1,12 @@
-import { findHook, HOOK_CATEGORY } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { OrderType, PriceOrder } from '@pancakeswap/price-api-sdk'
-import { PoolType } from '@pancakeswap/smart-router'
+import { PriceOrder } from '@pancakeswap/price-api-sdk'
 import { FlexGap, SkeletonV2, Text } from '@pancakeswap/uikit'
 import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { memo, useMemo } from 'react'
-import { Address } from 'viem'
-import { isAddress } from 'viem/utils'
 import { isXOrder } from 'views/Swap/utils'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
+import { useHasDynamicHook } from '../hooks/useHasDynamicHook'
 
 interface TradingFeeProps {
   loaded: boolean
@@ -24,21 +21,7 @@ export const TradingFee: React.FC<TradingFeeProps> = memo(({ order, loaded }) =>
     [order],
   )
 
-  const containsDynamicHooks = useMemo(() => {
-    if (!order?.trade || order.type !== OrderType.PCS_CLASSIC) return false
-    const chainId = order.trade.inputAmount.currency.chainId
-    const pools = order.trade.routes
-      .map((r) => r.pools)
-      .flat()
-      .filter((pool) => pool.type === PoolType.InfinityBIN || pool.type === PoolType.InfinityCL)
-    if (pools.length === 0) return false
-
-    const hooks = pools.map((pool) => pool.hooks).filter((hook) => hook && isAddress(hook)) as Address[]
-
-    return hooks.some((hook) => {
-      return findHook(hook, chainId)?.category?.includes(HOOK_CATEGORY.DynamicFees) ?? false
-    })
-  }, [order?.trade])
+  const hasDynamicHooks = useHasDynamicHook(order)
   const isWrapping = useIsWrapping()
 
   if (isWrapping || !order || !order.trade || !slippageAdjustedAmounts) {
@@ -57,10 +40,9 @@ export const TradingFee: React.FC<TradingFeeProps> = memo(({ order, loaded }) =>
             0 {inputAmount?.currency?.symbol}
           </Text>
         ) : (
-          <Text color="textSubtle" fontSize="14px">{`${containsDynamicHooks ? '~' : ''}${formatAmount(
-            lpFeeAmount,
-            4,
-          )} ${inputAmount?.currency?.symbol}`}</Text>
+          <Text color="textSubtle" fontSize="14px">{`${hasDynamicHooks ? '~' : ''}${formatAmount(lpFeeAmount, 4)} ${
+            inputAmount?.currency?.symbol
+          }`}</Text>
         )}
       </SkeletonV2>
     </FlexGap>

--- a/apps/web/src/views/SwapSimplify/InfinitySwap/TradingFee.tsx
+++ b/apps/web/src/views/SwapSimplify/InfinitySwap/TradingFee.tsx
@@ -1,8 +1,12 @@
+import { findHook, HOOK_CATEGORY } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { PriceOrder } from '@pancakeswap/price-api-sdk'
+import { OrderType, PriceOrder } from '@pancakeswap/price-api-sdk'
+import { PoolType } from '@pancakeswap/smart-router'
 import { FlexGap, SkeletonV2, Text } from '@pancakeswap/uikit'
 import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { memo, useMemo } from 'react'
+import { Address } from 'viem'
+import { isAddress } from 'viem/utils'
 import { isXOrder } from 'views/Swap/utils'
 import { useIsWrapping, useSlippageAdjustedAmounts } from '../../Swap/V3Swap/hooks'
 import { computeTradePriceBreakdown } from '../../Swap/V3Swap/utils/exchange'
@@ -19,6 +23,22 @@ export const TradingFee: React.FC<TradingFeeProps> = memo(({ order, loaded }) =>
     () => computeTradePriceBreakdown(isXOrder(order) ? order.ammTrade : order?.trade),
     [order],
   )
+
+  const containsDynamicHooks = useMemo(() => {
+    if (!order?.trade || order.type !== OrderType.PCS_CLASSIC) return false
+    const chainId = order.trade.inputAmount.currency.chainId
+    const pools = order.trade.routes
+      .map((r) => r.pools)
+      .flat()
+      .filter((pool) => pool.type === PoolType.InfinityBIN || pool.type === PoolType.InfinityCL)
+    if (pools.length === 0) return false
+
+    const hooks = pools.map((pool) => pool.hooks).filter((hook) => hook && isAddress(hook)) as Address[]
+
+    return hooks.some((hook) => {
+      return findHook(hook, chainId)?.category?.includes(HOOK_CATEGORY.DynamicFees) ?? false
+    })
+  }, [order?.trade])
   const isWrapping = useIsWrapping()
 
   if (isWrapping || !order || !order.trade || !slippageAdjustedAmounts) {
@@ -37,9 +57,10 @@ export const TradingFee: React.FC<TradingFeeProps> = memo(({ order, loaded }) =>
             0 {inputAmount?.currency?.symbol}
           </Text>
         ) : (
-          <Text color="textSubtle" fontSize="14px">{`${formatAmount(lpFeeAmount, 4)} ${
-            inputAmount?.currency?.symbol
-          }`}</Text>
+          <Text color="textSubtle" fontSize="14px">{`${containsDynamicHooks ? '~' : ''}${formatAmount(
+            lpFeeAmount,
+            4,
+          )} ${inputAmount?.currency?.symbol}`}</Text>
         )}
       </SkeletonV2>
     </FlexGap>

--- a/apps/web/src/views/SwapSimplify/hooks/useHasDynamicHook.ts
+++ b/apps/web/src/views/SwapSimplify/hooks/useHasDynamicHook.ts
@@ -1,0 +1,24 @@
+import { findHook, HOOK_CATEGORY } from '@pancakeswap/infinity-sdk'
+import { OrderType, PriceOrder } from '@pancakeswap/price-api-sdk'
+import { PoolType } from '@pancakeswap/smart-router'
+import { useMemo } from 'react'
+import { Address } from 'viem'
+import { isAddress } from 'viem/utils'
+
+export const useHasDynamicHook = (order?: PriceOrder): boolean => {
+  return useMemo(() => {
+    if (!order?.trade || order.type !== OrderType.PCS_CLASSIC) return false
+    const chainId = order.trade.inputAmount.currency.chainId
+    const pools = order.trade.routes
+      .map((r) => r.pools)
+      .flat()
+      .filter((pool) => pool.type === PoolType.InfinityBIN || pool.type === PoolType.InfinityCL)
+    if (pools.length === 0) return false
+
+    const hooks = pools.map((pool) => pool.hooks).filter((hook) => hook && isAddress(hook)) as Address[]
+
+    return hooks.some((hook) => {
+      return findHook(hook, chainId)?.category?.includes(HOOK_CATEGORY.DynamicFees) ?? false
+    })
+  }, [order?.trade])
+}

--- a/packages/infinity-sdk/src/constants/hooksList/bsc.ts
+++ b/packages/infinity-sdk/src/constants/hooksList/bsc.ts
@@ -16,6 +16,7 @@ export const CL_DYNAMIC_HOOK: HookData = {
   isVerified: false,
   isUpgradable: false,
   creator: 'https://github.com/pancakeswap/',
+  defaultFee: 3000,
   hooksRegistration: {
     afterInitialize: true,
     beforeSwap: true,
@@ -62,6 +63,7 @@ export const bscHooksList: HookData[] = [
       beforeSwap: true,
     },
     hookType: HookType.Universal,
+    defaultFee: 3000,
   },
   {
     address: checksumAddress('0x9F0D5091D31a7801d34da352572BAc84e8Ac48Ad'),
@@ -78,6 +80,7 @@ export const bscHooksList: HookData[] = [
       beforeSwap: true,
     },
     hookType: HookType.PerPool,
+    defaultFee: 100000,
   },
   {
     address: checksumAddress('0x4910a4852A06D0F6B206bd737ea3C98866Be796C'),
@@ -94,6 +97,7 @@ export const bscHooksList: HookData[] = [
       beforeSwap: true,
     },
     hookType: HookType.PerPool,
+    defaultFee: 100000,
   },
   // {
   //   address: '0x0A6440c9cfb5f28BE699a9e4e83BF8A89de72498',

--- a/packages/infinity-sdk/src/types.ts
+++ b/packages/infinity-sdk/src/types.ts
@@ -204,6 +204,8 @@ export interface HookData {
 
   hooksRegistration?: HooksRegistration
   hookType?: HookType
+
+  defaultFee?: number
 }
 
 export enum HookType {

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3796,5 +3796,6 @@
   "These values represent the rewards earned in the last epoch. For the first epoch, the values are estimates.": "These values represent the rewards earned in the last epoch. For the first epoch, the values are estimates.",
   "Epoch = 8-hour reward cycle": "Epoch = 8-hour reward cycle",
   "You’re trading via Brevis Hook-enabled pool, check for discount eligibility on pool page.": "You’re trading via Brevis Hook-enabled pool, check for discount eligibility on pool page.",
-  "You’ve qualified for a discount via a Brevis Hook-enabled pool!": "You’ve qualified for a discount via a Brevis Hook-enabled pool!"
+  "You’ve qualified for a discount via a Brevis Hook-enabled pool!": "You’ve qualified for a discount via a Brevis Hook-enabled pool!",
+  "This route uses a dynamic fee pool; actual fees may vary.": "This route uses a dynamic fee pool; actual fees may vary."
 }

--- a/packages/smart-router/evm/infinity-router/queries/getInfinityClPools.ts
+++ b/packages/smart-router/evm/infinity-router/queries/getInfinityClPools.ts
@@ -4,6 +4,7 @@ import {
   INFI_CL_POOL_MANAGER_ADDRESSES,
   PoolKey,
   decodeHooksRegistration,
+  findHook,
   getPoolId,
   isInfinitySupported,
 } from '@pancakeswap/infinity-sdk'
@@ -149,12 +150,13 @@ export const getInfinityClPoolsWithoutTicks = createOnChainPoolFactory<InfinityC
     }
     const [sqrtPriceX96, tick, protocolFee, lpFee] = slot0
     const [currency0, currency1] = sortCurrencies([currencyA, currencyB])
+    const whitelistHook = findHook(hooks, currencyA.wrapped.chainId)
     return {
       id,
       type: PoolType.InfinityCL,
       currency0,
       currency1,
-      fee: lpFee,
+      fee: whitelistHook?.defaultFee ?? lpFee,
       protocolFee,
       liquidity: BigInt(liquidity.toString()),
       sqrtRatioX96: BigInt(sqrtPriceX96.toString()),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of dynamic fees in the trading process by introducing new hooks and updating associated components to support dynamic fee structures.

### Detailed summary
- Added `defaultFee` property to `HooksRegistration` and `HookType`.
- Updated translation strings in `translations.json`.
- Integrated `findHook` to fetch dynamic fees in `getInfinityClPools.ts`.
- Modified fee assignment logic to use `whitelistHook?.defaultFee`.
- Updated `bscHooksList` with new `defaultFee` values.
- Created `useHasDynamicHook` to determine if a dynamic fee hook is applicable.
- Enhanced `TradeDetails` and `TradeSummary` components to display dynamic fee information.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->