### PR TITLE
chore: Remove polygon zkevm eth from buy crypto

### DIFF
--- a/apps/web/src/components/SearchModal/OnRampCurrencyModal.tsx
+++ b/apps/web/src/components/SearchModal/OnRampCurrencyModal.tsx
@@ -108,7 +108,7 @@ const SearchModalNetworkPopOver = ({
           <>
             {[chains[0], ...chains]
               .filter((chain) => {
-                if (('testnet' in chain && chain.testnet) || chain.id === 204) return false
+                if (('testnet' in chain && chain.testnet) || chain.id === 204 || chain.id === 1101) return false
                 return true
               })
               .map((chain, index: number) => {

--- a/apps/web/src/views/BuyCrypto/constants.ts
+++ b/apps/web/src/views/BuyCrypto/constants.ts
@@ -243,7 +243,7 @@ export const onRampCurrenciesMap: { [tokenSymbol: string]: Currency } = {
   ETH_1: Native.onChain(OnRampChainId.ETHEREUM),
   BNB_56: Native.onChain(OnRampChainId.BSC),
   ETH_42161: Native.onChain(OnRampChainId.ARBITRUM_ONE),
-  ETH_1101: Native.onChain(OnRampChainId.POLYGON_ZKEVM),
+  // ETH_1101: Native.onChain(OnRampChainId.POLYGON_ZKEVM),
   ETH_324: Native.onChain(OnRampChainId.ZKSYNC),
   ETH_59144: Native.onChain(OnRampChainId.LINEA),
   ETH_8453: Native.onChain(OnRampChainId.BASE),

--- a/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
@@ -305,7 +305,7 @@ const OnRampCurrencySelectPopOver = ({
   isError,
   setSelectedQuote,
   setShowProvidersPopOver,
-  showProvidersPopOver: showProivdersPopOver,
+  showProvidersPopOver,
 }: OnRampCurrencySelectPopOverProps) => {
   const { t } = useTranslation()
 
@@ -321,7 +321,7 @@ const OnRampCurrencySelectPopOver = ({
     [showProvidersOnClick, setSelectedQuote],
   )
   return (
-    <PopOverScreenContainer showPopover={showProivdersPopOver} onClick={showProvidersOnClick}>
+    <PopOverScreenContainer showPopover={showProvidersPopOver} onClick={showProvidersOnClick}>
       <AutoRow borderBottom="1" borderColor="cardBorder" paddingX="24px" py="16px">
         <Text fontSize="20px" fontWeight="600">
           {t('Choose a provider')}

--- a/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
@@ -195,9 +195,9 @@ export function BuyCryptoForm({ providerAvailabilities }: { providerAvailabiliti
           disableInput={false}
           unit={unit}
         />
-        <Box width="100%" position="absolute" zIndex="100" left="45%" top="53px">
+        <Flex width="100%" zIndex="100" justifyContent="center" alignItems="center">
           <SwapUI.SwitchButton onClick={onFlip} />
-        </Box>
+        </Flex>
         <BuyCryptoSelector
           id={isFiat(unit) ? 'onramp-crypto' : 'onramp-fiat'}
           inputLoading={Boolean(isLoading || inputError || quotesError)}

--- a/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/BuyCryptoForm.tsx
@@ -68,7 +68,7 @@ interface OnRampCurrencySelectPopOverProps {
   isError: boolean
   setSelectedQuote: (quote: OnRampProviderQuote) => void
   setShowProvidersPopOver: Dispatch<SetStateAction<boolean>>
-  showProivdersPopOver: boolean
+  showProvidersPopOver: boolean
 }
 type InputEvent = ChangeEvent<HTMLInputElement>
 
@@ -80,7 +80,7 @@ export function BuyCryptoForm({ providerAvailabilities }: { providerAvailabiliti
   const theme = useTheme()
 
   const [searchQuery, setSearchQuery] = useState<string>('')
-  const [showProivdersPopOver, setShowProvidersPopOver] = useState<boolean>(false)
+  const [showProvidersPopOver, setShowProvidersPopOver] = useState<boolean>(false)
   const [showNotificationsPopOver, setShowNotificationsPopOver] = useState<boolean>(false)
   const [selectedQuote, setSelectedQuote] = useState<OnRampProviderQuote | undefined>(undefined)
   const [unit, setUnit] = useState<OnRampUnit>(OnRampUnit.Fiat)
@@ -174,7 +174,7 @@ export function BuyCryptoForm({ providerAvailabilities }: { providerAvailabiliti
         isFetching={isLoading}
         setSelectedQuote={setSelectedQuote}
         setShowProvidersPopOver={setShowProvidersPopOver}
-        showProivdersPopOver={showProivdersPopOver}
+        showProvidersPopOver={showProvidersPopOver}
       />
       <NotificationsOnboardPopover
         setShowNotificationsPopOver={setShowNotificationsPopOver}
@@ -305,7 +305,7 @@ const OnRampCurrencySelectPopOver = ({
   isError,
   setSelectedQuote,
   setShowProvidersPopOver,
-  showProivdersPopOver,
+  showProvidersPopOver: showProivdersPopOver,
 }: OnRampCurrencySelectPopOverProps) => {
   const { t } = useTranslation()
 

--- a/apps/web/src/views/BuyCrypto/containers/FormContainer.tsx
+++ b/apps/web/src/views/BuyCrypto/containers/FormContainer.tsx
@@ -5,7 +5,7 @@ import { Wrapper } from '../styles'
 export const FormContainer = memo(function FormContainer({ children }: PropsWithChildren) {
   return (
     <Wrapper>
-      <Column gap="lg" pl="8px" pr="8px" pb="8px" pt="0px">
+      <Column gap="md" pl="8px" pr="8px" pb="8px" pt="0px">
         {children}
       </Column>
     </Wrapper>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the `BuyCrypto` components, improving code clarity, and fixing minor typos. It updates UI elements and conditions for filtering chains in the `SearchModal`, and comments out a specific chain in constants.

### Detailed summary
- Changed `gap` from `lg` to `md` in the `Column` of `FormContainer.tsx`.
- Updated chain filtering logic to exclude `chain.id === 1101` in `OnRampCurrencyModal.tsx`.
- Commented out `ETH_1101` in `constants.ts`.
- Fixed typo from `showProivdersPopOver` to `showProvidersPopOver` in `BuyCryptoForm.tsx`.
- Replaced `Box` with `Flex` for layout adjustments in `BuyCryptoForm.tsx`.
- Updated `showProivdersPopOver` to `showProvidersPopOver` in `OnRampCurrencySelectPopOver`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->