### PR TITLE
chore: Add iswrongnetwork param to account active chain hook

### DIFF
--- a/apps/web/src/hooks/infinity/useAddCLLiquidity.tsx
+++ b/apps/web/src/hooks/infinity/useAddCLLiquidity.tsx
@@ -187,7 +187,7 @@ export const useAddCLPoolAndPosition = (
     true,
     'infinity-cl-add-liquidity-modal',
   )
-  const [onPresentErrorModal, onDismissErrorModal] = useModal(
+  const [onPresentErrorModal] = useModal(
     <ErrorModal title={t('Add Liquidity')} subTitle={txnErrorMessage} />,
     true,
     true,

--- a/apps/web/src/hooks/useAccountActiveChain.ts
+++ b/apps/web/src/hooks/useAccountActiveChain.ts
@@ -8,21 +8,22 @@ import { useActiveChainId } from './useActiveChainId'
 interface AccountChainState {
   account?: `0x${string}`
   chainId: number | undefined
+  isWrongNetwork: boolean
   status: 'connected' | 'disconnected' | 'connecting' | 'reconnecting' | null
 }
 
-const accountChainProxy = proxy<AccountChainState>({ chainId: undefined, status: null })
+const accountChainProxy = proxy<AccountChainState>({ chainId: undefined, isWrongNetwork: false, status: null })
 export const accountActiveChainAtom = atomWithProxy(accountChainProxy)
 
 const useAccountActiveChain = () => {
   const { address: account, status } = useAccount()
-  const { chainId } = useActiveChainId()
+  const { chainId, isWrongNetwork } = useActiveChainId()
 
   const [, setProxy] = useAtom(accountActiveChainAtom)
 
   useEffect(() => {
-    setProxy({ account, chainId, status })
-  }, [account, chainId, status, setProxy])
+    setProxy({ account, chainId, isWrongNetwork, status })
+  }, [account, chainId, status, isWrongNetwork, setProxy])
 
   return useAtomValue(accountActiveChainAtom)
 }

--- a/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
+++ b/apps/web/src/views/AddLiquidityV3/IncreaseLiquidityV3.tsx
@@ -22,7 +22,7 @@ import { useRouter } from 'next/router'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { calculateGasMargin } from 'utils'
 import Page from 'views/Page'
-import { useAccount, useSendTransaction } from 'wagmi'
+import { useSendTransaction } from 'wagmi'
 
 import { BodyWrapper } from 'components/App/AppBody'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
@@ -38,7 +38,7 @@ import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
 import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
 import { useSingleCallResult } from 'state/multicall/hooks'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
-import { useActiveChainId } from 'hooks/useActiveChainId'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { V3SubmitButton } from './components/V3SubmitButton'
 import LockedDeposit from './formViews/V3FormView/components/LockedDeposit'
 import { PositionPreview } from './formViews/V3FormView/components/PositionPreview'
