### PR TITLE
feat: add market price to slippage check and start price

### DIFF
--- a/apps/web/src/hooks/infinity/usePoolCurrentPrice.ts
+++ b/apps/web/src/hooks/infinity/usePoolCurrentPrice.ts
@@ -1,0 +1,17 @@
+import { BinPool, Pool as CLPool, getCurrencyPriceFromId } from '@pancakeswap/infinity-sdk'
+import { Price } from '@pancakeswap/swap-sdk-core'
+import { useMemo } from 'react'
+
+export const usePoolCurrentPrice = (pool: BinPool | CLPool | undefined | null) => {
+  return useMemo(() => {
+    if (!pool) return undefined
+    if (pool.poolType === 'CL') {
+      return new Price(pool.token0, pool.token1, 2n ** 192n, pool.sqrtRatioX96 * pool.sqrtRatioX96)
+    }
+    if (pool.poolType === 'Bin') {
+      const pool_ = pool as BinPool
+      return getCurrencyPriceFromId(pool_.activeId, pool_.binStep, pool_.token0, pool_.token1)
+    }
+    return undefined
+  }, [pool])
+}

--- a/apps/web/src/hooks/usePoolMarketPriceSlippage.ts
+++ b/apps/web/src/hooks/usePoolMarketPriceSlippage.ts
@@ -33,3 +33,27 @@ export const usePoolMarketPriceSlippage = (
     ]
   }, [currency1marketPrice, currency0marketPrice, poolCurrencyPrice, currency0, currency1])
 }
+
+export const usePoolMarketPrice = (
+  currency0?: Currency,
+  currency1?: Currency,
+): [number | undefined, number | undefined, Price<Currency, Currency> | undefined] => {
+  const { data: currency0marketPrice } = useCurrencyUsdPrice(currency0, {
+    enabled: Boolean(currency0),
+  })
+  const { data: currency1marketPrice } = useCurrencyUsdPrice(currency1, {
+    enabled: Boolean(currency1),
+  })
+
+  return useMemo(() => {
+    if (!currency1marketPrice || !currency0marketPrice) return [undefined, undefined, undefined]
+
+    const marketPrice = tryParsePrice(
+      currency0,
+      currency1,
+      new BigNumber(currency0marketPrice).div(currency1marketPrice).toString(),
+    )
+
+    return [currency0marketPrice, currency1marketPrice, marketPrice]
+  }, [currency1marketPrice, currency0marketPrice, currency0, currency1])
+}

--- a/apps/web/src/hooks/usePoolMarketPriceSlippage.ts
+++ b/apps/web/src/hooks/usePoolMarketPriceSlippage.ts
@@ -1,0 +1,35 @@
+import { Currency, Price } from '@pancakeswap/swap-sdk-core'
+import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
+import { useCurrencyUsdPrice } from './useCurrencyUsdPrice'
+import { tryParsePrice } from './v3/utils'
+
+export const usePoolMarketPriceSlippage = (
+  currency0?: Currency,
+  currency1?: Currency,
+  poolCurrencyPrice?: Price<Currency, Currency>,
+) => {
+  const { data: currency0marketPrice } = useCurrencyUsdPrice(currency0, {
+    enabled: Boolean(currency0),
+  })
+  const { data: currency1marketPrice } = useCurrencyUsdPrice(currency1, {
+    enabled: Boolean(currency1),
+  })
+
+  return useMemo(() => {
+    if (!currency1marketPrice || !currency0marketPrice || !poolCurrencyPrice) return [undefined, undefined, undefined]
+
+    const marketPrice = tryParsePrice(
+      currency0,
+      currency1,
+      new BigNumber(currency0marketPrice).div(currency1marketPrice).toString(),
+    )
+
+    if (!poolCurrencyPrice || !marketPrice) return [undefined, undefined]
+
+    return [
+      marketPrice,
+      marketPrice.divide(poolCurrencyPrice).subtract(1).multiply(100), // slippage in percentage
+    ]
+  }, [currency1marketPrice, currency0marketPrice, poolCurrencyPrice, currency0, currency1])
+}

--- a/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
@@ -1,11 +1,11 @@
-import { BinPool, getCurrencyPriceFromId } from '@pancakeswap/infinity-sdk'
+import { BinPool } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { Price } from '@pancakeswap/swap-sdk-core'
 import { AddIcon, AutoColumn, Text, usePrompt } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import PageLoader from 'components/Loader/PageLoader'
 import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
