### PR TITLE
fix: Remove pm liquidity when account connects

### DIFF
--- a/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
+++ b/apps/web/src/components/Menu/UserMenu/WalletInfo.tsx
@@ -19,7 +19,6 @@ import {
 } from '@pancakeswap/uikit'
 import { ChainLogo } from 'components/Logo/ChainLogo'
 import { FetchStatus } from 'config/constants/types'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useAuth from 'hooks/useAuth'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import useTokenBalance, { useBSCCakeBalance } from 'hooks/useTokenBalance'
@@ -31,7 +30,8 @@ import { useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { getBlockExploreLink, getBlockExploreName } from 'utils'
 import { Address } from 'viem'
-import { useBalance } from 'wagmi'
+import { useAccount, useBalance } from 'wagmi'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 
 const COLORS = {
   ETH: '#627EEA',
@@ -46,7 +46,8 @@ interface WalletInfoProps {
 
 const WalletInfo: React.FC<WalletInfoProps> = ({ hasLowNativeBalance, onDismiss }) => {
   const { t } = useTranslation()
-  const { account, chainId, chain } = useActiveWeb3React()
+  const { chainId } = useActiveChainId()
+  const { address: account, chain } = useAccount()
   const { domainName } = useDomainNameForAddress(account ?? '')
   const isBSC = chainId === ChainId.BSC
   const bnbBalance = useBalance({ address: account ?? undefined, chainId: ChainId.BSC })

--- a/apps/web/src/components/NetworkModal/NetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/NetworkModal.tsx
@@ -60,6 +60,7 @@ export const NetworkModal = ({ pageSupportedChains = SUPPORT_ONLY_BSC }: { pageS
     )
   }
 
+  // @ts-ignore
   if ((chain?.unsupported ?? false) || isPageNotSupported) {
     return (
       <ModalV2 isOpen closeOnOverlayClick={false}>

--- a/apps/web/src/components/NetworkModal/NetworkModal.tsx
+++ b/apps/web/src/components/NetworkModal/NetworkModal.tsx
@@ -1,12 +1,13 @@
 import { ChainId } from '@pancakeswap/chains'
 import { ModalV2 } from '@pancakeswap/uikit'
 import { SUPPORT_ONLY_BSC } from 'config/constants/supportChains'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { atom, useAtom } from 'jotai'
 import dynamic from 'next/dynamic'
 import { useCallback, useMemo } from 'react'
 import { viemClients } from 'utils/viem'
 import { CHAIN_IDS } from 'utils/wagmi'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 
 export const hideWrongNetworkModalAtom = atom(false)
 
@@ -23,7 +24,8 @@ const UnsupportedNetworkModal = dynamic(
 )
 
 export const NetworkModal = ({ pageSupportedChains = SUPPORT_ONLY_BSC }: { pageSupportedChains?: number[] }) => {
-  const { chainId, chain, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { chain } = useAccount()
   const [dismissWrongNetwork, setDismissWrongNetwork] = useAtom(hideWrongNetworkModalAtom)
 
   const isBNBOnlyPage = useMemo(() => {

--- a/apps/web/src/components/ZapLiquidityWidget.tsx
+++ b/apps/web/src/components/ZapLiquidityWidget.tsx
@@ -13,7 +13,6 @@ import {
 } from '@pancakeswap/uikit'
 import { Pool } from '@pancakeswap/v3-sdk'
 import { ToastDescriptionWithTx } from 'components/Toast'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import dynamic from 'next/dynamic'
 import { useCallback, useMemo, useState } from 'react'
 import { useTransactionAdder } from 'state/transactions/hooks'
@@ -25,6 +24,7 @@ import { CommonBasesType } from 'components/SearchModal/types'
 import { isAddressEqual } from 'utils'
 import WalletModalManager from 'components/WalletModalManager'
 import { useMasterchefV3 } from 'hooks/useContract'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 
 interface ZapLiquidityProps {
   tickLower?: number
@@ -63,7 +63,7 @@ export const ZapLiquidityWidget: React.FC<ZapLiquidityProps> = ({
 
   const { isDark } = useTheme()
 
-  const { account, chainId } = useActiveWeb3React()
+  const { account, chainId } = useAccountActiveChain()
 
   const { data: walletClient } = useWalletClient()
 
@@ -221,30 +221,32 @@ export const ZapLiquidityWidget: React.FC<ZapLiquidityProps> = ({
       <WalletModalManager isOpen={isWalletModalOpen} onDismiss={handleWalletModalOnDismiss} />
       <ModalV2 closeOnOverlayClick isOpen={isModalOpen} onDismiss={handleOnDismiss}>
         <ModalContainer style={{ maxHeight: '90vh', overflow: 'auto' }}>
-          <LiquidityWidget
-            theme={isDark ? 'dark' : 'light'}
-            feeAddress="0xB82bb6Ce9A249076Ca7135470e7CA634806De168"
-            feePcm={0}
-            walletClient={walletClient}
-            account={account ?? undefined}
-            networkChainId={chainId}
-            chainId={chainId}
-            initTickLower={tickLower ? +tickLower : undefined}
-            initTickUpper={tickUpper ? +tickUpper : undefined}
-            positionId={tokenId || undefined}
-            initAmounts={amounts}
-            initDepositTokens={depositTokens}
-            poolAddress={poolAddress ?? '0x'}
-            farmContractAddresses={masterChefV3Addresses}
-            onConnectWallet={handleOnWalletConnect}
-            onAddTokens={handleAddTokens}
-            onOpenTokenSelectModal={onPresentCurrencyModal}
-            onRemoveToken={handleRemoveToken}
-            onAmountChange={handleAmountChange}
-            onDismiss={handleOnDismiss}
-            onTxSubmit={handleTransaction}
-            source="pancakeswap"
-          />
+          {chainId ? (
+            <LiquidityWidget
+              theme={isDark ? 'dark' : 'light'}
+              feeAddress="0xB82bb6Ce9A249076Ca7135470e7CA634806De168"
+              feePcm={0}
+              walletClient={walletClient}
+              account={account ?? undefined}
+              networkChainId={chainId}
+              chainId={chainId}
+              initTickLower={tickLower ? +tickLower : undefined}
+              initTickUpper={tickUpper ? +tickUpper : undefined}
+              positionId={tokenId || undefined}
+              initAmounts={amounts}
+              initDepositTokens={depositTokens}
+              poolAddress={poolAddress ?? '0x'}
+              farmContractAddresses={masterChefV3Addresses}
+              onConnectWallet={handleOnWalletConnect}
+              onAddTokens={handleAddTokens}
+              onOpenTokenSelectModal={onPresentCurrencyModal}
+              onRemoveToken={handleRemoveToken}
+              onAmountChange={handleAmountChange}
+              onDismiss={handleOnDismiss}
+              onTxSubmit={handleTransaction}
+              source="pancakeswap"
+            />
+          ) : null}
         </ModalContainer>
       </ModalV2>
     </>

--- a/apps/web/src/hooks/useAccountLocalEventListener.ts
+++ b/apps/web/src/hooks/useAccountLocalEventListener.ts
@@ -1,11 +1,11 @@
 import { useAccountEffect } from 'wagmi'
 import { useMemo } from 'react'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import useLocalDispatch from '../contexts/LocalRedux/useLocalDispatch'
 import { resetUserState } from '../state/global/actions'
-import useActiveWeb3React from './useActiveWeb3React'
 
 export const useAccountLocalEventListener = () => {
-  const { chainId } = useActiveWeb3React()
+  const { chainId } = useActiveChainId()
   const dispatch = useLocalDispatch()
 
   useAccountEffect(

--- a/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
@@ -4,7 +4,6 @@ import { AddIcon, AutoColumn } from '@pancakeswap/uikit'
 import PageLoader from 'components/Loader/PageLoader'
 import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
 import { usePermit2 } from 'hooks/usePermit2'
 import { useRouter } from 'next/router'
@@ -21,6 +20,8 @@ import {
   LowTVLMessage,
   OutOfRangeMessage,
 } from 'views/CreateLiquidityPool/components/SubmitCreateButton'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 import { useAddDepositAmounts, useAddDepositAmountsEnabled } from '../hooks/useAddDepositAmounts'
 import { useAddFormSubmitCallback } from '../hooks/useAddFormSubmitCallback'
 import { useAddFormSubmitEnabled } from '../hooks/useAddFormSubmitEnabled'
@@ -30,7 +31,8 @@ import { usePool } from '../hooks/usePool'
 export const SubmitButton = () => {
   const router = useRouter()
   const { t } = useTranslation()
-  const { account, isWrongNetwork } = useActiveWeb3React()
+  const { isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
 
   const { chainId, poolId } = useInfinityPoolIdRouteParams()
   const [inverted] = useInverted()

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -17,13 +17,12 @@ import { CurrencyField as Field } from 'utils/types'
 import { useTranslation } from '@pancakeswap/localization'
 import { AppHeader } from 'components/App'
 import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useMasterchefV3, useV3NFTPositionManagerContract } from 'hooks/useContract'
 import { useRouter } from 'next/router'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { calculateGasMargin } from 'utils'
 import Page from 'views/Page'
-import { useSendTransaction } from 'wagmi'
+import { useAccount, useSendTransaction } from 'wagmi'
 
 import { BodyWrapper } from 'components/App/AppBody'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
@@ -39,6 +38,7 @@ import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
 import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
 import { useSingleCallResult } from 'state/multicall/hooks'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { V3SubmitButton } from './components/V3SubmitButton'
 import LockedDeposit from './formViews/V3FormView/components/LockedDeposit'
 import { PositionPreview } from './formViews/V3FormView/components/PositionPreview'
@@ -64,7 +64,8 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   } = useTranslation()
   const expertMode = useIsExpertMode()
 
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
 
   const masterchefV3 = useMasterchefV3()
   const { tokenIds: stakedTokenIds, loading: tokenIdsInMCv3Loading } = useV3TokenIdsByAccount(

--- a/apps/web/src/views/AddLiquidityV3/formViews/StableFormView.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/StableFormView.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from '@pancakeswap/localization'
 import { useIsExpertMode } from '@pancakeswap/utils/user'
 import { LightGreyCard } from 'components/Card'
 import ConnectWalletButton from 'components/ConnectWalletButton'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 
 import { CurrencyAmount, Percent } from '@pancakeswap/sdk'
 import { BIG_ONE_HUNDRED } from '@pancakeswap/utils/bigNumber'
@@ -28,6 +27,8 @@ import { RowFixed } from 'components/Layout/Row'
 
 import { ReactElement } from 'react'
 import { formatAmount } from 'utils/formatInfoNumbers'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 import { HideMedium, MediumOnly, RightContainer } from './V3FormView'
 
 export default function StableFormView({
@@ -62,7 +63,8 @@ export default function StableFormView({
   const addIsUnsupported = useIsTransactionUnsupported(currencies?.CURRENCY_A, currencies?.CURRENCY_B)
   const addIsWarning = useIsTransactionWarning(currencies?.CURRENCY_A, currencies?.CURRENCY_B)
 
-  const { account, isWrongNetwork } = useActiveWeb3React()
+  const { isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { t } = useTranslation()
   const expertMode = useIsExpertMode()
 

--- a/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
@@ -23,7 +23,6 @@ import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import { CommonBasesType } from 'components/SearchModal/types'
 import { Bound } from 'config/constants/types'
 import { useActiveChainId } from 'hooks/useActiveChainId'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { CurrencyField as Field } from 'utils/types'
 import { getBlockExploreLink } from 'utils'
 import { logGTMClickAddLiquidityEvent } from 'utils/customGTMEventTracking'
@@ -31,6 +30,7 @@ import { LP2ChildrenProps } from 'views/AddLiquidity'
 
 import { InfoBox } from '@pancakeswap/widgets-internal'
 import ApproveLiquidityTokens from 'views/AddLiquidityV3/components/ApproveLiquidityTokens'
+import { useAccount } from 'wagmi'
 import { HideMedium, MediumOnly, RightContainer } from './V3FormView'
 import RangeSelector from './V3FormView/components/RangeSelector'
 
@@ -62,8 +62,8 @@ export default function V2FormView({
 }: LP2ChildrenProps) {
   const mockFn = useCallback(() => undefined, [])
 
-  const { chainId } = useActiveChainId()
-  const { account, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { t } = useTranslation()
   const expertMode = useIsExpertMode()
   const pairExplorerLink = useMemo(

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -46,7 +46,6 @@ import { useTranslation } from '@pancakeswap/localization'
 import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
 import { Bound } from 'config/constants/types'
 import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import { useRouter } from 'next/router'
 import { useTransactionAdder } from 'state/transactions/hooks'
@@ -58,12 +57,13 @@ import { getViemClients } from 'utils/viem'
 import { hexToBigInt } from 'viem'
 import { V3SubmitButton } from 'views/AddLiquidityV3/components/V3SubmitButton'
 import { QUICK_ACTION_CONFIGS } from 'views/AddLiquidityV3/types'
-import { useSendTransaction, useWalletClient } from 'wagmi'
+import { useAccount, useSendTransaction, useWalletClient } from 'wagmi'
 
 import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
 import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { useDensityChartData } from 'views/AddLiquidityV3/hooks/useDensityChartData'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import LockedDeposit from './components/LockedDeposit'
 import { PositionPreview } from './components/PositionPreview'
 import RangeSelector from './components/RangeSelector'
@@ -137,7 +137,8 @@ export default function V3FormView({
   const expertMode = useIsExpertMode()
 
   const positionManager = useV3NFTPositionManagerContract()
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const addTransaction = useTransactionAdder()
 
   // mint state

--- a/apps/web/src/views/Farms/components/MultiChainHarvestModal.tsx
+++ b/apps/web/src/views/Farms/components/MultiChainHarvestModal.tsx
@@ -22,7 +22,6 @@ import { LightGreyCard } from 'components/Card'
 import { ChainLogo } from 'components/Logo/ChainLogo'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { TokenPairImage } from 'components/TokenImage'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { useSwitchNetwork } from 'hooks/useSwitchNetwork'
 import Cookie from 'js-cookie'
@@ -31,6 +30,8 @@ import { farmFetcher } from 'state/farms'
 import { styled } from 'styled-components'
 import { useFarmCProxyAddress } from 'views/Farms/hooks/useFarmCProxyAddress'
 import useCrossChainHarvestFarm from 'views/Farms/hooks/useCrossChainHarvestFarm'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 
 const TokenWrapper = styled.div`
   padding-right: 8px;
@@ -61,7 +62,8 @@ const MultiChainHarvestModal: React.FC<MultiChainHarvestModalProp> = ({
 }) => {
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { switchNetworkAsync } = useSwitchNetwork()
   const { cProxyAddress } = useFarmCProxyAddress(account, chainId)
   const { onReward } = useCrossChainHarvestFarm(pid, cProxyAddress)

--- a/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
+++ b/apps/web/src/views/FixedStaking/hooks/useStakedPools.ts
@@ -2,7 +2,6 @@ import { VaultKey } from '@pancakeswap/pools'
 import { getBalanceAmount } from '@pancakeswap/utils/formatBalance'
 import BigNumber from 'bignumber.js'
 import { useOfficialsAndUserAddedTokens } from 'hooks/Tokens'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useFixedStakingContract, useVaultPoolContract } from 'hooks/useContract'
 import toNumber from 'lodash/toNumber'
 import { useMemo } from 'react'
@@ -14,6 +13,7 @@ import { useAccount } from 'wagmi'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useReadContract } from '@pancakeswap/wagmi'
 import { safeGetAddress } from 'utils'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { DISABLED_POOLS } from '../constant'
 import { FixedStakingPool, StakedPosition } from '../type'
 
@@ -46,7 +46,7 @@ export function useShouldNotAllowWithdraw({ lockPeriod, lastDayAction }) {
 
 export function useIfUserLocked() {
   const vaultPoolContract = useVaultPoolContract(VaultKey.CakeVault)
-  const { account, chainId } = useActiveWeb3React()
+  const { account, chainId } = useAccountActiveChain()
 
   const { data } = useReadContract({
     chainId,

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ClaimButton.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/ClaimButton.tsx
@@ -1,10 +1,10 @@
 import { PoolIds } from '@pancakeswap/ifos'
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { WalletIfoData } from 'views/Ifos/types'
+import { useAccount } from 'wagmi'
 
 interface Props {
   poolId: PoolIds
@@ -16,7 +16,7 @@ const ClaimButton: React.FC<React.PropsWithChildren<Props>> = ({ poolId, ifoVers
   const userPoolCharacteristics = walletIfoData[poolId]
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { fetchWithCatchTxError } = useCatchTxError()
 
   const setPendingTx = (isPending: boolean) => walletIfoData.setPendingTx(isPending, poolId)

--- a/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/VestingClaimButton.tsx
+++ b/apps/web/src/views/Ifos/components/IfoFoldableCard/IfoPoolCard/VestingClaimButton.tsx
@@ -1,13 +1,13 @@
 import { PoolIds } from '@pancakeswap/ifos'
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { useCallback } from 'react'
 import { Address } from 'viem'
 import { WalletIfoData } from 'views/Ifos/types'
+import { useAccount } from 'wagmi'
 
 interface Props {
   poolId: PoolIds
@@ -19,7 +19,7 @@ const ClaimButton: React.FC<React.PropsWithChildren<Props>> = ({ poolId, amountA
   const userPoolCharacteristics = walletIfoData[poolId]
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { fetchWithCatchTxError } = useCatchTxError()
 
   const setPendingTx = useCallback(

--- a/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Claim.tsx
+++ b/apps/web/src/views/Ifos/components/IfoVesting/VestingPeriod/Claim.tsx
@@ -1,7 +1,6 @@
 import { PoolIds } from '@pancakeswap/ifos'
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { useIfoV3Contract } from 'hooks/useContract'
@@ -9,6 +8,7 @@ import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
 import { VestingData } from 'views/Ifos/hooks/vesting/fetchUserWalletIfoData'
 
+import { useAccount } from 'wagmi'
 import { SwitchNetworkTips } from '../../IfoFoldableCard/IfoPoolCard/SwitchNetworkTips'
 
 interface Props {
@@ -28,7 +28,7 @@ const ClaimButton: React.FC<React.PropsWithChildren<Props>> = ({
   fetchUserVestingData,
   enabled,
 }) => {
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
   const { address, token, chainId } = data.ifo

--- a/apps/web/src/views/IncreaseLiquidity/index.tsx
+++ b/apps/web/src/views/IncreaseLiquidity/index.tsx
@@ -32,7 +32,6 @@ import { useInfinityClPositionFromTokenId } from 'hooks/infinity/useInfinityPosi
 import useIsTickAtLimit from 'hooks/infinity/useIsTickAtLimit'
 import { usePositionAmount } from 'hooks/infinity/usePositionAmount'
 import { useCurrencyByChainId } from 'hooks/Tokens'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { ApprovalState } from 'hooks/useApproveCallback'
 import { usePermit2 } from 'hooks/usePermit2'
 import { useStablecoinPrice } from 'hooks/useStablecoinPrice'
@@ -51,6 +50,8 @@ import { INITIAL_ALLOWED_SLIPPAGE, useUserSlippage } from '@pancakeswap/utils/us
 import { useHookByPoolId } from 'hooks/infinity/useHooksList'
 import { calculateSlippageAmount } from 'utils/exchange'
 import { NavBreadcrumbs } from 'views/RemoveLiquidityInfinity/components/NavBreadcrumbs'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 import { useErrorMsg } from './hooks/useErrorMsg'
 import { useIncreaseForm } from './hooks/useIncreaseForm'
 
@@ -93,7 +94,8 @@ export const IncreaseLiquidity = () => {
     t,
     currentLanguage: { locale },
   } = useTranslation()
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { tokenId } = useInfinityClammPositionIdRouteParams()
 
   const { position } = useInfinityClPositionFromTokenId(tokenId, chainId)

--- a/apps/web/src/views/LiquidStaking/components/WithdrawRequest/index.tsx
+++ b/apps/web/src/views/LiquidStaking/components/WithdrawRequest/index.tsx
@@ -4,7 +4,6 @@ import { Button, CardBody, Flex, Message, MessageText, RowBetween, Text } from '
 import { getFullDisplayBalance } from '@pancakeswap/utils/formatBalance'
 import ConnectWalletButton from 'components/ConnectWalletButton'
 import { useCurrency } from 'hooks/Tokens'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import { useStablecoinPrice } from 'hooks/useStablecoinPrice'
 import useTokenBalance from 'hooks/useTokenBalance'
@@ -17,6 +16,7 @@ import { Address } from 'viem'
 import { NativeToken } from 'views/LiquidStaking/constants/types'
 import { useCallClaimContract } from 'views/LiquidStaking/hooks/useCallStakingContract'
 import { useReadWithdrawRequestInfo } from 'views/LiquidStaking/hooks/useReadWithdrawRequestInfo'
+import { useAccount } from 'wagmi'
 
 function passCheckNativeToken(currency: Token | NativeToken, native: NativeCurrency) {
   if (currency.symbol.toUpperCase() === native.symbol.toUpperCase()) return currency.symbol
@@ -45,7 +45,7 @@ function ClaimButton({ tokenAmount, claimIndex }: { tokenAmount?: CurrencyAmount
 
 export const WithdrawRequest = ({ selectedList }: { selectedList: OptionProps }) => {
   const { t } = useTranslation()
-  const { account } = useActiveWeb3React()
+  const { address: account } = useAccount()
   const { balance: stakedTokenBalance } = useTokenBalance(selectedList.token1.address as Address)
   const userCakeDisplayBalance = getFullDisplayBalance(stakedTokenBalance, selectedList.token1.decimals, 6)
   const native = useNativeCurrency()

--- a/apps/web/src/views/LiquidStaking/hooks/useReadWithdrawRequestInfo.ts
+++ b/apps/web/src/views/LiquidStaking/hooks/useReadWithdrawRequestInfo.ts
@@ -3,10 +3,10 @@ import BigNumber from 'bignumber.js'
 import { unwrappedEth } from 'config/abi/unwrappedEth'
 import { UNWRAPPED_ETH_ADDRESS } from 'config/constants/liquidStaking'
 import dayjs from 'dayjs'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { useReadContract } from '@pancakeswap/wagmi'
 import { useMemo } from 'react'
 import { Address } from 'viem'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 
 interface UserWithdrawRequest {
   allocated: boolean
@@ -31,7 +31,7 @@ export function useReadWithdrawRequestInfo():
       claimableIndexes: ClaimableIndex[]
     }
   | undefined {
-  const { account, chainId } = useActiveWeb3React()
+  const { account, chainId } = useAccountActiveChain()
 
   const { data } = useReadContract({
     chainId,

--- a/apps/web/src/views/Migration/components/bCake/PositionManagerTable.tsx
+++ b/apps/web/src/views/Migration/components/bCake/PositionManagerTable.tsx
@@ -2,11 +2,11 @@ import { FarmWithStakedValue } from '@pancakeswap/farms'
 import { useTranslation } from '@pancakeswap/localization'
 import { VaultConfig } from '@pancakeswap/position-managers'
 import { Flex, Spinner } from '@pancakeswap/uikit'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import noop from 'lodash/noop'
 import React, { useMemo } from 'react'
 import { styled } from 'styled-components'
 import { usePositionManager } from 'views/PositionManagers/hooks/usePositionManager'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import EmptyText from '../MigrationTable/EmptyText'
 import TableStyle from '../MigrationTable/StyledTable'
 import TableHeader from '../MigrationTable/TableHeader'
@@ -41,7 +41,7 @@ export const PosManagerMigrationFarmTable: React.FC<React.PropsWithChildren<ITab
   step,
 }) => {
   const { t } = useTranslation()
-  const { chainId } = useActiveWeb3React()
+  const { chainId } = useActiveChainId()
   const VAULTS_CONFIG_BY_CHAIN = usePositionManager(chainId)
 
   const rows = useMemo(() => {

--- a/apps/web/src/views/Migration/components/bCake/StakedButton.tsx
+++ b/apps/web/src/views/Migration/components/bCake/StakedButton.tsx
@@ -2,13 +2,14 @@ import { useTranslation } from '@pancakeswap/localization'
 import { ChainId, CurrencyAmount, Token } from '@pancakeswap/sdk'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePositionManagerBCakeWrapperContract } from 'hooks/useContract'
 import React, { useMemo } from 'react'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useLpData } from './V2StakedButton'
 
 export interface StakeButtonProps {
@@ -26,7 +27,8 @@ const StakeButton: React.FC<React.PropsWithChildren<StakeButtonProps>> = ({
 }) => {
   const { t } = useTranslation()
 
-  const { account, chain, chainId } = useWeb3React()
+  const { address: account, chain } = useAccount()
+  const { chainId } = useActiveChainId()
 
   const { toastSuccess } = useToast()
 

--- a/apps/web/src/views/Migration/components/bCake/UnstakeButton.tsx
+++ b/apps/web/src/views/Migration/components/bCake/UnstakeButton.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePositionManagerWrapperContract } from 'hooks/useContract'
 import React from 'react'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
 
 export interface UnStakeButtonProps {
   userStakedLp?: bigint
@@ -20,7 +20,7 @@ const UnstakeButton: React.FC<React.PropsWithChildren<UnStakeButtonProps>> = ({
 }) => {
   const { t } = useTranslation()
 
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
 
   const { toastSuccess } = useToast()
 

--- a/apps/web/src/views/Migration/components/bCake/V2StakedButton.tsx
+++ b/apps/web/src/views/Migration/components/bCake/V2StakedButton.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from '@pancakeswap/localization'
 import { ChainId, CurrencyAmount, Token } from '@pancakeswap/sdk'
 import { AutoRenewIcon, Button, useToast } from '@pancakeswap/uikit'
 import tryParseAmount from '@pancakeswap/utils/tryParseAmount'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { useQuery } from '@tanstack/react-query'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
@@ -12,6 +11,9 @@ import React, { useMemo } from 'react'
 import { useFarmFromPid } from 'state/farms/hooks'
 import { publicClient } from 'utils/wagmi'
 import { Address, erc20Abi } from 'viem'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { useAccount } from 'wagmi'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 
 export interface StakeButtonProps {
   wrapperAddress?: Address
@@ -66,7 +68,7 @@ export async function getLpData({ lpAddress, chainId, account, wrapperAddress })
 }
 
 export const useLpData = (lpAddress: Address, wrapperAddress: Address) => {
-  const { chainId, account } = useWeb3React()
+  const { account, chainId } = useAccountActiveChain()
   const { data, refetch, isLoading } = useQuery({
     queryKey: ['lpContractData', lpAddress, chainId, wrapperAddress],
     queryFn: () => getLpData({ lpAddress, chainId, account, wrapperAddress }),
@@ -89,7 +91,8 @@ const StakeButton: React.FC<React.PropsWithChildren<StakeButtonProps>> = ({
   const { data, refetch, isDataLoading } = useLpData(lpAddress ?? '0x', wrapperAddress ?? '0x')
   const { lpDecimals, userLp, allowanceLp } = data ?? {}
 
-  const { account, chain, chainId } = useWeb3React()
+  const { address: account, chain } = useAccount()
+  const { chainId } = useActiveChainId()
 
   const { toastSuccess } = useToast()
 

--- a/apps/web/src/views/PositionManagers/components/Header.tsx
+++ b/apps/web/src/views/PositionManagers/components/Header.tsx
@@ -9,14 +9,12 @@ import {
   Text,
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useTheme from 'hooks/useTheme'
 import { memo, useCallback } from 'react'
 
 export const Header = memo(function Header() {
   const { t } = useTranslation()
-  const { isDesktop, isMobile } = useMatchBreakpoints()
-  const { chainId } = useActiveWeb3React()
+  const { isMobile } = useMatchBreakpoints()
   const { theme } = useTheme()
   const redirectToDocs = useCallback(() => {
     if (typeof window !== 'undefined' && window) {

--- a/apps/web/src/views/PositionManagers/components/RemoveLiquidity.tsx
+++ b/apps/web/src/views/PositionManagers/components/RemoveLiquidity.tsx
@@ -5,7 +5,7 @@ import type { AtomBoxProps } from '@pancakeswap/uikit'
 import { Box, Button, Flex, ModalV2, RowBetween, Text, useToast } from '@pancakeswap/uikit'
 import { formatAmount } from '@pancakeswap/utils/formatFractions'
 import { FeeAmount } from '@pancakeswap/v3-sdk'
-import { useWeb3React } from '@pancakeswap/wagmi'
+import { useAccount } from 'wagmi'
 import { ConfirmationPendingContent, CurrencyLogo } from '@pancakeswap/widgets-internal'
 import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
@@ -63,7 +63,7 @@ export const RemoveLiquidity = memo(function RemoveLiquidity({
   manager,
 }: Props) {
   const { t } = useTranslation()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const [percent, setPercent] = useState(0)
   const tokenPairName = useMemo(() => `${currencyA.symbol}-${currencyB.symbol}`, [currencyA, currencyB])
   const bCakeWrapperContract = usePositionManagerBCakeWrapperContract(bCakeWrapper ?? '0x')

--- a/apps/web/src/views/PositionManagers/components/RewardAssets.tsx
+++ b/apps/web/src/views/PositionManagers/components/RewardAssets.tsx
@@ -1,13 +1,13 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Currency } from '@pancakeswap/sdk'
 import { Balance, Box, Button, Flex, Text, useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePositionManagerBCakeWrapperContract, usePositionManagerWrapperContract } from 'hooks/useContract'
 import { useCallback, useMemo } from 'react'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
 import { useEarningTokenPriceInfo } from '../hooks'
 
 interface RewardAssetsProps {
@@ -26,7 +26,7 @@ export const RewardAssets: React.FC<RewardAssetsProps> = ({
   bCakeWrapper,
 }) => {
   const { t } = useTranslation()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
   const { earningUsdValue, earningsBalance } = useEarningTokenPriceInfo(earningToken, pendingReward)

--- a/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
+++ b/apps/web/src/views/PositionManagers/hooks/useOnStake.tsx
@@ -4,11 +4,11 @@ import { Currency, CurrencyAmount } from '@pancakeswap/sdk'
 import { useToast } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePositionManagerBCakeWrapperContract, usePositionManagerWrapperContract } from 'hooks/useContract'
 import { useCallback } from 'react'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
 import { usePMSlippage } from './usePMSlippage'
 
 export const useOnStake = (
@@ -21,7 +21,7 @@ export const useOnStake = (
   const positionManagerWrapperContract = usePositionManagerWrapperContract(contractAddress)
   const { fetchWithCatchTxError, loading: pendingTx } = useCatchTxError()
   const { toastSuccess } = useToast()
-  const { chain, account } = useActiveWeb3React()
+  const { address: account, chain } = useAccount()
   const { t } = useTranslation()
   const slippage = usePMSlippage(bCakeWrapperAddress)
 

--- a/apps/web/src/views/Pottery/hooks/useClaimPottery.tsx
+++ b/apps/web/src/views/Pottery/hooks/useClaimPottery.tsx
@@ -1,16 +1,16 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePotterytDrawContract } from 'hooks/useContract'
 import { useCallback } from 'react'
 import { useAppDispatch } from 'state'
 import { fetchPotteryUserDataAsync } from 'state/pottery'
+import { useAccount } from 'wagmi'
 
 export const useClaimPottery = () => {
   const { t } = useTranslation()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const dispatch = useAppDispatch()
   const { toastSuccess } = useToast()
   const contract = usePotterytDrawContract()

--- a/apps/web/src/views/Pottery/hooks/useDepositPottery.tsx
+++ b/apps/web/src/views/Pottery/hooks/useDepositPottery.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import BigNumber from 'bignumber.js'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import { DEFAULT_TOKEN_DECIMAL } from 'config'
@@ -10,10 +9,11 @@ import { useCallback } from 'react'
 import { useAppDispatch } from 'state'
 import { fetchPotteryUserDataAsync } from 'state/pottery'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
 
 export const useDepositPottery = (amount: string, potteryVaultAddress: Address) => {
   const { t } = useTranslation()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const dispatch = useAppDispatch()
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, loading: isPending } = useCatchTxError()

--- a/apps/web/src/views/Pottery/hooks/useWithdrawPottery.tsx
+++ b/apps/web/src/views/Pottery/hooks/useWithdrawPottery.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { useToast } from '@pancakeswap/uikit'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import { ToastDescriptionWithTx } from 'components/Toast'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { usePotterytVaultContract } from 'hooks/useContract'
@@ -8,11 +7,12 @@ import { useCallback } from 'react'
 import { useAppDispatch } from 'state'
 import { fetchPotteryUserDataAsync } from 'state/pottery'
 import { Address } from 'viem'
+import { useAccount } from 'wagmi'
 
 export const useWithdrawPottery = (redeemShare: string, vaultAddress: Address) => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { toastSuccess } = useToast()
   const { fetchWithCatchTxError, loading: isPending } = useCatchTxError()
   const contract = usePotterytVaultContract(vaultAddress)

--- a/apps/web/src/views/Profile/components/EditProfileModal/ApproveCakeView.tsx
+++ b/apps/web/src/views/Profile/components/EditProfileModal/ApproveCakeView.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { AutoRenewIcon, Button, Flex, InjectedModalProps, Text } from '@pancakeswap/uikit'
 import { formatBigInt } from '@pancakeswap/utils/formatBalance'
-import { useWeb3React } from '@pancakeswap/wagmi'
 import useCatchTxError from 'hooks/useCatchTxError'
 import { useCake } from 'hooks/useContract'
 import { useProfile } from 'state/profile/hooks'
 import { getPancakeProfileAddress } from 'utils/addressHelpers'
 import useGetProfileCosts from 'views/Profile/hooks/useGetProfileCosts'
+import { useAccount } from 'wagmi'
 import { UseEditProfileResponse } from './reducer'
 
 interface ApproveCakePageProps extends InjectedModalProps {
@@ -16,7 +16,7 @@ interface ApproveCakePageProps extends InjectedModalProps {
 const ApproveCakePage: React.FC<React.PropsWithChildren<ApproveCakePageProps>> = ({ goToChange, onDismiss }) => {
   const { profile } = useProfile()
   const { t } = useTranslation()
-  const { account, chain } = useWeb3React()
+  const { address: account, chain } = useAccount()
   const { fetchWithCatchTxError, loading: isApproving } = useCatchTxError()
   const {
     costs: { numberCakeToUpdate, numberCakeToReactivate },

--- a/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
@@ -59,7 +59,6 @@ import StyledInternalLink from '../../../components/Links'
 import Dots from '../../../components/Loader/Dots'
 import { CurrencyLogo } from '../../../components/Logo'
 import SettingsModal from '../../../components/Menu/GlobalSettings/SettingsModal'
-import useActiveWeb3React from '../../../hooks/useActiveWeb3React'
 import ConfirmLiquidityModal from '../../Swap/components/ConfirmRemoveLiquidityModal'
 import { useStableDerivedBurnInfo } from './hooks/useStableDerivedBurnInfo'
 

--- a/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
@@ -50,6 +50,8 @@ import { useGasPrice } from 'state/user/hooks'
 import { logGTMClickRemoveLiquidityEvent } from 'utils/customGTMEventTracking'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { isUserRejected, logError } from 'utils/sentry'
+import { useActiveChainId } from 'hooks/useActiveChainId'
+import { useAccount } from 'wagmi'
 import { RemoveLiquidityLayout } from '..'
 import ConnectWalletButton from '../../../components/ConnectWalletButton'
 import CurrencyInputPanel from '../../../components/CurrencyInputPanel'
@@ -72,7 +74,8 @@ export default function RemoveStableLiquidity({ currencyA, currencyB, currencyId
   const native = useNativeCurrency()
   const { isMobile } = useMatchBreakpoints()
 
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { toastError } = useToast()
   const [tokenA, tokenB] = useMemo(() => [currencyA?.wrapped, currencyB?.wrapped], [currencyA, currencyB])
 

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -33,7 +33,7 @@ import { styled } from 'styled-components'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 // import { splitSignature } from 'utils/splitSignature'
 import { Hash } from 'viem'
-import { useSignTypedData } from 'wagmi'
+import { useAccount, useSignTypedData } from 'wagmi'
 
 import { LightGreyCard } from 'components/Card'
 import { RowBetween } from 'components/Layout/Row'
@@ -62,7 +62,6 @@ import StyledInternalLink from '../../components/Links'
 import Dots from '../../components/Loader/Dots'
 import { CurrencyLogo } from '../../components/Logo'
 import SettingsModal from '../../components/Menu/GlobalSettings/SettingsModal'
-import useActiveWeb3React from '../../hooks/useActiveWeb3React'
 import { useTransactionDeadline } from '../../hooks/useTransactionDeadline'
 import { formatAmount } from '../../utils/formatInfoNumbers'
 import Page from '../Page'
@@ -79,7 +78,8 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
   const native = useNativeCurrency()
   const { isMobile } = useMatchBreakpoints()
 
-  const { account, chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
+  const { address: account } = useAccount()
   const { signTypedDataAsync } = useSignTypedData()
   const { toastError } = useToast()
   const [tokenA, tokenB] = useMemo(() => [currencyA?.wrapped, currencyB?.wrapped], [currencyA, currencyB])

--- a/apps/web/src/views/Swap/hooks/useWarningImport.tsx
+++ b/apps/web/src/views/Swap/hooks/useWarningImport.tsx
@@ -8,16 +8,16 @@ import shouldShowSwapWarning from 'utils/shouldShowSwapWarning'
 
 import ImportTokenWarningModal from 'components/ImportTokenWarningModal'
 import { useAllTokens, useCurrency } from 'hooks/Tokens'
-import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import { Field } from 'state/swap/actions'
 import { useSwapState } from 'state/swap/hooks'
 import { safeGetAddress } from 'utils'
 
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import SwapWarningModal from '../components/SwapWarningModal'
 
 export default function useWarningImport() {
   const router = useRouter()
-  const { chainId, isWrongNetwork } = useActiveWeb3React()
+  const { chainId, isWrongNetwork } = useActiveChainId()
   const {
     [Field.INPUT]: { currencyId: inputCurrencyId },
     [Field.OUTPUT]: { currencyId: outputCurrencyId },


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the codebase to replace instances of `useActiveWeb3React` with `useAccount` and `useActiveChainId`, enhancing the clarity and maintainability of the code. This change aims to streamline the management of account and chain information across various components.

### Detailed summary
- Replaced `useActiveWeb3React` with `useAccount` and `useActiveChainId` in multiple files.
- Updated destructured properties to use `address` from `useAccount` instead of `account`.
- Removed unnecessary imports of `useActiveWeb3React`.
- Ensured consistent use of new hooks across components for account and chain management.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->