### PR TITLE
chore: disable zksync CAKE bridging on Main and V1 widgets

### DIFF
--- a/apps/bridge/components/layerZero/index.tsx
+++ b/apps/bridge/components/layerZero/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Message, MessageText } from '@pancakeswap/uikit'
+import { Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
 import AptosBridgeFooter from 'components/layerZero/AptosBridgeFooter'
 import { LayerZeroWidget } from 'components/layerZero/LayerZeroWidget'
 import { FEE_COLLECTOR, FEE_TENTH_BPS, LAYER_ZERO_JS, PARTNER_ID } from 'components/layerZero/config'
@@ -61,12 +61,13 @@ const LayerZero = ({ isCake }: { isCake?: boolean }) => {
               // @ts-ignore
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               app!.bridgeStore!.currencies.length = 0
-              app?.bridgeStore?.addCurrencies(currencies?.filter((i: any) => i.symbol.toLowerCase() === 'cake'))
 
-              const srcCake = app?.bridgeStore?.currencies?.find(
-                (i: any) => i.symbol.toUpperCase() === 'CAKE' && i.chainId === 102,
-              )
-              app?.bridgeStore?.setSrcCurrency(srcCake)
+              // Temporarily disable CAKE bridging (commented out lines below)
+              // app?.bridgeStore?.addCurrencies(currencies?.filter((i: any) => i.symbol.toLowerCase() === 'cake'))
+              // const srcCake = app?.bridgeStore?.currencies?.find(
+              //   (i: any) => i.symbol.toUpperCase() === 'CAKE' && i.chainId === 102,
+              // )
+              // app?.bridgeStore?.setSrcCurrency(srcCake)
             }
           } catch (error) {
             console.error('Failed to load lz-bridge', error)
@@ -86,6 +87,17 @@ const LayerZero = ({ isCake }: { isCake?: boolean }) => {
         <Box width={['100%', null, '420px']} m="auto">
           <Message variant="warning" m={['16px', '16px', '16px 0']}>
             <MessageText>
+              <Text mb="8px" small bold>
+                Notice: ZKsync CAKE Bridging Maintenance
+              </Text>
+              Bridging to/from ZKsync is currently unavailable until further notice.
+              <br />
+              Bridging on all other supported networks continues to function as normal.
+              <br />
+              <br />
+              Please refer to our X account for updates.
+              <br />
+              <br />
               Outbound transfers from Polygon zkEVM are subject to a 7 days delay for block confirmations.
             </MessageText>
           </Message>

--- a/packages/canonical-bridge/src/hooks/useTransferConfig.ts
+++ b/packages/canonical-bridge/src/hooks/useTransferConfig.ts
@@ -122,6 +122,7 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
             excludedChains: [],
             excludedTokens: {
               56: ['0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'],
+              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
               42161: ['0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9', '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'], // ['USDT', 'USDC.e']
             },
           }),
@@ -136,6 +137,7 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
                 '0x0000000000000000000000000000000000000000',
                 '0x9c7beba8f6ef6643abd725e45a4e8387ef260649',
               ],
+              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
               137: ['cUSDCv3'],
               42161: ['cUSDCv3'],
               43114: ['BNB'],
@@ -150,17 +152,22 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
           stargate({
             config: stargateConfig,
             excludedChains: [],
-            excludedTokens: {},
+            excludedTokens: {
+              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
+            },
           }),
           layerZero({
             config: layerZeroConfig,
             excludedChains: [],
-            excludedTokens: {},
+            excludedTokens: {
+              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
+            },
           }),
           meson({
             config: mesonConfig,
             excludedChains: [],
             excludedTokens: {
+              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
               42161: ['SOL'],
             },
           }),

--- a/packages/canonical-bridge/src/views/index.tsx
+++ b/packages/canonical-bridge/src/views/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, useToast } from '@pancakeswap/uikit'
+import { Flex, Message, MessageText, Text, useToast } from '@pancakeswap/uikit'
 import { useCallback, useMemo } from 'react'
 
 import {
@@ -92,6 +92,19 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
       <GlobalStyle />
       <CanonicalBridgeProvider config={config}>
         <Flex flexDirection="column" justifyContent="center" maxWidth="480px" width="100%">
+          <Message variant="warning" mb="16px">
+            <MessageText>
+              <Text mb="8px" small bold>
+                {t('Notice: ZKsync CAKE Bridging Maintenance')}
+              </Text>
+              {t('Bridging to/from ZKsync is currently unavailable until further notice.')}
+              <br />
+              {t('Bridging on all other supported networks continues to function as normal.')}
+              <br />
+              <br />
+              {t('Please refer to our X account for updates.')}
+            </MessageText>
+          </Message>
           <BridgeTransfer />
           <V1BridgeLink />
         </Flex>

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3801,5 +3801,9 @@
   "The change in pool price caused by your swap.": "The change in pool price caused by your swap.",
   "Estimated time to complete this transaction.": "Estimated time to complete this transaction.",
   "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!": "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!",
-  "Developer Doc": "Developer Doc"
+  "Developer Doc": "Developer Doc",
+  "Notice: ZKsync CAKE Bridging Maintenance": "Notice: ZKsync CAKE Bridging Maintenance",
+  "Bridging to/from ZKsync is currently unavailable until further notice.": "Bridging to/from ZKsync is currently unavailable until further notice.",
+  "Bridging on all other supported networks continues to function as normal.": "Bridging on all other supported networks continues to function as normal.",
+  "Please refer to our X account for updates.": "Please refer to our X account for updates."
 }


### PR DESCRIPTION
ZKsync CAKE bridging is facing issues at the moment.
1. Add disclaimers on both `/bridge` and bridge.pancakeswap.finance pages
2. Disable all CAKE bridging on bridge.pancakeswap.finance
3. Disable ZKsync CAKE bridging at `/bridge`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding maintenance notices for ZKsync CAKE bridging and updating the configuration to exclude CAKE tokens from certain operations.

### Detailed summary
- Updated `translations.json` to include maintenance messages for ZKsync CAKE bridging.
- Added a warning message in `CanonicalBridge` to inform users about ZKsync bridging unavailability.
- Modified `useTransferConfig` to exclude CAKE tokens from transfers.
- Commented out CAKE bridging logic in `LayerZero` component.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->