### PR TITLE
feat: network switcher

### DIFF
--- a/apps/solana/src/components/AppLayout/AppNavLayout.tsx
+++ b/apps/solana/src/components/AppLayout/AppNavLayout.tsx
@@ -8,6 +8,7 @@ import React, { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Desktop, Mobile } from '../MobileDesktop'
+import { NetworkSwitcher } from '../NetworkSwitcher'
 import SolWallet from '../SolWallet'
 import { MobileBottomNavbar } from './MobileBottomNavbar'
 import { ColorThemeSettingField } from './components/ColorThemeSettingField'
@@ -72,6 +73,7 @@ function AppNavLayout({
         <Flex gap={[0.5, 2]} align="center">
           <PriorityButton />
           <SettingsMenu />
+          <NetworkSwitcher />
           <SolWallet />
         </Flex>
       </HStack>

--- a/apps/solana/src/components/NetworkSwitcher.tsx
+++ b/apps/solana/src/components/NetworkSwitcher.tsx
@@ -1,0 +1,77 @@
+import { APEX_DOMAIN, ASSET_CDN } from '@/utils/config/endpoint'
+import { useIsMounted } from '@pancakeswap/hooks'
+import { Box, Text, UserMenu, UserMenuDivider, UserMenuItem } from '@pancakeswap/uikit'
+
+import { APTOS_MENU } from '@/utils/config/chains'
+import Image from 'next/image'
+import { useTranslation } from 'react-i18next'
+
+const evmChains = [
+  { id: 56, name: 'BNB Chain', chainName: 'bsc' },
+  { id: 1, name: 'Ethereum', chainName: 'eth' },
+  { id: 324, name: 'zkSync Era', chainName: 'zkSync' },
+  { id: 1101, name: 'Polygon zkEVM', chainName: 'polygonZkEVM' },
+  { id: 42161, name: 'Arbitrum One', chainName: 'arb' },
+  { id: 59144, name: 'Linea', chainName: 'linea' },
+  { id: 8453, name: 'Base', chainName: 'base' },
+  { id: 204, name: 'opBNB Mainnet', chainName: 'opBNB' },
+  { id: 10143, name: 'Monad Testnet', chainName: 'monad' }
+]
+
+const NON_EVM_CHAINS = [APTOS_MENU]
+
+const NetworkSelect = () => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <Box px="16px" py="8px">
+        <Text color="textSubtle">{t('Select a Network')}</Text>
+      </Box>
+      <UserMenuDivider />
+      {evmChains.map((chain) => (
+        <UserMenuItem
+          key={chain.id}
+          style={{ justifyContent: 'flex-start' }}
+          as="a"
+          target="_blank"
+          href={`${APEX_DOMAIN}?chain=${chain.chainName}`}
+        >
+          <Image src={`${ASSET_CDN}/web/chains/${chain.id}.png`} width={24} height={24} unoptimized alt={`chain-${chain.id}`} />
+          <Text color="text" pl="12px">
+            {chain.name}
+          </Text>
+        </UserMenuItem>
+      ))}
+      {NON_EVM_CHAINS.map((chain) => (
+        <UserMenuItem key={chain.id} style={{ justifyContent: 'flex-start' }} as="a" target="_blank" href={chain.link}>
+          <Image src={chain.image} width={24} height={24} unoptimized alt={`chain-${chain.id}`} />
+          <Text color="text" pl="12px">
+            {chain.name}
+          </Text>
+        </UserMenuItem>
+      ))}
+    </>
+  )
+}
+
+export const NetworkSwitcher = () => {
+  const isMounted = useIsMounted()
+
+  return (
+    <UserMenu
+      mr="8px"
+      variant="default"
+      avatarSrc="https://tokens.pancakeswap.finance/images/symbol/sol.png"
+      placement="bottom"
+      text={
+        <>
+          <Box display={['none', null, null, null, null, 'block']}>Solana</Box>
+          <Box display={['block', null, null, null, null, 'none']}>SOL</Box>
+        </>
+      }
+    >
+      {() => <NetworkSelect />}
+    </UserMenu>
+  )
+}

--- a/apps/solana/src/utils/config/chains.ts
+++ b/apps/solana/src/utils/config/chains.ts
@@ -1,0 +1,6 @@
+export const APTOS_MENU = {
+  id: 1,
+  name: 'Aptos',
+  link: process.env.APTOS_SWAP_PAGE ?? 'https://aptos.pancakeswap.finance/swap',
+  image: 'https://tokens.pancakeswap.finance/images/symbol/apt.png'
+}

--- a/apps/solana/src/utils/config/endpoint.ts
+++ b/apps/solana/src/utils/config/endpoint.ts
@@ -1,5 +1,5 @@
 export const ASSET_CDN = process.env.NEXT_PUBLIC_ASSET_CDN || 'https://assets.pancakeswap.finance'
-
+export const APEX_DOMAIN = process.env.NEXT_PUBLIC_APEX_URL || 'https://pancakeswap.finance'
 const parseRPCConf = () => {
   const fallback = [
     {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new network configuration options and enhances the user interface by adding a `NetworkSwitcher` component that allows users to select different blockchain networks, including EVM and non-EVM chains.

### Detailed summary
- Added `APEX_DOMAIN` constant in `endpoint.ts` for the base URL.
- Introduced `APTOS_MENU` object in `chains.ts` for Aptos network details.
- Integrated `NetworkSwitcher` component in `AppNavLayout.tsx`.
- Created `NetworkSelect` function in `NetworkSwitcher.tsx` to display network options.
- Added support for several EVM chains in `NetworkSwitcher.tsx`.
- Included Aptos as a non-EVM chain in the network selection.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->