### PR TITLE
feat(PAN-5928): add whitelist hooks default fee

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/utils/exchange.ts
+++ b/apps/web/src/views/Swap/V3Swap/utils/exchange.ts
@@ -1,3 +1,4 @@
+import { findHook, HOOK_CATEGORY } from '@pancakeswap/infinity-sdk'
 import { OrderType } from '@pancakeswap/price-api-sdk'
 import {
   Currency,
@@ -15,7 +16,9 @@ import { FeeAmount } from '@pancakeswap/v3-sdk'
 
 import { BIPS_BASE, INPUT_FRACTION_AFTER_FEE } from 'config/constants/exchange'
 import { Field } from 'state/swap/actions'
+import { isAddressEqual } from 'utils'
 import { basisPointsToPercent } from 'utils/exchange'
+import { zeroAddress } from 'viem'
 import { InterfaceOrder } from 'views/Swap/utils'
 
 export type SlippageAdjustedAmounts = {
@@ -82,7 +85,15 @@ export function computeTradePriceBreakdown(trade?: TradeEssentialForPriceBreakdo
           return currentFee.multiply(ONE_HUNDRED_PERCENT.subtract(v3FeeToPercent(pool.fee)))
         }
         if (SmartRouter.isInfinityClPool(pool) || SmartRouter.isInfinityBinPool(pool)) {
-          const v4FeePercent = new Percent(calculateInfiFeePercent(pool.fee, pool.protocolFee).totalFee, 1e6)
+          let poolFee = pool.fee
+          // override pool fee if the pool is a dynamic fee pool
+          if (pool.hooks && !isAddressEqual(pool.hooks, zeroAddress)) {
+            const hook = findHook(pool.hooks, trade.inputAmount.currency.chainId)
+            if (hook && hook.category?.includes(HOOK_CATEGORY.DynamicFees) && hook.defaultFee) {
+              poolFee = hook.defaultFee
+            }
+          }
+          const v4FeePercent = new Percent(calculateInfiFeePercent(poolFee, pool.protocolFee).totalFee, 1e6)
           return currentFee.multiply(ONE_HUNDRED_PERCENT.subtract(v4FeePercent))
         }
         return currentFee

--- a/apps/web/src/views/Swap/V3Swap/utils/exchange.ts
+++ b/apps/web/src/views/Swap/V3Swap/utils/exchange.ts
@@ -93,8 +93,8 @@ export function computeTradePriceBreakdown(trade?: TradeEssentialForPriceBreakdo
               poolFee = hook.defaultFee
             }
           }
-          const v4FeePercent = new Percent(calculateInfiFeePercent(poolFee, pool.protocolFee).totalFee, 1e6)
-          return currentFee.multiply(ONE_HUNDRED_PERCENT.subtract(v4FeePercent))
+          const infinityFeePercent = new Percent(calculateInfiFeePercent(poolFee, pool.protocolFee).totalFee, 1e6)
+          return currentFee.multiply(ONE_HUNDRED_PERCENT.subtract(infinityFeePercent))
         }
         return currentFee
       }, ONE_HUNDRED_PERCENT),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the fee calculation logic in the `computeTradePriceBreakdown` function within the `exchange.ts` file. It introduces dynamic fee handling for certain pools based on hooks.

### Detailed summary
- Added import for `isAddressEqual` and `zeroAddress`.
- Introduced logic to override the pool fee for dynamic fee pools using hooks.
- Updated the fee calculation to use the overridden pool fee when applicable.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->