### PR TITLE
fix: update cache validation logic

### DIFF
--- a/packages/utils/__tests__/lru.test.ts
+++ b/packages/utils/__tests__/lru.test.ts
@@ -76,4 +76,28 @@ describe('cacheByLRU', () => {
     await expect(cachedFn()).rejects.toThrow('Failed')
     expect(errorFn).toBeCalledTimes(2)
   })
+
+  it('should use old epoch cache if has same contentCacheKey', async () => {
+    const cachedFn = cacheByLRU(testFn, { ttl, maxAge: ttl * 10 })
+
+    const res1 = cachedFn(10)
+    vi.runAllTimers()
+    expect(await res1).toBe(20)
+    expect(testFn).toBeCalledTimes(1)
+
+    vi.advanceTimersByTime(ttl * 2)
+
+    const res2 = cachedFn(10)
+    vi.runAllTimers()
+    expect(await res2).toBe(20)
+    expect(testFn).toBeCalledTimes(2)
+
+    // advance time to test old epoch reuse
+    vi.advanceTimersByTime(ttl)
+
+    const res3 = cachedFn(10)
+    vi.runAllTimers()
+    expect(await res3).toBe(20)
+    expect(testFn).toBeCalledTimes(3) // Should trigger re-fetch but return old epoch cache immediately
+  })
 })

--- a/packages/utils/__tests__/lru.test.ts
+++ b/packages/utils/__tests__/lru.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cacheByLRU } from '../cacheByLRU'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('cacheByLRU', () => {
+  const ttl = 100
+  const testFn = vi.fn(async (x: number) => {
+    await sleep(10)
+    return x * 2
+  })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    testFn.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should cache the result of the function', async () => {
+    const cachedFn = cacheByLRU(testFn, { ttl })
+
+    const res1 = cachedFn(2)
+    vi.runAllTimers()
+    expect(await res1).toBe(4)
+    expect(testFn).toBeCalledTimes(1)
+
+    const res2 = cachedFn(2)
+    vi.runAllTimers()
+    expect(await res2).toBe(4)
+    expect(testFn).toBeCalledTimes(1) // Cached result
+  })
+
+  it('should revalidate cache after TTL', async () => {
+    const cachedFn = cacheByLRU(testFn, { ttl })
+
+    const res1 = cachedFn(3)
+    vi.runAllTimers()
+    expect(await res1).toBe(6)
+    expect(testFn).toBeCalledTimes(1)
+
+    vi.advanceTimersByTime(ttl + 1)
+
+    const res2 = cachedFn(3)
+    vi.runAllTimers()
+    expect(await res2).toBe(6)
+    expect(testFn).toBeCalledTimes(2) // Revalidated
+  })
+
+  it('should use isValid to invalidate cache', async () => {
+    const isValid = (result: number) => result !== 0
+    const cachedFn = cacheByLRU(async (x) => 0, { ttl, isValid })
+
+    const res1 = cachedFn(4)
+    vi.runAllTimers()
+    expect(await res1).toBe(0)
+
+    const res2 = cachedFn(4)
+    vi.runAllTimers()
+    expect(await res2).toBe(0)
+    expect(testFn).toBeCalledTimes(0) // Not cached due to invalid result
+  })
+
+  it('should handle promise rejection gracefully', async () => {
+    const errorFn = vi.fn(async () => {
+      throw new Error('Failed')
+    })
+    const cachedFn = cacheByLRU(errorFn, { ttl })
+
+    await expect(cachedFn()).rejects.toThrow('Failed')
+    expect(errorFn).toBeCalledTimes(1)
+
+    // Retry after rejection
+    await expect(cachedFn()).rejects.toThrow('Failed')
+    expect(errorFn).toBeCalledTimes(2)
+  })
+})

--- a/packages/utils/cacheByLRU.ts
+++ b/packages/utils/cacheByLRU.ts
@@ -34,6 +34,19 @@ type CacheOptions<T extends AsyncFunction<any>> = {
   maxAge?: number
 }
 
+function defaultIsValid(val: any) {
+  if (typeof val === 'undefined' || val === '') {
+    return false
+  }
+  if (Array.isArray(val)) {
+    return val.length > 0
+  }
+  if (typeof val === 'object') {
+    return Object.keys(val).length > 0
+  }
+  return true
+}
+
 function calcCacheKey(args: any[], epoch: number) {
   const json = stringify(args)
   const r = keccak256(`0x${json}@${epoch}`)
@@ -130,7 +143,7 @@ export const cacheByLRU = <T extends AsyncFunction<any>>(
             cache.delete(cacheKey)
             return
           }
-          if (isValid && !isValid(result)) {
+          if (!(isValid || defaultIsValid)(result)) {
             cache.delete(cacheKey)
             return
           }

--- a/packages/utils/cacheByLRU.ts
+++ b/packages/utils/cacheByLRU.ts
@@ -11,9 +11,9 @@ interface CacheItem {
 }
 
 interface Epoch {
-  id: string
   createTime: number
   cacheKey: string
+  contentCacheKey: string
 }
 
 // Type definitions for the cache.
@@ -100,6 +100,9 @@ export const cacheByLRU = <T extends AsyncFunction<any>>(
     const halfTTS = epoch % 1 > 0.5
     const epochId = Math.floor(epoch)
 
+    // Uniq cache ke related to content
+    const contentCacheKey = calcCacheKey(keyFunction(args), 0)
+
     const cacheForEpoch = (epochId: number) => {
       const cacheKey = calcCacheKey(keyFunction(args), epochId)
       if (cache.has(cacheKey)) {
@@ -114,9 +117,9 @@ export const cacheByLRU = <T extends AsyncFunction<any>>(
         epochId,
       }
       epochs.push({
-        id: cacheKey,
         createTime: item.createTime,
         cacheKey,
+        contentCacheKey,
       })
       item.promise = ensurePersist(item, cacheKey)
       cache.set(cacheKey, item)
@@ -177,6 +180,9 @@ export const cacheByLRU = <T extends AsyncFunction<any>>(
     for (let i = epochs.length - 2, j = 5; i >= 0 && j > 0; i--, j--) {
       const epoch = epochs[i]
       if (maxAge && epoch.createTime + maxAge < Date.now()) {
+        continue
+      }
+      if (epoch.contentCacheKey !== contentCacheKey) {
         continue
       }
       const epochCache = cache.get(epoch.cacheKey)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `cacheByLRU` utility by adding a `contentCacheKey` to the `Epoch` interface and implementing a `defaultIsValid` function to improve cache validation logic. It also introduces new tests to ensure the functionality works as intended.

### Detailed summary
- Added `contentCacheKey` to the `Epoch` interface.
- Implemented `defaultIsValid` function for better cache validation.
- Updated cache logic to use `defaultIsValid`.
- Added tests for caching behavior, including:
  - Caching results.
  - Revalidating cache after TTL.
  - Invalidating cache based on custom `isValid` function.
  - Gracefully handling promise rejections.
  - Using old epoch cache if `contentCacheKey` matches.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->