### PR TITLE
feat: add position manager warning

### DIFF
--- a/apps/web/src/views/PositionManagers/components/SunsetWarning.tsx
+++ b/apps/web/src/views/PositionManagers/components/SunsetWarning.tsx
@@ -1,0 +1,48 @@
+import { Link, Message, MessageText, Text } from '@pancakeswap/uikit'
+
+const SunsetWarning = () => {
+  return (
+    <Message variant="warning" m="16px 0">
+      <MessageText>
+        <Text mb="8px" small bold>
+          Position Managers Sunsetting — 21 June 2025, 08:00 UTC
+        </Text>
+        Action required: Withdraw all positions before this time.
+        <br />
+        Note: After the deadline, positions will no longer be actively managed and may fall out of range, which could
+        lead to impermanent loss.
+        <br />
+        <br />
+        Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to
+        recover or prevent any losses from positions left unmanaged.
+        <br />
+        <br />
+        For more details, read the{' '}
+        <Link
+          style={{
+            display: 'inline',
+            fontSize: '14px',
+          }}
+          external
+          href="https://blog.pancakeswap.finance/articles/action-required-retirement-of-position-managers-bril-defiedge-teahouse-range-and-alpaca"
+        >
+          official blog post
+        </Link>{' '}
+        or view the{' '}
+        <Link
+          external
+          href="https://x.com/PancakeSwap/status/1925120544396963964"
+          style={{
+            display: 'inline',
+            fontSize: '14px',
+          }}
+        >
+          announcement on X
+        </Link>
+        .
+      </MessageText>
+    </Message>
+  )
+}
+
+export default SunsetWarning

--- a/apps/web/src/views/PositionManagers/components/SunsetWarning.tsx
+++ b/apps/web/src/views/PositionManagers/components/SunsetWarning.tsx
@@ -1,23 +1,27 @@
+import { useTranslation } from '@pancakeswap/localization'
 import { Link, Message, MessageText, Text } from '@pancakeswap/uikit'
 
 const SunsetWarning = () => {
+  const { t } = useTranslation()
   return (
     <Message variant="warning" m="16px 0">
       <MessageText>
         <Text mb="8px" small bold>
-          Position Managers Sunsetting — 21 June 2025, 08:00 UTC
+          {t('Position Managers Sunsetting — 21 June 2025, 08:00 UTC')}
         </Text>
-        Action required: Withdraw all positions before this time.
+        {t('Action required: Withdraw all positions before this time.')}
         <br />
-        Note: After the deadline, positions will no longer be actively managed and may fall out of range, which could
-        lead to impermanent loss.
-        <br />
-        <br />
-        Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to
-        recover or prevent any losses from positions left unmanaged.
+        {t(
+          'Note: After the deadline, positions will no longer be actively managed and may fall out of range, which could lead to impermanent loss.',
+        )}
         <br />
         <br />
-        For more details, read the{' '}
+        {t(
+          'Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to recover or prevent any losses from positions left unmanaged.',
+        )}
+        <br />
+        <br />
+        {t('For more details, read the')}{' '}
         <Link
           style={{
             display: 'inline',
@@ -26,9 +30,9 @@ const SunsetWarning = () => {
           external
           href="https://blog.pancakeswap.finance/articles/action-required-retirement-of-position-managers-bril-defiedge-teahouse-range-and-alpaca"
         >
-          official blog post
+          {t('official blog post')}
         </Link>{' '}
-        or view the{' '}
+        {t('or view the')}{' '}
         <Link
           external
           href="https://x.com/PancakeSwap/status/1925120544396963964"
@@ -37,7 +41,7 @@ const SunsetWarning = () => {
             fontSize: '14px',
           }}
         >
-          announcement on X
+          {t('announcement on X')}
         </Link>
         .
       </MessageText>

--- a/apps/web/src/views/PositionManagers/index.tsx
+++ b/apps/web/src/views/PositionManagers/index.tsx
@@ -1,12 +1,25 @@
+import { Box, useMatchBreakpoints } from '@pancakeswap/uikit'
 import Page from 'components/Layout/Page'
 import { Header } from './components'
+import SunsetWarning from './components/SunsetWarning'
 import { Controls, VaultContent } from './containers'
 
 export function PositionManagers() {
+  const { isMobile } = useMatchBreakpoints()
   return (
     <>
       <Header />
+
       <Page>
+        <Box
+          width="100%"
+          style={{
+            marginTop: isMobile ? '-20px' : '-60px',
+          }}
+          m="auto"
+        >
+          <SunsetWarning />
+        </Box>
         <Controls />
         <VaultContent />
       </Page>

--- a/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolsBanner.tsx
@@ -21,6 +21,9 @@ import { useUserPancakePicks } from 'state/user/hooks/useUserPancakePicks'
 import styled from 'styled-components'
 import { FarmFlexWrapper, FarmH1, FarmH2 } from 'views/Farms/styled'
 
+const StyledPageHeader = styled(PageHeader)`
+  background: ${({ theme }) => (theme.isDark ? undefined : theme.colors.gradientBubblegum)};
+`
 export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }) => {
   const { t } = useTranslation()
   const { theme } = useTheme()
@@ -38,7 +41,7 @@ export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }
   }, [])
 
   return (
-    <PageHeader
+    <StyledPageHeader
       style={isMobile ? { padding: '16px 0' } : undefined}
       innerProps={isMobile ? { style: { padding: '0 16px' } } : undefined}
     >
@@ -133,6 +136,6 @@ export const PoolsBanner = ({ additionLink }: { additionLink?: React.ReactNode }
           </Box>
         </FarmFlexWrapper>
       </Column>
-    </PageHeader>
+    </StyledPageHeader>
   )
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3801,5 +3801,13 @@
   "The change in pool price caused by your swap.": "The change in pool price caused by your swap.",
   "Estimated time to complete this transaction.": "Estimated time to complete this transaction.",
   "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!": "Requested amount exceeds the available bridge liquidity. Please try again with a lower amount!",
-  "Developer Doc": "Developer Doc"
+  "Developer Doc": "Developer Doc",
+  "Position Managers Sunsetting — 21 June 2025, 08:00 UTC": "Position Managers Sunsetting — 21 June 2025, 08:00 UTC",
+  "Action required: Withdraw all positions before this time.": "Action required: Withdraw all positions before this time.",
+  "Note: After the deadline, positions will no longer be actively managed and may fall out of range, which could lead to impermanent loss.": "Note: After the deadline, positions will no longer be actively managed and may fall out of range, which could lead to impermanent loss.",
+  "Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to recover or prevent any losses from positions left unmanaged.": "Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to recover or prevent any losses from positions left unmanaged.",
+  "For more details, read the": "For more details, read the",
+  "official blog post": "official blog post",
+  "or view the": "or view the",
+  "announcement on X": "announcement on X"
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a `SunsetWarning` component to inform users about the sunsetting of the Position Managers feature, along with updates to the `PoolsBanner` component for styling consistency.

### Detailed summary
- Added `SunsetWarning` component in `PositionManagers/index.tsx`.
- Integrated `SunsetWarning` into the layout with responsive margin adjustments.
- Created `StyledPageHeader` in `PoolsBanner.tsx` for improved styling.
- Replaced `<PageHeader>` with `<StyledPageHeader>` in `PoolsBanner`.
- Updated `translations.json` with new warning messages related to the sunsetting.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->