### PR TITLE
fix: xchain don't show desc amounts if failed state

### DIFF
--- a/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/OrderStatus/OrderResultModalContent.tsx
+++ b/apps/web/src/views/Swap/Bridge/CrossChainConfirmSwapModal/OrderStatus/OrderResultModalContent.tsx
@@ -40,21 +40,31 @@ const IconContainer = styled(Box)`
 // Since Translation not support interpolation for <element>
 // We need to use this component to display partially bold text
 function Description({
+  showAmounts,
   currencyAmount,
   description,
 }: {
+  showAmounts: boolean
   currencyAmount: CurrencyAmount<Currency>
   description: ReactNode
 }) {
   return (
     <FlexGap alignItems="center">
-      <Text small>
-        <b>
-          {formatAmount(currencyAmount)} {currencyAmount.currency.symbol}
-        </b>
-        {description}
-        <b>{getFullChainNameById(currencyAmount.currency.chainId)}</b>
-      </Text>
+      <p>
+        {showAmounts && (
+          <Text small bold as="span">
+            {formatAmount(currencyAmount)} {currencyAmount.currency.symbol}
+          </Text>
+        )}
+        <Text small as="span">
+          {description}
+        </Text>
+        {showAmounts && (
+          <Text small bold as="span">
+            {getFullChainNameById(currencyAmount.currency.chainId)}
+          </Text>
+        )}
+      </p>
     </FlexGap>
   )
 }
@@ -240,6 +250,7 @@ export const OrderResultModalContent = ({ overrideActiveOrderMetadata, ...props 
               }
             >
               <Description
+                showAmounts={status !== BridgeStatus.FAILED}
                 currencyAmount={resultCurrencyAmount}
                 description={
                   isRefundCase


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `Description` component in `OrderResultModalContent.tsx` to conditionally display amounts based on the `showAmounts` prop. It improves the rendering of the text by using `<p>` and `<span>` elements for better formatting.

### Detailed summary
- Added `showAmounts` prop to the `Description` function.
- Wrapped the amount and chain name in `<Text>` components with `bold` and `as="span"` for conditional rendering.
- Replaced the previous `<Text>` structure with a `<p>` element for improved text formatting.
- Updated the `Description` call in `OrderResultModalContent` to pass `showAmounts` based on `status`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->