### PR TITLE
fix: back to link

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -424,7 +424,7 @@ export function AddLiquidityV3Layout({
     <BodyWrapper mb={isMobile ? '40px' : '0px'}>
       <AppHeader
         title={title}
-        backTo={router.back}
+        backTo={router.back ?? '/liquidity/positions'}
         IconSlot={
           <>
             {selectType === SELECTOR_TYPE.V3 && <AprCalculatorV2 derived pool={pool} inverted={inverted} />}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AddLiquidityV3` component's `AppHeader` to provide a default value for the `backTo` prop when `router.back` is not defined.

### Detailed summary
- Updated the `backTo` prop in `AppHeader` from `router.back` to `router.back ?? '/liquidity/positions'`, ensuring a fallback URL is used if `router.back` is null or undefined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->