### PR TITLE
fix: update swap token address

### DIFF
--- a/apps/solana/next.config.mjs
+++ b/apps/solana/next.config.mjs
@@ -36,7 +36,7 @@ const nextConfig = {
     return [
       {
         source: '/',
-        destination: '/jupiter-swap/',
+        destination: '/swap/',
         permanent: false
       }
     ]

--- a/apps/solana/src/features/Pools/components/PoolTableColumns/ColumnsPoolActions.tsx
+++ b/apps/solana/src/features/Pools/components/PoolTableColumns/ColumnsPoolActions.tsx
@@ -26,7 +26,8 @@ export const ColumnsPoolActions: React.FC<{
   const onClickSwap = useCallback(() => {
     logGTMDepositLiquidityEvent()
     const getMint = (address: string) => {
-      return pageRoutePathnames.swap.includes('jupiter') ? address : wSolToSol(address)
+      // todo: update to wSolToSol(address) when update to our own swap page
+      return address
     }
     const [inputMint, outputMint] = [getMint(pool.mintA.address), getMint(pool.mintB.address)]
     router.push({

--- a/apps/solana/src/pages/__swap_.tsx
+++ b/apps/solana/src/pages/__swap_.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic'
+
+const Swap = dynamic(() => import('@/features/Swap'), {
+  ssr: false
+})
+
+function SwapPage() {
+  return <Swap />
+}
+
+export default SwapPage

--- a/apps/solana/src/pages/jupiter-swap.tsx
+++ b/apps/solana/src/pages/jupiter-swap.tsx
@@ -1,7 +1,0 @@
-import Swap from '@/features/JupiterSwap'
-
-function SwapPage() {
-  return <Swap />
-}
-
-export default SwapPage

--- a/apps/solana/src/pages/swap.tsx
+++ b/apps/solana/src/pages/swap.tsx
@@ -1,8 +1,4 @@
-import dynamic from 'next/dynamic'
-
-const Swap = dynamic(() => import('@/features/Swap'), {
-  ssr: false
-})
+import Swap from '@/features/JupiterSwap'
 
 function SwapPage() {
   return <Swap />

--- a/apps/solana/src/utils/config/routers.ts
+++ b/apps/solana/src/utils/config/routers.ts
@@ -54,8 +54,8 @@ export type PageRouteConfigs = {
 }
 export const pageRoutePathnames: Record<keyof PageRouteConfigs, string> = {
   '(home)': '/',
-  swap: '/jupiter-swap',
-  'legacy-swap': '/swap',
+  swap: '/swap',
+  'legacy-swap': '/__swap_',
   'edit-farm': '/farms/edit',
   portfolio: '/positions',
   staking: '/staking',


### PR DESCRIPTION
- **chore: update swap link**
- **fix: update swap token address**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the routing and components related to the swap functionality in the Solana application, transitioning from a Jupiter swap implementation to a new swap page.

### Detailed summary
- Deleted `jupiter-swap.tsx` and modified routing in `next.config.mjs` to redirect from `/jupiter-swap/` to `/swap/`.
- Updated `swap.tsx` to import `JupiterSwap` instead of using dynamic import for `Swap`.
- Created a new `__swap_.tsx` file with a dynamic import for `Swap`.
- Modified `routers.ts` to change the route for `swap` to `/swap` and `legacy-swap` to `/__swap_`.
- Updated `getMint` function to return the address directly with a note to revisit the logic later.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->