### PR TITLE
fix: hooks list undefined in infinity router

### DIFF
--- a/packages/smart-router/evm/infinity-router/queries/remotePoolTransform.ts
+++ b/packages/smart-router/evm/infinity-router/queries/remotePoolTransform.ts
@@ -124,7 +124,9 @@ export function toLocalInfinityPool(remote: RemotePoolCL | RemotePoolBIN, chainI
   const { id, feeTier, protocol, protocolFee, hookAddress, tvlUSD } = remote
 
   const type = protocol === 'infinityCl' ? PoolType.InfinityCL : PoolType.InfinityBIN
-  const relatedHook = hooksList[chainId].find((hook) => hook.address.toLowerCase() === hookAddress?.toLocaleLowerCase())
+  const relatedHook = hooksList[chainId]?.find(
+    (hook) => hook.address.toLowerCase() === hookAddress?.toLocaleLowerCase(),
+  )
   const hookNotInWhitelist = hookAddress && !relatedHook
   if (hookNotInWhitelist) {
     return null


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the handling of finding a related hook in the `remotePoolTransform.ts` file. It updates the code to safely access the `find` method on `hooksList[chainId]`, ensuring it gracefully handles cases where `hooksList[chainId]` may be undefined.

### Detailed summary
- Changed `const relatedHook` assignment to use optional chaining: `hooksList[chainId]?.find(...)`.
- Reformatted the `find` method call for better readability by placing the function definition on a new line.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->