### PR TITLE
chore: Use grove for zkevm

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -125,10 +125,10 @@ export const PUBLIC_NODES: Record<ChainId, string[] | readonly string[]> = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.default.http,
   [ChainId.POLYGON_ZKEVM]: [
+    getGroveUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_GROVE_API_KEY) || '',
     process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '',
     ...polygonZkEvm.rpcUrls.default.http,
     'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
-    getGroveUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_GROVE_API_KEY) || '',
   ].filter(Boolean),
   [ChainId.POLYGON_ZKEVM_TESTNET]: [
     ...polygonZkEvmTestnet.rpcUrls.default.http,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the RPC URLs for `ChainId.POLYGON_ZKEVM` in the `nodes.ts` configuration file, specifically by modifying the way the Grove API URL is included.

### Detailed summary
- Added `getGroveUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_GROVE_API_KEY) || ''` to the RPC URLs for `ChainId.POLYGON_ZKEVM`.
- Removed the duplicate `getGroveUrl` line from the same section.
- Ensured the list of URLs is filtered to remove any falsy values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->