### PR TITLE
fix: Stable apr when accessing positions directly

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolAprButton/PoolGlobalAprButton.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolAprButton/PoolGlobalAprButton.tsx
@@ -21,7 +21,7 @@ type PoolGlobalAprButtonProps = {
 export const PoolGlobalAprButton: React.FC<PoolGlobalAprButtonProps> = ({ pool, detailMode, aprInfo }) => {
   const key = useMemo(() => `${pool.chainId}:${pool.lpAddress}` as const, [pool.chainId, pool.lpAddress])
 
-  const hookAprInfo = usePoolApr(key, pool, !aprInfo)
+  const hookAprInfo = usePoolApr(key, pool, !pool.stableSwapAddress && !aprInfo, !aprInfo)
   const { lpApr, merklApr, cakeApr } = aprInfo ?? hookAprInfo
 
   const numerator = useMemo(() => {

--- a/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
+++ b/apps/web/src/views/universalFarms/components/PositionActions/V2PositionActions.tsx
@@ -22,6 +22,7 @@ import { useV2CakeEarning } from 'views/universalFarms/hooks/useCakeEarning'
 import { useV2FarmActions } from 'views/universalFarms/hooks/useV2FarmActions'
 import { sumApr } from 'views/universalFarms/utils/sumApr'
 import { useAccount } from 'wagmi'
+import { fetchAllUniversalFarmsMap } from '@pancakeswap/farms'
 import { StopPropagation } from '../StopPropagation'
 import { DepositStakeAction, HarvestAction, ModifyStakeActions } from './StakeActions'
 
@@ -79,7 +80,8 @@ const useDepositModal = (props: V2PositionActionsProps) => {
 
   useEffect(() => {
     const fetchBCakeAddress = async () => {
-      const address = await getBCakeWrapperAddress(lpAddress, chainId)
+      const farmsMap = await fetchAllUniversalFarmsMap()
+      const address = await getBCakeWrapperAddress(lpAddress, chainId, farmsMap)
       setBCakeAddress(address)
     }
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of `bCakeWrapperAddress` retrieval by incorporating a `farmsMap` parameter, allowing for more efficient data access and reducing unnecessary fetch calls.

### Detailed summary
- Updated `usePoolApr` call in `PoolGlobalAprButton.tsx` to include a check for `pool.stableSwapAddress`.
- Introduced `fetchAllUniversalFarmsMap` import in `V2PositionActions.tsx`.
- Modified `getBCakeWrapperAddress` to accept `farmsMap` as an argument.
- Updated calls to `getBCakeWrapperAddress` to pass `farmsMap` in `fetcher.ts`.
- Adjusted `getAccountV2LpDetails` and `getStablePairDetails` to use `farmsMap` when calling `getBCakeWrapperAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->