### PR TITLE
fix: prevent layout shift when modal opens

### DIFF
--- a/packages/uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/uikit/src/components/Overlay/Overlay.tsx
@@ -40,15 +40,21 @@ const StyledOverlay = styled(Box)<{ isUnmounting?: boolean }>`
 const BodyLock = () => {
   useEffect(() => {
     if (document?.body?.style) {
-      document.body.style.cssText = `
-      overflow: hidden;
-    `;
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      const previousOverflow = document.body.style.overflow;
+      const previousPaddingRight = document.body.style.paddingRight;
+
       document.body.style.overflow = "hidden";
+      if (scrollbarWidth > 0) {
+        document.body.style.paddingRight = `${scrollbarWidth}px`;
+      }
+
       return () => {
-        document.body.style.cssText = `
-        overflow: visible;
-        overflow: overlay;
-      `;
+        document.body.style.overflow = previousOverflow || "visible";
+        document.body.style.paddingRight = previousPaddingRight;
+        if (!previousOverflow) {
+          document.body.style.overflow = "overlay";
+        }
       };
     }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `useEffect` hook in the `Overlay` component to manage the body's overflow and padding styles more effectively when the overlay is active, ensuring the correct handling of scrollbars.

### Detailed summary
- Removed direct manipulation of `document.body.style.cssText`.
- Introduced variables to store previous `overflow` and `paddingRight` values.
- Calculated `scrollbarWidth` to adjust `paddingRight` when necessary.
- Restored previous styles on cleanup, ensuring proper overflow handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->