### PR TITLE
fix: Missing pool from subgraph

### DIFF
--- a/.github/workflows/deploy-apis.yml
+++ b/.github/workflows/deploy-apis.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build:packages
 
       - name: Publish
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@3
         if: ${{ (env.HAVE_CLOUDFLARE_TOKEN == 'true') && (env.IS_DEV == 'false') }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-apis.yml
+++ b/.github/workflows/deploy-apis.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build:packages
 
       - name: Publish
-        uses: cloudflare/wrangler-action@3
+        uses: cloudflare/wrangler-action@v3
         if: ${{ (env.HAVE_CLOUDFLARE_TOKEN == 'true') && (env.IS_DEV == 'false') }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-apis.yml
+++ b/.github/workflows/deploy-apis.yml
@@ -51,7 +51,7 @@ jobs:
           command: publish --env ${{ github.event.inputs.environment }}
 
       - name: Publish dev
-        uses: cloudflare/wrangler-action@2.0.0
+        uses: cloudflare/wrangler-action@v3
         if: ${{ (env.HAVE_CLOUDFLARE_TOKEN == 'true') && (env.IS_DEV == 'true') }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apis/routing/src/bindings.d.ts
+++ b/apis/routing/src/bindings.d.ts
@@ -8,6 +8,7 @@ declare global {
   const BSC_TESTNET_NODE: string
   const NODE_REAL_SUBGRAPH_API_KEY: string
   const THE_GRAPH_API_KEY: string
+  const EXPLORER_API_KEY: string
 
   const SUBGRAPH_POOLS: R2Bucket
 }

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -72,6 +72,10 @@ export function poolsRoute(router: Router) {
           address: '0x5968FEACbA91D55010975E0CFe8ACfc32664ad33',
           tvlUSD: '876383',
         })
+        value.push({
+          address: '0xEa27B3E61144f0417f27AeDaa1B9e46FA5a49ff1',
+          tvlUSD: '305600',
+        })
 
         return new Response(JSON.stringify(value), {
           headers,

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -68,6 +68,10 @@ export function poolsRoute(router: Router) {
           address: '0x7d94b911A51670f78a44A7Af3C2Bf773C42f2497',
           tvlUSD: '3748455',
         })
+        value.push({
+          address: '0x5968FEACbA91D55010975E0CFe8ACfc32664ad33',
+          tvlUSD: '876383',
+        })
 
         return new Response(JSON.stringify(value), {
           headers,

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -56,8 +56,20 @@ export function poolsRoute(router: Router) {
           'Cache-Control',
           isQueryByDate ? 's-maxage=86400, stale-while-revalidate=3600' : 's-maxage=1800, stale-while-revalidate=900',
         )
+        if (route !== '/v0/v3-pools-tvl/:chainId' || chainId !== '56') {
+          return new Response(object.body, {
+            headers,
+          })
+        }
 
-        return new Response(object.body, {
+        // FIXME: remove this hardcode once we understand the reason for out-dated tvl
+        const value: any = await object.json()
+        value.push({
+          address: '0x7d94b911A51670f78a44A7Af3C2Bf773C42f2497',
+          tvlUSD: '3748455',
+        })
+
+        return new Response(JSON.stringify(value), {
           headers,
         })
       })

--- a/apis/routing/src/pools.ts
+++ b/apis/routing/src/pools.ts
@@ -56,28 +56,8 @@ export function poolsRoute(router: Router) {
           'Cache-Control',
           isQueryByDate ? 's-maxage=86400, stale-while-revalidate=3600' : 's-maxage=1800, stale-while-revalidate=900',
         )
-        if (route !== '/v0/v3-pools-tvl/:chainId' || chainId !== '56') {
-          return new Response(object.body, {
-            headers,
-          })
-        }
 
-        // FIXME: remove this hardcode once we understand the reason for out-dated tvl
-        const value: any = await object.json()
-        value.push({
-          address: '0x7d94b911A51670f78a44A7Af3C2Bf773C42f2497',
-          tvlUSD: '3748455',
-        })
-        value.push({
-          address: '0x5968FEACbA91D55010975E0CFe8ACfc32664ad33',
-          tvlUSD: '876383',
-        })
-        value.push({
-          address: '0xEa27B3E61144f0417f27AeDaa1B9e46FA5a49ff1',
-          tvlUSD: '305600',
-        })
-
-        return new Response(JSON.stringify(value), {
+        return new Response(object.body, {
           headers,
         })
       })

--- a/apis/routing/src/queries/pools.ts
+++ b/apis/routing/src/queries/pools.ts
@@ -1,0 +1,56 @@
+import { ChainId } from '@pancakeswap/chains'
+import { getAddress } from 'viem'
+
+const CHAIN_TO_QUERY = {
+  [ChainId.ETHEREUM]: 'ethereum',
+  [ChainId.BSC]: 'bsc',
+  [ChainId.ARBITRUM_ONE]: 'arbitrum',
+  [ChainId.POLYGON_ZKEVM]: 'polygon-zkevm',
+  [ChainId.ZKSYNC]: 'zksync',
+  [ChainId.LINEA]: 'linea',
+  [ChainId.BASE]: 'base',
+  [ChainId.OPBNB]: 'opbnb',
+} as const
+
+const requireCheck = [EXPLORER_API_KEY]
+requireCheck.forEach((node) => {
+  if (!node) {
+    throw new Error('Missing env var')
+  }
+})
+
+export async function getPoolsTvlFromExplorerAPI({ chainId }: { chainId: ChainId }) {
+  const chain = (CHAIN_TO_QUERY as any)[chainId]
+  const pageSize = 50
+  let hasMorePools = true
+  let endCursor = ''
+  let pools: any[] = []
+  while (hasMorePools) {
+    // eslint-disable-next-line no-await-in-loop
+    const res = await fetch(
+      `https://explorer.pancakeswap.com/api/cached/pools/list?orderBy=tvlUSD&protocols=v3&chains=${chain}${
+        endCursor ? `&after=${endCursor}` : ''
+      }`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': EXPLORER_API_KEY,
+        },
+      },
+    )
+    // eslint-disable-next-line no-await-in-loop
+    const data: any = await res.json()
+    if (data.rows.length < pageSize) {
+      hasMorePools = false
+      pools = [...pools, ...data.rows]
+      break
+    }
+    endCursor = data.endCursor
+    pools = [...pools, ...data.rows]
+  }
+
+  return pools.map((p) => ({
+    address: getAddress(p.id),
+    tvlUSD: String(Math.floor(Number(p.tvlUSD))),
+  }))
+}

--- a/apis/routing/wrangler.toml
+++ b/apis/routing/wrangler.toml
@@ -1,20 +1,18 @@
 compatibility_date = "2022-05-20"
 kv_namespaces = [
-  {binding = "POOLS", id = "29d3e7e6c3c44fa7bf7174ee2b7b1295", preview_id = "c808d98df0444ae1a680bc84a029baaa"},
+  { binding = "POOLS", id = "29d3e7e6c3c44fa7bf7174ee2b7b1295", preview_id = "c808d98df0444ae1a680bc84a029baaa" },
 ]
 r2_buckets = [
-  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools-dev", preview_bucket_name = "subgraph-pools-dev" }
+  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools-dev", preview_bucket_name = "subgraph-pools-dev" },
 ]
 main = "src/index.ts"
 name = "routing-dev"
 node_compat = true
 
 [env.production]
-kv_namespaces = [
-  {binding = "POOLS", id = "5261431ca6b74625b08ffe288b86a2a5"},
-]
+kv_namespaces = [{ binding = "POOLS", id = "5261431ca6b74625b08ffe288b86a2a5" }]
 r2_buckets = [
-  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools", preview_bucket_name = "subgraph-pools-dev" }
+  { binding = "SUBGRAPH_POOLS", bucket_name = "subgraph-pools", preview_bucket_name = "subgraph-pools-dev" },
 ]
 name = "routing"
 
@@ -25,4 +23,5 @@ name = "routing"
 # - BSC_TESTNET_NODE
 # - NODE_REAL_SUBGRAPH_API_KEY
 # - THE_GRAPH_API_KEY
+# - EXPLORER_API_KEY
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `EXPLORER_API_KEY` constant, updates the `wrangler-action` version in the GitHub Actions workflow, and enhances the handling of pool data by integrating a new API for fetching TVL (Total Value Locked) data from an explorer.

### Detailed summary
- Added `EXPLORER_API_KEY` constant in `bindings.d.ts`.
- Updated `wrangler-action` from version `2.0.0` to `v3` in `deploy-apis.yml`.
- Modified `kv_namespaces` and `r2_buckets` formatting in `wrangler.toml`.
- Implemented `getPoolsTvlFromExplorerAPI` function in `pools.ts` to fetch pool TVL data.
- Enhanced `handleScheduled` function in `subgraphPoolBackup.ts` to combine results from subgraph and explorer API.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->