### PR TITLE
chore: Block framing for embedded wallet

### DIFF
--- a/apps/web/src/hooks/useSecurityBlocking.ts
+++ b/apps/web/src/hooks/useSecurityBlocking.ts
@@ -1,0 +1,20 @@
+import { usePrivy } from '@privy-io/react-auth'
+import { useEffect, useState } from 'react'
+
+function useConnectedViaEmbeddedWallet() {
+  const { authenticated } = usePrivy()
+  return authenticated
+}
+
+export function useSecurityBlocking() {
+  const [blocking, setBlocking] = useState(false)
+  const isConnectedViaEmbeddedWallet = useConnectedViaEmbeddedWallet()
+
+  useEffect(() => {
+    if (isConnectedViaEmbeddedWallet && typeof window !== 'undefined' && window.self !== window.top) {
+      setBlocking(true)
+    }
+  }, [isConnectedViaEmbeddedWallet])
+
+  return blocking
+}

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -39,6 +39,7 @@ import { useVercelFeatureFlagOverrides } from 'hooks/useVercelToolbar'
 import { useWalletConnectRouterSync } from 'hooks/useWalletConnectRouterSync'
 import { useWeb3WalletView } from 'hooks/useWeb3WalletView'
 import { useInitGlobalWorker } from 'hooks/useWorker'
+import { useSecurityBlocking } from 'hooks/useSecurityBlocking'
 import { persistor, useStore } from 'state'
 import { usePollBlockNumber } from 'state/block/hooks'
 import { Blocklist, Updaters } from '..'
@@ -145,6 +146,12 @@ type AppPropsWithLayout = AppProps & {
 const ProductionErrorBoundary = process.env.NODE_ENV === 'production' ? SentryErrorBoundary : Fragment
 
 const App = ({ Component, pageProps }: AppPropsWithLayout) => {
+  const blocking = useSecurityBlocking()
+
+  if (blocking) {
+    return null
+  }
+
   if (Component.pure) {
     return <Component {...pageProps} />
   }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a security feature that blocks access to the application if the user is connected via an embedded wallet. It utilizes the `usePrivy` hook to check authentication and manages the blocking state in the `useSecurityBlocking` hook.

### Detailed summary
- Added `useConnectedViaEmbeddedWallet` function to check if the user is authenticated.
- Created `useSecurityBlocking` hook to manage blocking state based on wallet connection.
- Integrated `useSecurityBlocking` in the `App` component to conditionally render `null` if blocking is active.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->