### PR TITLE
fix: CurrencySearch Modal slow response due to getting all balances on-chain

### DIFF
--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
   ModalCloseButton,
   ModalTitle,
+  Spinner,
   Text,
   useMatchBreakpoints,
 } from '@pancakeswap/uikit'
@@ -28,6 +29,7 @@ import { safeGetAddress } from 'utils'
 import { UpdaterByChainId } from 'state/lists/updater'
 import { useAllTokenBalances } from 'state/wallet/hooks'
 import { getTokenAddressFromSymbolAlias } from 'utils/getTokenAlias'
+import { useAccount } from 'wagmi'
 import { useAllTokens, useIsUserAddedToken, useToken } from '../../hooks/Tokens'
 import Row from '../Layout/Row'
 import CommonBases, { BaseWrapper } from './CommonBases'
@@ -127,6 +129,7 @@ function CurrencySearch({
   onSettingsClick,
 }: CurrencySearchProps) {
   const { t } = useTranslation()
+  const account = useAccount()
   const [searchQuery, setSearchQuery] = useState<string>('')
   const debouncedQuery = useDebounce(getTokenAddressFromSymbolAlias(searchQuery, selectedChainId, searchQuery), 200)
   // refs for fixed size lists
@@ -163,7 +166,7 @@ function CurrencySearch({
 
   const filteredQueryTokens = useSortedTokensByQuery(filteredTokens, debouncedQuery)
 
-  const balances = useAllTokenBalances(selectedChainId)
+  const { balances, isLoading: isLoadingBalances } = useAllTokenBalances(selectedChainId)
 
   const filteredSortedTokens: Token[] = useMemo(() => {
     const tokenComparator = getTokenComparator(balances ?? {})
@@ -335,7 +338,13 @@ function CurrencySearch({
           />
         )}
       </AutoColumn>
-      {getCurrencyListRows()}
+      {account && isLoadingBalances ? (
+        <Flex width="100%" justifyContent="center" alignItems="center" pt="24px">
+          <Spinner />
+        </Flex>
+      ) : (
+        getCurrencyListRows()
+      )}
     </>
   )
 }

--- a/apps/web/src/hooks/useTokenComparator.ts
+++ b/apps/web/src/hooks/useTokenComparator.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { useAllTokenBalances } from '../state/wallet/hooks'
 
 export function useTokenComparator(inverted: boolean, chainId?: number): (tokenA: Token, tokenB: Token) => number {
-  const balances = useAllTokenBalances(chainId)
+  const { balances } = useAllTokenBalances(chainId)
   const comparator = useMemo(() => getTokenComparator(balances ?? {}), [balances])
 
   return useMemo(() => {

--- a/apps/web/src/state/wallet/hooks.ts
+++ b/apps/web/src/state/wallet/hooks.ts
@@ -125,13 +125,9 @@ export function useCurrencyBalance(account?: string, currency?: Currency | null)
   )[0]
 }
 
-type BalanceAmount = {
-  [tokenAddress: string]: CurrencyAmount<Token> | undefined
-}
-
 // get all token balances for the current account by using api
 export function useAllTokenBalances(selectedChainId?: number): {
-  balances: BalanceAmount
+  balances: { [tokenAddress: string]: CurrencyAmount<Token> | undefined }
   isLoading: boolean
 } {
   const { address: account } = useAccount()

--- a/apps/web/src/state/wallet/hooks.ts
+++ b/apps/web/src/state/wallet/hooks.ts
@@ -1,4 +1,4 @@
-import { ChainId, Currency, CurrencyAmount, Native, Token } from '@pancakeswap/sdk'
+import { ChainId, Currency, CurrencyAmount, Native, Token, ZERO_ADDRESS } from '@pancakeswap/sdk'
 import { useQuery } from '@tanstack/react-query'
 import { multicallABI } from 'config/abi/Multicall'
 import { FAST_INTERVAL } from 'config/constants'
@@ -151,7 +151,8 @@ export function useAllTokenBalances(selectedChainId?: number): {
 
         const checksummedTokenAddress = safeGetAddress(tokenAddress)
 
-        if (!checksummedTokenAddress) {
+        // Ignore native token because this hook is designed for tokens only, not native one
+        if (!checksummedTokenAddress || checksummedTokenAddress === ZERO_ADDRESS) {
           return acc
         }
         // eslint-disable-next-line no-param-reassign

--- a/apps/web/src/state/wallet/hooks.ts
+++ b/apps/web/src/state/wallet/hooks.ts
@@ -133,13 +133,17 @@ export function useAllTokenBalances(chainId?: number): { [tokenAddress: string]:
 
   const [tokenBalances] = useTokenBalancesWithLoadingIndicator(account, allTokensArray)
 
-  return Object.keys(tokenBalances).reduce((acc, key) => {
-    const [_, address] = key.split('-')
-    return {
-      ...acc,
-      [address]: tokenBalances[key],
-    }
-  }, {} as { [tokenAddress: string]: CurrencyAmount<Token> | undefined })
+  return useMemo(
+    () =>
+      Object.keys(tokenBalances).reduce((acc, key) => {
+        const [_, address] = key.split('-')
+        return {
+          ...acc,
+          [address]: tokenBalances[key],
+        }
+      }, {} as { [tokenAddress: string]: CurrencyAmount<Token> | undefined }),
+    [tokenBalances],
+  )
 }
 
 /**

--- a/apps/web/src/state/wallet/hooks.ts
+++ b/apps/web/src/state/wallet/hooks.ts
@@ -2,8 +2,8 @@ import { ChainId, Currency, CurrencyAmount, Native, Token } from '@pancakeswap/s
 import { useQuery } from '@tanstack/react-query'
 import { multicallABI } from 'config/abi/Multicall'
 import { FAST_INTERVAL } from 'config/constants'
-import { useAllTokens } from 'hooks/Tokens'
 import { useActiveChainId } from 'hooks/useActiveChainId'
+import useAddressBalance from 'hooks/useAddressBalance'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import orderBy from 'lodash/orderBy'
 import { useMemo } from 'react'
@@ -125,25 +125,57 @@ export function useCurrencyBalance(account?: string, currency?: Currency | null)
   )[0]
 }
 
-// mimics useAllBalances
-export function useAllTokenBalances(chainId?: number): { [tokenAddress: string]: CurrencyAmount<Token> | undefined } {
+type BalanceAmount = {
+  [tokenAddress: string]: CurrencyAmount<Token> | undefined
+}
+
+// get all token balances for the current account by using api
+export function useAllTokenBalances(selectedChainId?: number): {
+  balances: BalanceAmount
+  isLoading: boolean
+} {
   const { address: account } = useAccount()
-  const allTokens = useAllTokens(chainId)
-  const allTokensArray = useMemo(() => Object.values(allTokens ?? {}), [allTokens])
 
-  const [tokenBalances] = useTokenBalancesWithLoadingIndicator(account, allTokensArray)
+  // Fetch balances using the hook we created
+  const { balances: apiBalances, isLoading: isLoadingBalance } = useAddressBalance(account, {
+    includeSpam: false,
+    onlyWithPrice: false,
+    filterByChainId: selectedChainId,
+  })
 
-  return useMemo(
-    () =>
-      Object.keys(tokenBalances).reduce((acc, key) => {
-        const [_, address] = key.split('-')
-        return {
-          ...acc,
-          [address]: tokenBalances[key],
+  return useMemo(() => {
+    /// [tokenAddress: string]: CurrencyAmount<Token> | undefined
+    const balances = apiBalances.reduce<{ [tokenAddress: string]: CurrencyAmount<Token> | undefined }>(
+      (acc, balance) => {
+        const [chainId, tokenAddress] = balance.id.split('-')
+
+        const checksummedTokenAddress = safeGetAddress(tokenAddress)
+
+        if (!checksummedTokenAddress) {
+          return acc
         }
-      }, {} as { [tokenAddress: string]: CurrencyAmount<Token> | undefined }),
-    [tokenBalances],
-  )
+        // eslint-disable-next-line no-param-reassign
+        acc[checksummedTokenAddress] = CurrencyAmount.fromRawAmount(
+          new Token(
+            Number(chainId),
+            checksummedTokenAddress,
+            balance.token.decimals,
+            balance.token.symbol,
+            balance.token.name,
+          ),
+          balance.value,
+        )
+
+        return acc
+      },
+      {} as { [tokenAddress: string]: CurrencyAmount<Token> | undefined },
+    )
+
+    return {
+      balances,
+      isLoading: isLoadingBalance,
+    }
+  }, [apiBalances, isLoadingBalance, selectedChainId])
 }
 
 /**


### PR DESCRIPTION
## Description
This PR adds memoization to improve performance when fetching all token balances.

## Changes
- Added memo optimization for balance fetching operations

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useAllTokenBalances` hook to return an object containing both token balances and a loading state. It also updates the `CurrencySearch` component to handle loading states and improves the handling of balances when comparing tokens.

### Detailed summary
- Changed `useAllTokenBalances` to return an object with `balances` and `isLoading`.
- Updated `useTokenComparator` to destructure `balances` from `useAllTokenBalances`.
- Introduced a loading spinner in `CurrencySearch` when balances are being fetched.
- Modified balance fetching logic in `useAllTokenBalances` to use `useAddressBalance`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->