### PR TITLE
chore: remove zkSync quicknode

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -136,7 +136,6 @@ export const PUBLIC_NODES: Record<ChainId, string[] | readonly string[]> = {
   ],
   [ChainId.ZKSYNC]: [
     ...zkSync.rpcUrls.default.http,
-    process.env.NEXT_PUBLIC_QUICK_NODE_ZKSYNC || '',
     getNodeRealUrl(ChainId.ZKSYNC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH) || '',
   ].filter(Boolean),
   [ChainId.ZKSYNC_TESTNET]: zksyncSepoliaTestnet.rpcUrls.default.http,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `nodes.ts` configuration to enhance the handling of the `ChainId.ZKSYNC` node URLs by incorporating environment variables and a function call to ensure valid URLs.

### Detailed summary
- Modified the array for `ChainId.ZKSYNC` to include:
  - The `NEXT_PUBLIC_QUICK_NODE_ZKSYNC` environment variable.
  - The result of `getNodeRealUrl(ChainId.ZKSYNC, process.env.NEXT_PUBLIC_NODE_REAL_API_ETH)`.
- Retained the existing configuration for `ChainId.ZKSYNC_TESTNET`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->