### PR TITLE
fix: Redeem cake when vault is unlocked

### DIFF
--- a/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
+++ b/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
@@ -6,7 +6,7 @@ import { ASSET_CDN } from 'config/constants/endpoints'
 import { WEEK } from 'config/constants/veCake'
 import { createWriteContractCallback } from 'hooks/createWriteContractCallback'
 import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { useCurrentBlockTimestamp } from 'state/block/hooks'
 import styled from 'styled-components'
@@ -45,7 +45,6 @@ export const VeCakeRedeem: React.FC = () => {
     refetchRevenueShareVeCake,
     refetchRevenueShareCake,
   } = useCakeExitInfo()
-  console.info(nativeCakeLockedAmount)
   const userStaked = lockedCake.gt(0)
   const unlockTimeDisplay = unlockTime ? formatTime(unlockTime) : '-'
 
@@ -142,26 +141,29 @@ export const VeCakeRedeem: React.FC = () => {
   }, [proxyCakeLockedAmount, account, chainId, currentBlockTimestamp, withdrawAll, proxyCakeLockedAmountDisplay, t])
   const [expand, setExpand] = useState(false)
 
-  const buttons = [
-    {
-      key: 'cakepool',
-      handler: handleCakePool,
-      enabled: proxyCakeLockedAmount > 0,
-    },
-    {
-      key: 'vecake',
-      handler: handleVeCake,
-      enabled: nativeCakeLockedAmount > 0,
-    },
-    {
-      key: 'claimall',
-      handler: handleClaim,
-      enabled: userHasRewards,
-    },
-  ]
+  const buttons = useMemo(
+    () => [
+      {
+        key: 'cakepool',
+        handler: handleCakePool,
+        enabled: proxyCakeLockedAmount > 0,
+      },
+      {
+        key: 'vecake',
+        handler: handleVeCake,
+        enabled: nativeCakeLockedAmount > 0,
+      },
+      {
+        key: 'claimall',
+        handler: handleClaim,
+        enabled: userHasRewards,
+      },
+    ],
+    [handleCakePool, proxyCakeLockedAmount, handleVeCake, nativeCakeLockedAmount, handleClaim, userHasRewards],
+  )
 
   const [processing, setProcessing] = useState(false)
-  const handleProcessAll = async () => {
+  const handleProcessAll = useCallback(async () => {
     if (buttons.every((button) => !button.enabled)) return
     setProcessing(true)
 
@@ -177,7 +179,7 @@ export const VeCakeRedeem: React.FC = () => {
     } finally {
       setProcessing(false)
     }
-  }
+  }, [buttons])
 
   const allSettled = buttons.every((button) => !button.enabled)
 

--- a/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
+++ b/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
@@ -59,7 +59,6 @@ export const VeCakeRedeem: React.FC = () => {
 
   const proxyCakeLockedAmountDisplay = useDisplayValue(proxyCakeLockedAmount)
   const nativeCakeDisplay = useDisplayValue(nativeCakeLockedAmount)
-  const cakePoolRewardDisplay = useDisplayValue(cakePoolRewards.plus(veCakeRewards))
 
   const handleClaim = useCallback(async () => {
     if (!account || !chainId || !currentBlockTimestamp) return
@@ -139,7 +138,7 @@ export const VeCakeRedeem: React.FC = () => {
         },
       })
     }
