### PR TITLE
chore: ranking rpcs by session

### DIFF
--- a/apps/web/src/utils/fallbackWithRank.test.ts
+++ b/apps/web/src/utils/fallbackWithRank.test.ts
@@ -1,9 +1,9 @@
 import { createServer, RequestListener } from 'node:http'
 import { AddressInfo } from 'node:net'
 import { http } from 'viem'
-import { bsc, bscTestnet } from 'viem/chains'
+import { bsc, bscTestnet, opBNB } from 'viem/chains'
 import { Transport } from 'wagmi'
-import { fallbackWithRank, rankTransports } from './fallbackWithRank'
+import { rankTransports } from './fallbackWithRank'
 
 function createHttpServer(handler: RequestListener): Promise<{ close: () => Promise<unknown>; url: string }> {
   const server = createServer(handler)
@@ -85,72 +85,11 @@ describe('rankTransports', () => {
     })
 
     rankTransports({
-      chain: bsc,
+      chain: opBNB,
       onTransports: mockFn,
       transports: [transportFailed, transport100, transport1],
     })
 
     await new Promise((resolve) => setTimeout(resolve, 100))
-  })
-})
-
-describe('fallbackWithRank', () => {
-  test('should fallback and re-rank after 429', async () => {
-    let shouldRateLimit = false
-    let server0Calls = 0
-    let server1Calls = 0
-    const server0 = await createHttpServer((_req, res) => {
-      server0Calls++
-      setTimeout(() => {
-        if (shouldRateLimit) {
-          res.writeHead(429, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Rate limit exceeded' }))
-        } else {
-          res.writeHead(200, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ result: '0x1' }))
-        }
-      }, 1)
-    })
-    const server1 = await createHttpServer((_req, res) => {
-      server1Calls++
-      setTimeout(() => {
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ result: '0x1' }))
-      }, 50)
-    })
-
-    const transport0 = http(server0.url, { key: 'transport0' })
-    const transport1 = http(server1.url, { key: 'transport1' })
-
-    const transport = fallbackWithRank([transport1, transport0], { retryCount: 0 })({ chain: bsc, retryCount: 0 })
-
-    await new Promise((resolve) => setTimeout(resolve, 100))
-
-    expect([server0Calls, server1Calls]).toEqual([1, 1]) // initial rank
-
-    await transport.request({ method: 'eth_chainId' })
-
-    // current rank should be [transport0, transport1], and manual request increases calls
-    expect([server0Calls, server1Calls]).toEqual([2, 1])
-
-    shouldRateLimit = true
-
-    await transport.request({ method: 'eth_chainId' }).catch((error) => {
-      expect(error).toBeInstanceOf(Error)
-      expect(error.message).toContain('Rate limit exceeded')
-    })
-
-    await new Promise((resolve) => setTimeout(resolve, 110))
-
-    expect([server0Calls, server1Calls]).toEqual([4, 3])
-    // server0+2: 1 for manual request, 1 for re-rank after 429
-    // server1+2: 1 for fallback retry after 429, 1 for re-rank after 429
-
-    shouldRateLimit = false
-
-    await transport.request({ method: 'eth_chainId' })
-    await new Promise((resolve) => setTimeout(resolve, 110))
-
-    expect([server0Calls, server1Calls]).toEqual([4, 4]) // as previous rank, server1 is the faster one
   })
 })

--- a/apps/web/src/utils/fallbackWithRank.ts
+++ b/apps/web/src/utils/fallbackWithRank.ts
@@ -1,13 +1,5 @@
 import { memoizeAsync } from '@pancakeswap/utils/memoize'
