### PR TITLE
fix: remove raydium monitor events

### DIFF
--- a/apps/solana/src/components/WalletRecentTransactionBoard.tsx
+++ b/apps/solana/src/components/WalletRecentTransactionBoard.tsx
@@ -39,8 +39,8 @@ import { useAppStore } from '@/store'
 import { ToastStatus } from '@/types/tx'
 import { getTxAllRecord } from '@/utils/tx/historyTxStatus'
 import { MoonpaySell } from '@/components/Moonpay'
-import { sendWalletEvent } from '@/api/event'
 import { useEvent } from '@/hooks/useEvent'
+import { logGTMWalletDisconnectedEvent } from '@/utils/report/curstomGTMEventTracking'
 import ChevronUpDownArrow from './ChevronUpDownArrow'
 import AddressChip from './AddressChip'
 import TokenAvatar from './TokenAvatar'
@@ -98,11 +98,7 @@ export default function WalletRecentTransactionBoard({ wallet, address, isOpen =
   const handleDisConnect = useEvent(() => {
     onDisconnect()
     onClose()
-    sendWalletEvent({
-      type: 'connectWallet',
-      connectStatus: 'userUnlink',
-      walletName: wallet?.adapter.name || 'unknown'
-    })
+    logGTMWalletDisconnectedEvent(wallet?.adapter.name || 'unknown')
   })
 
   const { isOpen: isRecentTransactionDetailView, onOpen: turnOn, onClose: turnOff } = useDisclosure()

--- a/apps/solana/src/features/Portfolio/index.tsx
+++ b/apps/solana/src/features/Portfolio/index.tsx
@@ -15,7 +15,6 @@ export default function Portfolio() {
   const { isMobile } = useMatchBreakpoints()
   return (
     <Box overflowX="hidden">
-      <AcceleraytorAlertChip />
       <SectionMyPositions />
       {!isMobile && <Box pb="40px" />}
     </Box>

--- a/apps/solana/src/hooks/app/useInitConnection.ts
+++ b/apps/solana/src/hooks/app/useInitConnection.ts
@@ -8,8 +8,8 @@ import { useAppStore, defaultEndpoint } from '@/store/useAppStore'
 import usePrevious from '@/hooks/usePrevious'
 import { isLocal, cancelAllRetry } from '@/utils/common'
 import { getDevOnlyStorage } from '@/utils/localStorage'
-import { sendWalletEvent } from '@/api/event'
 import { validateTxData, extendTxData } from '@/api/txService'
+import { logGTMWalletConnectedEvent } from '@/utils/report/curstomGTMEventTracking'
 import { SSRData } from '../../type'
 import { toastSubject } from '../toast/useGlobalToast'
 
@@ -184,11 +184,7 @@ function useInitConnection(props: SSRData) {
 
   useEffect(() => {
     if (connected && publicKey) {
-      sendWalletEvent({
-        type: 'connectWallet',
-        connectStatus: 'success',
-        walletName: wallet?.adapter.name || 'unknown'
-      })
+      logGTMWalletConnectedEvent(wallet?.adapter.name || 'unknown')
       if (wallet) localStorage.setItem(WALLET_STORAGE_KEY, `"${wallet?.adapter.name}"`)
     }
   }, [publicKey, connected, wallet?.adapter.name])

--- a/apps/solana/src/provider/WalletProvider.tsx
+++ b/apps/solana/src/provider/WalletProvider.tsx
@@ -21,8 +21,8 @@ import {
 } from '@solana/wallet-adapter-wallets'
 import { initialize, SolflareWalletAdapter } from '@solflare-wallet/wallet-adapter'
 import { WalletConnectWalletAdapter } from '@walletconnect/solana-adapter'
-import { sendWalletEvent } from '@/api/event'
 import { useEvent } from '@/hooks/useEvent'
+import { logGTMSolErrorLogEvent } from '@/utils/report/curstomGTMEventTracking'
 
 import { defaultEndpoint, defaultNetWork, useAppStore } from '../store/useAppStore'
 import { BackpackWalletAdapter } from './walletAdapter/BackpackWalletAdapter'
@@ -88,11 +88,9 @@ const App: FC<PropsWithChildren<any>> = ({ children }) => {
 
   const onWalletError = useEvent((error: WalletError, adapter?: Adapter) => {
     if (!adapter) return
-    sendWalletEvent({
-      type: 'connectWallet',
-      walletName: adapter.name,
-      connectStatus: 'failure',
-      errorMsg: error.message || error.stack
+    logGTMSolErrorLogEvent({
+      action: 'Wallet Connect Fail',
+      e: error.message || error.stack
     })
   })
 

--- a/apps/solana/src/utils/report/curstomGTMEventTracking.ts
+++ b/apps/solana/src/utils/report/curstomGTMEventTracking.ts
@@ -1,6 +1,7 @@
 export enum GTMEvent {
   SwapTXSuccess = 'swapTXSuccess',
   WalletConnected = 'walletConnected',
+  WalletDisconnect = 'walletDisconnect',
   CreateLiquidityPool = 'createLiquidityPool',
   PoolFarmVersion = 'poolFarmVersion',
   V3lpStep1 = 'V3lpStep1',
@@ -30,6 +31,7 @@ export enum GTMCategory {
 export enum GTMAction {
   SwapTransactionSent = 'swap_transaction_sent',
   WalletConnected = 'Wallet Connected',
+  WalletDisconnect = 'Wallet Disconnect',
   ClickCreateBtn = 'Click Create Button on SOL LP Page',
   ClickContinueButton = 'Click on continue Button',
   ClickPreviewPoolButton = 'Click Preview Pool Button',
@@ -102,6 +104,16 @@ export const logGTMWalletConnectedEvent = (name: string) => {
   window?.dataLayer?.push({
     event: GTMEvent.WalletConnected,
     action: GTMAction.WalletConnected,
+    category: GTMCategory.Wallet,
+    label: name
+  })
+}
+
+export const logGTMWalletDisconnectedEvent = (name: string) => {
+  console.info('---wallet disconnected---')
+  window?.dataLayer?.push({
+    event: GTMEvent.WalletDisconnect,
+    action: GTMAction.WalletDisconnect,
     category: GTMCategory.Wallet,
     label: name
   })
@@ -284,7 +296,7 @@ export const logGTMPoolLiquiditySubSuccessEvent = ({
 }
 
 export interface SolErrorLogParams {
-  action: 'Add Liquidity Fail' | 'Remove Liquidity Fail' | 'Create Liquidity Pool Fail' | 'Swap Fail'
+  action: 'Add Liquidity Fail' | 'Remove Liquidity Fail' | 'Create Liquidity Pool Fail' | 'Swap Fail' | 'Wallet Connect Fail'
   e: any
 }
 
@@ -299,7 +311,7 @@ export const logGTMSolErrorLogEvent = ({ action, e }: SolErrorLogParams) => {
   window?.dataLayer?.push({
     event: GTMEvent.SolErrorLog,
     action,
-    category: action === 'Swap Fail' ? GTMCategory.Swap : GTMCategory.Liquidity,
+    category: action === 'Swap Fail' ? GTMCategory.Swap : action === 'Wallet Connect Fail' ? GTMCategory.Wallet : GTMCategory.Liquidity,
     label: 0,
     desc: errorMsg
   })

--- a/apps/solana/src/utils/report/datadog.ts
+++ b/apps/solana/src/utils/report/datadog.ts
@@ -58,3 +58,11 @@ export const logDDWalletConnectedEvent = (name: string) => {
     label: name
   })
 }
+
+export const logDDNetworkErrorEvent = ({ url, errorMsg }: { url: string; errorMsg: string }) => {
+  logger.info(GTMEvent.SolErrorLog, {
+    event: GTMEvent.SolErrorLog,
+    url,
+    errorMsg
+  })
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing event logging related to wallet connections and network errors within the application. It introduces new logging functions and replaces existing event sending logic with these new functions to improve tracking and error handling.

### Detailed summary
- Removed `<AcceleraytorAlertChip />` from `apps/solana/src/features/Portfolio/index.tsx`.
- Added `logDDNetworkErrorEvent` in `apps/solana/src/utils/report/datadog.ts` for logging network errors.
- Replaced `sendWalletEvent` with `logGTMWalletConnectedEvent` in `apps/solana/src/hooks/app/useInitConnection.ts`.
- Replaced `sendWalletEvent` with `logGTMWalletDisconnectedEvent` in `apps/solana/src/components/WalletRecentTransactionBoard.tsx`.
- Replaced `sendWalletEvent` with `logGTMSolErrorLogEvent` in `apps/solana/src/provider/WalletProvider.tsx`.
- Removed the `sendNetworkEvent` function in `apps/solana/src/api/axios.ts` and integrated `logDDNetworkErrorEvent` for error logging.
- Added `WalletDisconnect` event to `GTMAction` in `apps/solana/src/utils/report/curstomGTMEventTracking.ts`.
- Updated `logGTMSolErrorLogEvent` to include `Wallet Connect Fail` in the action parameter options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->