### PR TITLE
fix: update tg links and blog lang

### DIFF
--- a/apps/blog/hooks/useLanguage.ts
+++ b/apps/blog/hooks/useLanguage.ts
@@ -7,8 +7,8 @@ interface ResponseLanguageType {
 }
 
 // We can't hide the language in Strapi only can delete it.
-// 日本語, Georgian, Français, Deutsch
-const HIDE_LANGUAGE_CODE = ['ja', 'ka', 'fr', 'de']
+// 日本語, Georgian, Français, Deutsch, Italiano
+const HIDE_LANGUAGE_CODE = ['ja', 'ka', 'fr', 'de', 'it']
 
 const useLanguage = () => {
   const { t } = useTranslation()

--- a/packages/localization/src/config/languages.ts
+++ b/packages/localization/src/config/languages.ts
@@ -12,7 +12,6 @@ export const FR: Language = { locale: 'fr-FR', language: 'Français', code: 'fr'
 export const HI: Language = { locale: 'hi-IN', language: 'हिंदी', code: 'hi' }
 export const HU: Language = { locale: 'hu-HU', language: 'Magyar', code: 'hu' }
 export const ID: Language = { locale: 'id-ID', language: 'Bahasa Indonesia', code: 'id' }
-export const IT: Language = { locale: 'it-IT', language: 'Italiano', code: 'it' }
 export const JA: Language = { locale: 'ja-JP', language: '日本語', code: 'ja' }
 export const KO: Language = { locale: 'ko-KR', language: '한국어', code: 'ko' }
 export const NL: Language = { locale: 'nl-NL', language: 'Nederlands', code: 'nl' }
@@ -41,7 +40,6 @@ export const languages: Record<string, Language> = {
   'hi-IN': HI,
   'hu-HU': HU,
   'id-ID': ID,
-  'it-IT': IT,
   'ja-JP': JA,
   'ko-KR': KO,
   'nl-NL': NL,

--- a/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
+++ b/packages/uikit/src/__tests__/widgets/__snapshots__/menu.test.tsx.snap
@@ -2656,15 +2656,6 @@ exports[`renders correctly 1`] = `
               Tiếng Việt
             </a>
             <a
-              aria-label="Italiano"
-              class="c26 c13"
-              href="https://t.me/pancakeswap_Ita"
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              Italiano
-            </a>
-            <a
               aria-label="русский"
               class="c26 c13"
               href="https://t.me/pancakeswap_ru"
@@ -2672,15 +2663,6 @@ exports[`renders correctly 1`] = `
               target="_blank"
             >
               русский
-            </a>
-            <a
-              aria-label="Türkiye"
-              class="c26 c13"
-              href="https://t.me/pancakeswapturkiye"
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              Türkiye
             </a>
             <a
               aria-label="Português"
@@ -2708,15 +2690,6 @@ exports[`renders correctly 1`] = `
               target="_blank"
             >
               日本語
-            </a>
-            <a
-              aria-label="Français"
-              class="c26 c13"
-              href="https://t.me/pancakeswapFR"
-              rel="noreferrer noopener"
-              target="_blank"
-            >
-              Français
             </a>
             <a
               aria-label="Deutsch"

--- a/packages/uikit/src/components/Footer/config.tsx
+++ b/packages/uikit/src/components/Footer/config.tsx
@@ -103,16 +103,8 @@ export const socials = [
         href: "https://t.me/PancakeSwapVN",
       },
       {
-        label: "Italiano",
-        href: "https://t.me/pancakeswap_Ita",
-      },
-      {
         label: "русский",
         href: "https://t.me/pancakeswap_ru",
-      },
-      {
-        label: "Türkiye",
-        href: "https://t.me/pancakeswapturkiye",
       },
       {
         label: "Português",
@@ -125,10 +117,6 @@ export const socials = [
       {
         label: "日本語",
         href: "https://t.me/pancakeswapJP",
-      },
-      {
-        label: "Français",
-        href: "https://t.me/pancakeswapFR",
       },
       {
         label: "Filipino",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating language configurations and social media links in the application, specifically adding Italian and removing several other languages from the visibility and social links.

### Detailed summary
- Updated `HIDE_LANGUAGE_CODE` to include `it` (Italian).
- Removed social media link for `Italiano`.
- Removed social media link for `Français`.
- Removed social media link for `Türkiye`.
- Removed `IT` language export from `languages.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->