### PR TITLE
feat: add back retry

### DIFF
--- a/apps/web/src/config/nodes.ts
+++ b/apps/web/src/config/nodes.ts
@@ -156,6 +156,8 @@ export const PUBLIC_NODES: Record<ChainId, string[] | readonly string[]> = {
     process.env.NEXT_PUBLIC_NODIES_BASE || '',
     // getGroveUrl(ChainId.BASE, process.env.NEXT_PUBLIC_GROVE_API_KEY) || '',
     // process.env.NEXT_PUBLIC_NODE_REAL_BASE_PRODUCTION,
+    'https://base.llamarpc.com',
+    'https://base.meowrpc.com',
     ...base.rpcUrls.default.http,
   ].filter(Boolean),
   [ChainId.BASE_TESTNET]: baseGoerli.rpcUrls.default.http,

--- a/apps/web/src/utils/fallbackWithRank.ts
+++ b/apps/web/src/utils/fallbackWithRank.ts
@@ -99,7 +99,20 @@ export const fallbackWithRank = <const transports extends readonly Transport[]>(
                 status: 'error',
               })
 
-              throw err
+              // If we've reached the end of the fallbacks, throw the error.
+              if (i === transports.length - 1) throw err
+
+              // Check if at least one other transport includes the method
+              includes ??= transports.slice(i + 1).some((transport) => {
+                const { include, exclude } = transport({ chain }).config.methods || {}
+                if (include) return include.includes(method)
+                if (exclude) return !exclude.includes(method)
+                return true
+              })
+              if (!includes) throw err
+
+              // Otherwise, try the next fallback.
+              return fetch(i + 1)
             }
           }
           return fetch()


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `nodes.ts` configuration with new RPC URLs and enhancing error handling in the `fallbackWithRank.ts` utility.

### Detailed summary
- In `nodes.ts`, added two new RPC URLs: 
  - `'https://base.llamarpc.com'`
  - `'https://base.meowrpc.com'`
- In `fallbackWithRank.ts`, improved error handling by:
  - Adding a check to throw an error if all fallbacks are exhausted.
  - Introducing a method to check if other transports include or exclude a method before proceeding.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->