### PR TITLE
chore: hide disclaimer

### DIFF
--- a/apps/solana/src/components/AppLayout/components/DisclaimerModal.tsx
+++ b/apps/solana/src/components/AppLayout/components/DisclaimerModal.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Flex, VStack } from '@chakra-ui/react'
 import { useTranslation } from '@pancakeswap/localization'
 import { Checkbox, ModalV2, MotionModal, Text, useMatchBreakpoints, useModalV2 } from '@pancakeswap/uikit'
 import { useEffect, useState } from 'react'
-import { getStorageItem, setStorageItem } from '@/utils/localStorage'
+import { setStorageItem } from '@/utils/localStorage'
 import { colors } from '@/theme/cssVariables'
 
 const DISCLAIMER_KEY = '_r_have_agreed_disclaimer_'
@@ -19,7 +19,8 @@ function DisclaimerModal() {
   }
 
   useEffect(() => {
-    const haveAgreedDisclaimer = getStorageItem(DISCLAIMER_KEY)
+    // const haveAgreedDisclaimer = getStorageItem(DISCLAIMER_KEY)
+    const haveAgreedDisclaimer = '1'
     if (!haveAgreedDisclaimer || haveAgreedDisclaimer !== '1') {
       setIsOpen(true)
     }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `DisclaimerModal` component by removing the `getStorageItem` function and hardcoding the value of `haveAgreedDisclaimer` to '1', ensuring that the disclaimer modal is always displayed.

### Detailed summary
- Removed the import of `getStorageItem` from `localStorage`.
- Commented out the line that retrieves the disclaimer agreement status.
- Set `haveAgreedDisclaimer` to a hardcoded value of '1'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->