### PR TITLE
Add Buck Norris Coin (BUCK) to token list

### DIFF
--- a/apps/aptos/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/aptos/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -221,3 +221,11 @@
     }
   ]
 }
+{
+  "name": "Buck Norris Coin",
+  "symbol": "BUCK",
+  "address": "0x909ec2E99f0A8E5BF9C3bf2F7A5aCC44026D4dd3",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://yachtmaster92.github.io/bucknorris/images/logo-256.png"
+}


### PR DESCRIPTION
Adding Buck Norris Coin (BUCK) with logo at https://yachtmaster92.github.io/bucknorris/images/logo-256.png. Token adress: 0x909ec2E99f0A8E5BF9C3bf2F7A5aCC44026D4dd3
ChainId: 56 (Binance Smart Chain)
