### PR TITLE
fix: remove no used chart

### DIFF
--- a/apps/web/src/views/SwapSimplify/index.tsx
+++ b/apps/web/src/views/SwapSimplify/index.tsx
@@ -1,19 +1,13 @@
-import { Currency } from '@pancakeswap/sdk'
-import { BottomDrawer, Box, Flex, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Box, Flex, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { useRouter } from 'next/router'
 import { useContext, useEffect, useState } from 'react'
 
 import { MobileCard } from 'components/AdPanel/MobileCard'
-import { useCurrency } from 'hooks/Tokens'
 import { AutoSlippageProvider } from 'hooks/useAutoSlippageWithFallback'
 import { useSwapHotTokenDisplay } from 'hooks/useSwapHotTokenDisplay'
-import { useSingleTokenSwapInfo } from 'quoter/hook/useSingleTokenSwapInfo'
 import { QuoteProvider } from 'quoter/QuoteProvider'
-import { Field } from 'state/swap/actions'
-import { useSwapState } from 'state/swap/hooks'
 import { styled } from 'styled-components'
 import Page from '../Page'
-import PriceChartContainer from '../Swap/components/Chart/PriceChartContainer'
 import { StyledSwapContainer } from '../Swap/styles'
 import { SwapFeaturesContext } from '../Swap/SwapFeaturesContext'
 import { InfinitySwapForm } from './InfinitySwap'
@@ -28,15 +22,8 @@ const Wrapper = styled(Box)`
 
 const InfinitySwapInner = () => {
   const { query } = useRouter()
-  const { isDesktop, isMobile } = useMatchBreakpoints()
-  const {
-    isChartExpanded,
-    isChartDisplayed,
-    setIsChartDisplayed,
-    setIsChartExpanded,
-    isChartSupported,
-    // isHotTokenSupported,
-  } = useContext(SwapFeaturesContext)
+  const { isMobile } = useMatchBreakpoints()
+  const { isChartExpanded, isChartDisplayed, setIsChartDisplayed, setIsChartExpanded } = useContext(SwapFeaturesContext)
   const [isSwapHotTokenDisplay, setIsSwapHotTokenDisplay] = useSwapHotTokenDisplay()
   // const { t } = useTranslation()
   const [firstTime, setFirstTime] = useState(true)
@@ -52,26 +39,6 @@ const InfinitySwapInner = () => {
     }
   }, [firstTime, isChartDisplayed, isSwapHotTokenDisplay, query, setIsSwapHotTokenDisplay, setIsChartDisplayed])
 
-  // swap state & price data
-  const {
-    [Field.INPUT]: { currencyId: inputCurrencyId },
-    [Field.OUTPUT]: { currencyId: outputCurrencyId },
-  } = useSwapState()
-  const inputCurrency = useCurrency(inputCurrencyId)
-  const outputCurrency = useCurrency(outputCurrencyId)
-
-  const currencies: { [field in Field]?: Currency } = {
-    [Field.INPUT]: inputCurrency ?? undefined,
-    [Field.OUTPUT]: outputCurrency ?? undefined,
-  }
-
-  const singleTokenPrice = useSingleTokenSwapInfo({
-    inputCurrencyId,
-    inputCurrency: inputCurrency || undefined,
-    outputCurrencyId,
-    outputCurrency: outputCurrency || undefined,
-  })
-
   return (
     <Page removePadding hideFooterOnDesktop={isChartExpanded || false} showExternalLink={false} showHelpLink={false}>
       <Flex
@@ -82,38 +49,6 @@ const InfinitySwapInner = () => {
         mt={isChartExpanded ? undefined : isMobile ? '18px' : '42px'}
         p={isChartExpanded ? undefined : isMobile ? '16px' : '24px'}
       >
-        {isDesktop && isChartSupported && (
-          <PriceChartContainer
-            inputCurrencyId={inputCurrencyId}
-            inputCurrency={currencies[Field.INPUT]}
-            outputCurrencyId={outputCurrencyId}
-            outputCurrency={currencies[Field.OUTPUT]}
-            isChartExpanded={isChartExpanded}
-            setIsChartExpanded={setIsChartExpanded}
-            isChartDisplayed={isChartDisplayed}
-            currentSwapPrice={singleTokenPrice}
-          />
-        )}
-        {!isDesktop && isChartSupported && (
-          <BottomDrawer
-            content={
-              <PriceChartContainer
-                inputCurrencyId={inputCurrencyId}
-                inputCurrency={currencies[Field.INPUT]}
-                outputCurrencyId={outputCurrencyId}
-                outputCurrency={currencies[Field.OUTPUT]}
-                isChartExpanded={isChartExpanded}
-                setIsChartExpanded={setIsChartExpanded}
-                isChartDisplayed={isChartDisplayed}
-                currentSwapPrice={singleTokenPrice}
-                isFullWidthContainer
-                isMobile
-              />
-            }
-            isOpen={isChartDisplayed}
-            setIsOpen={(isOpen) => setIsChartDisplayed?.(isOpen)}
-          />
-        )}
         <Flex
           flexDirection="column"
           alignItems="center"


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `InfinitySwapInner` component in `apps/web/src/views/SwapSimplify/index.tsx` by removing unused imports and variables, streamlining context usage, and eliminating the conditional rendering of the `PriceChartContainer` and `BottomDrawer`.

### Detailed summary
- Removed import of `BottomDrawer` and `PriceChartContainer`.
- Removed unused `useCurrency`, `useSingleTokenSwapInfo`, and related swap state variables.
- Streamlined context usage by retaining only necessary properties.
- Eliminated conditional rendering of chart components based on `isDesktop` and `isChartSupported`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->