### PR TITLE
fix: Input parameters not being used

### DIFF
--- a/.changeset/cuddly-trains-repeat.md
+++ b/.changeset/cuddly-trains-repeat.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/multicall': patch
+---
+
+Fix input parameters not being used

--- a/packages/multicall/src/multicall.ts
+++ b/packages/multicall/src/multicall.ts
@@ -36,6 +36,7 @@ export async function multicallByGasLimit(
     signal,
     retryFailedCallsWithGreaterLimit,
     account,
+    blockConflictTolerance,
     ...rest
   }: CallByGasLimitParams,
 ) {
@@ -52,6 +53,7 @@ export async function multicallByGasLimit(
     dropUnexecutedCalls,
     signal,
     account,
+    blockConflictTolerance,
   })
   if (!retryFailedCallsWithGreaterLimit) {
     return callResult
@@ -89,6 +91,8 @@ export async function multicallByGasLimit(
       chainId,
       dropUnexecutedCalls,
       signal,
+      account,
+      blockConflictTolerance,
     })
     const resultsAfterRetry = [...result.results]
     for (const [retryIndex, originalIndex] of failedCallIndexes.entries()) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the usage of input parameters in the `multicallByGasLimit` function within the `multicall.ts` file.

### Detailed summary
- Added `blockConflictTolerance` to the parameters of the `multicallByGasLimit` function.
- Included `account` in the parameters for the same function.
- Updated the function's logic to utilize the new parameters correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->