+import { usePoolCurrentPrice } from 'hooks/infinity/usePoolCurrentPrice'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
 import { usePermit2 } from 'hooks/usePermit2'
@@ -48,17 +48,7 @@ export const SubmitButton = () => {
   }, [pool])
 
   const currencies = useMemo(() => ({ CURRENCY_A: currencyA, CURRENCY_B: currencyB }), [currencyA, currencyB])
-  const poolCurrentPrice = useMemo(() => {
-    if (!pool) return undefined
-    if (pool.poolType === 'CL') {
-      return new Price(pool.token0, pool.token1, 2n ** 192n, pool.sqrtRatioX96 * pool.sqrtRatioX96)
-    }
-    if (pool.poolType === 'Bin') {
-      const pool_ = pool as BinPool
-      return getCurrencyPriceFromId(pool_.activeId, pool_.binStep, pool_.token0, pool_.token1)
-    }
-    return undefined
-  }, [pool])
+  const poolCurrentPrice = usePoolCurrentPrice(pool)
   const [, marketPriceSlippage] = usePoolMarketPriceSlippage(pool?.token0, pool?.token1, poolCurrentPrice)
   const [displayMarketPriceSlippageWarning, disableAddByHighSlippage] = useMemo(() => {
     if (marketPriceSlippage === undefined) return [false, false]

--- a/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
@@ -1,11 +1,16 @@
-import { BinPool } from '@pancakeswap/infinity-sdk'
+import { BinPool, getCurrencyPriceFromId } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { AddIcon, AutoColumn } from '@pancakeswap/uikit'
+import { Currency, Price } from '@pancakeswap/swap-sdk-core'
+import { AddIcon, AutoColumn, Text, usePrompt } from '@pancakeswap/uikit'
+import BigNumber from 'bignumber.js'
 import PageLoader from 'components/Loader/PageLoader'
 import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
+import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
+import { useCurrencyUsdPrice } from 'hooks/useCurrencyUsdPrice'
 import { usePermit2 } from 'hooks/usePermit2'
+import { tryParsePrice } from 'hooks/v3/utils'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import { usePoolInfo } from 'state/farmsV4/hooks'
@@ -18,9 +23,9 @@ import {
   InvalidBinRangeMessage,
   InvalidCLRangeMessage,
   LowTVLMessage,
+  MarketPriceSlippageWarning,
   OutOfRangeMessage,
 } from 'views/CreateLiquidityPool/components/SubmitCreateButton'
-import { useActiveChainId } from 'hooks/useActiveChainId'
 import { useAccount } from 'wagmi'
 import { useAddDepositAmounts, useAddDepositAmountsEnabled } from '../hooks/useAddDepositAmounts'
 import { useAddFormSubmitCallback } from '../hooks/useAddFormSubmitCallback'
@@ -44,15 +49,89 @@ export const SubmitButton = () => {
   }, [pool])
 
   const currencies = useMemo(() => ({ CURRENCY_A: currencyA, CURRENCY_B: currencyB }), [currencyA, currencyB])
+  const { data: currency1marketPrice } = useCurrencyUsdPrice(pool?.token1, {
+    enabled: Boolean(pool?.token1),
+  })
+  const { data: currency0marketPrice } = useCurrencyUsdPrice(pool?.token0, {
+    enabled: Boolean(pool?.token0),
+  })
+  const [currentPrice, marketPrice, marketPriceSlippage] = useMemo(() => {
+    if (!currency1marketPrice || !currency0marketPrice || !pool) return [undefined, undefined, undefined]
+    let currentPrice: Price<Currency, Currency> | undefined
+    if (pool?.poolType === 'CL') {
+      currentPrice = new Price(pool.token0, pool.token1, 2n ** 192n, pool.sqrtRatioX96 * pool.sqrtRatioX96)
+    } else if (pool?.poolType === 'Bin') {
+      const pool_ = pool as BinPool
+      currentPrice = getCurrencyPriceFromId(pool_.activeId, pool_.binStep, pool_.token0, pool_.token1)
+    }
 
+    const marketPrice = tryParsePrice(
+      pool.token0,
+      pool.token1,
+      new BigNumber(currency0marketPrice).div(currency1marketPrice).toString(),
+    )
+
+    if (!currentPrice || !marketPrice) return [undefined, undefined, undefined]
+
+    return [
+      currentPrice,
+      marketPrice,
+      marketPrice.divide(currentPrice).subtract(1).multiply(100), // slippage in percentage
+    ]
+  }, [currency1marketPrice, currency0marketPrice, pool])
+  const [displayMarketPriceSlippageWarning, disableAddByHighSlippage] = useMemo(() => {
+    if (marketPriceSlippage === undefined) return [false, false]
+    const slippage = new BigNumber(marketPriceSlippage.toFixed(0)).abs()
+    return [
+      slippage.gt(5), // 5% slippage
+      slippage.gt(10), // 10% slippage
+    ]
+  }, [marketPriceSlippage])
   const addIsUnsupported = useIsTransactionUnsupported(currencyA, currencyB)
   const addIsWarning = useIsTransactionWarning(currencyA, currencyB)
 
   const { onSubmit, attemptingTx } = useAddFormSubmitCallback()
+  const prompt = usePrompt()
   const handleSubmit = useCallback(async () => {
-    await onSubmit()
+    if (displayMarketPriceSlippageWarning) {
+      const confirmWord = 'confirm'
+      let resolve: (value: boolean) => void
+      const p = new Promise<boolean>((res) => {
+        resolve = res
+      })
+
+      prompt({
+        message: (
+          <>
+            <AutoColumn gap="8px">
+              <Text>
+                {t(
+                  'The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage.',
+                  {
+                    slippage: `${marketPriceSlippage?.toFixed(0)}%`,
+                  },
+                )}
+              </Text>
+              <Text>{t('To proceed, please type the word "%word%"', { word: confirmWord })}</Text>
+            </AutoColumn>
+          </>
+        ),
+        onConfirm: (value: string) => {
+          return resolve(value === confirmWord)
+        },
+      })
+      await p.then(async (confirmed) => {
+        if (!confirmed) {
+          return
+        }
+
+        await onSubmit()
+      })
+    } else {
+      await onSubmit()
+    }
     // router.push('/liquidity/pools')
-  }, [onSubmit, router])
+  }, [onSubmit, router, displayMarketPriceSlippageWarning, marketPriceSlippage, prompt, t])
 
   const { depositCurrencyAmount0, depositCurrencyAmount1 } = useAddDepositAmounts()
   const parsedAmounts = useMemo(
@@ -159,7 +238,14 @@ export const SubmitButton = () => {
       return [t('Insufficient %symbol% balance', { symbol: currencyB?.symbol ?? 'Unknown' }), undefined]
     }
 
-    return [t('Add'), <AddIcon key="add-icon" color={enabled ? 'invertedContrast' : 'textDisabled'} width="24px" />]
+    return [
+      t('Add'),
+      <AddIcon
+        key="add-icon"
+        color={!enabled || disableAddByHighSlippage ? 'textDisabled' : 'invertedContrast'}
+        width="24px"
+      />,
+    ]
   }, [
     currency0Balance,
     currency1Balance,
@@ -168,6 +254,7 @@ export const SubmitButton = () => {
     depositCurrencyAmount0,
     depositCurrencyAmount1,
     enabled,
+    disableAddByHighSlippage,
     isDeposit0Enabled,
     isDeposit1Enabled,
     t,
@@ -179,6 +266,9 @@ export const SubmitButton = () => {
 
   return (
     <AutoColumn mt="24px" gap="8px">
+      {displayMarketPriceSlippageWarning ? (
+        <MarketPriceSlippageWarning slippage={`${marketPriceSlippage?.toFixed(0)} %`} />
+      ) : null}
       {Number(poolInfo?.tvlUsd) < 1000 ? <LowTVLMessage /> : null}
       {outOfRange && <OutOfRangeMessage />}
       {invalidClRange && <InvalidCLRangeMessage />}
@@ -193,6 +283,7 @@ export const SubmitButton = () => {
         />
       )}
       <V3SubmitButton
+        highMarketPriceSlippage={disableAddByHighSlippage}
         addIsUnsupported={addIsUnsupported}
         addIsWarning={addIsWarning}
         account={account ?? undefined}

--- a/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/SubmitButton.tsx
@@ -1,6 +1,6 @@
 import { BinPool, getCurrencyPriceFromId } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { Currency, Price } from '@pancakeswap/swap-sdk-core'
+import { Price } from '@pancakeswap/swap-sdk-core'
 import { AddIcon, AutoColumn, Text, usePrompt } from '@pancakeswap/uikit'
 import BigNumber from 'bignumber.js'
 import PageLoader from 'components/Loader/PageLoader'
@@ -8,9 +8,8 @@ import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trad
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
-import { useCurrencyUsdPrice } from 'hooks/useCurrencyUsdPrice'
 import { usePermit2 } from 'hooks/usePermit2'
-import { tryParsePrice } from 'hooks/v3/utils'
+import { usePoolMarketPriceSlippage } from 'hooks/usePoolMarketPriceSlippage'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import { usePoolInfo } from 'state/farmsV4/hooks'
@@ -49,36 +48,18 @@ export const SubmitButton = () => {
   }, [pool])
 
   const currencies = useMemo(() => ({ CURRENCY_A: currencyA, CURRENCY_B: currencyB }), [currencyA, currencyB])
-  const { data: currency1marketPrice } = useCurrencyUsdPrice(pool?.token1, {
-    enabled: Boolean(pool?.token1),
-  })
-  const { data: currency0marketPrice } = useCurrencyUsdPrice(pool?.token0, {
-    enabled: Boolean(pool?.token0),
-  })
-  const [currentPrice, marketPrice, marketPriceSlippage] = useMemo(() => {
-    if (!currency1marketPrice || !currency0marketPrice || !pool) return [undefined, undefined, undefined]
-    let currentPrice: Price<Currency, Currency> | undefined
-    if (pool?.poolType === 'CL') {
-      currentPrice = new Price(pool.token0, pool.token1, 2n ** 192n, pool.sqrtRatioX96 * pool.sqrtRatioX96)
-    } else if (pool?.poolType === 'Bin') {
-      const pool_ = pool as BinPool
-      currentPrice = getCurrencyPriceFromId(pool_.activeId, pool_.binStep, pool_.token0, pool_.token1)
+  const poolCurrentPrice = useMemo(() => {
+    if (!pool) return undefined
+    if (pool.poolType === 'CL') {
+      return new Price(pool.token0, pool.token1, 2n ** 192n, pool.sqrtRatioX96 * pool.sqrtRatioX96)
     }
-
-    const marketPrice = tryParsePrice(
-      pool.token0,
-      pool.token1,
-      new BigNumber(currency0marketPrice).div(currency1marketPrice).toString(),
-    )
-
-    if (!currentPrice || !marketPrice) return [undefined, undefined, undefined]
-
-    return [
-      currentPrice,
-      marketPrice,
-      marketPrice.divide(currentPrice).subtract(1).multiply(100), // slippage in percentage
-    ]
-  }, [currency1marketPrice, currency0marketPrice, pool])
+    if (pool.poolType === 'Bin') {
+      const pool_ = pool as BinPool
+      return getCurrencyPriceFromId(pool_.activeId, pool_.binStep, pool_.token0, pool_.token1)
+    }
+    return undefined
+  }, [pool])
+  const [, marketPriceSlippage] = usePoolMarketPriceSlippage(pool?.token0, pool?.token1, poolCurrentPrice)
   const [displayMarketPriceSlippageWarning, disableAddByHighSlippage] = useMemo(() => {
     if (marketPriceSlippage === undefined) return [false, false]
     const slippage = new BigNumber(marketPriceSlippage.toFixed(0)).abs()
@@ -131,7 +112,7 @@ export const SubmitButton = () => {
       await onSubmit()
     }
     // router.push('/liquidity/pools')
-  }, [onSubmit, router, displayMarketPriceSlippageWarning, marketPriceSlippage, prompt, t])
+  }, [onSubmit, displayMarketPriceSlippageWarning, marketPriceSlippage, prompt, t])
 
   const { depositCurrencyAmount0, depositCurrencyAmount1 } = useAddDepositAmounts()
   const parsedAmounts = useMemo(

--- a/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
+++ b/apps/web/src/views/AddLiquidityV3/components/V3SubmitButton.tsx
@@ -40,6 +40,7 @@ export interface V3SubmitButtonProps {
   endIcon?: ReactNode
   depositADisabled: boolean
   depositBDisabled: boolean
+  highMarketPriceSlippage?: boolean
 }
 
 export function V3SubmitButton({
@@ -67,6 +68,7 @@ export function V3SubmitButton({
   endIcon,
   depositADisabled,
   depositBDisabled,
+  highMarketPriceSlippage,
 }: V3SubmitButtonProps) {
   const { t } = useTranslation()
 
@@ -115,6 +117,7 @@ export function V3SubmitButton({
           }
           onClick={onClick}
           disabled={
+            highMarketPriceSlippage ||
             !isValid ||
             attemptingTxn ||
             (approvalA !== ApprovalState.APPROVED && !depositADisabled) ||

--- a/apps/web/src/views/CreateLiquidityPool/components/SubmitCreateButton.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/components/SubmitCreateButton.tsx
@@ -80,6 +80,23 @@ export const LowTVLMessage = () => {
   )
 }
 
+export const MarketPriceSlippageWarning = ({ slippage }) => {
+  const { t } = useTranslation()
+  return (
+    <Message variant="warning">
+      <RowBetween>
+        <Text ml="12px" fontSize="12px">
+          <b>{t('Warning')}: </b>
+          {t(
+            'The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution.',
+            { slippage },
+          )}
+        </Text>
+      </RowBetween>
+    </Message>
+  )
+}
+
 export const InvalidBinRangeMessage: React.FC<{
   minBinId?: number | null
   maxBinId?: number | null

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3746,5 +3746,7 @@
   "Expanding Search..": "Expanding Search..",
   "To proceed, please type the word \"%word%\"": "To proceed, please type the word \"%word%\"",
   "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage.": "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage.",
-  "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution.": "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution."
+  "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution.": "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution.",
+  "The price is estimated from the market price. Please verify it before using it.": "The price is estimated from the market price. Please verify it before using it.",
+  "Use this Price": "Use this Price"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3743,5 +3743,8 @@
   "Receive crypto from another wallet.": "Receive crypto from another wallet.",
   "Bridge Crypto": "Bridge Crypto",
   "Search by token name/address, pool type (e.g. clamm, lbamm), features (e.g. dynamic fees), or pool address. Example: 'bnb usdt infinity clamm'": "Search by token name/address, pool type (e.g. clamm, lbamm), features (e.g. dynamic fees), or pool address. Example: 'bnb usdt infinity clamm'",
-  "Expanding Search..": "Expanding Search.."
+  "Expanding Search..": "Expanding Search..",
+  "To proceed, please type the word \"%word%\"": "To proceed, please type the word \"%word%\"",
+  "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage.": "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage.",
+  "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution.": "The pool price shows a significant deviation from current market rates (%slippage%). This increases the risk of losses from arbitrage. Please proceed with caution."
 }

--- a/packages/uikit/src/hooks/useDialog/Dialog.tsx
+++ b/packages/uikit/src/hooks/useDialog/Dialog.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "@pancakeswap/localization";
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import styled from "styled-components";
 import { BoxProps, Flex } from "../../components/Box";
 import { Button } from "../../components/Button";
@@ -12,7 +12,7 @@ import { ModalV2, ModalV2Props } from "../../widgets/Modal/ModalV2";
 type DialogProps = ModalV2Props &
   BoxProps & {
     title?: string;
-    message?: string;
+    message?: string | React.ReactNode;
     defaultValue?: string;
     confirmText?: string;
     cancelText?: string;
@@ -75,7 +75,7 @@ export const Dialog: React.FC<DialogProps> = ({
         width={["100%", "100%", "100%", "367px"]}
       >
         <FlexGap flexDirection="column" gap="20px" mt="auto">
-          <Text>{message}</Text>
+          {React.isValidElement(message) ? message : <Text>{message}</Text>}
           {useInput ? (
             <Input
               value={value}

--- a/packages/uikit/src/hooks/useDialog/DialogContext.tsx
+++ b/packages/uikit/src/hooks/useDialog/DialogContext.tsx
@@ -4,16 +4,20 @@ import { Dialog } from "./Dialog";
 
 export type PromptFn = (params: {
   title?: string;
-  message?: string;
+  message?: string | React.ReactNode;
   defaultValue?: string;
   onConfirm: (value: string) => void;
 }) => void;
 
-export type ConfirmFn = (params: { title?: string; message?: string; onConfirm: (value: boolean) => void }) => void;
+export type ConfirmFn = (params: {
+  title?: string;
+  message?: string | React.ReactNode;
+  onConfirm: (value: boolean) => void;
+}) => void;
 
 export type DialogOptions = {
   title?: string;
-  message?: string;
+  message?: string | React.ReactNode;
   defaultValue?: string;
   placeholder?: string;
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements related to market price slippage warnings in liquidity pool transactions, improving user awareness of potential risks. It adds new components and hooks to handle slippage calculations and warnings effectively.

### Detailed summary
- Added `highMarketPriceSlippage` prop to `V3SubmitButton`.
- Introduced `MarketPriceSlippageWarning` component for displaying slippage warnings.
- Implemented `usePoolMarketPriceSlippage` hook for slippage calculations.
- Updated `V3FormView` to include slippage checks and warnings.
- Enhanced `SubmitButton` to prompt users about high slippage risks before proceeding.
- Updated translations for slippage-related messages.
- Modified `FieldStartingPrice` to show market price and allow users to set it.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->