### PR TITLE
fix: jupiter build fail

### DIFF
--- a/packages/jupiter-terminal/scripts/build.sh
+++ b/packages/jupiter-terminal/scripts/build.sh
@@ -3,6 +3,7 @@
 # Create temp directory for Jupiter terminal
 TEMP_DIR="temp-jupiter"
 BUNDLE_DEST="./dist"
+COMMIT="34f8c0a3160e493dee4ecc22d5effbc1506c5c11"
 
 # 1. Clone and prepare Jupiter terminal repo
 if [ -d "$TEMP_DIR" ]; then
@@ -11,7 +12,8 @@ fi
 git clone --depth 1 --branch main "https://${GITHUB_TOKEN}@github.com/jup-ag/terminal.git" $TEMP_DIR
 cd $TEMP_DIR
 git reset --hard origin/main
-git checkout 34f8c0a3160e493dee4ecc22d5effbc1506c5c11
+git fetch origin $COMMIT
+git reset --hard $COMMIT
 
 # 2. Copy our customized files
 cd ../


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `build.sh` script for the `jupiter-terminal` project to fetch a specific commit more efficiently. It replaces a `git checkout` command with `git fetch` and `git reset`, improving the process of preparing the terminal repository.

### Detailed summary
- Added a new variable `COMMIT` to store the commit hash.
- Replaced `git checkout` with `git fetch` followed by `git reset --hard` to check out the specified commit.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->