### PR TITLE
chore: refactor loadable with monad design

### DIFF
--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -66,8 +66,8 @@ export function useStablecoinPrice(
     speedQuoteEnabled: true,
     routeKey: 'stable-coin-price',
   })
-  const { data: quoteResult } = useAtomValue(bestAMMTradeFromQuoterWorkerAtom(priceQuoter))
-  const { trade } = quoteResult || {}
+  const quoteResult = useAtomValue(bestAMMTradeFromQuoterWorkerAtom(priceQuoter))
+  const trade = quoteResult.map((x) => x.trade).unwrapOr(undefined)
 
   const price = useMemo(() => {
     if (!currency || !stableCoin || !enabled) {

--- a/apps/web/src/quoter/atom/routingStrategy.ts
+++ b/apps/web/src/quoter/atom/routingStrategy.ts
@@ -1,14 +1,14 @@
+import { Loadable } from '@pancakeswap/utils/Loadable'
 import { Atom } from 'jotai'
 import { AtomFamily } from 'jotai/vanilla/utils/atomFamily'
 import { QuoteQuery } from 'quoter/quoter.types'
 import { InterfaceOrder } from 'views/Swap/utils'
-import { Loadable } from './atomWithLoadable'
 import { bestAMMTradeFromQuoterWorker2Atom } from './bestAMMTradeFromQuoterWorker2Atom'
 import { bestAMMTradeFromQuoterWorkerAtom } from './bestAMMTradeFromQuoterWorkerAtom'
 import { bestRoutingSDKTradeAtom } from './bestRoutingSDKTradeAtom'
 import { bestXApiAtom } from './bestXAPIAtom'
 
-type AtomType = AtomFamily<QuoteQuery, Atom<Loadable<InterfaceOrder | undefined>>>
+type AtomType = AtomFamily<QuoteQuery, Atom<Loadable<InterfaceOrder>>>
 export interface StrategyRoute {
   query: AtomType
   overrides: Partial<QuoteQuery>

--- a/apps/web/src/quoter/hook/useQuoterSync.ts
+++ b/apps/web/src/quoter/hook/useQuoterSync.ts
@@ -146,18 +146,21 @@ export const useQuoterSync = () => {
   }, [quoteQuery.hash, paused, quoteResult.loading])
 
   useEffect(() => {
-    if (quoteResult.data?.trade && quoteResult.placeholderHash && !quoteResult.loading) {
-      setPlaceholder(quoteResult.placeholderHash, quoteResult.data)
+    if (quoteResult.isJust() && !quoteResult.hasFlag('placeholder')) {
+      const placeholderHash = quoteResult.getExtra('placeholderHash') as string
+      setPlaceholder(placeholderHash, quoteResult.unwrap())
     }
 
     if (paused) {
       return
     }
 
+    const order = quoteResult.unwrapOr(undefined)
+
     setTrade({
-      bestOrder: quoteResult.data,
-      tradeLoaded: !quoteResult?.loading,
-      tradeError: quoteResult?.error,
+      bestOrder: order,
+      tradeLoaded: !quoteResult.isPending(),
+      tradeError: quoteResult.error,
       refreshDisabled: false,
       refreshOrder: () => {
         setNonce((v) => v + 1)
@@ -173,5 +176,5 @@ export const useQuoterSync = () => {
       },
     })
     setTyping(false)
-  }, [quoteResult.data, quoteResult.loading, quoteResult.error, pauseQuote, setTrade, setTyping, setNonce, paused])
+  }, [quoteResult.value, quoteResult.loading, quoteResult.error, pauseQuote, setTrade, setTyping, setNonce, paused])
 }

--- a/apps/web/src/quoter/hook/useSingleTokenSwapInfo.ts
+++ b/apps/web/src/quoter/hook/useSingleTokenSwapInfo.ts
@@ -39,7 +39,7 @@ export function useSingleTokenSwapInfo(query: Query): { [key: string]: number } 
   })
 
   const quoteResult = useAtomValue(bestAMMTradeFromQuoterWorkerAtom(quoteOption))
-  const bestTradeExactIn = quoteResult.data?.trade
+  const bestTradeExactIn = quoteResult.map((x) => x.trade).unwrapOr(undefined)
   if (!inputCurrency || !outputCurrency || !bestTradeExactIn) {
     return {}
   }

--- a/apps/web/src/views/Swap/Twap/Twap.tsx
+++ b/apps/web/src/views/Swap/Twap/Twap.tsx
@@ -81,8 +81,7 @@ const useBestTrade = (fromToken?: string, toToken?: string, value?: string) => {
     routeKey: 'twap',
   })
   const tradeResult = useAtomValue(bestQuoteAtom(quoteOption))
-  const { data } = tradeResult
-  const trade = data?.trade
+  const trade = tradeResult.map((x) => x.trade).unwrapOr(undefined)
 
   const inCurrency = useCurrency(fromToken)
   const outCurrency = useCurrency(toToken)

