### PR TITLE
fix: enable crosschain ss

### DIFF
--- a/apps/web/src/quoter/utils/crosschain-utils/utils/ContextBuilder.ts
+++ b/apps/web/src/quoter/utils/crosschain-utils/utils/ContextBuilder.ts
@@ -87,8 +87,7 @@ export class ContextBuilder {
             infinitySwap,
             // Disable xSwap is not supported for cross chain swap
             xEnabled: false,
-            // disable stable swap, wait for BE to support it
-            stableSwap: false,
+
             ...swapOption,
           }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the configuration options in the `ContextBuilder.ts` file to disable certain swap functionalities for cross-chain swaps.

### Detailed summary
- Set `xEnabled` to `false`, indicating that cross-chain swaps are not supported.
- Removed the comment and setting for `stableSwap`, which was previously set to `false`, indicating that stable swap functionality is also disabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->