### PR TITLE
feat: add symbol alias in import tokens & info search

### DIFF
--- a/apps/web/src/components/SearchModal/ImportTokenRow.tsx
+++ b/apps/web/src/components/SearchModal/ImportTokenRow.tsx
@@ -1,6 +1,7 @@
-import { CSSProperties } from 'react'
-import { Token, Currency } from '@pancakeswap/swap-sdk-core'
+import { Currency, Token } from '@pancakeswap/swap-sdk-core'
 import { TokenRowButton } from '@pancakeswap/widgets-internal'
+import { CSSProperties } from 'react'
+import { getTokenSymbolAlias } from 'utils/getTokenAlias'
 import TokenRowWithCurrencyLogo from './TokenRowWithCurrencyLogo'
 
 interface ImportTokenRowProps {
@@ -30,6 +31,7 @@ const ImportTokenRow: React.FC<React.PropsWithChildren<ImportTokenRowProps>> = (
     <TokenRowWithCurrencyLogo
       style={style}
       token={token}
+      symbolAlias={getTokenSymbolAlias(token?.address, token?.chainId, token?.symbol)}
       dim={dim}
       list={list}
       onCurrencySelect={onCurrencySelect}

--- a/apps/web/src/views/InfinityInfo/components/Search/index.tsx
+++ b/apps/web/src/views/InfinityInfo/components/Search/index.tsx
@@ -13,7 +13,7 @@ import { CurrencyLogo, DoubleCurrencyLogo } from 'views/Info/components/Currency
 
 import { chainIdToExplorerInfoChainName } from 'state/info/api/client'
 import useFetchSearchResults from 'state/info/queries/search'
-import { getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
+import { getTokenAddressFromSymbolAlias, getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { GreyBadge } from 'views/V3Info/components/Card'
 import { feeTierPercent } from 'views/V3Info/utils'
 import { infinityInfoPath } from '../../constants'
@@ -137,7 +137,7 @@ const Search = () => {
 
   const [showMenu, setShowMenu] = useState(false)
   const [value, setValue] = useState('')
-  const debouncedSearchTerm = useDebounce(value, 600)
+  const debouncedSearchTerm = useDebounce(getTokenAddressFromSymbolAlias(value, chainId, value), 600)
 
   const { tokens, pools, poolsLoading: loading, error } = useFetchSearchResults(debouncedSearchTerm, showMenu)
 

--- a/apps/web/src/views/Info/components/InfoSearch/index.tsx
+++ b/apps/web/src/views/Info/components/InfoSearch/index.tsx
@@ -11,7 +11,7 @@ import { useChainNameByQuery, useMultiChainPath } from 'state/info/hooks'
 import useFetchSearchResults from 'state/info/queries/search'
 import { styled } from 'styled-components'
 import { formatAmount } from 'utils/formatInfoNumbers'
-import { getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
+import { getTokenAddressFromSymbolAlias, getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'views/Info/components/CurrencyLogo'
 
 const Container = styled.div`
@@ -133,7 +133,7 @@ const Search = () => {
 
   const [showMenu, setShowMenu] = useState(false)
   const [value, setValue] = useState('')
-  const debouncedSearchTerm = useDebounce(value, 600)
+  const debouncedSearchTerm = useDebounce(getTokenAddressFromSymbolAlias(value, chainId, value), 600)
 
   const { tokens, pools, tokensLoading, poolsLoading, error } = useFetchSearchResults(debouncedSearchTerm, showMenu)
 

--- a/apps/web/src/views/V3Info/components/Search/index.tsx
+++ b/apps/web/src/views/V3Info/components/Search/index.tsx
@@ -11,7 +11,7 @@ import { styled } from 'styled-components'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { CurrencyLogo, DoubleCurrencyLogo } from 'views/Info/components/CurrencyLogo'
 
-import { getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
+import { getTokenAddressFromSymbolAlias, getTokenNameAlias, getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { v3InfoPath } from '../../constants'
 import { useSearchData } from '../../hooks'
 import { feeTierPercent } from '../../utils'
@@ -136,7 +136,7 @@ const Search = () => {
 
   const [showMenu, setShowMenu] = useState(false)
   const [value, setValue] = useState('')
-  const debouncedSearchTerm = useDebounce(value, 600)
+  const debouncedSearchTerm = useDebounce(getTokenAddressFromSymbolAlias(value, chainId, value), 600)
 
   const { tokens, pools, loading, error } = useSearchData(debouncedSearchTerm, showMenu)
 

--- a/packages/widgets-internal/swap/withCurrencyLogo.tsx
+++ b/packages/widgets-internal/swap/withCurrencyLogo.tsx
@@ -1,8 +1,8 @@
-import { CSSProperties, ReactElement } from "react";
-import { BaseCurrency } from "@pancakeswap/swap-sdk-core";
 import { useTranslation } from "@pancakeswap/localization";
-import { styled } from "styled-components";
+import { BaseCurrency } from "@pancakeswap/swap-sdk-core";
 import { AutoColumn, AutoRow, Button, Flex, RowFixed, Text, useMatchBreakpoints } from "@pancakeswap/uikit";
+import { CSSProperties, ReactElement } from "react";
+import { styled } from "styled-components";
 import { ListLogo } from "./ListLogo";
 
 const TokenSection = styled.div<{ dim?: boolean }>`
@@ -40,6 +40,7 @@ export function withCurrencyLogo<T extends BaseCurrency>(
 ) {
   return ({
     token,
+    symbolAlias,
     style,
     dim,
     onCurrencySelect,
@@ -48,6 +49,7 @@ export function withCurrencyLogo<T extends BaseCurrency>(
     children,
   }: {
     token: T;
+    symbolAlias?: string;
     style?: CSSProperties;
     dim?: boolean;
     onCurrencySelect?: (currency: T) => void;
@@ -73,7 +75,7 @@ export function withCurrencyLogo<T extends BaseCurrency>(
         <AutoColumn gap="4px" style={{ opacity: dim ? "0.6" : "1" }}>
           <AutoRow>
             <NameOverflow title={token.name}>
-              {token.symbol}
+              {symbolAlias ?? token.symbol}
               <Text ellipsis color="textDisabled" fontSize="12px">
                 {token.name}
               </Text>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the way token symbols are handled in various components by introducing the `getTokenAddressFromSymbolAlias` function and updating the usage of token symbols throughout the application.

### Detailed summary
- In `ImportTokenRow.tsx`, added `symbolAlias` prop to `TokenRowWithCurrencyLogo` using `getTokenSymbolAlias`.
- Updated `debouncedSearchTerm` in multiple components to use `getTokenAddressFromSymbolAlias`.
- Adjusted imports to include `getTokenAddressFromSymbolAlias` where necessary.
- Modified the rendering of token symbols to use `symbolAlias` if available in `withCurrencyLogo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->