### PR TITLE
feat: add points card for pools

### DIFF
--- a/apps/web/src/views/PoolDetail/components/PoolInfo.tsx
+++ b/apps/web/src/views/PoolDetail/components/PoolInfo.tsx
@@ -43,7 +43,7 @@ import { getBlockExploreLink } from 'utils'
 import { getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { isInfinityProtocol } from 'utils/protocols'
 import { Tooltips } from 'views/CakeStaking/components/Tooltips'
-import { getRewardProvider } from 'views/universalFarms/components/FarmStatusDisplay/hooks'
+import { getRewardProvider, getRewardMultiplier } from 'views/universalFarms/components/FarmStatusDisplay/hooks'
 import { PoolGlobalAprButtonV3 } from 'views/universalFarms/components/PoolAprButtonV3'
 import { RewardInfoCard } from 'views/universalFarms/components/RewardInfoCard'
 import LiquiditySunsetWarning from 'components/Liquidity/LiquiditySunsetWarning'
@@ -64,11 +64,12 @@ enum PoolDetailTab {
 
 const RewardInfoCardContainer = ({ poolInfo }: { poolInfo: PoolInfoType }) => {
   const provider = getRewardProvider(poolInfo.chainId, poolInfo.lpAddress)
+  const multiplier = getRewardMultiplier(poolInfo.chainId, poolInfo.lpAddress)
   const hasPoolReward = !!provider
 
   if (!hasPoolReward) return null
 
-  return <RewardInfoCard provider={provider} />
+  return <RewardInfoCard provider={provider} multiplier={multiplier} />
 }
 
 export const PoolInfo = () => {

--- a/apps/web/src/views/universalFarms/components/FarmStatusDisplay/config.ts
+++ b/apps/web/src/views/universalFarms/components/FarmStatusDisplay/config.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pancakeswap/chains'
 import { RewardProvider, RewardConfig } from './types'
 
-export const rewardConfig: Record<ChainId, RewardConfig[]> = {
+export const rewardConfig: Partial<Record<ChainId, RewardConfig[]>> = {
   [ChainId.BSC]: [
     {
       poolAddress: '0xdc35157217A3AeFF3dcaF2e86327254FBF9f4601',
@@ -14,7 +14,7 @@ export const rewardConfig: Record<ChainId, RewardConfig[]> = {
       multiplier: 30,
     },
     {
-      poolAddress: '0xe38b4d4dc90e6a0859bee047689d97db7fd94621',
+      poolAddress: '0xE38B4d4Dc90E6a0859bEE047689d97db7fD94621',
       rewardProvider: RewardProvider.Falcon,
       multiplier: 60,
     },

--- a/apps/web/src/views/universalFarms/components/FarmStatusDisplay/config.ts
+++ b/apps/web/src/views/universalFarms/components/FarmStatusDisplay/config.ts
@@ -1,12 +1,34 @@
 import { ChainId } from '@pancakeswap/chains'
-import { RewardProvider } from './types'
+import { RewardProvider, RewardConfig } from './types'
 
-export const rewardConfig = {
+export const rewardConfig: Record<ChainId, RewardConfig[]> = {
   [ChainId.BSC]: [
-    { poolAddress: '0xdc35157217A3AeFF3dcaF2e86327254FBF9f4601', rewardProvider: RewardProvider.Ethena },
-    { poolAddress: '0x345E7D44E1eb8894b4524Cfc918906718bc1FFe2', rewardProvider: RewardProvider.Ethena },
+    {
+      poolAddress: '0xdc35157217A3AeFF3dcaF2e86327254FBF9f4601',
+      rewardProvider: RewardProvider.Ethena,
+      multiplier: 30,
+    },
+    {
+      poolAddress: '0x345E7D44E1eb8894b4524Cfc918906718bc1FFe2',
+      rewardProvider: RewardProvider.Ethena,
+      multiplier: 30,
+    },
+    {
+      poolAddress: '0xe38b4d4dc90e6a0859bee047689d97db7fd94621',
+      rewardProvider: RewardProvider.Falcon,
+      multiplier: 60,
+    },
+    {
+      poolAddress: '0x24618d12b5eA15bB6fe3c81bBb9E011b5D5b107c',
+      rewardProvider: RewardProvider.Falcon,
+      multiplier: 50,
+    },
   ],
   [ChainId.ETHEREUM]: [
-    { poolAddress: '0x0d9EA0D5E3f400b1df8F695be04292308c041E77', rewardProvider: RewardProvider.Falcon },
+    {
+      poolAddress: '0x0d9EA0D5E3f400b1df8F695be04292308c041E77',
+      rewardProvider: RewardProvider.Falcon,
+      multiplier: 40,
+    },
   ],
 }

--- a/apps/web/src/views/universalFarms/components/FarmStatusDisplay/hooks.ts
+++ b/apps/web/src/views/universalFarms/components/FarmStatusDisplay/hooks.ts
@@ -2,23 +2,37 @@ import { ChainId } from '@pancakeswap/chains'
 import memoize from 'lodash/memoize'
 import { isAddressEqual } from 'utils'
 import { rewardConfig } from './config'
-import { RewardProvider } from './types'
+import { RewardProvider, RewardConfig } from './types'
 
 // Pure function to check if a farm has rewards
 export const checkHasReward = memoize(
   (chainId?: ChainId, poolAddress?: string): boolean => {
-    return getRewardProvider(chainId, poolAddress) !== undefined
+    return getRewardConfig(chainId, poolAddress) !== undefined
+  },
+  (chainId, poolAddress) => `${chainId}#${poolAddress}`,
+)
+
+export const getRewardConfig = memoize(
+  (chainId?: ChainId, poolAddress?: string): RewardConfig | undefined => {
+    if (!chainId || !poolAddress) return undefined
+    const chainConfig = rewardConfig[chainId]
+    if (!chainConfig) return undefined
+
+    return chainConfig.find((config) => isAddressEqual(config.poolAddress, poolAddress))
   },
   (chainId, poolAddress) => `${chainId}#${poolAddress}`,
 )
 
 export const getRewardProvider = memoize(
   (chainId?: ChainId, poolAddress?: string): RewardProvider | undefined => {
-    if (!chainId || !poolAddress) return undefined
-    const chainConfig = rewardConfig[chainId]
-    if (!chainConfig) return undefined
+    return getRewardConfig(chainId, poolAddress)?.rewardProvider
+  },
+  (chainId, poolAddress) => `${chainId}#${poolAddress}`,
+)
 
-    return chainConfig.find((config) => isAddressEqual(config.poolAddress, poolAddress))?.rewardProvider
+export const getRewardMultiplier = memoize(
+  (chainId?: ChainId, poolAddress?: string): number | undefined => {
+    return getRewardConfig(chainId, poolAddress)?.multiplier
   },
   (chainId, poolAddress) => `${chainId}#${poolAddress}`,
 )

--- a/apps/web/src/views/universalFarms/components/FarmStatusDisplay/index.tsx
+++ b/apps/web/src/views/universalFarms/components/FarmStatusDisplay/index.tsx
@@ -26,9 +26,10 @@ const StyledRewardIcon = styled(RewardIcon)`
 
 interface RewardStatusDisplayProps {
   provider?: RewardProvider
+  multiplier?: number
 }
 
-export const RewardStatusDisplay: React.FC<RewardStatusDisplayProps> = ({ provider }) => {
+export const RewardStatusDisplay: React.FC<RewardStatusDisplayProps> = ({ provider, multiplier = 40 }) => {
   const { t } = useTranslation()
   const { isMobile } = useMatchBreakpoints()
 
@@ -57,7 +58,8 @@ export const RewardStatusDisplay: React.FC<RewardStatusDisplayProps> = ({ provid
         </Box>
         <Text as="span">
           {t(
-            "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
+            "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
+            { multiplier },
           )}
         </Text>
         <FlexGap gap="4px" justifyContent="flex-start" display="inline-flex" alignItems="center" flexWrap="wrap">

--- a/apps/web/src/views/universalFarms/components/FarmStatusDisplay/types.ts
+++ b/apps/web/src/views/universalFarms/components/FarmStatusDisplay/types.ts
@@ -2,3 +2,9 @@ export enum RewardProvider {
   Ethena = 1,
   Falcon = 2,
 }
+
+export interface RewardConfig {
+  poolAddress: string
+  rewardProvider: RewardProvider
+  multiplier: number
+}

--- a/apps/web/src/views/universalFarms/components/RewardInfoCard/index.tsx
+++ b/apps/web/src/views/universalFarms/components/RewardInfoCard/index.tsx
@@ -33,9 +33,10 @@ const StyledLink = styled(Link)`
 
 interface RewardInfoCardProps {
   provider?: RewardProvider
+  multiplier?: number
 }
 
-export const RewardInfoCard: React.FC<RewardInfoCardProps> = memo(({ provider }) => {
+export const RewardInfoCard: React.FC<RewardInfoCardProps> = memo(({ provider, multiplier = 40 }) => {
   const { t } = useTranslation()
 
   if (!provider) {
@@ -81,7 +82,8 @@ export const RewardInfoCard: React.FC<RewardInfoCardProps> = memo(({ provider })
         </FlexGap>
         <Text mb="8px">
           {t(
-            "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
+            "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
+            { multiplier },
           )}
         </Text>
         <StyledLink external href="https://app.falcon.finance/miles">

--- a/apps/web/src/views/universalFarms/components/useColumnConfig.tsx
+++ b/apps/web/src/views/universalFarms/components/useColumnConfig.tsx
@@ -16,7 +16,7 @@ import { getFarmAprInfo, getFarmHookData } from 'state/farmsV4/search/farm.util'
 import { getCurrencySymbol } from 'utils/getTokenAlias'
 import { getChainFullName } from '../utils'
 import { RewardStatusDisplay } from './FarmStatusDisplay'
-import { checkHasReward, getRewardProvider } from './FarmStatusDisplay/hooks'
+import { checkHasReward, getRewardProvider, getRewardMultiplier } from './FarmStatusDisplay/hooks'
 import { PoolGlobalAprButton } from './PoolAprButton'
 import { PoolListItemAction } from './PoolListItemAction'
 
@@ -175,6 +175,7 @@ export const PoolTokenOverview = <T extends PoolInfo = PoolInfo>({ data }: { dat
   const token1 = useTokenByChainId(getCurrencyAddress(data.token1), data.chainId) || data.token1
 
   const provider = getRewardProvider(data.chainId, data.lpAddress)
+  const multiplier = getRewardMultiplier(data.chainId, data.lpAddress)
   const showReward = !!provider
 
   return (
@@ -188,7 +189,7 @@ export const PoolTokenOverview = <T extends PoolInfo = PoolInfo>({ data }: { dat
         getCurrencySymbol={getCurrencySymbol}
         icon={<TokenPairLogo width={44} height={44} variant="inverted" primaryToken={token0} secondaryToken={token1} />}
       />
-      {showReward && <RewardStatusDisplay provider={provider} />}
+      {showReward && <RewardStatusDisplay provider={provider} multiplier={multiplier} />}
     </div>
   )
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -4182,6 +4182,7 @@
   "Smart contract wallets are currently not supported on Prediction. To continue, please switch back to an EOA (Externally Owned Account) wallet before interacting with the product.": "Smart contract wallets are currently not supported on Prediction. To continue, please switch back to an EOA (Externally Owned Account) wallet before interacting with the product.",
   "Earn Falcon Miles!": "Earn Falcon Miles!",
   "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.": "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
+  "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.": "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
   "Trade Binance Alpha Tokens to Win $250,000.": "Trade Binance Alpha Tokens to Win $250,000.",
   "Trade Alpha Tokens: Win $250K.": "Trade Alpha Tokens: Win $250K.",
   "Enter value between %min% and %max%": "Enter value between %min% and %max%",

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -4181,7 +4181,6 @@
   "Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to recover or prevent any losses from positions left unmanaged.": "Reminder: Users are responsible for managing and withdrawing their positions. PancakeSwap will not be able to recover or prevent any losses from positions left unmanaged.",
   "Smart contract wallets are currently not supported on Prediction. To continue, please switch back to an EOA (Externally Owned Account) wallet before interacting with the product.": "Smart contract wallets are currently not supported on Prediction. To continue, please switch back to an EOA (Externally Owned Account) wallet before interacting with the product.",
   "Earn Falcon Miles!": "Earn Falcon Miles!",
-  "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.": "LPs earns 40x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
   "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.": "LPs earns %multiplier%x Falcon's Miles based on total TVL contributed to the pool. Miles only accrue to positions within 0.95 to 1.05 range.",
   "Trade Binance Alpha Tokens to Win $250,000.": "Trade Binance Alpha Tokens to Win $250,000.",
   "Trade Alpha Tokens: Win $250K.": "Trade Alpha Tokens: Win $250K.",


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `RewardConfig` interface and updates various components to utilize a `multiplier` for rewards. It enhances reward-related functionality by allowing dynamic multipliers in both the `RewardInfoCard` and `RewardStatusDisplay`, and modifies related hooks and configurations.

### Detailed summary
- Added `RewardConfig` interface in `types.ts`.
- Updated `RewardInfoCard` and `RewardStatusDisplay` to accept a `multiplier` prop with a default value of 40.
- Modified text in both components to display dynamic multipliers.
- Enhanced `PoolInfo` and `PoolTokenOverview` to pass the `multiplier` to the respective components.
- Updated `rewardConfig` in `config.ts` to include multipliers for each pool.
- Refactored hooks in `hooks.ts` to include `getRewardConfig` and `getRewardMultiplier` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->