### PR TITLE
fix: Merkl api remove items and add protocolid

### DIFF
--- a/apps/web/src/hooks/useMerkl.tsx
+++ b/apps/web/src/hooks/useMerkl.tsx
@@ -47,7 +47,7 @@ export function useMerklInfo(poolAddress?: string): {
       const responsev4 = await fetch(
         `${MERKL_API_V4}/opportunities?${supportedChainIdV4.join(
           ',',
-        )}&test=false&items=1000&action=POOL,HOLD&status=LIVE`,
+        )}&test=false&mainProtocolId=pancake-swap&action=POOL,HOLD&status=LIVE`,
       )
 
       if (!responsev4.ok) {

--- a/scripts/updateMerkl/index.ts
+++ b/scripts/updateMerkl/index.ts
@@ -23,7 +23,7 @@ const fetchAllMerklConfig = async (): Promise<any[]> => {
   const response = await fetch(
     `https://api.merkl.xyz/v4/opportunities/?chainId=${Object.keys(chainIdToChainName).join(
       ',',
-    )}&test=false&status=LIVE&items=1000&action=POOL,HOLD`,
+    )}&test=false&mainProtocolId=pancake-swap&action=POOL,HOLD&status=LIVE`,
   )
 
   if (!response.ok) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating API requests in the `useMerkl` hook and related files to include a `mainProtocolId` parameter set to `pancake-swap`, enhancing the filtering of opportunities retrieved from the `Merkl` API.

### Detailed summary
- In `useMerkl.tsx`, added `mainProtocolId=pancake-swap` to the API URL.
- In `updateMerkl/index.ts`, similarly updated the API URL to include `mainProtocolId=pancake-swap`.
- In `fetcher.ts`:
  - Modified the API URL to include `mainProtocolId=pancake-swap`.
  - Removed the old `fetchList` function and replaced it with a direct fetch that includes filtering for opportunities related to `pancake-swap`.
  - Added error handling to throw the response if not ok.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->