### PR TITLE
fix: Stablecoin price in useStablecoin hook

### DIFF
--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -40,19 +40,21 @@ const queryStablecoinPrice = async (currency: Currency, overrideChainId?: number
 interface StableCoinPriceParams {
   currency?: Currency
   chainId?: number
+  enabled?: boolean
 }
 const stableCoinPriceAtom = atomFamily(
   (params: StableCoinPriceParams) => {
     return atom(async () => {
-      if (!params.currency) {
+      const enabled = params.enabled ?? true
+      if (!params.currency || !enabled) {
         return undefined
       }
       return queryStablecoinPrice(params.currency, params.chainId)
     })
   },
   (a, b) => {
-    const hashA = `${a.currency ? getCurrencyAddress(a.currency) : ''}:${a.chainId}`
-    const hashB = `${b.currency ? getCurrencyAddress(b.currency) : ''}:${b.chainId}`
+    const hashA = `${a.currency ? getCurrencyAddress(a.currency) : ''}:${a.chainId}:${a.enabled}`
+    const hashB = `${b.currency ? getCurrencyAddress(b.currency) : ''}:${b.chainId}:${b.enabled}`
     return hashA === hashB
   },
 )
@@ -81,14 +83,15 @@ export function useStablecoinPrice(
     stableCoinPriceAtom({
       currency: currency || undefined,
       chainId,
+      enabled: shouldEnabled,
     }),
   )
 
   const price = useMemo(() => {
-    if (!priceUSD) {
-      return undefined
+    if (isStableCoin) {
+      return new Price(stableCoin, stableCoin, '1', '1')
     }
-    if (!currency || !stableCoin || !shouldEnabled) {
+    if (!priceUSD || !currency || !stableCoin || !shouldEnabled) {
       return undefined
     }
 

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -73,24 +73,17 @@ export function useStablecoinPrice(
   const isCake = Boolean(chainId && currency && CAKE[chainId] && currency.wrapped.equals(CAKE[chainId]))
   const stableCoin = chainId && chainId in ChainId ? STABLE_COIN[chainId as ChainId] : undefined
 
-  const isStableCoin = currency && stableCoin && currency.wrapped.equals(stableCoin)
-
-  const shouldEnabled = Boolean(
-    currency && stableCoin && enabled && currentChainId === chainId && !isCake && !isStableCoin,
-  )
+  const shouldEnabled = Boolean(currency && enabled && currentChainId === chainId && !isCake)
 
   const priceUSD = useAtomValue(
     stableCoinPriceAtom({
       currency: currency || undefined,
       chainId,
-      enabled: shouldEnabled,
+      enabled,
     }),
   )
 
   const price = useMemo(() => {
-    if (isStableCoin) {
-      return new Price(stableCoin, stableCoin, '1', '1')
-    }
     if (!priceUSD || !currency || !stableCoin || !shouldEnabled) {
       return undefined
     }

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@pancakeswap/chains'
 import { Currency, getCurrencyAddress, Price } from '@pancakeswap/sdk'
-import { CAKE, STABLE_COIN } from '@pancakeswap/tokens'
+import { STABLE_COIN } from '@pancakeswap/tokens'
 import { getFullDecimalMultiplier } from '@pancakeswap/utils/getFullDecimalMultiplier'
 import { atom, useAtomValue } from 'jotai'
 import { atomFamily } from 'jotai/utils'
@@ -70,10 +70,9 @@ export function useStablecoinPrice(
   const chainId = currency?.chainId || activeChainId
   const { enabled, hideIfPriceImpactTooHigh } = { ...DEFAULT_CONFIG, ...config }
 
-  const isCake = Boolean(chainId && currency && CAKE[chainId] && currency.wrapped.equals(CAKE[chainId]))
   const stableCoin = chainId && chainId in ChainId ? STABLE_COIN[chainId as ChainId] : undefined
 
-  const shouldEnabled = Boolean(currency && enabled && currentChainId === chainId && !isCake)
+  const shouldEnabled = Boolean(currency && enabled && currentChainId === chainId)
 
   const priceUSD = useAtomValue(
     stableCoinPriceAtom({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `useStablecoinPrice` hook by adding an `enabled` parameter to control the execution of the price query and modifying how dependencies are hashed for the atom family.

### Detailed summary
- Removed the import of `CAKE` from `@pancakeswap/tokens`.
- Added an `enabled` property to the `StableCoinPriceParams` interface.
- Updated the condition to return `undefined` in the atom if `currency` is not provided or `enabled` is `false`.
- Modified the hash generation in the atom family to include the `enabled` parameter.
- Simplified the `shouldEnabled` condition to exclude checks for `isCake` and `isStableCoin`.
- Updated the price calculation logic to check for `priceUSD` in conjunction with `currency`, `stableCoin`, and `shouldEnabled`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->