### PR TITLE
fix: increase infi cl pool form

### DIFF
--- a/apps/web/src/views/IncreaseLiquidity/hooks/useIncreaseForm.ts
+++ b/apps/web/src/views/IncreaseLiquidity/hooks/useIncreaseForm.ts
@@ -14,12 +14,16 @@ export const useIncreaseForm = ({
   poolKey,
   tickLower,
   tickUpper,
+  outOfRange,
+  invalidRange,
 }: {
   currency0: Currency | undefined
   currency1: Currency | undefined
   poolKey: PoolKey<'CL'> | undefined
   tickLower: number | undefined
   tickUpper: number | undefined
+  outOfRange: boolean
+  invalidRange: boolean
 }) => {
   const poolId = useMemo(() => (poolKey ? getPoolId(poolKey) : undefined), [poolKey])
   const [lastEditCurrency, setLastEditCurrency] = useState<0 | 1>(0)
@@ -53,9 +57,11 @@ export const useIncreaseForm = ({
         return
       }
       setLastEditCurrency(1)
-      setOutputAmountRaw(newAmount1)
+      if (!outOfRange) {
+        setOutputAmountRaw(newAmount1)
+      }
     },
-    [currency0, outputAmountRaw, pool, tickUpper, tickLower],
+    [currency0, outputAmountRaw, pool, tickUpper, tickLower, outOfRange],
   )
 
   const _updateInputAmount = useCallback(
@@ -72,9 +78,11 @@ export const useIncreaseForm = ({
         return
       }
       setLastEditCurrency(0)
-      setInputAmountRaw(newAmount0)
+      if (!outOfRange) {
+        setInputAmountRaw(newAmount0)
+      }
     },
-    [currency1, inputAmountRaw, pool, tickUpper, tickLower],
+    [currency1, inputAmountRaw, pool, tickUpper, tickLower, outOfRange],
   )
 
   const onInputAmountChange = useCallback(

--- a/apps/web/src/views/IncreaseLiquidity/index.tsx
+++ b/apps/web/src/views/IncreaseLiquidity/index.tsx
@@ -109,6 +109,11 @@ export const IncreaseLiquidity = () => {
     poolId,
   } = useExtraInfinityPositionInfo(position)
 
+  const isOutOfRange = useMemo(() => {
+    if (!pool || typeof tickLower === 'undefined' || typeof tickUpper === 'undefined') return false
+    return pool.tickCurrent < tickLower || pool.tickCurrent > tickUpper
+  }, [])
+
   const [manuallyInverted, setManuallyInverted] = useState(false)
   const { priceLower, priceUpper, base } = useInverter({
     priceLower: priceLower_,
@@ -158,6 +163,8 @@ export const IncreaseLiquidity = () => {
     poolKey: position?.poolKey,
     tickLower,
     tickUpper,
+    outOfRange: isOutOfRange,
+    invalidRange,
   })
 
   const parsedAmounts = useMemo(
@@ -173,6 +180,7 @@ export const IncreaseLiquidity = () => {
     currencyB: currency1,
     currencyAAmount: inputAmount,
     currencyBAmount: outputAmount,
+    allowSingleSide: deposit0Disabled !== deposit1Disabled,
   })
 
   const isValid = !(invalidRange || errorMessage)
@@ -230,18 +238,14 @@ export const IncreaseLiquidity = () => {
   )
 
   const handleIncreaseLiquidity = useCallback(async () => {
-    if (
-      !position ||
-      !tokenId ||
-      !pool ||
-      !currency0 ||
-      !currency1 ||
-      !account ||
-      !inputAmount?.quotient ||
-      !outputAmount?.quotient
-    ) {
+    if (!position || !tokenId || !pool || !currency0 || !currency1 || !account) {
       return
     }
+
+    if (deposit0Disabled && inputAmount?.greaterThan(0)) return
+    if (deposit1Disabled && outputAmount?.greaterThan(0)) return
+    if (inputAmount?.equalTo(0) && outputAmount?.equalTo(0)) return
+
     let permit2Signature0: Permit2Signature | undefined
     let permit2Signature1: Permit2Signature | undefined
 
@@ -263,8 +267,8 @@ export const IncreaseLiquidity = () => {
       tickLower: position.tickLower,
       tickUpper: position.tickUpper,
       sqrtPriceX96: pool.sqrtRatioX96,
-      amount0Desired: inputAmount?.quotient,
-      amount1Desired: outputAmount?.quotient,
+      amount0Desired: inputAmount?.quotient ?? 0n,
+      amount1Desired: outputAmount?.quotient ?? 0n,
       recipient: account,
       amount0Max,
       amount1Max,
@@ -314,6 +318,11 @@ export const IncreaseLiquidity = () => {
         <Text>{t('Increase Liquidity')}</Text>
       </NavBreadcrumbs>
 
+      <span>tickCurrent: {pool?.tickCurrent}</span>
+      <span>tickLower: {position?.tickLower}</span>
+      <span>tickUpper: {position?.tickUpper}</span>
+      <span>outOfRange: {isOutOfRange ? 'Yes' : 'No'}</span>
+
       <StyledCard mt="24px" mx="auto">
         <CardBody>
           <Flex alignItems="center">
@@ -324,6 +333,7 @@ export const IncreaseLiquidity = () => {
               protocol={Protocol.InfinityCLAMM}
               currency0={currency0}
               currency1={currency1}
+              isOutOfRange={isOutOfRange}
               chainId={chainId}
               dynamic={dynamic}
               feeTier={fee}
@@ -414,6 +424,7 @@ export const IncreaseLiquidity = () => {
               value={inputAmountRaw}
               currency={currency0}
               maxAmount={inputBalance}
+              disabled={deposit0Disabled}
               showUSDPrice
               showMaxButton
               showQuickInputButton
@@ -433,6 +444,7 @@ export const IncreaseLiquidity = () => {
               showMaxButton
               showQuickInputButton
               disableCurrencySelect
+              disabled={deposit1Disabled}
             />
           </Box>
           <V3SubmitButton

--- a/apps/web/src/views/IncreaseLiquidity/index.tsx
+++ b/apps/web/src/views/IncreaseLiquidity/index.tsx
@@ -317,12 +317,6 @@ export const IncreaseLiquidity = () => {
       <NavBreadcrumbs currency0={currency0} currency1={currency1}>
         <Text>{t('Increase Liquidity')}</Text>
       </NavBreadcrumbs>
-
-      <span>tickCurrent: {pool?.tickCurrent}</span>
-      <span>tickLower: {position?.tickLower}</span>
-      <span>tickUpper: {position?.tickUpper}</span>
-      <span>outOfRange: {isOutOfRange ? 'Yes' : 'No'}</span>
-
       <StyledCard mt="24px" mx="auto">
         <CardBody>
           <Flex alignItems="center">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useIncreaseForm` hook and the `IncreaseLiquidity` component by introducing new state variables for range validation and adjusting liquidity input handling based on the out-of-range condition.

### Detailed summary
- Added `outOfRange` and `invalidRange` parameters to `useIncreaseForm`.
- Updated input amount handling to only set values when not out of range.
- Introduced `isOutOfRange` calculation in `IncreaseLiquidity` based on current pool ticks.
- Adjusted liquidity handling checks to include deposit restrictions.
- Modified input amount settings to default to `0n` if undefined.
- Passed `isOutOfRange` to relevant components and adjusted their behavior accordingly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->