### PR TITLE
fix: Liquidity selector default tokens when chain change and native token select

### DIFF
--- a/apps/web/src/views/AddLiquiditySelector/index.tsx
+++ b/apps/web/src/views/AddLiquiditySelector/index.tsx
@@ -110,11 +110,14 @@ export const AddLiquiditySelector = () => {
     const tokenParams =
       baseCurrency && quoteCurrency ? `${getCurrencyAddress(baseCurrency)}/${getCurrencyAddress(quoteCurrency)}` : ''
 
+    const baseToken = baseCurrency?.isNative ? baseCurrency.symbol : baseCurrency?.wrapped.address
+    const quoteToken = quoteCurrency?.isNative ? quoteCurrency.symbol : quoteCurrency?.wrapped.address
+
     return {
       infinity: `/liquidity/select/pools/${chainId}/infinity/${tokenParams}?${queryParams.toString()}`,
-      v3: `/add/${baseCurrency?.wrapped.address}/${quoteCurrency?.wrapped.address}?chain=${queryChainName}`,
-      v2: `/v2/add/${baseCurrency?.wrapped.address}/${quoteCurrency?.wrapped.address}?chain=${queryChainName}`,
-      stableSwap: `/stable/add/${baseCurrency?.wrapped.address}/${quoteCurrency?.wrapped.address}?chain=${queryChainName}`,
+      v3: `/add/${baseToken}/${quoteToken}?chain=${queryChainName}`,
+      v2: `/v2/add/${baseToken}/${quoteToken}?chain=${queryChainName}`,
+      stableSwap: `/stable/add/${baseToken}/${quoteToken}?chain=${queryChainName}`,
     } satisfies Record<LiquidityType, string>
   }, [baseCurrency, quoteCurrency, poolTypeQuery, chainId, queryChainName])
 
@@ -131,10 +134,13 @@ export const AddLiquiditySelector = () => {
   }, [baseCurrency, chainId, protocol, quoteCurrency])
 
   const { switchNetworkAsync } = useSwitchNetwork()
-  const handleNetworkChange = async (chain: Chain) => {
-    await switchNetworkAsync?.(chain.id)
-    updateParams({ chainId: chain.id })
-  }
+  const handleNetworkChange = useCallback(
+    async (chain: Chain) => {
+      await switchNetworkAsync?.(chain.id)
+      updateParams({ chainId: chain.id })
+    },
+    [switchNetworkAsync, updateParams],
+  )
 
   return (
     <StyledCard mt="48px" mb={['120px', null, null, '0px']} mx="auto" style={{ overflow: 'visible' }}>


### PR DESCRIPTION


<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of currency tokens in the `AddLiquiditySelector` component and the `useSelectIdRoute` hook. It introduces new logic for determining base and quote tokens and refines the route handling for better clarity and maintainability.

### Detailed summary
- Introduced `baseToken` and `quoteToken` variables to handle native and wrapped currency addresses in `AddLiquiditySelector`.
- Updated route strings in `AddLiquiditySelector` to use `baseToken` and `quoteToken`.
- Refactored `handleNetworkChange` function in `AddLiquiditySelector` to use `useCallback`.
- Removed unused path generation logic in `useSelectIdRoute`.
- Simplified the `router.replace` logic in `useSelectIdRoute` to improve clarity and performance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->