-  }, [proxyCakeLockedAmount, account, chainId, currentBlockTimestamp, withdrawAll])
+  }, [proxyCakeLockedAmount, account, chainId, currentBlockTimestamp, withdrawAll, proxyCakeLockedAmountDisplay, t])
   const [expand, setExpand] = useState(false)
 
   const buttons = [

--- a/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
+++ b/apps/web/src/views/CakeStaking/VeCakeRedeem.tsx
@@ -45,6 +45,7 @@ export const VeCakeRedeem: React.FC = () => {
     refetchRevenueShareVeCake,
     refetchRevenueShareCake,
   } = useCakeExitInfo()
+  console.info(nativeCakeLockedAmount)
   const userStaked = lockedCake.gt(0)
   const unlockTimeDisplay = unlockTime ? formatTime(unlockTime) : '-'
 
@@ -166,8 +167,10 @@ export const VeCakeRedeem: React.FC = () => {
 
     try {
       for (const button of buttons) {
-        // eslint-disable-next-line
-        await button.handler()
+        if (button.enabled) {
+          // eslint-disable-next-line
+          await button.handler()
+        }
       }
     } catch (ex) {
       console.warn(ex)

--- a/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
@@ -13,6 +13,7 @@ export type CakePoolInfo = {
   lockStartTime: bigint
   lockEndTime: bigint
   userBoostedShare: bigint
+  pricePerFullShare: bigint
   locked: boolean
   lockedAmount: bigint
 }
@@ -39,6 +40,7 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         _locked,
         lockedAmount,
       ] = await cakeVaultContract.read.userInfo([account])
+      const pricePerFullShare = await cakeVaultContract.read.getPricePerFullShare()
       const lockEndTimeStr = lockEndTime.toString()
       return {
         shares,
@@ -48,6 +50,7 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         lockStartTime,
         lockEndTime,
         userBoostedShare,
+        pricePerFullShare,
         locked:
           _locked &&
           lockEndTimeStr !== '0' &&

--- a/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
@@ -14,6 +14,8 @@ export type CakePoolInfo = {
   lockEndTime: bigint
   userBoostedShare: bigint
   pricePerFullShare: bigint
+  overdueFee: bigint
+  performanceFee: bigint
   locked: boolean
   isFlexible: boolean
   lockedAmount: bigint
@@ -42,6 +44,8 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         lockedAmount,
       ] = await cakeVaultContract.read.userInfo([account])
       const pricePerFullShare = await cakeVaultContract.read.getPricePerFullShare()
+      const overdueFee = await cakeVaultContract.read.overdueFee()
+      const performanceFee = await cakeVaultContract.read.performanceFee()
       const lockEndTimeStr = lockEndTime.toString()
       return {
         shares,
@@ -51,6 +55,8 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         lockStartTime,
         lockEndTime,
         userBoostedShare,
+        overdueFee,
+        performanceFee,
         pricePerFullShare,
         isFlexible: !_locked,
         locked:

--- a/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
@@ -17,7 +17,6 @@ export type CakePoolInfo = {
   overdueFee: bigint
   performanceFee: bigint
   locked: boolean
-  isFlexible: boolean
   lockedAmount: bigint
 }
 
@@ -58,7 +57,6 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         overdueFee,
         performanceFee,
         pricePerFullShare,
-        isFlexible: !_locked,
         locked:
           _locked &&
           lockEndTimeStr !== '0' &&

--- a/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCakePoolLockInfo.ts
@@ -15,6 +15,7 @@ export type CakePoolInfo = {
   userBoostedShare: bigint
   pricePerFullShare: bigint
   locked: boolean
+  isFlexible: boolean
   lockedAmount: bigint
 }
 
@@ -51,6 +52,7 @@ export const useCakePoolLockInfo = (targetChain?: ChainId) => {
         lockEndTime,
         userBoostedShare,
         pricePerFullShare,
+        isFlexible: !_locked,
         locked:
           _locked &&
           lockEndTimeStr !== '0' &&

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -149,7 +149,7 @@ export const useCakeLockStatus = (
   }, [userInfo])
 
   const proxyCakeLockedAmount = useMemo(() => {
-    if (!cakePoolLockInfo?.locked) {
+    if (cakePoolLockInfo?.isFlexible) {
       const { cakeAsBigNumber } = convertSharesToCake(
         new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
         new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -5,6 +5,8 @@ import { useVeCakeContract } from 'hooks/useContract'
 import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
 import { useAccount } from 'wagmi'
+import { convertSharesToCake } from 'views/Pools/helpers'
+import BigNumber from 'bignumber.js'
 import { CakeLockStatus, CakePoolType } from '../types'
 import { useCakePoolLockInfo } from './useCakePoolLockInfo'
 import { useCheckIsUserAllowMigrate } from './useCheckIsUserAllowMigrate'
@@ -147,10 +149,19 @@ export const useCakeLockStatus = (
   }, [userInfo])
 
   const proxyCakeLockedAmount = useMemo(() => {
+    if (!cakePoolLockInfo?.locked) {
+      const { cakeAsBigNumber } = convertSharesToCake(
+        new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
+        new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
+      )
+      if (!cakePoolLocked || delegated) return BigInt(cakeAsBigNumber.toString())
+
+      return (userInfo?.cakeAmount ?? 0n) + BigInt(cakeAsBigNumber.toString())
+    }
     if (!cakePoolLocked || delegated) return 0n
 
     return userInfo?.cakeAmount ?? 0n
-  }, [cakePoolLocked, delegated, userInfo?.cakeAmount])
+  }, [cakePoolLocked, cakePoolLockInfo, delegated, userInfo?.cakeAmount])
 
   const cakeLockedAmount = useMemo(() => {
     return nativeCakeLockedAmount + proxyCakeLockedAmount

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -7,6 +7,7 @@ import { Address } from 'viem'
 import { useAccount } from 'wagmi'
 import { convertSharesToCake } from 'views/Pools/helpers'
 import BigNumber from 'bignumber.js'
+import { BIG_ZERO } from '@pancakeswap/utils/bigNumber'
 import { CakeLockStatus, CakePoolType } from '../types'
 import { useCakePoolLockInfo } from './useCakePoolLockInfo'
 import { useCheckIsUserAllowMigrate } from './useCheckIsUserAllowMigrate'
@@ -149,11 +150,31 @@ export const useCakeLockStatus = (
   }, [userInfo])
 
   const proxyCakeLockedAmount = useMemo(() => {
-    if (cakePoolLockInfo?.isFlexible) {
-      const { cakeAsBigNumber } = convertSharesToCake(
-        new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
-        new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
-      )
+    if (!cakePoolLockInfo?.locked) {
+      let cakeAsBigNumber
+      if (cakePoolLockInfo?.isFlexible) {
+        cakeAsBigNumber = convertSharesToCake(
+          new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
+          new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
+        )?.cakeAsBigNumber
+      } else {
+        const currentOverdueFee = cakePoolLockInfo?.overdueFee
+          ? new BigNumber(cakePoolLockInfo?.overdueFee?.toString())
+          : BIG_ZERO
+        const currentPerformanceFee = cakePoolLockInfo?.performanceFee
+          ? new BigNumber(cakePoolLockInfo?.performanceFee?.toString())
+          : BIG_ZERO
+        cakeAsBigNumber = convertSharesToCake(
+          new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
+          new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
+          undefined,
+          undefined,
+          currentOverdueFee
+            .plus(currentPerformanceFee)
+            .plus(new BigNumber(cakePoolLockInfo?.userBoostedShare?.toString() ?? 0)),
+        )?.cakeAsBigNumber
+      }
+
       if (!cakePoolLocked || delegated) return BigInt(cakeAsBigNumber.toString())
 
       return (userInfo?.cakeAmount ?? 0n) + BigInt(cakeAsBigNumber.toString())

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -150,7 +150,7 @@ export const useCakeLockStatus = (
   }, [userInfo])
 
   const proxyCakeLockedAmount = useMemo(() => {
-    if (!cakePoolLockInfo?.locked) {
+    if (!cakePoolLocked || delegated) {
       const currentOverdueFee = cakePoolLockInfo?.overdueFee
         ? new BigNumber(cakePoolLockInfo?.overdueFee?.toString())
         : BIG_ZERO
@@ -167,11 +167,8 @@ export const useCakeLockStatus = (
           .plus(new BigNumber(cakePoolLockInfo?.userBoostedShare?.toString() ?? 0)),
       )
 
-      if (!cakePoolLocked || delegated) return BigInt(cakeAsBigNumber.toString())
-
-      return (userInfo?.cakeAmount ?? 0n) + BigInt(cakeAsBigNumber.toString())
+      return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toString() : 0)
     }
-    if (!cakePoolLocked || delegated) return 0n
 
     return userInfo?.cakeAmount ?? 0n
   }, [cakePoolLocked, cakePoolLockInfo, delegated, userInfo?.cakeAmount])

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -151,29 +151,21 @@ export const useCakeLockStatus = (
 
   const proxyCakeLockedAmount = useMemo(() => {
     if (!cakePoolLockInfo?.locked) {
-      let cakeAsBigNumber
-      if (cakePoolLockInfo?.isFlexible) {
-        cakeAsBigNumber = convertSharesToCake(
-          new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
-          new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
-        )?.cakeAsBigNumber
-      } else {
-        const currentOverdueFee = cakePoolLockInfo?.overdueFee
-          ? new BigNumber(cakePoolLockInfo?.overdueFee?.toString())
-          : BIG_ZERO
-        const currentPerformanceFee = cakePoolLockInfo?.performanceFee
-          ? new BigNumber(cakePoolLockInfo?.performanceFee?.toString())
-          : BIG_ZERO
-        cakeAsBigNumber = convertSharesToCake(
-          new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
-          new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
-          undefined,
-          undefined,
-          currentOverdueFee
-            .plus(currentPerformanceFee)
-            .plus(new BigNumber(cakePoolLockInfo?.userBoostedShare?.toString() ?? 0)),
-        )?.cakeAsBigNumber
-      }
+      const currentOverdueFee = cakePoolLockInfo?.overdueFee
+        ? new BigNumber(cakePoolLockInfo?.overdueFee?.toString())
+        : BIG_ZERO
+      const currentPerformanceFee = cakePoolLockInfo?.performanceFee
+        ? new BigNumber(cakePoolLockInfo?.performanceFee?.toString())
+        : BIG_ZERO
+      const { cakeAsBigNumber } = convertSharesToCake(
+        new BigNumber(cakePoolLockInfo?.shares?.toString() ?? 0),
+        new BigNumber(cakePoolLockInfo?.pricePerFullShare?.toString() ?? 0),
+        undefined,
+        undefined,
+        currentOverdueFee
+          .plus(currentPerformanceFee)
+          .plus(new BigNumber(cakePoolLockInfo?.userBoostedShare?.toString() ?? 0)),
+      )
 
       if (!cakePoolLocked || delegated) return BigInt(cakeAsBigNumber.toString())
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useCakePoolLockInfo` and `useVeCakeUserInfo` hooks by adding new properties related to fees and share prices, improving the calculation of locked amounts in the `VeCakeRedeem` component, and optimizing button handling for user interactions.

### Detailed summary
- Added `pricePerFullShare`, `overdueFee`, and `performanceFee` to `useCakePoolLockInfo`.
- Updated the return object of `useCakePoolLockInfo` to include new fee properties.
- Enhanced calculation of `proxyCakeLockedAmount` in `useVeCakeUserInfo` using new fee values.
- Refactored `buttons` in `VeCakeRedeem` to use `useMemo` for performance.
- Changed `handleProcessAll` to check button enabled status before executing handlers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->