### PR TITLE
fix: Multicall gas limit crash

### DIFF
--- a/packages/multicall/src/getGasLimit.ts
+++ b/packages/multicall/src/getGasLimit.ts
@@ -56,7 +56,14 @@ export async function getGasLimit({
   const maxGasLimit = toBigInt(maxGasLimitInput)
   const gasBuffer = toBigInt(gasBufferInput)
 
-  const gasLimit = gasLimitOverride || (await getGasLimitOnChain({ chainId, client })) || maxGasLimit
+  let onChainGasLimit: bigint | undefined
+  try {
+    onChainGasLimit = await getGasLimitOnChain({ chainId, client })
+  } catch (error) {
+    console.warn('Failed to fetch gas limit on chain:', error)
+    onChainGasLimit = undefined
+  }
+  const gasLimit = gasLimitOverride || onChainGasLimit || maxGasLimit
   const minGasLimit = gasLimit < maxGasLimit ? gasLimit : maxGasLimit
   return minGasLimit - gasBuffer
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the gas limit retrieval process by adding error handling for fetching gas limits on-chain and refactoring the `multicallGasLimitAtom` to use a retry mechanism. It also adjusts the configuration for refetching gas limits in the `useMulticallGasLimit` hook.

### Detailed summary
- Introduced error handling when fetching gas limit on-chain in `getGasLimit.ts`.
- Refactored `multicallGasLimitAtom` to use `atomWithAsyncRetry` for improved gas limit fetching.
- Removed redundant refetch interval setting in `useMulticallGasLimit`.
- Added `fallbackValue` for gas limit retrieval in the atom.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->