### PR TITLE
chore: Remove vecake from apr breakdown desc and sync aprs

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolAprButton/AprBreakdownModal.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/AprBreakdownModal.tsx
@@ -14,14 +14,11 @@ export const APRBreakdownModal = ({ isOpen, onDismiss, closeOnOverlayClick, ...p
   const { additionalDetails, primaryMsg } = useMemo(
     () => ({
       primaryMsg: t(
-        'User have to obtain veCAKE and this position must be staking in farm to apply the combined APR with boosted farming rewards.',
+        'Calculated at the current rates with historical trading volume data, and subject to change based on various external variables.',
       ),
-      additionalDetails: [
-        t(
-          'Calculated at the current rates with historical trading volume data, and subject to change based on various external variables.',
-        ),
-        t('This figure is provided for your convenience only, and by no means represents guaranteed returns.'),
-      ],
+      additionalDetails: t(
+        'This figure is provided for your convenience only, and by no means represents guaranteed returns.',
+      ),
     }),
     [t],
   )

--- a/apps/web/src/views/universalFarms/components/PoolAprButton/AprButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/AprButton.tsx
@@ -67,7 +67,7 @@ const AprButtonText = forwardRef<HTMLElement, AprButtonTextProps>(({ baseApr, ha
         </TooltipText>
       </FlexGap>
     ),
-    [baseApr],
+    [baseApr, hasFarm],
   )
 
   if (typeof baseApr === 'undefined') {

--- a/apps/web/src/views/universalFarms/components/PoolAprButton/PoolGlobalAprButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/PoolGlobalAprButton.tsx
@@ -54,7 +54,7 @@ export const PoolGlobalAprButton: React.FC<PoolGlobalAprButtonProps> = ({ pool, 
     return (
       <PoolAprButton
         pool={pool}
-        lpApr={parseFloat(lpApr) ?? 0}
+        lpApr={parseFloat(lpApr) || 0}
         cakeApr={cakeApr}
         merklApr={parseFloat(merklApr) ?? 0}
       />
@@ -65,7 +65,7 @@ export const PoolGlobalAprButton: React.FC<PoolGlobalAprButtonProps> = ({ pool, 
     <>
       <PoolAprButton
         pool={pool}
-        lpApr={parseFloat(lpApr) ?? 0}
+        lpApr={parseFloat(lpApr) || 0}
         cakeApr={cakeApr}
         merklApr={parseFloat(merklApr) ?? 0}
         onAPRTextClick={APRBreakdownModalState.onOpen}

--- a/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
@@ -21,16 +21,6 @@ import { useUserPancakePicks } from 'state/user/hooks/useUserPancakePicks'
 import styled from 'styled-components'
 import { FarmFlexWrapper, FarmH1, FarmH2 } from 'views/Farms/styled'
 
-const StyledBox = styled(Box)`
-  justify-items: right;
-  margin-bottom: 24px;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    justify-items: center;
-    margin-bottom: 0;
-  }
-`
-
 export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }) => {
   const { t } = useTranslation()
   const { theme } = useTheme()

--- a/apps/web/src/views/universalFarms/components/PositionItem/PositionDebugView.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/PositionDebugView.tsx
@@ -19,7 +19,6 @@ export const PositionDebugView: React.FC<React.PropsWithChildren<{ json: unknown
         )}
       </pre>
     ) : null,
-    {},
   )
 
   if (!isDevelopmentOrPreview) return children

--- a/apps/web/src/views/universalFarms/components/PositionItem/PositionDebugView.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionItem/PositionDebugView.tsx
@@ -3,21 +3,26 @@ import React from 'react'
 import { stringify } from 'viem'
 
 export const PositionDebugView: React.FC<React.PropsWithChildren<{ json: unknown }>> = ({ children, json }) => {
+  const isDevelopmentOrPreview =
+    window?.location?.hostname === 'localhost' || process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview'
+
   const { targetRef, tooltipVisible, tooltip } = useTooltip(
-    <pre>
-      {stringify(
-        json,
-        (k, v) => {
-          if (React.isValidElement(v)) return 'ReactElement'
-          return v
-        },
-        2,
-      )}
-    </pre>,
+    isDevelopmentOrPreview ? (
+      <pre>
+        {stringify(
+          json,
+          (k, v) => {
+            if (React.isValidElement(v)) return 'ReactElement'
+            return v
+          },
+          2,
+        )}
+      </pre>
+    ) : null,
     {},
   )
 
-  if (!(window?.location?.hostname === 'localhost' || process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview')) return children
+  if (!isDevelopmentOrPreview) return children
 
   return (
     <div ref={targetRef}>

--- a/apps/web/src/views/universalFarms/hooks/useAPRBreakdown.ts
+++ b/apps/web/src/views/universalFarms/hooks/useAPRBreakdown.ts
@@ -48,7 +48,7 @@ export const useAPRBreakdown = ({ currency0, currency1, lpApr, cakeApr, tvlUSD: 
         {
           apr: cakeApr.value,
           currency: bscTokens.cake,
-          title: t('CAKE Farm'),
+          title: 'CAKE',
           rewardPerDay: `${farmingRewardPerday} ${bscTokens.cake?.symbol}`,
         },
       ] as IRewardCardProps['rewards'],

--- a/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
+++ b/apps/web/src/views/universalFarms/hooks/usePositionAPR.ts
@@ -194,7 +194,7 @@ export const useV3PositionApr = (pool: PoolInfo, userPosition: PositionDetail) =
       .plus(cakeApr.value ?? BIG_ZERO)
       .plus(parseFloat(cakeApr.value) > 0 ? merklApr : 0)
       .times(userTVLUsd)
-  }, [cakeApr.value, lpApr, merklApr, outOfRange, removed, userPosition.isStaked, userTVLUsd])
+  }, [cakeApr.value, lpApr, merklApr, outOfRange, removed, userTVLUsd])
   const denominator = userTVLUsd
 
   return {

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3207,8 +3207,6 @@
   "Play": "Play",
   "Legacy products": "Legacy products",
   "APR Breakdown": "APR Breakdown",
-  "User have to obtain veCAKE and this position must be staking in farm to apply the combined APR with boosted farming rewards.": "User have to obtain veCAKE and this position must be staking in farm to apply the combined APR with boosted farming rewards.",
-  "CAKE Farm": "CAKE Farm",
   "Pool Feature": "Pool Feature",
   "Swap Now": "Swap Now",
   "Enjoy": "Enjoy",

--- a/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
+++ b/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
@@ -85,7 +85,7 @@ export const RewardCard = ({ rewards }: IRewardCardProps) => {
           <FlexGap alignItems="flex-start" flexDirection="column">
             {apr ? (
               <TooltipText fontSize="16px" bold decorationColor="secondary">
-                {displayApr(parseFloat(apr) ?? 0)}
+                {displayApr(parseFloat(apr) || 0)}
               </TooltipText>
             ) : null}
             <Text fontSize="12px" color="textSubtle">

--- a/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
+++ b/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
@@ -88,7 +88,6 @@ export const RewardCard = ({ rewards }: IRewardCardProps) => {
               <TooltipText fontSize="16px" bold decorationColor="secondary">
                 {`${formatNumber(new BigNumber(apr).times(100), {
                   maxDecimalDisplayDigits: 2,
-                  roundingMode: BigNumber.ROUND_UP,
                 })}%`}
               </TooltipText>
             ) : null}

--- a/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
+++ b/packages/widgets-internal/liquidity/infinity/RewardCard.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from "@pancakeswap/localization";
 import { Currency } from "@pancakeswap/swap-sdk-core";
 import { FlexGap, IColumnsType, TableView, Tag, Text, TooltipText, useTooltip } from "@pancakeswap/uikit";
+import { displayApr } from "@pancakeswap/utils/displayApr";
 import { useMemo } from "react";
 import styled from "styled-components";
-import { formatNumber } from "@pancakeswap/utils/formatNumber";
-import BigNumber from "bignumber.js";
 
 import { CurrencyLogo, DoubleCurrencyLogo } from "../../components/CurrencyLogo";
 
@@ -86,9 +85,7 @@ export const RewardCard = ({ rewards }: IRewardCardProps) => {
           <FlexGap alignItems="flex-start" flexDirection="column">
             {apr ? (
               <TooltipText fontSize="16px" bold decorationColor="secondary">
-                {`${formatNumber(new BigNumber(apr).times(100), {
-                  maxDecimalDisplayDigits: 2,
-                })}%`}
+                {displayApr(parseFloat(apr) ?? 0)}
               </TooltipText>
             ) : null}
             <Text fontSize="12px" color="textSubtle">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving the user interface and functionality of the `PoolAprButton` and related components in the `universalFarms` section, alongside updates to localization and debugging features.

### Detailed summary
- Added `hasFarm` to the `AprButton` component.
- Simplified `title` for the `CAKE Farm` in translations.
- Updated `lpApr` parsing to use `||` instead of `??` in `PoolGlobalAprButton`.
- Enhanced `AprBreakdownModal` messages for clarity.
- Introduced `isDevelopmentOrPreview` check in `PositionDebugView`.
- Replaced `formatNumber` with `displayApr` for APR display in `RewardCard`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->