### PR TITLE
fix: fee tier display issue of infinity

### DIFF
--- a/apps/web/src/state/farmsV4/search/farm.util.ts
+++ b/apps/web/src/state/farmsV4/search/farm.util.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@pancakeswap/chains'
+import { supportedChainIdV4 } from '@pancakeswap/farms'
 import {
   BinPoolManagerAbi,
   CLPoolManagerAbi,
@@ -15,7 +16,6 @@ import { Currency } from '@pancakeswap/swap-sdk-core'
 import { InfinityFeeTierPoolParams } from 'hooks/infinity/useInfinityFeeTier'
 import qs from 'qs'
 import { ALLOWED_PROTOCOLS } from 'quoter/utils/edgeQueries.util'
-import { supportedChainIdV4 } from '@pancakeswap/farms'
 import { CakeAprValue } from 'state/farmsV4/atom'
 import { AprInfo } from 'state/farmsV4/hooks'
 import { BasePoolInfo, PoolInfo } from 'state/farmsV4/state/type'
@@ -131,7 +131,7 @@ export const getPoolInfoForInfiFee = (farm: FarmInfo) => {
   const isDynamic = pool.fee === DYNAMIC_FEE_FLAG
   return {
     protocolFee: pool.protocolFee!,
-    fee: isDynamic ? hookData?.defaultFee ?? pool.fee! : pool.fee,
+    fee: pool.fee,
     poolType: pool.type === PoolType.InfinityCL ? 'CL' : 'Bin',
     dynamic: isDynamic,
     hookData,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining fee handling for `InfinityClPool` and `BinPool` in the `farm.util.ts` and `batchFarmDataFiller.ts` files. It introduces dynamic fee logic based on hook data and removes redundant imports.

### Detailed summary
- Removed redundant import of `supportedChainIdV4` in `farm.util.ts`.
- Updated fee assignment logic in `getPoolInfoForInfiFee` to directly use `pool.fee`.
- Added `DYNAMIC_FEE_FLAG` and `findHook` imports in `batchFarmDataFiller.ts`.
- Implemented dynamic fee calculation in `fillClPoolData` and `fillBinPoolData` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->