### PR TITLE
fix: update FormattedUltraQuoteResponse

### DIFF
--- a/packages/jupiter-terminal/overrides/src/entity/FormattedUltraQuoteResponse.ts
+++ b/packages/jupiter-terminal/overrides/src/entity/FormattedUltraQuoteResponse.ts
@@ -1,0 +1,64 @@
+import { PublicKey } from '@solana/web3.js'
+import JSBI from 'jsbi'
+import {
+  array,
+  boolean,
+  coerce,
+  defaulted,
+  enums,
+  Infer,
+  instance,
+  integer,
+  literal,
+  nullable,
+  number,
+  optional,
+  string,
+  type,
+} from 'superstruct'
+
+const PublicKeyFromString = coerce(instance(PublicKey), string(), (value) => new PublicKey(value))
+
+//@ts-ignore bug because JSBI ctor being private?!?
+const AmountFromString = coerce<JSBI, null, string>(instance(JSBI), string(), (value) => JSBI.BigInt(value))
+
+const NumberFromString = coerce<string, null, number>(string(), number(), (value) => Number(value))
+
+const SwapInfo = type({
+  ammKey: PublicKeyFromString,
+  label: string(),
+  inputMint: string(),
+  outputMint: string(),
+  inAmount: AmountFromString,
+  outAmount: AmountFromString,
+  feeAmount: AmountFromString,
+  feeMint: PublicKeyFromString,
+})
+
+const RoutePlanStep = type({
+  swapInfo: SwapInfo,
+  percent: number(),
+})
+const RoutePlanWithMetadata = array(RoutePlanStep)
+
+export const FormattedUltraQuoteResponse = type({
+  inputMint: PublicKeyFromString,
+  inAmount: AmountFromString,
+  outputMint: PublicKeyFromString,
+  outAmount: AmountFromString,
+  otherAmountThreshold: AmountFromString,
+  priceImpactPct: NumberFromString,
+  routePlan: RoutePlanWithMetadata,
+  slippageBps: number(),
+  contextSlot: defaulted(number(), 0),
+  computedAutoSlippage: optional(number()),
+  transaction: nullable(string()),
+  swapType: string(),
+  gasless: boolean(),
+  requestId: string(),
+  prioritizationFeeLamports: optional(number()),
+  feeBps: number(),
+  router: string(),
+})
+
+export type FormattedUltraQuoteResponse = Infer<typeof FormattedUltraQuoteResponse>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new TypeScript file, `FormattedUltraQuoteResponse.ts`, which defines structured types for handling ultra quote responses in a Solana-based application. It utilizes `superstruct` for type validation and coercion of various fields.

### Detailed summary
- Added `PublicKey` and `JSBI` imports.
- Defined coercion functions: `PublicKeyFromString`, `AmountFromString`, and `NumberFromString`.
- Created `SwapInfo`, `RoutePlanStep`, and `RoutePlanWithMetadata` types.
- Defined `FormattedUltraQuoteResponse` type with multiple fields, including `inputMint`, `inAmount`, and `routePlan`.
- Exported `FormattedUltraQuoteResponse` type for use in other modules.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->