### PR TITLE
chore: add payerIsUser options and related test

### DIFF
--- a/.changeset/nice-timers-train.md
+++ b/.changeset/nice-timers-train.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/universal-router-sdk': patch
+---
+
+Add unit test for option payerIsUser

--- a/packages/universal-router-sdk/src/PancakeSwapUniversalRouter.ts
+++ b/packages/universal-router-sdk/src/PancakeSwapUniversalRouter.ts
@@ -18,12 +18,13 @@ export abstract class PancakeSwapUniversalRouter {
    */
   public static swapERC20CallParameters(
     trade: Omit<SmartRouterTrade<TradeType>, 'gasEstimate'>,
-    { payerIsUser = true, ...options }: PancakeSwapOptions,
+    _options: PancakeSwapOptions,
   ): MethodParameters {
+    const options = { payerIsUser: true, ..._options }
     const planner = new TradePlanner(trade, options)
 
     const inputCurrency = planner.trade.inputAmount.currency
-    if (payerIsUser) {
+    if (options.payerIsUser) {
       invariant(!(inputCurrency.isNative && !!options.inputTokenPermit), 'NATIVE_INPUT_PERMIT')
     }
 
@@ -31,7 +32,7 @@ export abstract class PancakeSwapUniversalRouter {
       encodePermit(planner, options.inputTokenPermit)
     }
 
-    const nativeCurrencyValue = payerIsUser
+    const nativeCurrencyValue = options.payerIsUser
       ? inputCurrency.isNative
         ? SmartRouter.maximumAmountIn(planner.trade, options.slippageTolerance, planner.trade.inputAmount).quotient
         : 0n

--- a/packages/universal-router-sdk/src/entities/protocols/TradePlanner.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/TradePlanner.ts
@@ -332,8 +332,7 @@ export class TradePlanner extends RoutePlanner {
     if (this.context.takeOverWrapSweep) {
       const route = this.context.routes[0]
       const outputCurrency = route.sections[route.sections.length - 1].poolOut
-      const quotient = outAmount.quotient
-      outAmount = CurrencyAmount.fromRawAmount(outputCurrency, quotient)
+      outAmount = CurrencyAmount.fromRawAmount(outputCurrency, outAmount.quotient)
     }
 
     const { fee, flatFee } = this.options

--- a/packages/universal-router-sdk/src/entities/protocols/parseSwapTradeContext.ts
+++ b/packages/universal-router-sdk/src/entities/protocols/parseSwapTradeContext.ts
@@ -78,7 +78,9 @@ export const parseSwapTradeContext = (
         route: newRoute,
         isInfinity: section[0].type === PoolType.InfinityBIN || section[0].type === PoolType.InfinityCL,
       }
-      swap.payerIsUser = swap.isFirstSection && !(swap.wrapInput || swap.unwrapInput)
+      swap.payerIsUser = context.options.payerIsUser
+        ? swap.isFirstSection && !(swap.wrapInput || swap.unwrapInput)
+        : false
       inputCurrency = poolOut
       routeContext.sections.push(swap)
     }

--- a/packages/universal-router-sdk/src/utils/getPoolKey.ts
+++ b/packages/universal-router-sdk/src/utils/getPoolKey.ts
@@ -19,7 +19,7 @@ export const getPoolKey = (pool: InfinityBinPool | InfinityClPool): PoolKey => {
     fee: pool.fee,
   }
 
-  const chainId = pool.currency0.chainId
+  const { chainId } = pool.currency0
 
   if (isDynamicFeeHook(chainId, pool.hooks)) {
     base.fee = DYNAMIC_FEE_FLAG

--- a/packages/universal-router-sdk/test/__snapshots__/router.Infinity.clamm.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/router.Infinity.clamm.test.ts.snap
@@ -266,6 +266,80 @@ exports[`PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test >
 ]
 `;
 
+exports[`PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test > Infinity-CL > should encode a single exactInput ETH-CAKE CL swap zeroForOne ( payerIsUser = false )  1`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "10000000000000000"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": false
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": true,
+              "amountIn": "10000000000000000",
+              "amountOutMinimum": "952380952380952380",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000001"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+]
+`;
+
 exports[`PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test > Infinity-CL > should encode a single exactInput ETH-CAKE CL swap zeroForOne 1`] = `
 [
   {

--- a/packages/universal-router-sdk/test/__snapshots__/router.Infinity.clamm.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/router.Infinity.clamm.test.ts.snap
@@ -1,5 +1,79 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test > Infinity-CL > label: should encode a single exactInput ETH-CAKE CL swap zeroForOne ( payerIsUser = false )  1`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "10000000000000000"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": false
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": true,
+              "amountIn": "10000000000000000",
+              "amountOutMinimum": "952380952380952380",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000001"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+]
+`;
+
 exports[`PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test > Infinity-CL > should encode a edge-case single exactInput WBNB->CAKE via tBNB-CAKE-InfinityCL pool 1`] = `
 [
   {

--- a/packages/universal-router-sdk/test/__snapshots__/router.Infinity.mix.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/router.Infinity.mix.test.ts.snap
@@ -1,5 +1,243 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > label: should encode CAKE->USDC through mixed swaps Infinity(ETH-CAKE) -> v3(WETH-USDC) payerIsUser=false 1`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "50"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": false
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": false,
+              "amountIn": "50",
+              "amountOutMinimum": "0",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000002"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "command": "WRAP_ETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000002"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+      }
+    ]
+  },
+  {
+    "command": "V3_SWAP_EXACT_IN",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000001"
+      },
+      {
+        "type": "uint256",
+        "name": "amountIn",
+        "value": "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+      },
+      {
+        "type": "uint256",
+        "name": "amountOutMin",
+        "value": "9523"
+      },
+      {
+        "type": "bytes",
+        "name": "path",
+        "value": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      },
+      {
+        "type": "bool",
+        "name": "payerIsUser",
+        "value": false
+      }
+    ]
+  }
+]
+`;
+
+exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > label: should encode CAKE->USDC through mixed swaps Infinity(ETH-CAKE) -> v3(WETH-USDC) payerIsUser=false 2`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "50"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": false
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": false,
+              "amountIn": "50",
+              "amountOutMinimum": "0",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000002"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "command": "WRAP_ETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000002"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+      }
+    ]
+  },
+  {
+    "command": "V3_SWAP_EXACT_IN",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000001"
+      },
+      {
+        "type": "uint256",
+        "name": "amountIn",
+        "value": "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+      },
+      {
+        "type": "uint256",
+        "name": "amountOutMin",
+        "value": "9523"
+      },
+      {
+        "type": "bytes",
+        "name": "path",
+        "value": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      },
+      {
+        "type": "bool",
+        "name": "payerIsUser",
+        "value": false
+      }
+    ]
+  }
+]
+`;
+
 exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > label: should encode mixed consecutive Infinity swaps, ETH->CAKE(InfinityBin)->USDC(InfinityCl) 1`] = `
 [
   {

--- a/packages/universal-router-sdk/test/__snapshots__/router.Infinity.mix.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/router.Infinity.mix.test.ts.snap
@@ -1,5 +1,199 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > label: should encode mixed consecutive Infinity swaps, ETH->CAKE(InfinityBin)->USDC(InfinityCl) 1`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "BIN_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x0000000000000000000000000000000000000000000000000000000000050000"
+              },
+              "zeroForOne": true,
+              "amountIn": "50",
+              "amountOutMinimum": "0",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "50"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": true
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "currency1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": true,
+              "amountIn": "0",
+              "amountOutMinimum": "9523",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000001"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+]
+`;
+
+exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > label: should encode mixed consecutive Infinity swaps, ETH->CAKE(InfinityBin)->USDC(InfinityCl) 2`] = `
+[
+  {
+    "command": "INFI_SWAP",
+    "args": [],
+    "actions": [
+      {
+        "action": "BIN_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x0000000000000000000000000000000000000000",
+                "currency1": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x0000000000000000000000000000000000000000000000000000000000050000"
+              },
+              "zeroForOne": true,
+              "amountIn": "50",
+              "amountOutMinimum": "0",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "SETTLE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0x0000000000000000000000000000000000000000"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "50"
+          },
+          {
+            "type": "bool",
+            "name": "payerIsUser",
+            "value": true
+          }
+        ]
+      },
+      {
+        "action": "CL_SWAP_EXACT_IN_SINGLE",
+        "args": [
+          {
+            "type": "tuple",
+            "name": "params",
+            "value": {
+              "poolKey": {
+                "currency0": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+                "currency1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "hooks": "0x0000000000000000000000000000000000000000",
+                "poolManager": "0x0000000000000000000000000000000000000000",
+                "fee": 500,
+                "parameters": "0x00000000000000000000000000000000000000000000000000000000000a0000"
+              },
+              "zeroForOne": true,
+              "amountIn": "0",
+              "amountOutMinimum": "9523",
+              "hookData": "0x0000000000000000000000000000000000000000"
+            }
+          }
+        ]
+      },
+      {
+        "action": "TAKE",
+        "args": [
+          {
+            "type": "address",
+            "name": "currency",
+            "value": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          },
+          {
+            "type": "address",
+            "name": "recipient",
+            "value": "0x0000000000000000000000000000000000000001"
+          },
+          {
+            "type": "uint256",
+            "name": "amount",
+            "value": "0"
+          }
+        ]
+      }
+    ]
+  }
+]
+`;
+
 exports[`PancakeSwap Universal Mixed Router Command Generation Test > mixed > should encode CAKE->USDC through mixed swaps Infinity(ETH-CAKE) -> v3(WETH-USDC) 1`] = `
 [
   {

--- a/packages/universal-router-sdk/test/__snapshots__/trade.test.ts.snap
+++ b/packages/universal-router-sdk/test/__snapshots__/trade.test.ts.snap
@@ -2654,6 +2654,56 @@ exports[`PancakeSwap Universal Router Trade > v2 > should encode exactOutput USD
 ]
 `;
 
+exports[`PancakeSwap Universal Router Trade > v3 > label: should encode a single exactInput ETH->USDC swap (payerIsUser = false) 1`] = `
+[
+  {
+    "command": "WRAP_ETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000002"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "1000000000000000000"
+      }
+    ]
+  },
+  {
+    "command": "V3_SWAP_EXACT_IN",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000001"
+      },
+      {
+        "type": "uint256",
+        "name": "amountIn",
+        "value": "1000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountOutMin",
+        "value": "949053319313984300"
+      },
+      {
+        "type": "bytes",
+        "name": "path",
+        "value": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20009c4a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      },
+      {
+        "type": "bool",
+        "name": "payerIsUser",
+        "value": false
+      }
+    ]
+  }
+]
+`;
+
 exports[`PancakeSwap Universal Router Trade > v3 > should encode a exactInput ETH->USDC->USDT swap 1`] = `
 [
   {
@@ -2813,6 +2863,56 @@ exports[`PancakeSwap Universal Router Trade > v3 > should encode a exactOutput U
         "type": "uint256",
         "name": "amountMin",
         "value": "1000000000000000000"
+      }
+    ]
+  }
+]
+`;
+
+exports[`PancakeSwap Universal Router Trade > v3 > should encode a single exactInput ETH->USDC swap (payerIsUser = false) 1`] = `
+[
+  {
+    "command": "WRAP_ETH",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000002"
+      },
+      {
+        "type": "uint256",
+        "name": "amountMin",
+        "value": "1000000000000000000"
+      }
+    ]
+  },
+  {
+    "command": "V3_SWAP_EXACT_IN",
+    "args": [
+      {
+        "type": "address",
+        "name": "recipient",
+        "value": "0x0000000000000000000000000000000000000001"
+      },
+      {
+        "type": "uint256",
+        "name": "amountIn",
+        "value": "1000000000000000000"
+      },
+      {
+        "type": "uint256",
+        "name": "amountOutMin",
+        "value": "949053319313984300"
+      },
+      {
+        "type": "bytes",
+        "name": "path",
+        "value": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc20009c4a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      },
+      {
+        "type": "bool",
+        "name": "payerIsUser",
+        "value": false
       }
     ]
   }

--- a/packages/universal-router-sdk/test/router.Infinity.bin.test.ts
+++ b/packages/universal-router-sdk/test/router.Infinity.bin.test.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pancakeswap/chains'
 import { ACTION_CONSTANTS, ACTIONS, decodePoolKey } from '@pancakeswap/infinity-sdk'
 import { CurrencyAmount, ERC20Token, Ether, Percent, TradeType, ZERO_ADDRESS } from '@pancakeswap/sdk'
-import { InfinityBinPool, InfinityClPool, MSG_SENDER, SmartRouter } from '@pancakeswap/smart-router'
+import { InfinityBinPool, MSG_SENDER, SmartRouter } from '@pancakeswap/smart-router'
 import { ADDRESS_ZERO } from '@pancakeswap/v3-sdk'
 import { isHex, parseEther, stringify } from 'viem'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -40,7 +40,6 @@ describe('PancakeSwap Universal Router Infinity-Bin Pool Command Generation Test
   let ETHER: Ether
   let USDC: ERC20Token
   let CAKE: ERC20Token
-  let ETH_CAKE_CL_INFI: InfinityClPool
   let ETH_CAKE_BIN_INFI: InfinityBinPool
   let ETH_USDC_BIN_INFI: InfinityBinPool
 
@@ -54,10 +53,7 @@ describe('PancakeSwap Universal Router Infinity-Bin Pool Command Generation Test
   })
 
   beforeEach(async () => {
-    ;({ ETHER, CAKE, USDC, ETH_CAKE_CL_INFI, ETH_CAKE_BIN_INFI, ETH_USDC_BIN_INFI } = await fixtureAddresses(
-      chainId,
-      liquidity,
-    ))
+    ;({ ETHER, CAKE, USDC, ETH_CAKE_BIN_INFI, ETH_USDC_BIN_INFI } = await fixtureAddresses(chainId, liquidity))
   })
 
   describe('Infinity-BIN', () => {

--- a/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
+++ b/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
@@ -99,7 +99,7 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
       testInfinityTakeAction(actions[2], CAKE, MSG_SENDER, ACTION_CONSTANTS.OPEN_DELTA)
     })
 
-    it('label: should encode a single exactInput ETH-CAKE CL swap zeroForOne ( payerIsUser = false ) ', async () => {
+    it('should encode a single exactInput ETH-CAKE CL swap zeroForOne ( payerIsUser = false ) ', async () => {
       const amountIn = parseEther('0.01')
       const inputAmount = CurrencyAmount.fromRawAmount(ETHER, amountIn)
       const outputAmount = CurrencyAmount.fromRawAmount(CAKE, parseEther('1'))
@@ -122,16 +122,16 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
       expect(decodedCommands[0].args.length).toEqual(0)
       const actions = decodedCommands[0].actions!
 
+      // SETTLE
+      testInfinitySettleAction(actions[0], ETHER, amountIn, false)
+
       // CL_SWAP_EXACT_IN_SINGLE
-      expect(actions[0].action).toEqual(ACTIONS[ACTIONS.CL_SWAP_EXACT_IN_SINGLE])
-      expect(actions[0].args[0].name).toEqual('params')
-      const encoded = actions[0].args[0].value as any
+      expect(actions[1].action).toEqual(ACTIONS[ACTIONS.CL_SWAP_EXACT_IN_SINGLE])
+      expect(actions[1].args[0].name).toEqual('params')
+      const encoded = actions[1].args[0].value as any
       const poolKey = decodePoolKey(encoded.poolKey, 'CL')
       expect(poolKey.currency0).toEqual(currencyAddressInfinity(inputAmount.currency))
       expect(poolKey.currency1).toEqual(currencyAddressInfinity(outputAmount.currency))
-
-      // SETTLE
-      testInfinitySettleAction(actions[1], ETHER, amountIn, true)
 
       // TAKE
       testInfinityTakeAction(actions[2], CAKE, MSG_SENDER, ACTION_CONSTANTS.OPEN_DELTA)
@@ -364,7 +364,7 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
       testInfinityTakeAction(actions[2], CAKE, MSG_SENDER, ACTION_CONSTANTS.OPEN_DELTA)
     })
 
-    it('label: should encode a multi-hop exactInput in Infinity: USDC->WETH->CAKE(via ETH->CAKE Pool)', async () => {
+    it('should encode a multi-hop exactInput in Infinity: USDC->WETH->CAKE(via ETH->CAKE Pool)', async () => {
       const inputAmount = CurrencyAmount.fromRawAmount(USDC, 1000)
       const outputAmount = CurrencyAmount.fromRawAmount(CAKE, 10000)
 

--- a/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
+++ b/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pancakeswap/chains'
 import { ACTIONS, decodePoolKey, POOL_TYPE } from '@pancakeswap/infinity-sdk'
 import { CurrencyAmount, ERC20Token, Ether, Percent, TradeType, ZERO_ADDRESS } from '@pancakeswap/sdk'
-import { InfinityBinPool, InfinityClPool, MSG_SENDER, SmartRouter } from '@pancakeswap/smart-router'
+import { InfinityClPool, MSG_SENDER, SmartRouter } from '@pancakeswap/smart-router'
 import { ADDRESS_ZERO } from '@pancakeswap/v3-sdk'
 import { isHex, parseEther, stringify } from 'viem'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -45,7 +45,6 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
   let ETH_CAKE_CL_INFI: InfinityClPool
   let ETH_USDC_CL_INFI: InfinityClPool
   let WETH_USDC_CL_INFI: InfinityClPool
-  let WETH_CAKE_CL_INFI: InfinityBinPool
   expect.addSnapshotSerializer({
     serialize(val) {
       return stringify(decodeUniversalCalldata(val), null, 2)
@@ -73,7 +72,6 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
 
       const { calldata, value } = PancakeSwapUniversalRouter.swapERC20CallParameters(trade, options)
       expect(calldata).toMatchSnapshot()
-      const minOut = SmartRouter.minimumAmountOut(trade, options.slippageTolerance)
 
       expect(BigInt(value)).toEqual(amountIn)
       // expect(calldata).toMatchSnapshot()
@@ -111,7 +109,6 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
 
       const { calldata, value } = PancakeSwapUniversalRouter.swapERC20CallParameters(trade, options)
       expect(calldata).toMatchSnapshot()
-      const minOut = SmartRouter.minimumAmountOut(trade, options.slippageTolerance)
 
       expect(BigInt(value)).toEqual(0n)
       // expect(calldata).toMatchSnapshot()
@@ -146,7 +143,6 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
 
       const { calldata, value } = PancakeSwapUniversalRouter.swapERC20CallParameters(trade, options)
       expect(calldata).toMatchSnapshot()
-      const minOut = SmartRouter.minimumAmountOut(trade, options.slippageTolerance)
 
       expect(BigInt(value)).toEqual(0n)
       // expect(calldata).toMatchSnapshot()
@@ -377,7 +373,6 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
       const { calldata, value } = PancakeSwapUniversalRouter.swapERC20CallParameters(trade, options)
       const maxInAmount = SmartRouter.maximumAmountIn(trade, options.slippageTolerance).quotient
       const minOutAmount = SmartRouter.minimumAmountOut(trade, options.slippageTolerance).quotient
-      console.log('minOut', minOutAmount)
 
       expect(BigInt(value)).toEqual(0n)
       const decodedCommands = decodeUniversalCalldata(calldata)

--- a/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
+++ b/packages/universal-router-sdk/test/router.Infinity.clamm.test.ts
@@ -99,6 +99,44 @@ describe('PancakeSwap Universal Router Infinity-Cl Pool Command Generation Test'
       testInfinityTakeAction(actions[2], CAKE, MSG_SENDER, ACTION_CONSTANTS.OPEN_DELTA)
     })
 
+    it('label: should encode a single exactInput ETH-CAKE CL swap zeroForOne ( payerIsUser = false ) ', async () => {
+      const amountIn = parseEther('0.01')
+      const inputAmount = CurrencyAmount.fromRawAmount(ETHER, amountIn)
+      const outputAmount = CurrencyAmount.fromRawAmount(CAKE, parseEther('1'))
+      const trade = buildInfinityTrade(TradeType.EXACT_INPUT, inputAmount, outputAmount, [ETH_CAKE_CL_INFI])
+
+      const options = swapOptions({
+        payerIsUser: false,
+      })
+
+      const { calldata, value } = PancakeSwapUniversalRouter.swapERC20CallParameters(trade, options)
+      expect(calldata).toMatchSnapshot()
+      const minOut = SmartRouter.minimumAmountOut(trade, options.slippageTolerance)
+
+      expect(BigInt(value)).toEqual(0n)
+      // expect(calldata).toMatchSnapshot()
+
+      const decodedCommands = decodeUniversalCalldata(calldata)
+
+      expect(decodedCommands[0].command).toEqual(CommandType[CommandType.INFI_SWAP])
+      expect(decodedCommands[0].args.length).toEqual(0)
+      const actions = decodedCommands[0].actions!
+
+      // CL_SWAP_EXACT_IN_SINGLE
+      expect(actions[0].action).toEqual(ACTIONS[ACTIONS.CL_SWAP_EXACT_IN_SINGLE])
+      expect(actions[0].args[0].name).toEqual('params')
+      const encoded = actions[0].args[0].value as any
+      const poolKey = decodePoolKey(encoded.poolKey, 'CL')
+      expect(poolKey.currency0).toEqual(currencyAddressInfinity(inputAmount.currency))
+      expect(poolKey.currency1).toEqual(currencyAddressInfinity(outputAmount.currency))
+
+      // SETTLE
+      testInfinitySettleAction(actions[1], ETHER, amountIn, true)
+
+      // TAKE
+      testInfinityTakeAction(actions[2], CAKE, MSG_SENDER, ACTION_CONSTANTS.OPEN_DELTA)
+    })
+
     it('should encode a single exactInput CAKE->ETH CL swap oneForZero', async () => {
       const inputAmount = CurrencyAmount.fromRawAmount(CAKE, 10000n)
       const outputAmount = CurrencyAmount.fromRawAmount(ETHER, 50n)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `payerIsUser` functionality in the `PancakeSwap Universal Router SDK`, including adding unit tests and refactoring existing code to improve clarity and maintainability.

### Detailed summary
- Added unit test for `payerIsUser` in various swap scenarios.
- Refactored `getPoolKey.ts` to destructure `chainId`.
- Updated `TradePlanner.ts` to use `outAmount.quotient` directly.
- Modified `parseSwapTradeContext.ts` to set `swap.payerIsUser` from context options.
- Changed `PancakeSwapUniversalRouter.ts` to handle options more consistently.
- Removed unused variables and imports in test files.
- Added new tests for encoding swaps with `payerIsUser = false`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->