### PR TITLE
chore: add alias for currency selector

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolsFilterPanel.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsFilterPanel.tsx
@@ -1,4 +1,3 @@
-import { getChainNameInKebabCase } from '@pancakeswap/chains'
 import { Protocol } from '@pancakeswap/farms'
 import { Flex } from '@pancakeswap/uikit'
 import {
@@ -17,6 +16,7 @@ import isUndefined from 'lodash/isUndefined'
 import React, { useMemo } from 'react'
 import { UpdaterByChainId } from 'state/lists/updater'
 import styled from 'styled-components'
+import { getCurrencySymbol } from 'utils/getTokenAlias'
 import { usePoolTypeQuery } from 'views/AddLiquiditySelector/hooks/usePoolTypeQuery'
 import { usePoolProtocols, usePoolTypes } from '../constants'
 import { MAINNET_CHAINS, useAllChainsOpts } from '../hooks/useMultiChains'
@@ -150,6 +150,7 @@ export const PoolsFilterPanel: React.FC<React.PropsWithChildren<IPoolsFilterPane
         )}
         {showTokenFilter && !isUndefined(selectedNetwork) && (
           <TokenFilter
+            getCurrencySymbol={getCurrencySymbol}
             selectedNetwork={selectedNetwork}
             selectedTokens={selectedTokens}
             onChange={handleTokensChange}

--- a/packages/widgets-internal/components/TokenFilter/TokenFilter.tsx
+++ b/packages/widgets-internal/components/TokenFilter/TokenFilter.tsx
@@ -14,6 +14,7 @@ export interface ITokenProps {
   value?: IMultiSelectProps<string>["value"];
   onChange?: (e: IMultiSelectChangeEvent) => void;
   getChainName?: (chainId: number) => string | undefined;
+  getCurrencySymbol?: (currency: Currency) => string | undefined;
   multiple?: boolean;
 }
 
@@ -107,6 +108,7 @@ export const TokenFilter: React.FC<ITokenProps> = ({
   onChange,
   getChainName = defaultGetChainName,
   multiple = true,
+  getCurrencySymbol = (currency) => currency.symbol || "",
 }) => {
   const { theme } = useTheme();
 
@@ -140,12 +142,13 @@ export const TokenFilter: React.FC<ITokenProps> = ({
 
   const itemTemplate = useCallback(
     (option: ISelectItem<string> & ERC20Token) => {
+      const symbol = getCurrencySymbol(option);
       return (
         <ItemContainer>
           <ItemLogoContainer>{option.icon}</ItemLogoContainer>
           <Column>
             <ItemTitle>
-              <ItemSymbol>{option.label}</ItemSymbol>
+              <ItemSymbol>{symbol}</ItemSymbol>
               <ItemName>{option.name}</ItemName>
             </ItemTitle>
             <ItemDesc>{getChainName(option.chainId)}</ItemDesc>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `PoolsFilterPanel` and `TokenFilter` components by integrating the `getCurrencySymbol` utility, allowing for better representation of token symbols in the UI.

### Detailed summary
- Added `getCurrencySymbol` import in `PoolsFilterPanel.tsx`.
- Passed `getCurrencySymbol` prop to the `TokenFilter` component.
- Updated `TokenFilter` to accept `getCurrencySymbol` as a prop.
- Modified the symbol display in `TokenFilter` to use `getCurrencySymbol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->