### PR TITLE
fix: lbamm liquidity chart default zoom level

### DIFF
--- a/apps/web/src/views/PoolDetail/components/ChartLiquidity/BasicChartLiquidity.tsx
+++ b/apps/web/src/views/PoolDetail/components/ChartLiquidity/BasicChartLiquidity.tsx
@@ -12,8 +12,12 @@ import { BasicChartLiquidityProps } from './type'
 const ZOOM_INTERVAL = 20
 const DEFAULT_ZOOM_LEVEL = 14
 
-export const BasicChartLiquidity: React.FC<BasicChartLiquidityProps> = ({ poolInfo, liquidityChartData }) => {
-  const [zoomLevel, setZoomLevel] = useState(DEFAULT_ZOOM_LEVEL)
+export const BasicChartLiquidity: React.FC<BasicChartLiquidityProps> = ({
+  poolInfo,
+  liquidityChartData,
+  defaultZoomLevel,
+}) => {
+  const [zoomLevel, setZoomLevel] = useState(defaultZoomLevel ?? DEFAULT_ZOOM_LEVEL)
   const [zoomInDisabled, setZoomInDisabled] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number | undefined>()
 

--- a/apps/web/src/views/PoolDetail/components/ChartLiquidity/ChartInfinityBinLiquidity.tsx
+++ b/apps/web/src/views/PoolDetail/components/ChartLiquidity/ChartInfinityBinLiquidity.tsx
@@ -60,5 +60,5 @@ export const ChartInfinityBinLiquidity: React.FC<InfinityBinChartLiquidityProps>
     [activeBinId, poolInfo, poolTickData],
   )
 
-  return <BasicChartLiquidity poolInfo={poolInfo} liquidityChartData={formattedData} />
+  return <BasicChartLiquidity poolInfo={poolInfo} liquidityChartData={formattedData} defaultZoomLevel={0} />
 }

--- a/apps/web/src/views/PoolDetail/components/ChartLiquidity/type.ts
+++ b/apps/web/src/views/PoolDetail/components/ChartLiquidity/type.ts
@@ -7,6 +7,7 @@ export type ChartLiquidityProps = {
 
 export type BasicChartLiquidityProps = ChartLiquidityProps & {
   liquidityChartData?: LiquidityChartData[]
+  defaultZoomLevel?: number
 }
 
 export type InfinityCLChartLiquidityProps = {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new optional property `defaultZoomLevel` to the `BasicChartLiquidityProps` type and updates the `BasicChartLiquidity` component to utilize this property for setting the initial zoom level, enhancing flexibility in zoom control.

### Detailed summary
- Added `defaultZoomLevel?: number` to `BasicChartLiquidityProps`.
- Updated `BasicChartLiquidity` component to accept `defaultZoomLevel`.
- Changed the initial state of `zoomLevel` to use `defaultZoomLevel` or fall back to `DEFAULT_ZOOM_LEVEL`. 
- Updated the return statement in `ChartInfinityBinLiquidity.tsx` to pass `defaultZoomLevel={0}`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->