### PR TITLE
chore: seperate light full candidates pool

### DIFF
--- a/apps/web/src/pages/api/pools/candidates.ts
+++ b/apps/web/src/pages/api/pools/candidates.ts
@@ -15,8 +15,13 @@ export default async function handler(req: NextRequest) {
   }
   const raw = new URL(req.url).search.slice(1)
   try {
-    const { chainId, addressA, addressB, protocols } = parseCandidatesQuery(raw)
-    const pools = await edgeQueries.fetchAllCandidatePools(addressA, addressB, chainId, protocols)
+    const { chainId, addressA, addressB, protocols, type } = parseCandidatesQuery(raw)
+
+    const pools =
+      type === 'light'
+        ? await edgeQueries.fetchAllCandidatePoolsLite(addressA, addressB, chainId, protocols)
+        : await edgeQueries.fetchAllCandidatePools(addressA, addressB, chainId, protocols)
+
     const age = Math.floor((POOLS_SLOW_REVALIDATE[chainId] as number) / 1000)
     const staleAge = age * 2
     return NextResponse.json(

--- a/apps/web/src/quoter/atom/bestSameChainAtom.ts
+++ b/apps/web/src/quoter/atom/bestSameChainAtom.ts
@@ -32,12 +32,15 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
       quote: Loadable<InterfaceOrder>
       anyShadowFail?: boolean
       anyTimeout?: boolean
+      key?: string
     } {
       try {
         const quotes = strategies.map((route) => ({
           result: get(route.query({ ...option, ...route.overrides, routeKey: route.key })),
           isShadow: route.isShadow,
+          key: route.key,
         }))
+
         const anyPending = quotes.some((x) => x.result.isPending())
         const anyFail = quotes.some((x) => x.result.isFail())
         const errors = quotes.filter((x) => x.result.isFail()).map((x) => x.result.error)
@@ -59,7 +62,7 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
             anyTimeout,
           }
         }
-        const [bestQuote] = best
+        const [bestQuote, index] = best
         if (bestQuote) {
           if (!anyPending) {
             // updateStrategy(strategyHash, routes[bestIndex])
@@ -67,6 +70,7 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
               quote: Loadable.Just<InterfaceOrder>(bestQuote),
               anyShadowFail,
               anyTimeout,
+              key: quotes[index].key,
             }
           }
           return {
@@ -116,7 +120,7 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
       const tests = [p1, p2]
       for (let i = 0; i < tests.length; i++) {
         const strategy = tests[i]
-        const { quote, anyShadowFail, anyTimeout } = executeRoutes(strategy, option, i)
+        const { quote, anyShadowFail, anyTimeout, key } = executeRoutes(strategy, option, i)
 
         if (quote.isJust()) {
           const order = quote.unwrap()
@@ -134,6 +138,7 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
             }
           }
           if (!anyShadowFail) {
+            logQuote(key)
             return quote
           }
         }
@@ -161,7 +166,12 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
   })
 }, isEqualQuoteQuery)
 
