### PR TITLE
fix(PAN-5761): position price display

### DIFF
--- a/apps/web/src/pages/liquidity/[tokenId].tsx
+++ b/apps/web/src/pages/liquidity/[tokenId].tsx
@@ -28,7 +28,14 @@ import {
 import { ConfirmationModalContent, NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 
 import { Trans, useTranslation } from '@pancakeswap/localization'
-import { MasterChefV3, NonfungiblePositionManager, Pool, Position, isPoolTickInRange } from '@pancakeswap/v3-sdk'
+import {
+  MasterChefV3,
+  NonfungiblePositionManager,
+  Pool,
+  Position,
+  isPoolTickInRange,
+  tickToPrice,
+} from '@pancakeswap/v3-sdk'
 import { useQuery } from '@tanstack/react-query'
 import { AppHeader } from 'components/App'
 import { LightGreyCard } from 'components/Card'
@@ -57,7 +64,6 @@ import { usePool } from 'hooks/v3/usePools'
 import { useV3PositionFees } from 'hooks/v3/useV3PositionFees'
 import { useV3PositionFromTokenId, useV3TokenIdsByAccount } from 'hooks/v3/useV3Positions'
 import { formatTickPrice } from 'hooks/v3/utils/formatTickPrice'
-import getPriceOrderingFromPositionForUI from 'hooks/v3/utils/getPriceOrderingFromPositionForUI'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
@@ -256,16 +262,14 @@ export default function PoolPage() {
 
   const tickAtLimit = useIsTickAtLimit(feeAmount, tickLower, tickUpper)
 
-  const pricesFromPosition = getPriceOrderingFromPositionForUI(position)
-
   const [manuallyInverted, setManuallyInverted] = useState(false)
 
   // handle manual inversion
   const { priceLower, priceUpper, base } = useInverter({
-    priceLower: pricesFromPosition.priceLower,
-    priceUpper: pricesFromPosition.priceUpper,
-    quote: pricesFromPosition.quote,
-    base: pricesFromPosition.base,
+    priceLower: position ? tickToPrice(position.pool.token0, position.pool.token1, position.tickLower) : undefined,
+    priceUpper: position ? tickToPrice(position.pool.token0, position.pool.token1, position.tickUpper) : undefined,
+    quote: position?.pool.token1,
+    base: position?.pool.token0,
     invert: manuallyInverted,
   })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `PoolPage` component in the `liquidity/[tokenId].tsx` file by adding a new utility function and removing an unused import, which improves the code's clarity and functionality related to price calculations.

### Detailed summary
- Added `tickToPrice` import from `@pancakeswap/v3-sdk`.
- Removed unused import: `getPriceOrderingFromPositionForUI`.
- Replaced the calculation of `priceLower` and `priceUpper` with values derived from `tickToPrice` based on `position.pool.token0` and `position.pool.token1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->