### PR TITLE
fix: Mev Toggle flash when switching network

### DIFF
--- a/apps/web/src/views/Mev/hooks/index.ts
+++ b/apps/web/src/views/Mev/hooks/index.ts
@@ -117,22 +117,23 @@ export function useIsMEVEnabled() {
   const { account, chainId } = useAccountActiveChain()
   const { walletType } = useWalletType()
 
+  const isMEVProtectAvailable =
+    Boolean(account) && chainId === ChainId.BSC && Boolean(walletClient) && walletType !== WalletType.mevNotSupported
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['isMEVEnabled', walletClient, account, chainId, walletType],
     queryFn: () => fetchMEVStatus(walletClient!),
-    enabled: Boolean(account) && walletClient && chainId === ChainId.BSC,
+    enabled: isMEVProtectAvailable,
     staleTime: 60000,
   })
 
-  // console.log('isMEVEnabled', data?.mevEnabled, walletType, chainId, walletClient)
+  const isMEVEnabledAfterValidation = data?.mevEnabled || walletType === WalletType.mevDefaultOnBSC
+
   return {
-    isMEVEnabled:
-      (walletType !== WalletType.mevNotSupported &&
-        (data?.mevEnabled || (walletType === WalletType.mevDefaultOnBSC && chainId === ChainId.BSC))) ??
-      false,
+    isMEVEnabled: isMEVProtectAvailable && isMEVEnabledAfterValidation,
     isLoading,
     refetch,
-    isMEVProtectAvailable: chainId === ChainId.BSC,
+    isMEVProtectAvailable,
   }
 }
 
@@ -141,6 +142,7 @@ export const useShouldShowMEVToggle = () => {
   const { address: account } = useAccount()
   const { isMEVEnabled, isLoading, isMEVProtectAvailable } = useIsMEVEnabled()
   const { walletType, isLoading: isWalletTypeLoading } = useWalletType()
+
   return (
     !isLoading &&
     !isWalletTypeLoading &&


### PR DESCRIPTION
## Description
This PR fixes the MEV toggle flash issue that occurs when switching networks.

## Changes
- Fixed the MEV toggle flash behavior when switching between different networks

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement (non-breaking change which improves performance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [ ] I have performed a self-review of my own code
- [ ] I have tested the fix across different network switches
- [ ] My changes generate no new warnings
- [ ] The UI remains stable during network transitions

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the MEV (Maximal Extractable Value) functionality by refining the conditions under which MEV protection is available and determining if MEV is enabled based on wallet type and account status.

### Detailed summary
- Introduced `isMEVProtectAvailable` to check MEV protection eligibility.
- Updated the `enabled` flag in the `useQuery` to use `isMEVProtectAvailable`.
- Modified the calculation of `isMEVEnabled` to include `isMEVProtectAvailable` and `isMEVEnabledAfterValidation`.
- Removed the old `isMEVEnabled` logic that directly checked wallet type and MEV status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->