### PR TITLE
chore: re-enable CAKE bridging, remove maintenance banners

### DIFF
--- a/apps/bridge/components/layerZero/index.tsx
+++ b/apps/bridge/components/layerZero/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Message, MessageText, Text } from '@pancakeswap/uikit'
+import { Box, Flex } from '@pancakeswap/uikit'
 import AptosBridgeFooter from 'components/layerZero/AptosBridgeFooter'
 import { LayerZeroWidget } from 'components/layerZero/LayerZeroWidget'
 import { FEE_COLLECTOR, FEE_TENTH_BPS, LAYER_ZERO_JS, PARTNER_ID } from 'components/layerZero/config'
@@ -61,13 +61,11 @@ const LayerZero = ({ isCake }: { isCake?: boolean }) => {
               // @ts-ignore
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               app!.bridgeStore!.currencies.length = 0
-
-              // Temporarily disable CAKE bridging (commented out lines below)
-              // app?.bridgeStore?.addCurrencies(currencies?.filter((i: any) => i.symbol.toLowerCase() === 'cake'))
-              // const srcCake = app?.bridgeStore?.currencies?.find(
-              //   (i: any) => i.symbol.toUpperCase() === 'CAKE' && i.chainId === 102,
-              // )
-              // app?.bridgeStore?.setSrcCurrency(srcCake)
+              app?.bridgeStore?.addCurrencies(currencies?.filter((i: any) => i.symbol.toLowerCase() === 'cake'))
+              const srcCake = app?.bridgeStore?.currencies?.find(
+                (i: any) => i?.symbol?.toUpperCase() === 'CAKE' && i?.chainId === 102,
+              )
+              app?.bridgeStore?.setSrcCurrency(srcCake)
             }
           } catch (error) {
             console.error('Failed to load lz-bridge', error)
@@ -85,22 +83,6 @@ const LayerZero = ({ isCake }: { isCake?: boolean }) => {
       <link rel="stylesheet" href={`${LAYER_ZERO_JS.css}`} />
       {show && (
         <Box width={['100%', null, '420px']} m="auto">
-          <Message variant="warning" m={['16px', '16px', '16px 0']}>
-            <MessageText>
-              <Text mb="8px" small bold>
-                Notice: ZKsync CAKE Bridging Maintenance
-              </Text>
-              Bridging to/from ZKsync is currently unavailable until further notice.
-              <br />
-              Bridging on all other supported networks continues to function as normal.
-              <br />
-              <br />
-              Please refer to our X account for updates.
-              <br />
-              <br />
-              Outbound transfers from Polygon zkEVM are subject to a 7 days delay for block confirmations.
-            </MessageText>
-          </Message>
           <Flex flexDirection="column" bg="backgroundAlt" borderRadius={[0, null, 24]} alignItems="center">
             <LayerZeroWidget theme={theme} />
             <Box display={['block', null, 'none']}>

--- a/packages/canonical-bridge/src/hooks/useTransferConfig.ts
+++ b/packages/canonical-bridge/src/hooks/useTransferConfig.ts
@@ -122,7 +122,7 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
             excludedChains: [],
             excludedTokens: {
               56: ['0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'],
-              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
+
               42161: ['0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9', '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'], // ['USDT', 'USDC.e']
             },
           }),
@@ -137,7 +137,7 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
                 '0x0000000000000000000000000000000000000000',
                 '0x9c7beba8f6ef6643abd725e45a4e8387ef260649',
               ],
-              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
+
               137: ['cUSDCv3'],
               42161: ['cUSDCv3'],
               43114: ['BNB'],
@@ -152,22 +152,17 @@ export function useTransferConfig(supportedChains: IChainConfig[]) {
           stargate({
             config: stargateConfig,
             excludedChains: [],
-            excludedTokens: {
-              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
-            },
+            excludedTokens: {},
           }),
           layerZero({
             config: layerZeroConfig,
             excludedChains: [],
-            excludedTokens: {
-              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
-            },
+            excludedTokens: {},
           }),
           meson({
             config: mesonConfig,
             excludedChains: [],
             excludedTokens: {
-              324: ['0x3A287a06c66f9E95a56327185cA2BDF5f031cEcD'], // CAKE
               42161: ['SOL'],
             },
           }),

--- a/packages/canonical-bridge/src/views/index.tsx
+++ b/packages/canonical-bridge/src/views/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Flex, Message, MessageText, Text, useToast } from '@pancakeswap/uikit'
+import { Flex, useToast } from '@pancakeswap/uikit'
 import { useCallback, useMemo } from 'react'
 
 import {
@@ -106,19 +106,6 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
       <GlobalStyle />
       <CanonicalBridgeProvider config={config}>
         <Flex flexDirection="column" justifyContent="center" maxWidth="480px" width="100%">
-          <Message variant="warning" mb="16px">
-            <MessageText>
-              <Text mb="8px" small bold>
-                {t('Notice: ZKsync CAKE Bridging Maintenance')}
-              </Text>
-              {t('Bridging to/from ZKsync is currently unavailable until further notice.')}
-              <br />
-              {t('Bridging on all other supported networks continues to function as normal.')}
-              <br />
-              <br />
-              {t('Please refer to our X account for updates.')}
-            </MessageText>
-          </Message>
           <BridgeTransfer />
           <V1BridgeLink />
         </Flex>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing references to CAKE bridging maintenance and adjusting the handling of excluded tokens in the transfer configuration.

### Detailed summary
- Removed warning `Message` about ZKsync CAKE bridging maintenance from `CanonicalBridge`.
- Updated `excludedTokens` in `useTransferConfig` to remove CAKE-related entries.
- Adjusted the `LayerZero` component to properly handle CAKE currency without commented-out code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->