### PR TITLE
chore(liquidity): add enabled option to make operator comparison updated

### DIFF
--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -185,7 +185,11 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     functionName: 'ownerOf',
     args: useMemo(() => [tokenIdBigInt], [tokenIdBigInt]),
     options: {
-      enabled: !!tokenIdBigInt && positionDetails?.operator !== account,
+      enabled: Boolean(
+        tokenIdBigInt && account && positionDetails?.operator !== account && isStakedInMCv3 !== 'loading'
+          ? isStakedInMCv3 !== 'true'
+          : false,
+      ),
     },
   }).result
 

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -184,6 +184,9 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     contract: tokenId && positionManager ? positionManager : undefined,
     functionName: 'ownerOf',
     args: useMemo(() => [tokenIdBigInt], [tokenIdBigInt]),
+    options: {
+      enabled: !!tokenIdBigInt,
+    },
   }).result
 
   const ownsNFT = owner === account || positionDetails?.operator === account

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -185,7 +185,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
     functionName: 'ownerOf',
     args: useMemo(() => [tokenIdBigInt], [tokenIdBigInt]),
     options: {
-      enabled: !!tokenIdBigInt,
+      enabled: !!tokenIdBigInt && positionDetails?.operator !== account,
     },
   }).result
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the logic for fetching ownership details in the `IncreaseLiquidityV3` component, specifically adjusting how the `ownerOf` function is called based on various conditions.

### Detailed summary
- Added an `options` object to the `ownerOf` function call.
- The `enabled` property in `options` determines if the function should execute based on several conditions involving `tokenIdBigInt`, `account`, `positionDetails`, and `isStakedInMCv3`.
- Updated the logic for determining `ownsNFT` based on `owner` and `positionDetails`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->