### PR TITLE
fix: zksync multicall Storage invocations limit reached

### DIFF
--- a/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
+++ b/apps/web/src/state/farmsV4/state/accountPositions/fetcher/v3/getAccountV3Positions.ts
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js'
 import { getMasterChefV3Contract } from 'utils/contractHelpers'
 import { publicClient } from 'utils/viem'
 import { Address, isAddress } from 'viem'
+import { zksync } from 'viem/chains'
 import { PositionDetail } from '../../type'
 import { getAccountV3TokenIds } from './getAccountV3TokenIds'
 
@@ -35,16 +36,18 @@ export const readPositions = async (chainId: number, tokenIds: bigint[]): Promis
           } as const
         })
       : []
-
+  const batchSize = chainId === zksync.id ? 1024 * 10 : undefined
   const [positions, farmingPosition] = await Promise.all([
     client.multicall({
       contracts: positionCalls,
       allowFailure: false,
+      batchSize,
     }),
     masterChefV3 && isAddress(masterChefV3.address)
       ? client.multicall({
           contracts: farmingCalls,
           allowFailure: false,
+          batchSize,
         })
       : [],
   ])


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `readPositions` function in `getAccountV3Positions.ts` to support batching for the `zksync` chain, improving efficiency when fetching account positions.

### Detailed summary
- Added import for `zksync` from `viem/chains`.
- Introduced a `batchSize` variable that is set to `10240` when `chainId` is `zksync`.
- Passed `batchSize` to the `client.multicall` for both `positions` and `farmingPosition` calls.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->