--- a/packages/utils/Loadable.ts
+++ b/packages/utils/Loadable.ts
@@ -1,0 +1,162 @@
+export enum LoadableTypeNames {
+  Pending,
+  Fail,
+  Just,
+  Nothing,
+}
+
+export type Just<T> = Loadable<T> & {
+  type: LoadableTypeNames.Just
+  loading: false
+  value: T
+}
+
+export type Nothing<T> = Loadable<T> & {
+  type: LoadableTypeNames.Nothing
+  loading: false
+  value: undefined
+}
+
+export type Fail<T> = Loadable<T> & {
+  type: LoadableTypeNames.Fail
+  loading: false
+  error: any
+}
+
+export type Pending<T> = Loadable<T> & {
+  type: LoadableTypeNames.Pending
+  loading: true
+}
+
+export class Loadable<T> {
+  type: LoadableTypeNames
+
+  value: T | undefined
+
+  error: any | undefined
+
+  loading: boolean
+
+  flags: Record<string, boolean> = {}
+
+  extra: Record<string, any> = {}
+
+  private constructor(type: LoadableTypeNames, value: T | undefined, error: any | undefined, loading: boolean) {
+    this.type = type
+    this.value = value
+    this.error = error
+    this.loading = loading
+  }
+
+  static Just<T>(value: T): Just<T> {
+    return new Loadable<T>(LoadableTypeNames.Just, value, undefined, false) as Just<T>
+  }
+
+  static Nothing<T>(): Nothing<T> {
+    return new Loadable<T>(LoadableTypeNames.Nothing, undefined, undefined, false) as Nothing<T>
+  }
+
+  static Fail<T>(error: any): Fail<T> {
+    return new Loadable<T>(LoadableTypeNames.Fail, undefined, error, false) as Fail<T>
+  }
+
+  static Pending<T>(): Pending<T> {
+    return new Loadable<T>(LoadableTypeNames.Pending, undefined, undefined, true) as Pending<T>
+  }
+
+  isJust(): this is Just<T> {
+    return this.type === LoadableTypeNames.Just
+  }
+
+  isNothing(): this is Nothing<T> {
+    return this.type === LoadableTypeNames.Nothing
+  }
+
+  isFail(): this is Fail<T> {
+    return this.type === LoadableTypeNames.Fail
+  }
+
+  isPending(): this is Pending<T> {
+    return this.type === LoadableTypeNames.Pending
+  }
+
+  map<U>(fn: (value: T) => U): Loadable<U> {
+    if (this.isJust()) {
+      try {
+        const newValue = fn(this.value)
+        return Loadable.Just(newValue)
+      } catch (error) {
+        return Loadable.Fail<U>(error)
+      }
+    }
+    if (this.isFail()) {
+      return Loadable.Fail<U>(this.error)
+    }
+    if (this.isNothing()) {
+      return Loadable.Nothing<U>()
+    }
+    return Loadable.Pending<U>()
+  }
+
+  async mapAsync<U>(fn: (value: T) => Promise<U>): Promise<Loadable<U>> {
+    if (this.isJust()) {
+      try {
+        const newValue = await fn(this.value)
+        return Loadable.Just(newValue)
+      } catch (error) {
+        return Loadable.Fail<U>(error)
+      }
+    }
+    if (this.isFail()) {
+      return Loadable.Fail<U>(this.error)
+    }
+    if (this.isNothing()) {
+      return Loadable.Nothing<U>()
+    }
+    return Loadable.Pending<U>()
+  }
+
+  unwrap(): T {
+    if (this.isJust()) {
+      return this.value
+    }
+    if (this.isNothing()) {
+      throw new Error('Cannot unwrap Nothing')
+    }
+    if (this.isFail()) {
+      throw new Error(`Cannot unwrap Fail: ${this.error}`)
+    }
+    throw new Error('Cannot unwrap Pending')
+  }
+
+  unwrapOr(defaultValue: T | undefined): T | undefined {
+    if (this.isJust()) {
+      return this.value
+    }
+    if (this.isNothing() || defaultValue === undefined || defaultValue === null) {
+      return undefined
+    }
+    if (this.isFail()) {
+      throw new Error(`Cannot unwrapOr Fail: ${this.error}`)
+    }
+    throw new Error('Cannot unwrapOr Pending')
+  }
+
+  public setFlag(flag: string) {
+    this.flags[flag] = true
+    return this
+  }
+
+  public hasFlag(flag: string) {
+    return this.flags[flag] || false
+  }
+
+  public setExtra(key: string, value: any) {
+    this.extra[key] = value
+    return this
+  }
+
+  public getExtra(key: string) {
+    return this.extra[key]
+  }
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the handling of trade data by utilizing a new `Loadable` type, improving the management of asynchronous data states, and enhancing error handling across various components.

### Detailed summary
- Updated trade data retrieval to use `unwrapOr` and `map` methods on `Loadable`.
- Refactored error handling in `executeRoutes` to return `Loadable` states.
- Enhanced `atomWithLoadable` to support validation options.
- Introduced `LoadableTypeNames` for clearer state management.
- Changed the handling of `bestQuoteAtom` to utilize the new `Loadable` structure.
- Improved the `findBestQuote` function to work with `Loadable` types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->