### PR TITLE
chore: remove gauges on menu

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -207,13 +207,8 @@ const config: (
         {
           label: t('Voting'),
           image: '/images/voting/voting-bunny.png',
-          items: [
-            {
-              label: t('Proposals'),
-              href: '/voting',
-              supportChainIds: SUPPORT_ONLY_BSC,
-            },
-          ].map((item) => addMenuItemSupported(item, chainId)),
+          href: '/voting',
+          supportChainIds: SUPPORT_ONLY_BSC,
         },
         {
           type: DropdownMenuItemType.DIVIDER,

--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -14,7 +14,7 @@ import {
   SwapFillIcon,
   SwapIcon,
 } from '@pancakeswap/uikit'
-import { SUPPORT_CAKE_STAKING, SUPPORT_FARMS, SUPPORT_ONLY_BSC } from 'config/constants/supportChains'
+import { SUPPORT_FARMS, SUPPORT_ONLY_BSC } from 'config/constants/supportChains'
 import { getPerpetualUrl } from 'utils/getPerpetualUrl'
 
 export type ConfigMenuDropDownItemsType = DropdownMenuItems & {
@@ -208,11 +208,6 @@ const config: (
           label: t('Voting'),
           image: '/images/voting/voting-bunny.png',
           items: [
-            {
-              label: t('Gauges'),
-              href: '/gauges-voting',
-              supportChainIds: SUPPORT_CAKE_STAKING,
-            },
             {
               label: t('Proposals'),
               href: '/voting',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the `config` for a dropdown menu by removing references to `SUPPORT_CAKE_STAKING` and streamlining the items within the menu.

### Detailed summary
- Removed the import of `SUPPORT_CAKE_STAKING` from `config/constants/supportChains`.
- Eliminated two menu items: "Gauges" and "Proposals" that referenced `SUPPORT_CAKE_STAKING`.
- Retained the "Voting" item with `supportChainIds` set to `SUPPORT_ONLY_BSC`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->