### PR TITLE
chore: add scope for farmsearch

### DIFF
--- a/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
+++ b/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
@@ -118,7 +118,9 @@ async function fetchFarms(query: {
   const protocols = _protocols.length > 0 ? _protocols : DEFAULT_PROTOCOLS
   const chainIds = chains.length > 0 ? chains : supportedChainIdV4
   if (!extend) {
-    return fetchExplorerFarmPools(protocols, Array.from(chainIds))
+    const farmPools = await fetchExplorerFarmPools(protocols, Array.from(chainIds))
+    const explorerPools = await fetchAllExplorerPools(protocols, Array.from(chainIds))
+    return [...farmPools, ...explorerPools]
   }
   if (address) {
     return fetchAllExplorerPoolsByAddress(Array.from(chainIds), address)
@@ -190,6 +192,7 @@ async function fetchAllExplorerPools(protocols: Protocol[], chains: FarmV4Suppor
     protocols: [protocol],
     chains: chains.map((chain) => getEdgeChainName(chain)),
     maxPages: 1, // Max check 3 pages for random extending
+    orderBy: 'volumeUSD24h' as const,
   }))
   const poolQueries = queries.map((query) => edgeQueries.fetchAllPools(query))
   const pools = await Promise.allSettled(poolQueries)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the functionality of the `fetchExplorerFarmPools` by adding the ability to combine results from multiple sources and introduce ordering based on volume.

### Detailed summary
- Updated logic to fetch farm pools and explorer pools, combining their results into a single return array.
- Introduced an `orderBy` parameter set to `'volumeUSD24h'` in the `fetchAllExplorerPools` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->