### PR TITLE
fix: xchain refund condition add a partial success case

### DIFF
--- a/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/components/Timeline/index.tsx
+++ b/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/components/Timeline/index.tsx
@@ -139,9 +139,9 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
       case 'completed':
         return <CheckmarkCircleFillIcon color="success" />
       case 'warning':
-        return <WarningIcon color="binance" />
+        return <WarningIcon color="binance" mr="2px" />
       case 'failed':
-        return <WarningIcon color="binance" />
+        return <WarningIcon color="binance" mr="2px" />
       case 'inProgress':
         return <SwapSpinner width="24px" height="24px" padding="3px" />
       case 'notStarted':


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of warning icons in the `Timeline` component and improving the logic for determining the result token in the `OrderResultModalContent` component of the swap feature.

### Detailed summary
- Added `mr="2px"` margin to `WarningIcon` for both 'warning' and 'failed' cases in `Timeline/index.tsx`.
- Introduced `lastExecutedCommandIndex` to track the index of the last executed command in `OrderResultModalContent.tsx`.
- Updated logic to determine `resultTokenAddress` and `resultAmount` based on the success of the previous step in the bridge status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->