### PR TITLE
fix: reward calc amount incorrect PAN-5468

### DIFF
--- a/apps/web/src/hooks/infinity/useFarmReward.ts
+++ b/apps/web/src/hooks/infinity/useFarmReward.ts
@@ -88,7 +88,7 @@ const fetchMerkleRootByTimestamp = async ({ chainId, timestamp }: FetchMerkleRoo
   if (!(chainId && timestamp)) {
     return undefined
   }
-  const resp = await rewardApiClient.GET('/farms/root/{chainId}/{timestamp}', {
+  let resp = await rewardApiClient.GET('/farms/root/{chainId}/{timestamp}', {
     params: {
       path: {
         chainId,
@@ -96,6 +96,16 @@ const fetchMerkleRootByTimestamp = async ({ chainId, timestamp }: FetchMerkleRoo
       },
     },
   })
+  if (!resp.data?.epochEndTimestamp) {
+    resp = await rewardApiClient.GET('/farms/epoch-root/{chainId}/{timestamp}', {
+      params: {
+        path: {
+          chainId,
+          timestamp,
+        },
+      },
+    })
+  }
   return resp.data ?? undefined
 }
 

--- a/apps/web/src/state/farmsV4/api/schema.d.ts
+++ b/apps/web/src/state/farmsV4/api/schema.d.ts
@@ -321,4 +321,21 @@ interface paths {
     patch?: never
     trace?: never
   }
+
+  '/farms/epoch-root/{chainId}/{timestamp}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getMerkleRootByTimestamp']
+    put?: never
+    post: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the API interaction for fetching farm data by adding a new endpoint and modifying the logic for retrieving the Merkle root based on timestamps.

### Detailed summary
- Added a new endpoint for `'/farms/epoch-root/{chainId}/{timestamp}'` in `schema.d.ts`.
- Updated the method in `useFarmReward.ts` to conditionally fetch data from the new endpoint if `epochEndTimestamp` is not present in the initial response.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->