### PR TITLE
fix: use router push

### DIFF
--- a/apps/web/src/views/universalFarms/components/AddLiquidityButton.tsx
+++ b/apps/web/src/views/universalFarms/components/AddLiquidityButton.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { AddIcon, Box, BoxProps, Button, ButtonProps } from '@pancakeswap/uikit'
+import { useRouter } from 'next/router'
+import { useCallback } from 'react'
 
 export const AddLiquidityButton: React.FC<ButtonProps & { wrapperProps?: BoxProps; to?: string }> = ({
   wrapperProps,
@@ -7,10 +9,13 @@ export const AddLiquidityButton: React.FC<ButtonProps & { wrapperProps?: BoxProp
   ...props
 }) => {
   const { t } = useTranslation()
+  const router = useRouter()
+  const handleClick = useCallback(() => {
+    router.push(to)
+  }, [])
   return (
     <Box width="100%" {...wrapperProps}>
-      {/* @ts-ignore */}
-      <Button as="a" href={to} endIcon={<AddIcon color="invertedContrast" />} {...props}>
+      <Button onClick={handleClick} endIcon={<AddIcon color="invertedContrast" />} {...props}>
         {t('Add Liquidity')}
       </Button>
     </Box>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `AddLiquidityButton` component to use client-side navigation with `next/router` instead of a traditional anchor link. This change improves performance and user experience by preventing full page reloads.

### Detailed summary
- Imported `useRouter` and `useCallback` from `next/router` and `react`.
- Added a `handleClick` function using `useCallback` to handle button clicks.
- Replaced the `<Button>`'s `href` prop with an `onClick` event that calls `router.push(to)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->