-export const bestSameChainAtom = atomFamily((_option: QuoteQuery) => {
+function logQuote(key?: string) {
+  // eslint-disable-next-line no-console
+  console.log(`%c[quote] with ${key}`, 'color: green; font-weight: bold;')
+}
+
+export const bestQuoteAtom = atomFamily((_option: QuoteQuery) => {
   return atom((get) => {
     const result = get(bestSameChainWithoutPlaceHolderAtom(_option))
 
@@ -176,18 +186,21 @@ export const bestSameChainAtom = atomFamily((_option: QuoteQuery) => {
 }, isEqualQuoteQuery)
 
 function findBestQuote(...args: Loadable<InterfaceOrder>[]): [InterfaceOrder, number] | undefined {
-  const fulfilledValues = args.filter((x) => x.isJust()).map((x) => x.unwrap())
+  const fulfilledValues = args.map((x) => x.unwrapOr(undefined))
 
   let bestOrder: InterfaceOrder | undefined
   let idx = -1
   for (let i = 0; i < fulfilledValues.length; i++) {
     const order = fulfilledValues[i]
+    if (!order) {
+      continue
+    }
+    if (!order?.trade) continue
     if (!bestOrder) {
       bestOrder = order
       idx = i
       continue
     }
-    if (!order?.trade) continue
     if (isBetterQuoteTrade(bestOrder.trade, order.trade)) {
       bestOrder = order
       idx = i

--- a/apps/web/src/quoter/atom/bestSameChainAtom.ts
+++ b/apps/web/src/quoter/atom/bestSameChainAtom.ts
@@ -171,7 +171,7 @@ function logQuote(key?: string) {
   console.log(`%c[quote] with ${key}`, 'color: green; font-weight: bold;')
 }
 
-export const bestQuoteAtom = atomFamily((_option: QuoteQuery) => {
+export const bestSameChainAtom = atomFamily((_option: QuoteQuery) => {
   return atom((get) => {
     const result = get(bestSameChainWithoutPlaceHolderAtom(_option))
 

--- a/apps/web/src/quoter/utils/edgePoolQueries.ts
+++ b/apps/web/src/quoter/utils/edgePoolQueries.ts
@@ -11,6 +11,7 @@ import {
   SmartRouter,
   StablePoolWithTvl,
   V2PoolWithTvl,
+  V3Pool,
   V3PoolWithTvl,
   WithTvl,
 } from '@pancakeswap/smart-router'
@@ -59,6 +60,28 @@ const fetchInfinityPools = async (addressA: Address, addressB: Address, chainId:
   return [...poolWithTicks, ...poolWithBins]
 }
 
+const fetchInfinityPoolsLight = async (addressA: Address, addressB: Address, chainId: ChainId) => {
+  const currencyA = mockCurrency(addressA, chainId)
+  const currencyB = mockCurrency(addressB, chainId)
+  const chain = getChainName(chainId)
+  const tvlMap = await poolTvlMap(['infinityBin', 'infinityCl'], chain as APIChain)
+  const ref: InfinityRouter.InfinityPoolTvlReferenceMap = {}
+  Object.entries(tvlMap).forEach(([id, tvlUSD]) => {
+    ref[id] = {
+      tvlUSD: BigInt(Math.floor(Number(tvlUSD))),
+      tvlRef: id,
+    }
+  })
+
+  const pools = await InfinityRouter.getInfinityCandidatePoolsLite({
+    currencyA,
+    currencyB,
+    clientProvider: getProvider(),
+    tvlRefMap: ref,
+  })
+  return pools
+}
+
 const fetchV2Pools = async (addressA: Address, addressB: Address, chainId: ChainId) => {
   const [currencyA, currencyB] = await Promise.all([mockCurrency(addressA, chainId), mockCurrency(addressB, chainId)])
 
@@ -80,13 +103,25 @@ const fetchV3Pools = async (addressA: Address, addressB: Address, chainId: Chain
     currencyA,
     currencyB,
     clientProvider: getProvider(),
-    disableFilterNoTicks: true,
   })
 
-  const chain = getChainName(chainId)
-  const tvlMap = await poolTvlMap(['v3'], chain as APIChain)
-  const poolsWithTvl = fillTvl(tvlMap, pools) as V3PoolWithTvl[]
-  return SmartRouter.v3PoolTvlSelector(currencyA, currencyB, poolsWithTvl)
+  return pools
+}
+
+const fetchV3PoolsWithoutTicks = async (addressA: Address, addressB: Address, chainId: ChainId) => {
+  const [currencyA, currencyB] = await Promise.all([mockCurrency(addressA, chainId), mockCurrency(addressB, chainId)])
+  const client = getProvider()
+  const blockNumber = await client({ chainId })?.getBlockNumber()
+
+  const pools = await SmartRouter.getV3CandidatePools({
+    currencyA,
+    currencyB,
+    subgraphProvider: ({ chainId }) => (chainId ? v3Clients[chainId] : undefined),
+    onChainProvider: getProvider(),
+    blockNumber,
+  })
+
+  return pools as V3Pool[]
 }
 
 const fetchSSPool = async (addressA: Address, addressB: Address, chainId: ChainId) => {
@@ -125,6 +160,26 @@ const querySingleType = async (chainId: ChainId, protocol: Protocol, addressA: A
       throw new Error('invalid pool')
   }
 }
+
+const querySingleTypeLite = async (chainId: ChainId, protocol: Protocol, addressA: Address, addressB: Address) => {
+  switch (protocol) {
+    case 'v2': {
+      return fetchV2Pools(addressA, addressB, chainId)
+    }
+    case 'stable': {
+      return fetchSSPool(addressA, addressB, chainId)
+    }
+    case 'v3': {
+      return fetchV3PoolsWithoutTicks(addressA, addressB, chainId)
+    }
+    case 'infinityBin':
+    case 'infinityCl': {
+      return fetchInfinityPoolsLight(addressA, addressB, chainId)
+    }
+    default:
+      throw new Error('invalid pool')
+  }
+}
 const fetchAllCandidatePools = async (
   addressA: Address,
   addressB: Address,
@@ -137,6 +192,23 @@ const fetchAllCandidatePools = async (
       .map((protocol) => querySingleType(chainId, protocol as Protocol, addressA, addressB)),
   )
   const pools = queries.flat() as (InfinityPoolWithTvl | V2PoolWithTvl | V3PoolWithTvl | StablePoolWithTvl)[]
+  return pools.map((pool) => {
+    return SmartRouter.Transformer.serializePool(pool as Pool)
+  })
+}
+
+const fetchAllCandidatePoolsLite = async (
+  addressA: Address,
+  addressB: Address,
+  chainId: ChainId,
+  protocols: Protocol[],
+) => {
+  const queries = await Promise.all(
+    protocols
+      .filter((x) => x !== 'infinityBin')
+      .map((protocol) => querySingleTypeLite(chainId, protocol as Protocol, addressA, addressB)),
+  )
+  const pools = queries.flat() as (InfinityPoolWithTvl | V2PoolWithTvl | V3Pool | V3PoolWithTvl | StablePoolWithTvl)[]
   return pools.map((pool) => {
     return SmartRouter.Transformer.serializePool(pool as Pool)
   })
@@ -303,11 +375,15 @@ async function fetchAllPools({
 
 export const edgeQueries = {
   fetchAllCandidatePools,
+  fetchAllCandidatePoolsLite,
   fetchAllPools,
   fetchV2Pools,
   fetchV3Pools,
+  fetchV3PoolsWithoutTicks,
   fetchSSPool,
   fetchInfinityPools,
+  fetchInfinityPoolsLight,
   querySingleType,
+  querySingleTypeLite,
   poolTvlMap,
 }

--- a/apps/web/src/quoter/utils/edgePoolQueries.ts
+++ b/apps/web/src/quoter/utils/edgePoolQueries.ts
@@ -61,8 +61,7 @@ const fetchInfinityPools = async (addressA: Address, addressB: Address, chainId:
 }
 
 const fetchInfinityPoolsLight = async (addressA: Address, addressB: Address, chainId: ChainId) => {
-  const currencyA = mockCurrency(addressA, chainId)
-  const currencyB = mockCurrency(addressB, chainId)
+  const [currencyA, currencyB] = await Promise.all([mockCurrency(addressA, chainId), mockCurrency(addressB, chainId)])
   const chain = getChainName(chainId)
   const tvlMap = await poolTvlMap(['infinityBin', 'infinityCl'], chain as APIChain)
   const ref: InfinityRouter.InfinityPoolTvlReferenceMap = {}

--- a/apps/web/src/quoter/utils/edgeQueries.util.ts
+++ b/apps/web/src/quoter/utils/edgeQueries.util.ts
@@ -94,6 +94,8 @@ export function parseCandidatesQuery(raw: string) {
   const addressB = checksumAddress(queryParsed.addressB as Address)
   const protocols = ((queryParsed.protocol as string) || '').split(',') as Protocol[]
   const chainId = Number.parseInt(queryParsed.chainId as string)
+  const typeParam = (queryParsed.type as string) || 'full'
+  const type = typeParam === 'light' ? 'light' : 'full'
   const includeInfinity = protocols.includes('infinityBin') || protocols.includes('infinityCl')
   if (!INFINITY_SUPPORTED_CHAINS.includes(chainId) && includeInfinity) {
     throw new Error('Invalid chainId')
@@ -108,6 +110,7 @@ export function parseCandidatesQuery(raw: string) {
     addressB,
     protocols,
     chainId,
+    type,
   }
 }
 

--- a/apps/web/src/quoter/utils/poolQueries.ts
+++ b/apps/web/src/quoter/utils/poolQueries.ts
@@ -208,7 +208,15 @@ export const fetchCandidatePools = async (query: PoolQuery, options: PoolQueryOp
 
   const defaultQuery = async () => {
     const protocols = protocolsFromQuery(options)
-    return edgePoolQueryClient.getAllCandidates(currencyA, currencyB, chainId, blockNumber, protocols, options.signal)
+    return edgePoolQueryClient.getAllCandidates(
+      currencyA,
+      currencyB,
+      chainId,
+      blockNumber,
+      protocols,
+      'full',
+      options.signal,
+    )
   }
 
   if (isTestnetChainId(chainId)) {
@@ -241,7 +249,7 @@ export const fetchCandidatePoolsLite = async (query: PoolQuery, options: PoolQue
 
   const defaultQuery = async () => {
     const protocols = protocolsFromQuery(options)
-    return edgePoolQueryClient.getAllCandidates(currencyA, currencyB, chainId, blockNumber, protocols)
+    return edgePoolQueryClient.getAllCandidates(currencyA, currencyB, chainId, blockNumber, protocols, 'light')
   }
 
   const call = createAsyncCallWithFallbacks(defaultQuery, {

--- a/packages/smart-router/evm/infinity-router/queries/index.ts
+++ b/packages/smart-router/evm/infinity-router/queries/index.ts
@@ -1,5 +1,6 @@
 export * from './getInfinityBinPools'
 export * from './getInfinityClPools'
 export * from './getInfinityPools'
+export * from './getPoolTvl'
 export * from './getV3Pools'
 export * from './remotePoolTransform'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `edgeQueries` functionality by adding support for fetching pool data in two types: `light` and `full`. It also adds new utility functions for handling TVL (Total Value Locked) and makes adjustments to existing queries to incorporate these changes.

### Detailed summary
- Added export for `getPoolTvl` in `index.ts`.
- Introduced `typeParam` and `type` variables in `edgeQueries.util.ts`.
- Modified `parseCandidatesQuery` to include `type`.
- Updated pool fetching logic in `candidates.ts` to handle `light` and `full` types.
- Adjusted `edgePoolQueryClient` calls to include `type`.
- Implemented `fetchInfinityPoolsLight` for light pool fetching.
- Added `fetchAllCandidatePoolsLite` for fetching candidate pools in light mode.
- Created `querySingleTypeLite` for querying pools by protocol in light mode.
- Updated `edgeQueries` to export new functions for light and full pool fetching.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->