### PR TITLE
fix: mobile stable swap farm apr display

### DIFF
--- a/apps/web/src/views/universalFarms/components/PoolListView.tsx
+++ b/apps/web/src/views/universalFarms/components/PoolListView.tsx
@@ -1,6 +1,7 @@
 import { BottomDrawer, Button, ChevronRightIcon, Column, MoreIcon } from '@pancakeswap/uikit'
 import { useRouter } from 'next/router'
 import { memo, ReactNode, useCallback, useState } from 'react'
+import { getFarmAprInfo } from 'state/farmsV4/search/farm.util'
 import { PoolInfo } from 'state/farmsV4/state/type'
 import styled from 'styled-components'
 import { PoolGlobalAprButton } from './PoolAprButton'
@@ -58,7 +59,7 @@ export const ListView = <T extends PoolInfo>({ data, getItemKey, onRowClick }: I
         <ListItemContainer key={getListItemKey(item)} onClick={() => onRowClick?.(item)}>
           <Column gap="12px" onClick={() => handleItemClick(item)}>
             <PoolTokenOverview data={item} />
-            <PoolGlobalAprButton pool={item} />
+            <PoolGlobalAprButton pool={item} aprInfo={getFarmAprInfo(item.farm)} />
           </Column>
 
           <Column>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `PoolGlobalAprButton` component by adding an `aprInfo` prop that retrieves APR information using the `getFarmAprInfo` utility function.

### Detailed summary
- Added import for `getFarmAprInfo` from `state/farmsV4/search/farm.util`.
- Updated the `PoolGlobalAprButton` component in the `ListView` to include the `aprInfo` prop, passing the result of `getFarmAprInfo(item.farm)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->