### PR TITLE
fix: add feature flag

### DIFF
--- a/apps/web/src/quoter/utils/crosschain-utils/utils/ContextBuilder.ts
+++ b/apps/web/src/quoter/utils/crosschain-utils/utils/ContextBuilder.ts
@@ -87,6 +87,8 @@ export class ContextBuilder {
             infinitySwap,
             // Disable xSwap is not supported for cross chain swap
             xEnabled: false,
+            // disable stable swap, wait for BE to support it
+            stableSwap: false,
             ...swapOption,
           }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `ContextBuilder.ts` file to disable certain swap options for cross-chain swaps.

### Detailed summary
- Added a new property `stableSwap` set to `false` to indicate that stable swap is not supported yet.
- The existing property `xEnabled` remains set to `false`, indicating that xSwap is disabled for cross-chain swaps.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->