### PR TITLE
fix: add missing tickspacing

### DIFF
--- a/packages/smart-router/evm/infinity-router/queries/getInfinityPools.ts
+++ b/packages/smart-router/evm/infinity-router/queries/getInfinityPools.ts
@@ -131,6 +131,7 @@ interface RemotePoolCL extends RemotePoolBase {
   liquidity: string
   sqrtPrice: string
   tick: number
+  tickSpacing: number
 }
 
 interface RemotePoolBIN extends RemotePoolBase {
@@ -198,7 +199,7 @@ function parsePool(remote: RemotePoolCL | RemotePoolBIN, chainId: keyof typeof h
       liquidity: BigInt(remoteClPool.liquidity),
       sqrtRatioX96: BigInt(remoteClPool.sqrtPrice),
       tick: remoteClPool.tick,
-      tickSpacing: 1,
+      tickSpacing: Number(remoteClPool.tickSpacing),
     } as InfinityClPool
   }
   if (pool.type === PoolType.InfinityBIN) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `tickSpacing` property in the `parsePool` function to ensure it is correctly converted to a number from the `remoteClPool` object.

### Detailed summary
- Added `tickSpacing: number` to the `RemotePoolBIN` interface.
- Updated the `tickSpacing` assignment in the `parsePool` function from a hardcoded value of `1` to `Number(remoteClPool.tickSpacing)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->