### PR TITLE
fix: monadTestnet wallet error

### DIFF
--- a/apps/gamification/components/ConnectWalletButton.tsx
+++ b/apps/gamification/components/ConnectWalletButton.tsx
@@ -31,8 +31,10 @@ const ConnectWalletButton = ({ children, ...props }: ButtonProps) => {
   const topWallets = useMemo(
     () =>
       TOP_WALLET_MAP[chainId]
-        .map((id) => wallets.find((w) => w.id === id))
-        .filter<WalletConfigV2<ConnectorNames>>((w): w is WalletConfigV2<ConnectorNames> => Boolean(w)),
+        ? TOP_WALLET_MAP[chainId]
+            .map((id) => wallets.find((w) => w.id === id))
+            .filter<WalletConfigV2<ConnectorNames>>((w): w is WalletConfigV2<ConnectorNames> => Boolean(w))
+        : [],
     [wallets, chainId],
   )
 

--- a/apps/web/src/components/WalletModalManager.tsx
+++ b/apps/web/src/components/WalletModalManager.tsx
@@ -25,8 +25,10 @@ const WalletModalManager: React.FC<{ isOpen: boolean; onDismiss?: () => void }> 
   const topWallets = useMemo(
     () =>
       TOP_WALLET_MAP[chainId]
-        .map((id) => wallets.find((w) => w.id === id))
-        .filter<WalletConfigV2<ConnectorNames>>((w): w is WalletConfigV2<ConnectorNames> => Boolean(w)),
+        ? TOP_WALLET_MAP[chainId]
+            .map((id) => wallets.find((w) => w.id === id))
+            .filter<WalletConfigV2<ConnectorNames>>((w): w is WalletConfigV2<ConnectorNames> => Boolean(w))
+        : [],
     [wallets, chainId],
   )
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a modification to how wallets are processed based on the `chainId` in two components: `WalletModalManager.tsx` and `ConnectWalletButton.tsx`. The code now includes a fallback to an empty array when `TOP_WALLET_MAP[chainId]` is undefined.

### Detailed summary
- In both `WalletModalManager.tsx` and `ConnectWalletButton.tsx`:
  - Added a fallback to an empty array (`: []`) when `TOP_WALLET_MAP[chainId]` is undefined.
  - Retained the existing logic for mapping and filtering wallets based on `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->