### PR TITLE
fix: apply wallet asset percent issue

### DIFF
--- a/apps/web/src/components/WalletModalV2/SendAssetForm.tsx
+++ b/apps/web/src/components/WalletModalV2/SendAssetForm.tsx
@@ -270,8 +270,7 @@ export const SendAssetForm: React.FC<SendAssetFormProps> = ({ asset, onViewState
   const handlePercentInput = useCallback(
     (percent: number) => {
       if (maxAmountInput) {
-        const { multiply } = maxAmountInput
-        handleAmountChange(multiply(new Percent(percent, 100)).toExact())
+        handleAmountChange(maxAmountInput.multiply(new Percent(percent, 100)).toExact())
       }
     },
     [maxAmountInput, handleAmountChange],

--- a/apps/web/src/components/WalletModalV2/WalletModal.tsx
+++ b/apps/web/src/components/WalletModalV2/WalletModal.tsx
@@ -180,8 +180,8 @@ export const WalletContent = ({
 
   return (
     <Box
-      minWidth={isMobile ? '100%' : '357px'}
       maxHeight={isMobile ? 'auto' : 'calc(100vh - 80px)'}
+      maxWidth={isMobile ? '100%' : '357px'}
       overflowY={isMobile ? undefined : 'auto'}
     >
       <FlexGap mb="10px" gap="8px" justifyContent="space-between" alignItems="center" paddingRight="16px" mt="8px">

--- a/apps/web/src/components/WalletModalV2/WalletModal.tsx
+++ b/apps/web/src/components/WalletModalV2/WalletModal.tsx
@@ -180,8 +180,9 @@ export const WalletContent = ({
 
   return (
     <Box
+      minWidth={isMobile ? '100%' : '357px'}
       maxHeight={isMobile ? 'auto' : 'calc(100vh - 80px)'}
-      maxWidth={isMobile ? '100%' : '357px'}
+      maxWidth={isMobile ? '100%' : '377px'}
       overflowY={isMobile ? undefined : 'auto'}
     >
       <FlexGap mb="10px" gap="8px" justifyContent="space-between" alignItems="center" paddingRight="16px" mt="8px">


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the handling of asset amounts in the `SendAssetForm` component and adjusting the layout properties in the `WalletModal` component.

### Detailed summary
- In `SendAssetForm.tsx`, the `multiply` method is called directly on `maxAmountInput` instead of destructuring it.
- In `WalletModal.tsx`, the `maxWidth` property is updated to `377px` for non-mobile views, enhancing the modal's responsiveness.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->