@@ -64,8 +64,7 @@ export default function IncreaseLiquidityV3({ currencyA: baseCurrency, currencyB
   } = useTranslation()
   const expertMode = useIsExpertMode()
 
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
 
   const masterchefV3 = useMasterchefV3()
   const { tokenIds: stakedTokenIds, loading: tokenIdsInMCv3Loading } = useV3TokenIdsByAccount(

--- a/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V2FormView.tsx
@@ -22,7 +22,6 @@ import ConnectWalletButton from 'components/ConnectWalletButton'
 import CurrencyInputPanel from 'components/CurrencyInputPanel'
 import { CommonBasesType } from 'components/SearchModal/types'
 import { Bound } from 'config/constants/types'
-import { useActiveChainId } from 'hooks/useActiveChainId'
 import { CurrencyField as Field } from 'utils/types'
 import { getBlockExploreLink } from 'utils'
 import { logGTMClickAddLiquidityEvent } from 'utils/customGTMEventTracking'
@@ -30,7 +29,7 @@ import { LP2ChildrenProps } from 'views/AddLiquidity'
 
 import { InfoBox } from '@pancakeswap/widgets-internal'
 import ApproveLiquidityTokens from 'views/AddLiquidityV3/components/ApproveLiquidityTokens'
-import { useAccount } from 'wagmi'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { HideMedium, MediumOnly, RightContainer } from './V3FormView'
 import RangeSelector from './V3FormView/components/RangeSelector'
 
@@ -62,8 +61,7 @@ export default function V2FormView({
 }: LP2ChildrenProps) {
   const mockFn = useCallback(() => undefined, [])
 
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const { t } = useTranslation()
   const expertMode = useIsExpertMode()
   const pairExplorerLink = useMemo(

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -57,13 +57,13 @@ import { getViemClients } from 'utils/viem'
 import { hexToBigInt } from 'viem'
 import { V3SubmitButton } from 'views/AddLiquidityV3/components/V3SubmitButton'
 import { QUICK_ACTION_CONFIGS } from 'views/AddLiquidityV3/types'
-import { useAccount, useSendTransaction, useWalletClient } from 'wagmi'
+import { useSendTransaction, useWalletClient } from 'wagmi'
 
 import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
 import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
 import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { useDensityChartData } from 'views/AddLiquidityV3/hooks/useDensityChartData'
-import { useActiveChainId } from 'hooks/useActiveChainId'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import LockedDeposit from './components/LockedDeposit'
 import { PositionPreview } from './components/PositionPreview'
 import RangeSelector from './components/RangeSelector'
@@ -137,8 +137,7 @@ export default function V3FormView({
   const expertMode = useIsExpertMode()
 
   const positionManager = useV3NFTPositionManagerContract()
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const addTransaction = useTransactionAdder()
 
   // mint state

--- a/apps/web/src/views/Farms/components/MultiChainHarvestModal.tsx
+++ b/apps/web/src/views/Farms/components/MultiChainHarvestModal.tsx
@@ -32,6 +32,7 @@ import { useFarmCProxyAddress } from 'views/Farms/hooks/useFarmCProxyAddress'
 import useCrossChainHarvestFarm from 'views/Farms/hooks/useCrossChainHarvestFarm'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useAccount } from 'wagmi'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 
 const TokenWrapper = styled.div`
   padding-right: 8px;
@@ -62,8 +63,7 @@ const MultiChainHarvestModal: React.FC<MultiChainHarvestModalProp> = ({
 }) => {
   const { t } = useTranslation()
   const { toastSuccess } = useToast()
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const { switchNetworkAsync } = useSwitchNetwork()
   const { cProxyAddress } = useFarmCProxyAddress(account, chainId)
   const { onReward } = useCrossChainHarvestFarm(pid, cProxyAddress)

--- a/apps/web/src/views/IncreaseLiquidity/index.tsx
+++ b/apps/web/src/views/IncreaseLiquidity/index.tsx
@@ -50,8 +50,7 @@ import { INITIAL_ALLOWED_SLIPPAGE, useUserSlippage } from '@pancakeswap/utils/us
 import { useHookByPoolId } from 'hooks/infinity/useHooksList'
 import { calculateSlippageAmount } from 'utils/exchange'
 import { NavBreadcrumbs } from 'views/RemoveLiquidityInfinity/components/NavBreadcrumbs'
-import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useAccount } from 'wagmi'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { useErrorMsg } from './hooks/useErrorMsg'
 import { useIncreaseForm } from './hooks/useIncreaseForm'
 
@@ -94,8 +93,7 @@ export const IncreaseLiquidity = () => {
     t,
     currentLanguage: { locale },
   } = useTranslation()
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const { tokenId } = useInfinityClammPositionIdRouteParams()
 
   const { position } = useInfinityClPositionFromTokenId(tokenId, chainId)
@@ -194,7 +192,7 @@ export const IncreaseLiquidity = () => {
   const [allowedSlippage] = useUserSlippage() || [INITIAL_ALLOWED_SLIPPAGE]
 
   const { addCLLiquidity, attemptingTx } = useAddCLPoolAndPosition(
-    chainId,
+    chainId ?? 0,
     account ?? zeroAddress,
     currency0Address,
     currency1Address,

--- a/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveStableLiquidity/index.tsx
@@ -50,8 +50,7 @@ import { useGasPrice } from 'state/user/hooks'
 import { logGTMClickRemoveLiquidityEvent } from 'utils/customGTMEventTracking'
 import { formatAmount } from 'utils/formatInfoNumbers'
 import { isUserRejected, logError } from 'utils/sentry'
-import { useActiveChainId } from 'hooks/useActiveChainId'
-import { useAccount } from 'wagmi'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { RemoveLiquidityLayout } from '..'
 import ConnectWalletButton from '../../../components/ConnectWalletButton'
 import CurrencyInputPanel from '../../../components/CurrencyInputPanel'
@@ -73,8 +72,7 @@ export default function RemoveStableLiquidity({ currencyA, currencyB, currencyId
   const native = useNativeCurrency()
   const { isMobile } = useMatchBreakpoints()
 
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const { toastError } = useToast()
   const [tokenA, tokenB] = useMemo(() => [currencyA?.wrapped, currencyB?.wrapped], [currencyA, currencyB])
 

--- a/apps/web/src/views/RemoveLiquidity/index.tsx
+++ b/apps/web/src/views/RemoveLiquidity/index.tsx
@@ -55,6 +55,7 @@ import { useRemoveLiquidityV2FormState } from 'state/burn/reducer'
 import { useGasPrice } from 'state/user/hooks'
 import { logGTMClickRemoveLiquidityEvent } from 'utils/customGTMEventTracking'
 import { isUserRejected, logError } from 'utils/sentry'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
 import { AppBody, AppHeader } from '../../components/App'
 import ConnectWalletButton from '../../components/ConnectWalletButton'
 import CurrencyInputPanel from '../../components/CurrencyInputPanel'
@@ -78,8 +79,7 @@ export default function RemoveLiquidity({ currencyA, currencyB, currencyIdA, cur
   const native = useNativeCurrency()
   const { isMobile } = useMatchBreakpoints()
 
-  const { chainId, isWrongNetwork } = useActiveChainId()
-  const { address: account } = useAccount()
+  const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const { signTypedDataAsync } = useSignTypedData()
   const { toastError } = useToast()
   const [tokenA, tokenB] = useMemo(() => [currencyA?.wrapped, currencyB?.wrapped], [currencyA, currencyB])


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the codebase to replace the usage of `useActiveChainId` and `useAccount` hooks with a new `useAccountActiveChain` hook across multiple components, streamlining the management of account and chain state in the application.

### Detailed summary
- Replaced `useActiveChainId` and `useAccount` with `useAccountActiveChain` in various components.
- Updated state management in `useAccountActiveChain` to include `isWrongNetwork`.
- Adjusted `setProxy` calls to use the new state structure in `useAccountActiveChain`.
- Modified components in `RemoveLiquidity`, `IncreaseLiquidity`, and `AddLiquidityV3` to reflect changes in account and chain logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->