### PR TITLE
chore: remove v2 in solana

### DIFF
--- a/apps/solana/src/features/Create/components/CreatePoolEntryDialog.tsx
+++ b/apps/solana/src/features/Create/components/CreatePoolEntryDialog.tsx
@@ -30,7 +30,7 @@ import CircleCheck from '@/icons/misc/CircleCheck'
 import { Desktop, Mobile } from '@/components/MobileDesktop'
 import { logGTMPoolFarmVersionEvent } from '@/utils/report/curstomGTMEventTracking'
 
-type CreateTarget = 'legacy-amm' | 'standard-amm' | 'concentrated-liquidity' | 'standard-farm' | 'clmm-lock' | 'cpmm-lock'
+type CreateTarget = 'concentrated-liquidity' | 'standard-farm' | 'clmm-lock' | 'cpmm-lock'
 
 export function CreatePoolEntryDialog({
   isOpen,
@@ -47,13 +47,6 @@ export function CreatePoolEntryDialog({
     let to = ''
     const query = { ...router.query }
     switch (type) {
-      case 'legacy-amm':
-        query.type = 'legacy-amm'
-        to = '/liquidity/create-pool'
-        break
-      case 'standard-amm':
-        to = '/liquidity/create-pool'
-        break
       case 'concentrated-liquidity':
         to = '/clmm/create-pool'
         break
@@ -166,7 +159,7 @@ function CreatePoolEntryMobileDrawer({
 
 export function CreatePoolEntryDialogBody({ type, onChange }: { type: CreateTarget; onChange: (val: CreateTarget) => void }) {
   const { t } = useTranslation()
-  const isCreatePool = ['concentrated-liquidity', 'standard-amm', 'legacy-amm'].includes(type)
+  const isCreatePool = type === 'concentrated-liquidity'
   // const isCreateFarm = type === 'standard-farm'
 
   return (
@@ -192,25 +185,6 @@ export function CreatePoolEntryDialogBody({ type, onChange }: { type: CreateTarg
                         </Box>
                       }
                       onClickSelf={() => onChange('concentrated-liquidity')}
-                    />
-                    <PoolTypeItem
-                      isDisabled
-                      isActive={false}
-                      content={
-                        <Box lineHeight="1.5">
-                          <Flex alignItems="flex-end" gap="2px">
-                            <Text whiteSpace="nowrap" fontSize="md" fontWeight={600}>
-                              {t('V2 Pools')}
-                            </Text>
-                            <Text fontSize="sm" color={colors.textSubtle}>
-                              Coming Soon
-                            </Text>
-                          </Flex>
-                          <Text fontSize="xs" color={colors.textSubtle}>
-                            {t('Newest CPMM, supports Token 2022')}
-                          </Text>
-                        </Box>
-                      }
                     />
                   </Stack>
                 </>

--- a/apps/solana/src/features/Pools/Pools.tsx
+++ b/apps/solana/src/features/Pools/Pools.tsx
@@ -191,11 +191,6 @@ export default function Pools() {
         value: PoolFetchType.Concentrated
       },
       {
-        name: 'V2',
-        label: 'V2',
-        value: PoolFetchType.Standard
-      },
-      {
         name: 'All',
         label: isEN && isMobile ? 'ALL' : t('All'),
         value: PoolFetchType.All

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -3879,8 +3879,6 @@
   "Create pool": "Create pool",
   "V3 Pools": "V3 Pools",
   "Custom ranges, increased capital efficiency": "Custom ranges, increased capital efficiency",
-  "V2 Pools": "V2 Pools",
-  "Newest CPMM, supports Token 2022": "Newest CPMM, supports Token 2022",
   "Suggested": "Suggested",
   "Farming starts": "Farming starts",
   "Farming ends": "Farming ends",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the pool types in the application by removing references to the `V2` pool type and modifying the `CreateTarget` type. It also adjusts the UI components related to pool creation and translation files.

### Detailed summary
- Removed `V2` pool type from `Pools.tsx`.
- Updated translations by deleting `V2 Pools` and related text from `translations.json`.
- Modified `CreateTarget` type in `CreatePoolEntryDialog.tsx` to exclude `legacy-amm` and `standard-amm`.
- Simplified `isCreatePool` logic to only check for `concentrated-liquidity`.
- Removed UI elements related to `V2 Pools` from `CreatePoolEntryDialogBody`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->