### PR TITLE
fix:  i18n template escape issue

### DIFF
--- a/apps/web/src/pages/swap/index.tsx
+++ b/apps/web/src/pages/swap/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Skeleton, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { useTranslation, Trans } from '@pancakeswap/localization'
+import { Box, Skeleton, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import dynamic from 'next/dynamic'
 import styled from 'styled-components'
 import { NextPageWithLayout } from 'utils/page.types'
@@ -42,9 +43,28 @@ const SwapFallback = () => {
 
 const View = () => {
   const { isMobile } = useMatchBreakpoints()
+  const { t } = useTranslation()
 
   return (
     <SwapLayout>
+      <Trans
+        i18nKey="solana.removed_liquidity_desc"
+        values={{
+          amountA: '123',
+          symbolA: 'SOL',
+          amountB: '456',
+          symbolB: 'USDC',
+        }}
+      />
+      <Text>
+        {t(
+          'This swap has a price impact of at least %amount%%. Please type the word "%word%" to continue with this swap.',
+          {
+            amount: 123,
+            word: 'confirm',
+          },
+        )}
+      </Text>
       <Container isMobile={isMobile}>
         <SwapSimplify />
       </Container>

--- a/apps/web/src/pages/swap/index.tsx
+++ b/apps/web/src/pages/swap/index.tsx
@@ -1,5 +1,4 @@
-import { useTranslation, Trans } from '@pancakeswap/localization'
-import { Box, Skeleton, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Box, Skeleton, useMatchBreakpoints } from '@pancakeswap/uikit'
 import dynamic from 'next/dynamic'
 import styled from 'styled-components'
 import { NextPageWithLayout } from 'utils/page.types'
@@ -43,28 +42,9 @@ const SwapFallback = () => {
 
 const View = () => {
   const { isMobile } = useMatchBreakpoints()
-  const { t } = useTranslation()
 
   return (
     <SwapLayout>
-      <Trans
-        i18nKey="solana.removed_liquidity_desc"
-        values={{
-          amountA: '123',
-          symbolA: 'SOL',
-          amountB: '456',
-          symbolB: 'USDC',
-        }}
-      />
-      <Text>
-        {t(
-          'This swap has a price impact of at least %amount%%. Please type the word "%word%" to continue with this swap.',
-          {
-            amount: 123,
-            word: 'confirm',
-          },
-        )}
-      </Text>
       <Container isMobile={isMobile}>
         <SwapSimplify />
       </Container>

--- a/packages/localization/src/Provider.tsx
+++ b/packages/localization/src/Provider.tsx
@@ -11,7 +11,7 @@ const initialState: ProviderState = {
   currentLanguage: EN,
 }
 
-const languageMap = new Map<Language['locale'], Record<string, string>>()
+export const languageMap = new Map<Language['locale'], Record<string, string>>()
 languageMap.set(EN.locale, translations as Record<string, string>)
 
 export const LanguageContext = createContext<ContextApi | undefined>(undefined)
@@ -24,7 +24,6 @@ export const LanguageProvider: React.FC<React.PropsWithChildren> = ({ children }
       currentLanguage: languages[codeFromStorage] || EN,
     }
   })
-  const { currentLanguage } = state
 
   useEffect(() => {
     const fetchInitialLocales = async () => {

--- a/packages/localization/src/useTranslation.ts
+++ b/packages/localization/src/useTranslation.ts
@@ -1,17 +1,50 @@
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useTranslation as useI18nTranslation } from 'react-i18next'
-import { LanguageContext } from './Provider'
-import { TranslateFunction } from './types'
+import { LanguageContext, languageMap } from './Provider'
+import { ContextData, TranslateFunction } from './types'
+import full from './config/translations.json'
+
+const cache = new Map<string, string>()
 
 const useTranslation = () => {
   const languageContext = useContext(LanguageContext)
-  const { t } = useI18nTranslation()
+  const { i18n } = useI18nTranslation()
 
   if (languageContext === undefined) {
     throw new Error('Language context is undefined')
   }
+  const translate: TranslateFunction = useCallback(
+    (key, data) => {
+      const lang = languageContext?.currentLanguage.locale
+      const cacheKey = `${lang}:${key}-${JSON.stringify(data)}`
+      if (cache.has(cacheKey)) {
+        return cache.get(cacheKey) || ''
+      }
+      function getTranslationValue() {
+        const value = full[key] || ''
+        if (!lang) {
+          return value
+        }
+        const data = languageMap.get(lang)
+        if (!data) {
+          return value
+        }
+        return data[key] || value
+      }
 
-  return { ...languageContext, t: t as TranslateFunction }
+      const value = getTranslationValue()
+
+      const interpolated = value.replace(/%([a-zA-Z9-9-_]+)%/g, (match, p1) => {
+        const replacement = data?.[p1] || ''
+        return replacement === undefined ? match : replacement
+      })
+      cache.set(cacheKey, interpolated)
+      return interpolated
+    },
+    [languageContext.currentLanguage.locale, i18n],
+  )
+
+  return { ...languageContext, t: translate }
 }
 
 export default useTranslation


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the localization logic by exporting the `languageMap` for broader access, enhancing the `useTranslation` hook to utilize a caching mechanism for translations, and modifying the translation function to improve performance and flexibility.

### Detailed summary
- Changed `languageMap` to be exported from `Provider.tsx`.
- Updated `useTranslation` in `useTranslation.ts` to use `i18n` instead of `t`.
- Implemented a caching mechanism for translations.
- Enhanced the translation function to handle interpolation and caching of results.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->