### PR TITLE
fix: Decimal cake redeem

### DIFF
--- a/apps/web/src/views/CakeStaking/hooks/useCakePoolV1Info.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useCakePoolV1Info.ts
@@ -31,6 +31,5 @@ export const useCakePoolV1Info = (targetChain?: ChainId) => {
 
     enabled: Boolean(account) && (chainId === ChainId.BSC || chainId === ChainId.BSC_TESTNET),
   })
-  console.info(info)
   return info || ({} as CakePoolV1Info)
 }

--- a/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
+++ b/apps/web/src/views/CakeStaking/hooks/useVeCakeUserInfo.ts
@@ -170,7 +170,7 @@ export const useCakeLockStatus = (
           .plus(new BigNumber(cakePoolLockInfo?.userBoostedShare?.toString() ?? 0)),
       )
 
-      return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toString() : 0)
+      return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toFixed(0) : 0)
     }
 
     return userInfo?.cakeAmount ?? 0n
@@ -188,7 +188,7 @@ export const useCakeLockStatus = (
       currentPerformanceFee,
     )
 
-    return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toString() : 0)
+    return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toFixed(0) : 0)
   }, [cakePoolV1Info])
 
   const cakeLockedAmount = useMemo(() => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of `BigInt` conversions in the `useVeCakeUserInfo` and `useCakeLockStatus` hooks to ensure consistency in the way values are represented, specifically changing from `toString()` to `toFixed(0)`.

### Detailed summary
- In `useVeCakeUserInfo.ts`, changed `return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toString() : 0)` to `return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toFixed(0) : 0)`.
- In `useCakeLockStatus.ts`, made the same change for consistency: `return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toString() : 0)` to `return BigInt(cakeAsBigNumber.gt(0) ? cakeAsBigNumber.toFixed(0) : 0)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->