-import {
-  Chain,
-  createTransport,
-  FallbackTransport,
-  FallbackTransportConfig,
-  HttpRequestError,
-  Prettify,
-  Transport,
-} from 'viem'
+import { Chain, createTransport, FallbackTransport, FallbackTransportConfig, Prettify, Transport } from 'viem'
 
 type OnResponseFn = (
   args: {
@@ -107,29 +99,7 @@ export const fallbackWithRank = <const transports extends readonly Transport[]>(
                 status: 'error',
               })
 
-              // If we've reached the end of the fallbacks, throw the error.
-              if (i === transports.length - 1) throw err
-
-              // Check if at least one other transport includes the method
-              includes ??= transports.slice(i + 1).some((transport) => {
-                const { include, exclude } = transport({ chain }).config.methods || {}
-                if (include) return include.includes(method)
-                if (exclude) return !exclude.includes(method)
-                return true
-              })
-              if (!includes) throw err
-
-              if (shouldReRank(err as Error)) {
-                rankTransports({
-                  chain,
-                  // eslint-disable-next-line no-return-assign
-                  onTransports: (transports_) => (transports = transports_ as transports),
-                  transports,
-                })
-              }
-
-              // Otherwise, try the next fallback.
-              return fetch(i + 1)
+              throw err
             }
           }
           return fetch()
@@ -174,13 +144,4 @@ export const rankTransports = ({
   }
 
   rankTransports_()
-}
-
-const shouldReRank = (error: Error) => {
-  // If the error is a rate limit error, we should re-rank the transports.
-  if (error instanceof HttpRequestError && error.status === 429) {
-    return true
-  }
-
-  return false
 }

--- a/apps/web/src/utils/fallbackWithRank.ts
+++ b/apps/web/src/utils/fallbackWithRank.ts
@@ -1,3 +1,4 @@
+import { memoizeAsync } from '@pancakeswap/utils/memoize'
 import {
   Chain,
   createTransport,
@@ -26,6 +27,37 @@ type OnResponseFn = (
       }
   ),
 ) => void
+
+type OrderArgs = { chain?: Chain; transports: readonly Transport[] }
+
+const getTransportOrder = memoizeAsync(
+  async ({ chain, transports }: OrderArgs): Promise<number[]> => {
+    if (!chain || Boolean(chain.testnet)) return transports.map((_, i) => i)
+
+    const scores = await Promise.all(
+      transports.map(async (transport, i) => {
+        const transport_ = transport({ chain, retryCount: 0, timeout: 1_000 })
+
+        const start = performance.now()
+        let end: number
+        let success = Number.MAX_SAFE_INTEGER
+        try {
+          await transport_.request({ method: 'eth_chainId' })
+          success = 1
+        } catch {
+          // ignore
+        } finally {
+          end = performance.now()
+        }
+
+        return [success * (end - start), i] as const
+      }),
+    )
+
+    return scores.sort((a, b) => a[0] - b[0]).map(([, i]) => i)
+  },
+  { resolver: ({ chain }) => chain?.id },
+)
 
 export const fallbackWithRank = <const transports extends readonly Transport[]>(
   transports_: transports,
@@ -136,28 +168,8 @@ export const rankTransports = ({
   if (!chain || Boolean(chain.testnet)) return
 
   const rankTransports_ = async () => {
-    const scores = await Promise.all(
-      transports.map(async (transport, i) => {
-        const transport_ = transport({ chain, retryCount: 0, timeout: 1_000 })
-
-        const start = performance.now()
-        let end: number
-        let success = Number.MAX_SAFE_INTEGER
-        try {
-          await transport_.request({ method: 'eth_chainId' })
-          success = 1
-        } catch {
-          // ignore
-        } finally {
-          end = performance.now()
-        }
-
-        return [success * (end - start), i, transport_.config.key] as const
-      }),
-    )
-
-    const rankedTransports = scores.sort((a, b) => a[0] - b[0]).map(([, i]) => transports[i])
-
+    const order = await getTransportOrder({ chain, transports })
+    const rankedTransports = order.map((i) => transports[i])
     onTransports(rankedTransports)
   }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `fallbackWithRank` functionality by modifying the transport chain used in tests, removing a test for fallback behavior, and enhancing the transport ranking mechanism with memoization. It also introduces a new transport, `opBNB`, and removes unused code.

### Detailed summary
- Added `opBNB` to imports in `fallbackWithRank.test.ts`.
- Changed the transport chain from `bsc` to `opBNB` in `rankTransports`.
- Removed the entire `fallbackWithRank` test suite from `fallbackWithRank.test.ts`.
- Introduced `getTransportOrder` function with memoization in `fallbackWithRank.ts`.
- Simplified the logic for ranking transports in `rankTransports` using `getTransportOrder`. 
- Removed obsolete error handling and ranking logic in `fallbackWithRank`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->