### PR TITLE
fix: tickLimit invert

### DIFF
--- a/apps/web/src/hooks/infinity/useIsTickAtLimit.ts
+++ b/apps/web/src/hooks/infinity/useIsTickAtLimit.ts
@@ -1,6 +1,6 @@
 import { nearestUsableTick, TickMath } from '@pancakeswap/v3-sdk'
-import { useMemo } from 'react'
 import { Bound } from 'config/constants/types'
+import { useMemo } from 'react'
 
 export default function useIsTickAtLimit(
   tickLower: number | undefined,
@@ -18,8 +18,8 @@ export default function useIsTickAtLimit(
   )
   return useMemo(
     () => ({
-      [Bound.LOWER]: tickLower === ticksLimit.LOWER,
-      [Bound.UPPER]: tickUpper === ticksLimit.UPPER,
+      [Bound.LOWER]: tickLower && ticksLimit.LOWER ? tickLower <= ticksLimit.LOWER : false,
+      [Bound.UPPER]: tickUpper && ticksLimit.UPPER ? tickUpper >= ticksLimit.UPPER : false,
     }),
     [ticksLimit, tickLower, tickUpper],
   )

--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -125,7 +125,7 @@ function PositionPriceSection({
   priceLower,
   inverted,
   pool,
-  tickAtLimit,
+  tickAtLimit: _tickAtLimit,
   setManuallyInverted,
   manuallyInverted,
 }) {
@@ -133,6 +133,16 @@ function PositionPriceSection({
     t,
     currentLanguage: { locale },
   } = useTranslation()
+
+  const tickAtLimit = useMemo(() => {
+    if (manuallyInverted) {
+      return {
+        [Bound.LOWER]: _tickAtLimit[Bound.UPPER],
+        [Bound.UPPER]: _tickAtLimit[Bound.LOWER],
+      }
+    }
+    return _tickAtLimit
+  }, [_tickAtLimit, manuallyInverted])
 
   return (
     <>

--- a/apps/web/src/views/PositionInfinity/components/PositionPrice.tsx
+++ b/apps/web/src/views/PositionInfinity/components/PositionPrice.tsx
@@ -5,7 +5,7 @@ import { AutoRow, Flex, SyncAltIcon, Text } from '@pancakeswap/uikit'
 import { RangePriceSection } from 'components/RangePriceSection'
 import { Bound } from 'config/constants/types'
 import { formatTickPrice } from 'hooks/v3/utils/formatTickPrice'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { formatPrice } from 'utils/formatCurrencyAmount'
 import RateToggle from 'views/AddLiquidityV3/formViews/V3FormView/components/RateToggle'
 
@@ -32,13 +32,23 @@ export const PositionPriceSection: React.FC<PositionPriceSectionProps> = ({
   priceLower,
   inverted,
   pool,
-  tickAtLimit,
+  tickAtLimit: _tickAtLimit,
   setInverted,
 }) => {
   const {
     t,
     currentLanguage: { locale },
   } = useTranslation()
+
+  const tickAtLimit = useMemo(() => {
+    if (inverted) {
+      return {
+        [Bound.LOWER]: _tickAtLimit[Bound.UPPER],
+        [Bound.UPPER]: _tickAtLimit[Bound.LOWER],
+      }
+    }
+    return _tickAtLimit
+  }, [_tickAtLimit, inverted])
 
   return (
     <>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of tick limits in the liquidity position management by introducing a memoized calculation for `tickAtLimit` based on the inversion state and refining the logic to determine if ticks are at their limits.

### Detailed summary
- Updated the `PositionPriceSection` in `apps/web/src/pages/liquidity/[tokenId].tsx` to use a memoized `tickAtLimit` based on the `manuallyInverted` state.
- Modified the `useIsTickAtLimit` hook in `apps/web/src/hooks/infinity/useIsTickAtLimit.ts` to ensure proper tick limit checks with additional conditions.
- Adjusted the `PositionPriceSection` in `apps/web/src/views/PositionInfinity/components/PositionPrice.tsx` to use the new `tickAtLimit` logic based on the `inverted` state.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->