### PR TITLE
fix: percent mobile position

### DIFF
--- a/apps/solana/src/components/AmountSlider.tsx
+++ b/apps/solana/src/components/AmountSlider.tsx
@@ -83,40 +83,7 @@ export default function AmountSlider({
           </Text>
         </HStack>
 
-        <Desktop>
-          <HStack spacing={2}>
-            {[25, 50, 75, 100].map((percent) => (
-              <Button
-                disabled={isDisabled}
-                height="28px"
-                px="8px"
-                variant="primary60"
-                size="xs"
-                onClick={() => {
-                  setHotPercent(percent)
-                  setPercent(percent)
-                }}
-              >
-                {percent}%
-              </Button>
-            ))}
-          </HStack>
-        </Desktop>
-      </HStack>
-      <Box>
-        <Slider
-          name="lp-amount"
-          disabled={isDisabled}
-          min={0}
-          max={100}
-          value={hotPercent}
-          onValueChanged={(percent_) => {
-            setHotPercent(percent_)
-          }}
-        />
-      </Box>
-      <Mobile>
-        <HStack spacing={sizes.buttonSpace}>
+        <HStack spacing={2}>
           {[25, 50, 75, 100].map((percent) => (
             <Button
               disabled={isDisabled}
@@ -133,7 +100,19 @@ export default function AmountSlider({
             </Button>
           ))}
         </HStack>
-      </Mobile>
+      </HStack>
+      <Box>
+        <Slider
+          name="lp-amount"
+          disabled={isDisabled}
+          min={0}
+          max={100}
+          value={hotPercent}
+          onValueChanged={(percent_) => {
+            setHotPercent(percent_)
+          }}
+        />
+      </Box>
     </PanelCard>
   )
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `AmountSlider` component by simplifying the layout and ensuring consistent spacing across different screen sizes.

### Detailed summary
- Removed `Desktop` and `Mobile` wrappers around the `HStack`.
- Unified `HStack` spacing to `2`.
- Kept the button rendering logic unchanged.
- Maintained the `Slider` component with unchanged props.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->