### PR TITLE
chore: add dollar sign for wallet asset list

### DIFF
--- a/apps/web/src/components/WalletModalV2/WalletModal.tsx
+++ b/apps/web/src/components/WalletModalV2/WalletModal.tsx
@@ -349,7 +349,7 @@ export const WalletContent = ({
                         {asset.price?.totalUsd
                           ? asset.price?.totalUsd < 0.01
                             ? '<$0.01'
-                            : `${formatAmount(asset.price.totalUsd)}`
+                            : `$${formatAmount(asset.price.totalUsd)}`
                           : '$0.00'}
                       </Text>
                     </Box>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the display format of the total USD price for an asset in the `WalletModal` component. It ensures that prices below $0.01 are represented as '<$0.01' while others are prefixed with a dollar sign.

### Detailed summary
- Changed the output for prices below $0.01 to display as '<$0.01'.
- Updated the formatting for prices above $0.01 to include a dollar sign prefix: `$${formatAmount(asset.price.totalUsd)}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->