### PR TITLE
fix: add error modal

### DIFF
--- a/apps/web/src/hooks/infinity/useAddCLLiquidity.tsx
+++ b/apps/web/src/hooks/infinity/useAddCLLiquidity.tsx
@@ -28,6 +28,7 @@ import { isUserRejected } from 'utils/sentry'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { getViemClients } from 'utils/viem'
 import { type Address, type Hex } from 'viem'
+import { ErrorModal } from 'views/AddLiquidityInfinity/components/ErrorModal'
 import { type UseSendTransactionReturnType, useSendTransaction } from 'wagmi'
 
 export type AddLiquidityParams = {
@@ -186,6 +187,12 @@ export const useAddCLPoolAndPosition = (
     true,
     'infinity-cl-add-liquidity-modal',
   )
+  const [onPresentErrorModal, onDismissErrorModal] = useModal(
+    <ErrorModal title={t('Add Liquidity')} subTitle={txnErrorMessage} />,
+    true,
+    true,
+    'infinity-cl-add-liquidity-error-modal',
+  )
 
   const addCLLiquidity = useCallback(
     (params: AddLiquidityParams) => {
@@ -216,6 +223,7 @@ export const useAddCLPoolAndPosition = (
         onDismissConfirmationModal()
         if (!isUserRejected(error)) {
           setTxnErrorMessage(transactionErrorToUserReadableMessage(error, t))
+          onPresentErrorModal()
         }
         onError?.(error)
       }

--- a/apps/web/src/hooks/infinity/usePool.ts
+++ b/apps/web/src/hooks/infinity/usePool.ts
@@ -2,7 +2,6 @@ import { ChainId } from '@pancakeswap/chains'
 import { BinPool, Pool as CLPool, findHook, PoolType } from '@pancakeswap/infinity-sdk'
 import { Token } from '@pancakeswap/swap-sdk-core'
 import { useQuery } from '@tanstack/react-query'
-import { QUERY_SETTINGS_IMMUTABLE } from 'config/constants'
 import { useCurrencyByChainId } from 'hooks/Tokens'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { PoolState } from 'hooks/v3/types'
@@ -29,7 +28,10 @@ export const usePoolById = <
     queryFn: () => fetchPoolInfo(poolId!, chainId),
     enabled: isPoolId(poolId) && !!chainId,
     retry: false,
-    ...QUERY_SETTINGS_IMMUTABLE,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    staleTime: 5 * 1000,
   })
 
   const currencyA = useCurrencyByChainId(data?.currency0, chainId) ?? undefined

--- a/apps/web/src/views/AddLiquidityInfinity/components/ErrorModal.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/ErrorModal.tsx
@@ -1,0 +1,25 @@
+import { AutoColumn, Box, ColumnCenter, ErrorIcon, Modal, ModalProps, Text } from '@pancakeswap/uikit'
+
+export const ErrorModal: React.FC<
+  {
+    title?: React.ReactNode
+    subTitle?: React.ReactNode
+  } & ModalProps
+> = ({ title, subTitle, ...props }) => {
+  return (
+    <Modal title={title} headerBackground="transparent" headerBorderColor="transparent" {...props}>
+      <Box width="100%">
+        <Box mb="16px" padding="16px">
+          <ColumnCenter>
+            <ErrorIcon strokeWidth={0.5} width="80px" color="failure" />
+          </ColumnCenter>
+        </Box>
+        <AutoColumn gap="12px" justify="center">
+          <Text bold textAlign="center" color="failure">
+            {subTitle}
+          </Text>
+        </AutoColumn>
+      </Box>
+    </Modal>
+  )
+}

--- a/apps/web/src/views/CreateLiquidityPool/hooks/useAddBinLiquidity.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/hooks/useAddBinLiquidity.tsx
@@ -23,6 +23,7 @@ import { isUserRejected } from 'utils/sentry'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { getViemClients } from 'utils/viem'
 import { type Address, Hash, type Hex, PublicClient, stringify } from 'viem'
+import { ErrorModal } from 'views/AddLiquidityInfinity/components/ErrorModal'
 import { type UseSendTransactionReturnType, usePublicClient, useSendTransaction } from 'wagmi'
 
 export type AddBinLiquidityParams = {
@@ -164,6 +165,12 @@ export const useAddBinLiquidity = (
     true,
     'infinity-bin-add-liquidity-modal',
   )
+  const [onPresentErrorModal, onDismissErrorModal] = useModal(
+    <ErrorModal title={t('Add Liquidity')} subTitle={txnErrorMessage} />,
+    true,
+    true,
+    'infinity-bin-add-liquidity-error-modal',
+  )
 
   const addLiquidity = useCallback(
     (params: AddBinLiquidityParams) => {
@@ -198,6 +205,7 @@ export const useAddBinLiquidity = (
         onDismissConfirmationModal()
         if (!isUserRejected(error)) {
           setTxnErrorMessage(transactionErrorToUserReadableMessage(error, t))
+          onPresentErrorModal()
         }
         onError?.(error)
       }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling and user feedback in liquidity-related components by introducing an `ErrorModal` and updating the `usePoolById`, `useAddCLPoolAndPosition`, and `useAddBinLiquidity` hooks to utilize this modal for displaying transaction errors.

### Detailed summary
- Added `ErrorModal` component in `ErrorModal.tsx`.
- Updated `usePoolById` in `usePool.ts` to modify query settings.
- Integrated `ErrorModal` in `useAddCLLiquidity.tsx` for transaction error handling.
- Integrated `ErrorModal` in `useAddBinLiquidity.tsx` for transaction error handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->