### PR TITLE
chore: Remove tp chain switch refresh

### DIFF
--- a/apps/web/src/hooks/useSwitchNetwork.ts
+++ b/apps/web/src/hooks/useSwitchNetwork.ts
@@ -11,6 +11,7 @@ import { useAtom } from 'jotai/index'
 import { queryChainIdAtom } from 'hooks/useActiveChainId'
 import { EXCHANGE_PAGE_PATHS } from 'config/constants/exchange'
 import { getHashFromRouter } from 'utils/getHashFromRouter'
+import useAuth from 'hooks/useAuth'
 import { useSwitchNetworkLoading } from './useSwitchNetworkLoading'
 
 const checkSwitchReloadNeeded = async (connector: Connector, chainId: number, address: `0x${string}` | undefined) => {
@@ -100,6 +101,8 @@ export function useSwitchNetwork() {
   const { toastError } = useToast()
   const { isConnected, connector, address } = useAccount()
 
+  const { logout } = useAuth()
+
   const switchNetworkLocal = useSwitchNetworkLocal()
 
   const isLoading = _isLoading || loading
@@ -113,7 +116,7 @@ export function useSwitchNetwork() {
           .then(async (c) => {
             switchNetworkLocal(chainId)
             if (await checkSwitchReloadNeeded(connector, chainId, address)) {
-              window.location.reload()
+              await logout()
             }
             return c
           })
@@ -127,7 +130,18 @@ export function useSwitchNetwork() {
         resolve(switchNetworkLocal(chainId))
       })
     },
-    [isConnected, _switchNetworkAsync, isLoading, setLoading, switchNetworkLocal, toastError, t, connector, address],
+    [
+      isConnected,
+      _switchNetworkAsync,
+      isLoading,
+      setLoading,
+      switchNetworkLocal,
+      toastError,
+      t,
+      connector,
+      address,
+      logout,
+    ],
   )
 
   const switchNetwork = useCallback(

--- a/apps/web/src/hooks/useSwitchNetwork.ts
+++ b/apps/web/src/hooks/useSwitchNetwork.ts
@@ -21,11 +21,10 @@ const checkSwitchReloadNeeded = async (connector: Connector, chainId: number, ad
 
     return Boolean(
       provider &&
-        (provider.isTokenPocket ||
-          (Array.isArray(provider.session?.namespaces?.eip155?.accounts) &&
-            !provider.session.namespaces.eip155.accounts.some((account: string) =>
-              account?.includes(`${chainId}:${address}`),
-            ))),
+        Array.isArray(provider.session?.namespaces?.eip155?.accounts) &&
+        !provider.session.namespaces.eip155.accounts.some((account: string) =>
+          account?.includes(`${chainId}:${address}`),
+        ),
     )
   } catch (error) {
     console.error(error, 'Error detecting provider')


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useSwitchNetwork` hook by integrating user authentication logic to log out users when switching networks, improving session management.

### Detailed summary
- Added import for `useAuth` hook.
- Introduced `logout` function from `useAuth`.
- Updated the logic in `useSwitchNetwork` to call `logout()` before reloading the page if a network switch is needed.
- Adjusted dependency array in `useEffect` to include `logout`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->