### PR TITLE
chore: Add nodies back

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -125,8 +125,8 @@ export const PUBLIC_NODES: Record<ChainId, string[] | readonly string[]> = {
   ].filter(Boolean),
   [ChainId.ARBITRUM_GOERLI]: arbitrumGoerli.rpcUrls.default.http,
   [ChainId.POLYGON_ZKEVM]: [
+    process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '',
     getGroveUrl(ChainId.POLYGON_ZKEVM, process.env.NEXT_PUBLIC_GROVE_API_KEY) || '',
-    // process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM || '',
     ...polygonZkEvm.rpcUrls.default.http,
     // 'https://f2562de09abc5efbd21eefa083ff5326.zkevm-rpc.com/',
   ].filter(Boolean),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `nodes.ts` configuration to include a new way of obtaining RPC URLs for the `ChainId.POLYGON_ZKEVM`, enhancing flexibility by allowing the use of an environment variable.

### Detailed summary
- Added `process.env.NEXT_PUBLIC_NODIES_POLYGON_ZKEVM` for `ChainId.POLYGON_ZKEVM` RPC URL.
- Included a fallback to an empty string if the environment variable is not set.
- Retained existing logic to filter out falsy values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->