### PR TITLE
chore: search query reset on close

### DIFF
--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -5,7 +5,7 @@ import { ChainId, Currency, getTokenComparator, Token } from '@pancakeswap/sdk'
 import { createFilterToken, WrappedTokenInfo } from '@pancakeswap/token-lists'
 import { AutoColumn, Box, Column, ModalCloseButton, ModalTitle, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useAudioPlay } from '@pancakeswap/utils/user'
-import { KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
+import { ChangeEvent, KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FixedSizeList } from 'react-window'
 import { isAddress } from 'viem'
 
@@ -15,7 +15,6 @@ import { useAllLists, useInactiveListUrls } from 'state/lists/hooks'
 import { safeGetAddress } from 'utils'
 
 import { UpdaterByChainId } from 'state/lists/updater'
-import { useSearchQuery } from 'state/tokenList/searchQueryAtom'
 import { useAllTokenBalances } from 'state/wallet/hooks'
 import { useAllTokens, useIsUserAddedToken, useToken } from '../../hooks/Tokens'
 import Row from '../Layout/Row'
@@ -109,7 +108,7 @@ function CurrencySearch({
   const { chainId: activeChainId } = useActiveChainId()
 
   const { t } = useTranslation()
-  const [searchQuery] = useSearchQuery()
+  const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 200)
   // refs for fixed size lists
   const fixedList = useRef<FixedSizeList>()
@@ -170,7 +169,10 @@ function CurrencySearch({
     if (!isMobile) inputRef.current?.focus()
   }, [isMobile])
 
-  const handleOnInput = useCallback(() => {
+  const handleOnInput = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const input = event.target.value
+    const checksummedInput = safeGetAddress(input)
+    setSearchQuery(checksummedInput || input)
     fixedList.current?.scrollTo(0)
   }, [])
 

--- a/apps/web/src/components/SearchModal/CurrencySearchInput.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearchInput.tsx
@@ -1,36 +1,24 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Input, InputProps } from '@pancakeswap/uikit'
-import { RefObject, useCallback, useRef } from 'react'
-import { useSearchQuery } from 'state/tokenList/searchQueryAtom'
-import { safeGetAddress } from 'utils'
+import { RefObject, useRef } from 'react'
 
 interface CurrencySearchInputProps extends InputProps {
+  value?: string
+  compact?: boolean
   inputRef?: ReturnType<typeof useRef<HTMLInputElement>> | null
   handleEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void
   onInput?: (event: React.ChangeEvent<HTMLInputElement>) => void
-  compact?: boolean
 }
 
 export const CurrencySearchInput = ({
+  value,
   inputRef = null,
+  compact = false,
   handleEnter,
   onInput,
-  compact = false,
-
   ...props
 }: CurrencySearchInputProps) => {
   const { t } = useTranslation()
-  const [searchQuery, setSearchQuery] = useSearchQuery()
-
-  const handleInput = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const input = event.target.value
-      const checksummedInput = safeGetAddress(input)
-      setSearchQuery(checksummedInput || input)
-      onInput?.(event)
-    },
-    [setSearchQuery, onInput],
-  )
 
   return (
     <Input
@@ -38,9 +26,9 @@ export const CurrencySearchInput = ({
       placeholder={t('Search name / address')}
       scale={compact ? 'md' : 'lg'}
       autoComplete="off"
-      value={searchQuery}
+      value={value}
       ref={inputRef as RefObject<HTMLInputElement>}
-      onChange={handleInput}
+      onChange={onInput}
       onKeyDown={handleEnter}
       {...props}
     />

--- a/apps/web/src/state/tokenList/searchQueryAtom.ts
+++ b/apps/web/src/state/tokenList/searchQueryAtom.ts
@@ -1,7 +1,0 @@
-import { atom, useAtom } from 'jotai'
-
-const searchQueryAtom = atom<string>('')
-
-export const useSearchQuery = () => {
-  return useAtom(searchQueryAtom)
-}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `CurrencySearchInput` and `CurrencySearch` components by removing the dependency on the `searchQueryAtom`, streamlining the input handling, and improving state management for the search query.

### Detailed summary
- Removed `useSearchQuery` from `CurrencySearchInput` and `CurrencySearch`.
- Added `value` prop to `CurrencySearchInput` for controlled input.
- Changed `onChange` in `CurrencySearchInput` to use `onInput`.
- Introduced local state management for `searchQuery` in `CurrencySearch` using `useState`. 
- Updated `handleOnInput` to manage the search query directly within `CurrencySearch`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->