### PR TITLE
fix: bin position status

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/infinity/getAccountInfinityBinPositions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/infinity/getAccountInfinityBinPositions.ts
@@ -156,6 +156,10 @@ export const parseBinPositions = async (rows: Rows, chainId: number): Promise<In
     const liquidity = row.reserveOfBins.reduce((acc, bin) => acc + BigInt(bin.userSharesOfBin), 0n)
     const activeLiquidity = activeBin ? BigInt(activeBin.userSharesOfBin ?? 0) : 0n
 
+    if (liquidity === 0n) {
+      status = POSITION_STATUS.CLOSED
+    }
+
     return {
       chainId,
       protocol: Protocol.InfinityBIN,

--- a/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountInfinityBinPositions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/hooks/useAccountInfinityBinPositions.ts
@@ -1,5 +1,5 @@
 import { useQueries, useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { FAST_INTERVAL, QUERY_SETTINGS_IMMUTABLE, SLOW_INTERVAL } from 'config/constants'
+import { QUERY_SETTINGS_IMMUTABLE, SLOW_INTERVAL } from 'config/constants'
 import { usePositionsWithFarming } from 'hooks/infinity/useIsFarming'
 import { useCallback, useMemo } from 'react'
 import { useUserAddedTokensByChainIds } from 'state/user/hooks/useUserAddedTokens'
@@ -18,7 +18,8 @@ export const useAccountInfinityBinPositions = (account: Address | undefined, cha
         queryKey: ['account-all-infinity-bin-position', chainId, account, latestTxReceipt?.blockHash],
         queryFn: () => getAccountInfinityBinPositionsWithFallback(chainId, account!, userAddedTokens[chainId]),
         enabled: !!account && !!chainId,
-        refetchInterval: FAST_INTERVAL,
+        staleTime: SLOW_INTERVAL,
+        refetchInterval: SLOW_INTERVAL,
         ...QUERY_SETTINGS_IMMUTABLE,
       } satisfies UseQueryOptions<InfinityBinPositionDetail[]>
     })

--- a/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
@@ -85,7 +85,7 @@ export const InfinityBinPosition = () => {
         ) : null}
         <Card style={{ maxWidth: '800px' }} mx="auto">
           <PositionHeader
-            isFarming={isFarming}
+            isFarming={isFarming && !isRemoved}
             isRemoved={isRemoved}
             protocol={Protocol.InfinityBIN}
             poolId={poolId}

--- a/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
@@ -61,6 +61,10 @@ export const InfinityBinPosition = () => {
     return amount0.add(amount1)
   }, [price0, price1, reserve0, reserve1])
 
+  const isRemoved = useMemo(() => {
+    return reserve0?.equalTo(0) && reserve1?.equalTo(0)
+  }, [reserve0, reserve1])
+
   // if (!binPool || !position) {
   if (!binPool) {
     return <PageLoader />
@@ -82,7 +86,7 @@ export const InfinityBinPosition = () => {
         <Card style={{ maxWidth: '800px' }} mx="auto">
           <PositionHeader
             isFarming={isFarming}
-            isRemoved={false}
+            isRemoved={isRemoved}
             protocol={Protocol.InfinityBIN}
             poolId={poolId}
             currency0={binPool?.token0}

--- a/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
@@ -289,7 +289,7 @@ export const InfinityCLPosition = () => {
                 <PositionHeader
                   isOwner={isOwnNFT}
                   isOutOfRange={!inRange}
-                  isFarming={isFarming}
+                  isFarming={isFarming && !removed}
                   protocol={Protocol.InfinityCLAMM}
                   currency0={currency0}
                   currency1={currency1}

--- a/apps/web/src/views/universalFarms/components/PositionItem/InfinityBinPositionItem.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/InfinityBinPositionItem.tsx
@@ -98,7 +98,7 @@ export const InfinityBinPositionItem = memo(
         currency0={currency0}
         currency1={currency1}
         outOfRange={data.status === POSITION_STATUS.INACTIVE}
-        removed={false}
+        removed={data.status === POSITION_STATUS.CLOSED}
         fee={pool?.feeTier ?? 0}
         feeTierBase={1_000_000}
         protocol={data.protocol}

--- a/apps/web/src/views/universalFarms/hooks/useInfinityPositions.tsx
+++ b/apps/web/src/views/universalFarms/hooks/useInfinityPositions.tsx
@@ -1,6 +1,6 @@
-import intersection from 'lodash/intersection'
 import { ALL_PROTOCOLS, Protocol } from '@pancakeswap/farms'
 import { INetworkProps, ITokenProps, toTokenValue } from '@pancakeswap/widgets-internal'
+import intersection from 'lodash/intersection'
 import { useCallback, useMemo } from 'react'
 import { getKeyForPools, useAccountInfinityBinPositions, useAccountInfinityCLPositions } from 'state/farmsV4/hooks'
 import {
@@ -8,8 +8,8 @@ import {
   InfinityCLPositionDetail,
   POSITION_STATUS,
 } from 'state/farmsV4/state/accountPositions/type'
-import { isInfinityProtocol } from 'utils/protocols'
 import { getHookByAddress } from 'utils/getHookByAddress'
+import { isInfinityProtocol } from 'utils/protocols'
 import { usePoolFeatureAndType } from 'views/AddLiquiditySelector/hooks/usePoolTypeQuery'
 import { useAccount } from 'wagmi'
 import { InfinityPositionActions } from '../components/PositionActions/InfinityPositionActions'
@@ -48,7 +48,10 @@ export const useInfinityPositionItems = ({
       if (!reward) {
         return false
       }
-      return !(pos.protocol === Protocol.InfinityCLAMM ? reward[Number(pos.tokenId)] ?? true : reward ?? true)
+
+      if (pos.protocol === Protocol.InfinityCLAMM) return false
+
+      return !(reward ?? true)
     },
     [positionEarningAmount],
   )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of position statuses and farming logic in the Infinity protocol components. It introduces new checks for position states and adjusts how farming status is determined based on liquidity and removal conditions.

### Detailed summary
- Updated `isFarming` logic to consider removal status.
- Added check for `liquidity` to set `status` to `CLOSED`.
- Changed `removed` property to reflect `CLOSED` status.
- Introduced `isRemoved` calculation based on `reserve0` and `reserve1`.
- Adjusted the `useAccountInfinityBinPositions` hook to modify refetch intervals.
- Enhanced default position handling in `MyInfinityBinPositions` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->