### PR TITLE
feat: add default hook fee

### DIFF
--- a/apps/web/src/views/IncreaseLiquidity/index.tsx
+++ b/apps/web/src/views/IncreaseLiquidity/index.tsx
@@ -48,6 +48,7 @@ import { V3SubmitButton } from 'views/AddLiquidityV3/components/V3SubmitButton'
 import { LiquidityTitle } from 'views/PositionDetails/components'
 
 import { INITIAL_ALLOWED_SLIPPAGE, useUserSlippage } from '@pancakeswap/utils/user'
+import { useHookByPoolId } from 'hooks/infinity/useHooksList'
 import { calculateSlippageAmount } from 'utils/exchange'
 import { NavBreadcrumbs } from 'views/RemoveLiquidityInfinity/components/NavBreadcrumbs'
 import { useErrorMsg } from './hooks/useErrorMsg'
@@ -108,6 +109,9 @@ export const IncreaseLiquidity = () => {
     pool,
     poolId,
   } = useExtraInfinityPositionInfo(position)
+
+  const hookData = useHookByPoolId(chainId, poolId)
+  const feeAmount = hookData?.defaultFee ?? fee
 
   const isOutOfRange = useMemo(() => {
     if (!pool || typeof tickLower === 'undefined' || typeof tickUpper === 'undefined') return false
@@ -370,7 +374,10 @@ export const IncreaseLiquidity = () => {
 
             <Flex justifyContent="space-between">
               <Text color="textSubtle">{t('Fee Tier')}</Text>
-              <Text>{(fee ?? 0) / 1e4}%</Text>
+              <Text>
+                {dynamic ? '↕️ ' : null}
+                {(feeAmount ?? 0) / 1e4}%
+              </Text>
             </Flex>
           </LightGreyCard>
           <RowBetween mt="20px">

--- a/apps/web/src/views/PositionDetails/components/PositionTitle.tsx
+++ b/apps/web/src/views/PositionDetails/components/PositionTitle.tsx
@@ -163,7 +163,7 @@ export const LiquidityTitle: React.FC<LiquidityDetailHeaderProps> = ({
               {t('fee tier')}
             </Text>
             {isInfinityProtocol(protocol) ? (
-              <InfinityFeeTierBreakdown poolId={poolId} chainId={chainId} />
+              <InfinityFeeTierBreakdown poolId={poolId} chainId={chainId} hookData={hookData} />
             ) : protocol && feeTier ? (
               <FeeTier type={protocol} fee={feeTier} dynamic={dynamic} denominator={feeTierBase} />
             ) : null}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `PositionTitle` and `IncreaseLiquidity` components by adding a `hookData` prop to `InfinityFeeTierBreakdown` and updating fee calculations in `IncreaseLiquidity` to use `hookData`. 

### Detailed summary
- Updated `InfinityFeeTierBreakdown` to include `hookData` prop in `PositionTitle.tsx`.
- Introduced `useHookByPoolId` in `IncreaseLiquidity` to fetch `hookData`.
- Changed fee calculation to use `hookData` in `IncreaseLiquidity`, replacing the previous `fee` variable.
- Modified the displayed fee percentage to reflect `feeAmount` in `IncreaseLiquidity`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->