### PR TITLE
chore: reset CAKE bridge after maintenance

### DIFF
--- a/.changeset/moody-dolphins-count.md
+++ b/.changeset/moody-dolphins-count.md
@@ -1,0 +1,6 @@
+---
+'@pancakeswap/canonical-bridge': patch
+'@pancakeswap/localization': patch
+---
+
+Re-enable CAKE bridging on Polygon zkEVM and remove the Scheduled Maintenance banners

--- a/apps/bridge/components/layerZero/index.tsx
+++ b/apps/bridge/components/layerZero/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
+import { Box, Flex, Message, MessageText } from '@pancakeswap/uikit'
 import AptosBridgeFooter from 'components/layerZero/AptosBridgeFooter'
 import { LayerZeroWidget } from 'components/layerZero/LayerZeroWidget'
 import { FEE_COLLECTOR, FEE_TENTH_BPS, LAYER_ZERO_JS, PARTNER_ID } from 'components/layerZero/config'
@@ -86,31 +86,7 @@ const LayerZero = ({ isCake }: { isCake?: boolean }) => {
         <Box width={['100%', null, '420px']} m="auto">
           <Message variant="warning" m={['16px', '16px', '16px 0']}>
             <MessageText>
-              <p>
-                <Text small bold>
-                  Notice: Temporary Unavailability of CAKE Bridging
-                </Text>
-                <br />
-                <Text small bold as="span">
-                  From 1:00 PM (GMT+8):
-                </Text>{' '}
-                <br />
-                CAKE bridging from Polygon zkEVM will be reverted; bridging to Polygon zkEVM remains available.
-                <br />
-                <br />
-                <Text small bold as="span">
-                  From 4:30 PM (GMT+8):
-                </Text>{' '}
-                <br />
-                CAKE bridging to/from all chains will be reverted; transactions created before this will be processed as
-                normal.
-                <br />
-                <br />
-                Stay tuned to our X account for real-time updates.
-                <br />
-                <br />
-                Outbound transfers from Polygon zkEVM are subject to a 7 days delay for block confirmations.
-              </p>
+              Outbound transfers from Polygon zkEVM are subject to a 7 days delay for block confirmations.
             </MessageText>
           </Message>
           <Flex flexDirection="column" bg="backgroundAlt" borderRadius={[0, null, 24]} alignItems="center">

--- a/packages/canonical-bridge/src/hooks/useTransferConfig.ts
+++ b/packages/canonical-bridge/src/hooks/useTransferConfig.ts
@@ -122,14 +122,14 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
             excludedChains: [],
             excludedTokens: {
               56: ['0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'],
-              42161: ['0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9', '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'],
-              1101: ['0x0D1E753a25eBda689453309112904807625bEFBe'],
+              42161: ['0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9', '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'], // ['USDT', 'USDC.e']
             },
           }),
           deBridge({
             config: deBridgeConfig,
             excludedChains: [],
             excludedTokens: {
+              // We excluded certain tokens because: previously during testing, these token transactions failed. Some due to internal errors from third parties, and others due to lack of liquidity, hence we removed them.
               1: ['cUSDCv3', '0x5e21d1ee5cf0077b314c381720273ae82378d613'],
               56: [
                 '0x67d66e8ec1fd25d98b3ccd3b19b7dc4b4b7fc493',
@@ -145,29 +145,23 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
                 '2kaRSuDcz1V1kqq1sDmP23Wy98jutHQQgr5fGDWRpump',
                 '2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk',
               ],
-              1101: ['0x0D1E753a25eBda689453309112904807625bEFBe'],
             },
           }),
           stargate({
             config: stargateConfig,
             excludedChains: [],
-            excludedTokens: {
-              1101: ['0x0D1E753a25eBda689453309112904807625bEFBe'],
-            },
+            excludedTokens: {},
           }),
           layerZero({
             config: layerZeroConfig,
             excludedChains: [],
-            excludedTokens: {
-              1101: ['0x0D1E753a25eBda689453309112904807625bEFBe'],
-            },
+            excludedTokens: {},
           }),
           meson({
             config: mesonConfig,
             excludedChains: [],
             excludedTokens: {
               42161: ['SOL'],
-              1101: ['0x0D1E753a25eBda689453309112904807625bEFBe'],
             },
           }),
         ],

--- a/packages/canonical-bridge/src/views/index.tsx
+++ b/packages/canonical-bridge/src/views/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, Message, MessageText, Text, useToast } from '@pancakeswap/uikit'
+import { Flex, useToast } from '@pancakeswap/uikit'
 import { useCallback, useMemo } from 'react'
 
 import {
@@ -92,29 +92,6 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
       <GlobalStyle />
       <CanonicalBridgeProvider config={config}>
         <Flex flexDirection="column" justifyContent="center" maxWidth="480px" width="100%">
-          <Message variant="warning" mb="16px">
-            <MessageText>
-              <Text bold>{t('Notice: Temporary Unavailability of CAKE Bridging')}</Text>
-              <br />
-              <Text small bold as="span">
-                From 1:00 PM (GMT+8):
-              </Text>{' '}
-              <br />
-              {t('CAKE bridging from Polygon zkEVM will be reverted; bridging to Polygon zkEVM remains available.')}
-              <br />
-              <br />
-              <Text small bold as="span">
-                From 4:30 PM (GMT+8):
-              </Text>{' '}
-              <br />
-              {t(
-                'CAKE bridging to/from all chains will be reverted; transactions created before this will be processed as normal.',
-              )}
-              <br />
-              <br />
-              {t('Stay tuned to our X account for real-time updates.')}
-            </MessageText>
-          </Message>
           <BridgeTransfer />
           <V1BridgeLink />
         </Flex>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3801,9 +3801,5 @@
   "The change in pool price caused by your swap.": "The change in pool price caused by your swap.",
   "Estimated time to complete this transaction.": "Estimated time to complete this transaction.",
   "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!": "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!",
-  "Developer Doc": "Developer Doc",
-  "Notice: Temporary Unavailability of CAKE Bridging": "Notice: Temporary Unavailability of CAKE Bridging",
-  "CAKE bridging from Polygon zkEVM will be reverted; bridging to Polygon zkEVM remains available.": "CAKE bridging from Polygon zkEVM will be reverted; bridging to Polygon zkEVM remains available.",
-  "CAKE bridging to/from all chains will be reverted; transactions created before this will be processed as normal.": "CAKE bridging to/from all chains will be reverted; transactions created before this will be processed as normal.",
-  "Stay tuned to our X account for real-time updates.": "Stay tuned to our X account for real-time updates."
+  "Developer Doc": "Developer Doc"
 }


### PR DESCRIPTION
Resets this PR: #11790 

1. Re-enable CAKE bridging on Polygon zkEVM
2. Remove the Scheduled Maintenance banners from `/bridge` and bridge.pancakeswap.finance (v1 bridge) pages

<!-- start pr-codex -->

---

## PR-Codex overview
This PR re-enables CAKE bridging on `Polygon zkEVM` and removes the associated maintenance messages from the user interface. It also updates the `excludedTokens` configuration in the code.

### Detailed summary
- Re-enabled CAKE bridging on `Polygon zkEVM`.
- Removed maintenance notice messages from `translations.json` and UI components.
- Updated `excludedTokens` in `useTransferConfig.ts` to reflect changes in token exclusions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->