### PR TITLE
fix: PAN 6545

### DIFF
--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -31,7 +31,11 @@ const queryStablecoinPrice = async (currency: Currency, overrideChainId?: number
   }
   const res = await fetch(`/api/token/price?${params.toString()}`)
   if (!res.ok) {
-    throw new Error('request failed')
+    // NOTE: comment this out to avoid prod crash for now.
+    // Fix root cause later.
+    // throw new Error('request failed')
+
+    return undefined
   }
   const json = await res.json()
   return json.priceUSD as number | undefined


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying error handling in the `useStablecoinPrice` hook to prevent a production crash by commenting out the error throw statement and returning `undefined` instead.

### Detailed summary
- Commented out the line that throws an error for a failed request: `// throw new Error('request failed')`
- Added comments explaining the reason for this change and the intention to fix the root cause later.
- Added a return statement that returns `undefined` in case of a failed request.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->