### PR TITLE
fix(gift): cannot download QR image when token logo URL images/tokens/:address

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -91,6 +91,11 @@ const config = {
         hostname: 'assets.pancakeswap.finance',
         pathname: '/web/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'tokens.pancakeswap.finance',
+        pathname: '/web/**',
+      }
     ],
   },
   async rewrites() {

--- a/apps/web/src/hooks/useElementToCanvas.ts
+++ b/apps/web/src/hooks/useElementToCanvas.ts
@@ -20,6 +20,7 @@ async function convertToCanvas(elementId: string, isDark: boolean): Promise<Blob
       scale: OPTIONS.scale,
       logging: false,
       useCORS: true,
+      allowTaint: true,
       windowWidth: element.scrollWidth,
       windowHeight: element.scrollHeight,
     })

--- a/apps/web/src/views/Gift/components/CurrencyAmountGiftDisplay.tsx
+++ b/apps/web/src/views/Gift/components/CurrencyAmountGiftDisplay.tsx
@@ -17,7 +17,7 @@ export const CurrencyAmountGiftDisplay = ({
 
   return (
     <Flex {...props}>
-      <CurrencyLogo showChainLogo currency={currencyAmount.currency.wrapped} size="40px" />
+      <CurrencyLogo crossOrigin="anonymous" showChainLogo currency={currencyAmount.currency.wrapped} size="40px" />
       <Flex flexDirection="column" ml="8px">
         <Text fontWeight="600" fontSize="14px" color="text">
           {currencyAmount.toSignificant(6)} {currencyAmount.currency.symbol}

--- a/packages/widgets-internal/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/packages/widgets-internal/components/CurrencyLogo/CurrencyLogo.tsx
@@ -103,6 +103,7 @@ export function CurrencyLogo({
         srcs={srcs}
         alt={`${currency?.symbol ?? "token"} logo`}
         style={style}
+        crossOrigin="anonymous"
         {...props}
       />
     );

--- a/packages/widgets-internal/components/CurrencyLogo/CurrencyLogo.tsx
+++ b/packages/widgets-internal/components/CurrencyLogo/CurrencyLogo.tsx
@@ -50,8 +50,10 @@ export function CurrencyLogo({
   imageRef,
   showChainLogo = false,
   containerStyle,
+  crossOrigin,
   ...props
 }: {
+  crossOrigin?: "anonymous" | "use-credentials";
   currency?: CurrencyInfo & {
     logoURI?: string | undefined;
   };
@@ -96,6 +98,8 @@ export function CurrencyLogo({
       );
     }
 
+    const crossOriginProp = crossOrigin ? { crossOrigin } : {};
+
     return (
       <StyledLogo
         imageRef={imageRef}
@@ -103,7 +107,7 @@ export function CurrencyLogo({
         srcs={srcs}
         alt={`${currency?.symbol ?? "token"} logo`}
         style={style}
-        crossOrigin="anonymous"
+        {...crossOriginProp}
         {...props}
       />
     );


### PR DESCRIPTION
the browser throws `Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported.` when token logo URL is `images/tokens/:address`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality and configuration of the application by adding new features related to cross-origin handling and canvas element usage.

### Detailed summary
- In `next.config.mjs`, added a new object for handling HTTPS requests to `tokens.pancakeswap.finance`.
- In `useElementToCanvas.ts`, introduced `allowTaint: true` for canvas operations.
- In `CurrencyAmountGiftDisplay.tsx`, added `crossOrigin="anonymous"` to the `CurrencyLogo` component.
- In `CurrencyLogo.tsx`, added a `crossOrigin` prop to manage cross-origin requests and applied it to the logo rendering logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->