### PR TITLE
perf: Enable stablecoin price fetch when amount greater than 0

### DIFF
--- a/apps/web/src/hooks/infinity/useFeesEarned.tsx
+++ b/apps/web/src/hooks/infinity/useFeesEarned.tsx
@@ -87,8 +87,8 @@ export const useFeesEarnedUSD = (params: LPFeesParam) => {
   const { currency0, currency1 } = params
   const [feeAmount0, feeAmount1] = useFeesEarned(params)
 
-  const price0 = useStablecoinPrice(currency0, { enabled: !!feeAmount0 })
-  const price1 = useStablecoinPrice(currency1, { enabled: !!feeAmount1 })
+  const price0 = useStablecoinPrice(currency0, { enabled: feeAmount0?.greaterThan(0) })
+  const price1 = useStablecoinPrice(currency1, { enabled: feeAmount1?.greaterThan(0) })
 
   const { totalFiatValue, fiatValue0, fiatValue1 } = useMemo(() => {
     const fiatValue0_ = price0 && feeAmount0 ? price0.quote(feeAmount0) : undefined

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -113,7 +113,7 @@ export const useStablecoinPriceAmount = (
   config?: UseStablecoinPriceConfig,
   overrideChainId?: number,
 ): number | undefined => {
-  const stablePrice = useStablecoinPrice(currency, { enabled: !!currency, ...config }, overrideChainId)
+  const stablePrice = useStablecoinPrice(currency, { enabled: Boolean(currency && amount), ...config }, overrideChainId)
 
   return useMemo(() => {
     if (amount) {

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/PositionPreview.tsx
@@ -58,8 +58,8 @@ export const PositionPreview = ({
   const priceLower = sorted ? position.token0PriceLower : position.token0PriceUpper.invert()
   const priceUpper = sorted ? position.token0PriceUpper : position.token0PriceLower.invert()
 
-  const price0 = useStablecoinPrice(position.pool.token0 ?? undefined, { enabled: !!position.amount0 })
-  const price1 = useStablecoinPrice(position.pool.token1 ?? undefined, { enabled: !!position.amount1 })
+  const price0 = useStablecoinPrice(position.pool.token0 ?? undefined, { enabled: position?.amount0?.greaterThan(0) })
+  const price1 = useStablecoinPrice(position.pool.token1 ?? undefined, { enabled: position?.amount1?.greaterThan(0) })
 
   const handleRateChange = useCallback(() => {
     setBaseCurrency(quoteCurrency)

--- a/apps/web/src/views/Liquidity/LiquidityView.tsx
+++ b/apps/web/src/views/Liquidity/LiquidityView.tsx
@@ -291,9 +291,18 @@ export const LiquidityView = () => {
 
   const isCollectPending = useIsTransactionPending(collectMigrationHash ?? undefined)
 
+  const enablePrice0 = useMemo(
+    () => position?.amount0?.greaterThan(0) || feeValue0?.greaterThan(0),
+    [position, feeValue0],
+  )
+  const enablePrice1 = useMemo(
+    () => position?.amount1?.greaterThan(0) || feeValue1?.greaterThan(0),
+    [position, feeValue1],
+  )
+
   // usdc prices always in terms of tokens
-  const price0 = useStablecoinPrice(token0 ?? undefined, { enabled: !!feeValue0 })
-  const price1 = useStablecoinPrice(token1 ?? undefined, { enabled: !!feeValue1 })
+  const price0 = useStablecoinPrice(token0 ?? undefined, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(token1 ?? undefined, { enabled: enablePrice1 })
 
   const fiatValueOfFees: CurrencyAmount<Currency> | null = useMemo(() => {
     if (!price0 || !price1 || !feeValue0 || !feeValue1) return null

--- a/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityBinPosition.tsx
@@ -54,9 +54,6 @@ export const InfinityBinPosition = () => {
     return [binPool.token0, binPool.token1]
   }, [binPool])
 
-  const price0 = useStablecoinPrice(currency0, { enabled: !!currency0 })
-  const price1 = useStablecoinPrice(currency1, { enabled: !!currency1 })
-
   const { data: position } = useInfinityBinPosition(poolId, chainId, account)
   const reserve0 = useMemo(
     () => (currency0 ? CurrencyAmount.fromRawAmount(currency0, position?.reserveX ?? 0n) : undefined),
@@ -66,6 +63,9 @@ export const InfinityBinPosition = () => {
     () => (currency1 ? CurrencyAmount.fromRawAmount(currency1, position?.reserveY ?? 0n) : undefined),
     [currency1, position],
   )
+
+  const price0 = useStablecoinPrice(currency0, { enabled: reserve0?.greaterThan(0) })
+  const price1 = useStablecoinPrice(currency1, { enabled: reserve1?.greaterThan(0) })
 
   const fiatValueOfLiquidity = useMemo(() => {
     if (!price0 || !price1 || !reserve0 || !reserve1) return undefined

--- a/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
+++ b/apps/web/src/views/PositionInfinity/InfinityCLPosition.tsx
@@ -110,10 +110,6 @@ export const InfinityCLPosition = () => {
   })
   const isCollectPending = useIsTransactionPending(collectMigrationHash ?? undefined)
 
-  // usdc prices always in terms of tokens
-  const price0 = useStablecoinPrice(currency0, { enabled: !!feeAmount0 })
-  const price1 = useStablecoinPrice(currency1, { enabled: !!feeAmount1 })
-
   const { amount0: positionAmount0, amount1: positionAmount1 } = usePositionAmount({
     token0: currency0,
     token1: currency1,
@@ -123,6 +119,19 @@ export const InfinityCLPosition = () => {
     sqrtRatioX96: pool?.sqrtRatioX96,
     liquidity,
   })
+
+  const enablePrice0 = useMemo(
+    () => positionAmount0?.greaterThan(0) || feeAmount0?.greaterThan(0),
+    [positionAmount0, feeAmount0],
+  )
+  const enablePrice1 = useMemo(
+    () => positionAmount1?.greaterThan(0) || feeAmount1?.greaterThan(0),
+    [positionAmount1, feeAmount1],
+  )
+
+  // usdc prices always in terms of tokens
+  const price0 = useStablecoinPrice(currency0, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(currency1, { enabled: enablePrice1 })
 
   const fiatValueOfLiquidity: CurrencyAmount<Currency> | null = useMemo(() => {
     if (!price0 || !price1 || !positionAmount0 || !positionAmount1) return null

--- a/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
+++ b/apps/web/src/views/RemoveLiquidity/RemoveLiquidityV3.tsx
@@ -240,8 +240,17 @@ function Remove({ tokenId }: { tokenId?: bigint }) {
 
   const removed = position?.liquidity === 0n
 
-  const price0 = useStablecoinPrice(liquidityValue0?.currency?.wrapped ?? undefined, { enabled: !!feeValue0 })
-  const price1 = useStablecoinPrice(liquidityValue1?.currency?.wrapped ?? undefined, { enabled: !!feeValue1 })
+  const enablePrice0 = useMemo(
+    () => liquidityValue0?.greaterThan(0) || feeValue0?.greaterThan(0),
+    [liquidityValue0, feeValue0],
+  )
+  const enablePrice1 = useMemo(
+    () => liquidityValue1?.greaterThan(0) || feeValue1?.greaterThan(0),
+    [liquidityValue1, feeValue1],
+  )
+
+  const price0 = useStablecoinPrice(liquidityValue0?.currency?.wrapped ?? undefined, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(liquidityValue1?.currency?.wrapped ?? undefined, { enabled: enablePrice1 })
 
   const modalHeader = useCallback(() => {
     return (

--- a/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveBinPosition.tsx
+++ b/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveBinPosition.tsx
@@ -104,8 +104,11 @@ export const RemoveBinPosition = () => {
     return CurrencyAmount.fromRawAmount(currency1, reserveY ?? 0n)
   }, [binPosition, currency1, selectedBinNums])
 
-  const price0 = useStablecoinPrice(currency0)
-  const price1 = useStablecoinPrice(currency1)
+  const enablePrice0 = useMemo(() => amount0?.greaterThan(0), [amount0])
+  const enablePrice1 = useMemo(() => amount1?.greaterThan(0), [amount1])
+
+  const price0 = useStablecoinPrice(currency0, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(currency1, { enabled: enablePrice1 })
 
   const removed = useMemo(() => {
     return binPosition?.reserveX === 0n && binPosition?.reserveY === 0n

--- a/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveClPosition.tsx
+++ b/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveClPosition.tsx
@@ -76,8 +76,11 @@ export const RemoveClPosition = () => {
   const [, pool] = usePoolById<'CL'>(poolId, chainId)
   const isFarming = usePositionIsFarming({ chainId, poolId })
 
-  const price0 = useStablecoinPrice(currency0)
-  const price1 = useStablecoinPrice(currency1)
+  const enablePrice0 = useMemo(() => amount0?.greaterThan(0) || feeValue0?.greaterThan(0), [amount0, feeValue0])
+  const enablePrice1 = useMemo(() => amount1?.greaterThan(0) || feeValue1?.greaterThan(0), [amount1, feeValue1])
+
+  const price0 = useStablecoinPrice(currency0, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(currency1, { enabled: enablePrice1 })
 
   const nativeCurrency = useNativeCurrency(chainId)
 

--- a/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveClPosition.tsx
+++ b/apps/web/src/views/RemoveLiquidityInfinity/components/RemoveClPosition.tsx
@@ -76,12 +76,6 @@ export const RemoveClPosition = () => {
   const [, pool] = usePoolById<'CL'>(poolId, chainId)
   const isFarming = usePositionIsFarming({ chainId, poolId })
 
-  const enablePrice0 = useMemo(() => amount0?.greaterThan(0) || feeValue0?.greaterThan(0), [amount0, feeValue0])
-  const enablePrice1 = useMemo(() => amount1?.greaterThan(0) || feeValue1?.greaterThan(0), [amount1, feeValue1])
-
-  const price0 = useStablecoinPrice(currency0, { enabled: enablePrice0 })
-  const price1 = useStablecoinPrice(currency1, { enabled: enablePrice1 })
-
   const nativeCurrency = useNativeCurrency(chainId)
 
   const [percent, setPercent] = useState(50)
@@ -110,6 +104,12 @@ export const RemoveClPosition = () => {
     tickLower,
     tickUpper,
   })
+
+  const enablePrice0 = useMemo(() => amount0?.greaterThan(0) || feeValue0?.greaterThan(0), [amount0, feeValue0])
+  const enablePrice1 = useMemo(() => amount1?.greaterThan(0) || feeValue1?.greaterThan(0), [amount1, feeValue1])
+
+  const price0 = useStablecoinPrice(currency0, { enabled: enablePrice0 })
+  const price1 = useStablecoinPrice(currency1, { enabled: enablePrice1 })
 
   const wrapAddress = useMemo(() => {
     if (!collectAsWrappedNative) return zeroAddress


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the conditions under which the `useStablecoinPrice` hook is enabled across multiple components, ensuring that prices are only fetched when relevant amounts are greater than zero.

### Detailed summary
- Updated `useStablecoinPrice` enabling condition in `useStablecoinPrice.ts` to check if both `currency` and `amount` are valid.
- Changed enabling condition in `useFeesEarned.tsx` to check if `feeAmount0` and `feeAmount1` are greater than zero.
- Modified enabling conditions for `price0` and `price1` in `RemoveBinPosition.tsx` to use `amount0` and `amount1`.
- Enhanced enabling conditions for `price0` and `price1` in `V3FormView.tsx` based on `position.amount0` and `position.amount1`.
- Updated enabling conditions for `price0` and `price1` in `InfinityBinPosition.tsx` to rely on `reserve0` and `reserve1`.
- Changed enabling conditions for `price0` and `price1` in `RemoveLiquidityV3.tsx` to consider `liquidityValue0`, `feeValue0`, `liquidityValue1`, and `feeValue1`.
- Enhanced enabling conditions in `RemoveClPosition.tsx` for `price0` and `price1` based on `amount0`, `amount1`, `feeValue0`, and `feeValue1`.
- Modified enabling conditions for `price0` and `price1` in `LiquidityView.tsx` to check `position.amount0`, `position.amount1`, `feeValue0`, and `feeValue1`.
- Updated enabling conditions for `price0` and `price1` in `InfinityCLPosition.tsx` to check `positionAmount0`, `positionAmount1`, `feeAmount0`, and `feeAmount1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->