### PR TITLE
chore: set  quote track timeout to 20s ( current revalidate time is 10s , actually for user is 10s)

### DIFF
--- a/apps/web/src/quoter/consts.ts
+++ b/apps/web/src/quoter/consts.ts
@@ -1,0 +1,2 @@
+export const QUOTE_TIMEOUT = 20_000
+export const QUOTE_REVALIDATE_TIME = 10

--- a/apps/web/src/quoter/hook/useQuoterSync.ts
+++ b/apps/web/src/quoter/hook/useQuoterSync.ts
@@ -8,6 +8,7 @@ import { activeQuoteHashAtom } from 'quoter/atom/abortControlAtoms'
 import { baseAllTypeBestTradeAtom, pauseAtom, userTypingAtom } from 'quoter/atom/bestTradeUISyncAtom'
 import { updatePlaceholderAtom } from 'quoter/atom/placeholderAtom'
 import { fetchCommonPoolsOnChain } from 'quoter/atom/poolsAtom'
+import { QUOTE_REVALIDATE_TIME } from 'quoter/consts'
 import { PoolQuery, QuoteQuery } from 'quoter/quoter.types'
 import { useEffect } from 'react'
 import { useCurrentBlock } from 'state/block/hooks'
@@ -18,8 +19,6 @@ import { bestQuoteAtom } from '../atom/bestQuoteAtom'
 import { quoteNonceAtom } from '../atom/revalidateAtom'
 import { createQuoteQuery } from '../utils/createQuoteQuery'
 import { useQuoteContext } from './QuoteContext'
-
-const REVALIDATE_TIME = 7
 
 export const useQuoterSync = () => {
   const swapState = useSwapState()
@@ -127,12 +126,12 @@ export const useQuoterSync = () => {
   useEffect(() => {
     let t = 0
     const interval = setInterval(() => {
-      const outdated = Date.now() - quoteQuery.createTime! > REVALIDATE_TIME
+      const outdated = Date.now() - quoteQuery.createTime! > QUOTE_REVALIDATE_TIME
       if (paused || (!outdated && quoteResult.loading)) {
         return
       }
       if (t > 0) {
-        if (t % REVALIDATE_TIME === 0) {
+        if (t % QUOTE_REVALIDATE_TIME === 0) {
           setNonce((v) => v + 1)
         }
       }

--- a/apps/web/src/utils/withTimeout.ts
+++ b/apps/web/src/utils/withTimeout.ts
@@ -1,0 +1,19 @@
+export function withTimeout<Args extends any[], Return>(
+  fn: (...args: Args) => Promise<Return>,
+  ms: number,
+): (...args: Args) => Promise<Return> {
+  return async (...args: Args): Promise<Return> => {
+    let timer: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`Operation timed out after ${ms}ms`))
+      }, ms)
+    })
+
+    try {
+      return await Promise.race([fn(...args), timeoutPromise])
+    } finally {
+      clearTimeout(timer!)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces timeout functionality for quote operations and refines the logic for quote revalidation, enhancing performance and reliability in the quoting process.

### Detailed summary
- Added `QUOTE_TIMEOUT` and `QUOTE_REVALIDATE_TIME` constants.
- Introduced `withTimeout` function for managing asynchronous timeouts.
- Replaced hardcoded `REVALIDATE_TIME` with `QUOTE_REVALIDATE_TIME` in `useQuoterSync`.
- Integrated `withTimeout` in several atom families for API calls, using `QUOTE_TIMEOUT`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->