### PR TITLE
fix(PAN-5491): force select chain same as active chainId

### DIFF
--- a/apps/web/src/hooks/dynamicRoute/useSelectIdRoute.ts
+++ b/apps/web/src/hooks/dynamicRoute/useSelectIdRoute.ts
@@ -1,4 +1,4 @@
-import { getChainName } from '@pancakeswap/chains'
+import { chainNames, getChainName } from '@pancakeswap/chains'
 import { INFINITY_SUPPORTED_CHAINS } from '@pancakeswap/infinity-sdk'
 import { CAKE, USDC } from '@pancakeswap/tokens'
 import { SelectIdRoute, zSelectId } from 'dynamicRoute'
@@ -79,7 +79,10 @@ export const useSelectIdRouteParams = () => {
       router.replace(
         {
           pathname: path,
-          query: router.query, // keep other query params
+          query: {
+            ...router.query,
+            chain: chainNames[p.chainId ?? params.chainId],
+          }, // keep other query params
         },
         undefined,
         { shallow: true },

--- a/apps/web/src/views/AddLiquiditySelector/index.tsx
+++ b/apps/web/src/views/AddLiquiditySelector/index.tsx
@@ -27,7 +27,9 @@ import { INFINITY_SUPPORTED_CHAINS } from '@pancakeswap/infinity-sdk'
 import { CurrencySelectV2 } from 'components/CurrencySelectV2'
 import { useSelectIdRouteParams } from 'hooks/dynamicRoute/useSelectIdRoute'
 import { useStableSwapSupportedTokens } from 'hooks/useStableSwapSupportedTokens'
+import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
 import { COMPACT_LIQUIDITY_TYPES, LIQUIDITY_TYPES, LiquidityType } from 'utils/types'
+import { Chain } from 'viem/chains'
 import { usePoolTypeQuery } from './hooks/usePoolTypeQuery'
 
 const StyledCard = styled(Card)`
@@ -128,6 +130,12 @@ export const AddLiquiditySelector = () => {
     return noCurrency || networkNoSupport
   }, [baseCurrency, chainId, protocol, quoteCurrency])
 
+  const { switchNetworkAsync } = useSwitchNetwork()
+  const handleNetworkChange = async (chain: Chain) => {
+    await switchNetworkAsync?.(chain.id)
+    updateParams({ chainId: chain.id })
+  }
+
   return (
     <StyledCard mt="48px" mb={['120px', null, null, '0px']} mx="auto" style={{ overflow: 'visible' }}>
       <CardBody>
@@ -146,11 +154,7 @@ export const AddLiquiditySelector = () => {
               ))}
             </ButtonMenu>
 
-            <NetworkSelector
-              version={protocol}
-              chainId={chainId}
-              onChange={(chainValue) => updateParams({ chainId: chainValue.id })}
-            />
+            <NetworkSelector version={protocol} chainId={chainId} onChange={handleNetworkChange} />
           </FlexGap>
 
           <FlexGap gap="6px" flexDirection="column">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `useSelectIdRouteParams` hook and the `AddLiquiditySelector` component to include network switching capabilities and to ensure the selected chain is reflected in the route parameters.

### Detailed summary
- Updated `useSelectIdRouteParams` to include the selected `chain` in the query parameters.
- Added `useSwitchNetwork` hook in `AddLiquiditySelector` for network switching.
- Implemented `handleNetworkChange` function to switch networks and update parameters.
- Refactored `NetworkSelector` to use the new `handleNetworkChange` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->