### PR TITLE
fix: add harvest button to close position if it have reward

### DIFF
--- a/apps/web/src/views/PoolDetail/components/MyPositions.tsx
+++ b/apps/web/src/views/PoolDetail/components/MyPositions.tsx
@@ -883,7 +883,13 @@ const MyInfinityCLPPositions: React.FC<{
             {t('closed')}
           </Text>
           {positions?.[PositionFilter.Closed]?.map((position) => {
-            return <InfinityCLPositionItem key={position.tokenId} data={position} />
+            return (
+              <InfinityCLPositionItem
+                key={position.tokenId}
+                data={position}
+                action={<InfinityPositionActions pos={position} positionList={infinityPositions} />}
+              />
+            )
           })}
         </AutoColumn>
       ) : null}

--- a/apps/web/src/views/universalFarms/components/PositionItem/PositionInfo.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/PositionInfo.tsx
@@ -233,7 +233,7 @@ const Earnings: React.FC<{ earningsAmount?: number; earningsBusd?: number }> = (
 }) => {
   const { t } = useTranslation()
   return (
-    earningsBusd > 0 && (
+    earningsAmount > 0 && (
       <Row gap="8px">
         <DetailInfoLabel>
           {t('CAKE earned')}: {earningsAmount} (~${formatBalance(earningsBusd)})


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the display of earnings in the `PositionItem` and enhancing the rendering of `InfinityCLPositionItem` in the `MyPositions` component.

### Detailed summary
- In `PositionInfo.tsx`, changed the condition from `earningsBusd > 0` to `earningsAmount > 0` for rendering.
- In `MyPositions.tsx`, modified the return statement to format `InfinityCLPositionItem` with additional props, including `action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->