### PR TITLE
fix: using full route when high price impact

### DIFF
--- a/apps/web/src/quoter/hook/useQuoterSync.ts
+++ b/apps/web/src/quoter/hook/useQuoterSync.ts
@@ -174,7 +174,7 @@ const prefetchPoolsAtom = atomFamily(
     }
     const ttl = POOLS_FAST_REVALIDATE[chainId]
     const epochA = Math.floor(a.createTime / ttl)
-    const epochB = Math.floor(a.createTime / ttl)
+    const epochB = Math.floor(b.createTime / ttl)
     return epochB === epochA
   },
 )


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the quote selection logic in the `bestQuoteAtom` by improving the handling of price impacts and modifying the epoch calculation in `useQuoterSync`.

### Detailed summary
- In `useQuoterSync.ts`, updated `epochB` to use `b.createTime` instead of `a.createTime`.
- In `bestQuoteAtom.ts`:
  - Added `warningSeverity` and `isXOrder` imports.
  - Added logic to compute `priceImpactWithoutFee` and check if it's high impact before continuing.
  - Enhanced quote return logic to consider `priceImpactWithoutFee`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->