### PR TITLE
fix: fee tier number

### DIFF
--- a/packages/uikit/src/components/FeeTier/FeeTier.tsx
+++ b/packages/uikit/src/components/FeeTier/FeeTier.tsx
@@ -20,7 +20,7 @@ export const FeeTier = forwardRef<HTMLSpanElement, FeeTierProps>(
         <span style={{ opacity: 0.5 }}>|</span>
         <span>
           {dynamic ? <span style={{ marginRight: "2px" }}>↕️</span> : ""}
-          {Number(percent.toFixed(2))}%
+          {Number(percent.toString())}%
         </span>
       </StyledFeeTier>
     );


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on modifying how the `percent` value is displayed in the `FeeTier` component by changing the method of conversion to a string.

### Detailed summary
- Changed the display of `percent` from `Number(percent.toFixed(2))%` to `Number(percent.toString())%` in the `FeeTier` component, affecting the precision of the percentage shown.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->