### PR TITLE
fix: PAN 7397

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -126,6 +126,7 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
   const executionPriceDisplay = useMemo(() => {
     const price =
       SmartRouter.getExecutionPrice({
+        // TODO: to remove as UnifiedCurrencyAmount, SmartRouter will be updated to use UnifiedCurrencyAmount
         inputAmount: order?.trade?.inputAmount as UnifiedCurrencyAmount<Currency>,
         outputAmount: order?.trade?.outputAmount as UnifiedCurrencyAmount<Currency>,
       }) ?? undefined

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -126,9 +126,9 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
   const executionPriceDisplay = useMemo(() => {
     const price =
       SmartRouter.getExecutionPrice({
-        // TODO: to remove as UnifiedCurrencyAmount, SmartRouter will be updated to use UnifiedCurrencyAmount
-        inputAmount: order?.trade?.inputAmount as UnifiedCurrencyAmount<Currency>,
-        outputAmount: order?.trade?.outputAmount as UnifiedCurrencyAmount<Currency>,
+        // TODO: to remove as CurrencyAmount, SmartRouter will be updated to use UnifiedCurrencyAmount
+        inputAmount: order?.trade?.inputAmount as CurrencyAmount<Currency>,
+        outputAmount: order?.trade?.outputAmount as CurrencyAmount<Currency>,
       }) ?? undefined
     return formatExecutionPrice(price, inputAmount, outputAmount, showInverted)
   }, [order, inputAmount, outputAmount, showInverted])

--- a/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/SwapModalFooterV2.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Currency, CurrencyAmount, Percent, TradeType } from '@pancakeswap/sdk'
+import { Currency, CurrencyAmount, Percent, TradeType, UnifiedCurrencyAmount } from '@pancakeswap/sdk'
 import { SmartRouter } from '@pancakeswap/smart-router'
 import {
   AutoColumn,
@@ -124,7 +124,11 @@ export const SwapModalFooterV2 = memo(function SwapModalFooterV2({
   const severity = warningSeverity(priceImpactWithoutFee)
 
   const executionPriceDisplay = useMemo(() => {
-    const price = isSVMOrder(order) ? undefined : SmartRouter.getExecutionPrice(order?.trade) ?? undefined
+    const price =
+      SmartRouter.getExecutionPrice({
+        inputAmount: order?.trade?.inputAmount as UnifiedCurrencyAmount<Currency>,
+        outputAmount: order?.trade?.outputAmount as UnifiedCurrencyAmount<Currency>,
+      }) ?? undefined
     return formatExecutionPrice(price, inputAmount, outputAmount, showInverted)
   }, [order, inputAmount, outputAmount, showInverted])
 

--- a/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
+++ b/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
@@ -1,16 +1,15 @@
-import { Currency, Price, UnifiedCurrencyAmount, ZERO } from '@pancakeswap/sdk'
+import { Currency, Price, TradeType, ZERO } from '@pancakeswap/sdk'
 
-interface GetExecutionPriceParams {
-  inputAmount?: UnifiedCurrencyAmount<Currency>
-  outputAmount?: UnifiedCurrencyAmount<Currency>
-}
+import { SmartRouterTrade } from '../types'
 
-export function getExecutionPrice(params?: GetExecutionPriceParams): Price<Currency, Currency> | undefined {
-  if (!params) {
+export function getExecutionPrice(
+  trade: Pick<SmartRouterTrade<TradeType>, 'inputAmount' | 'outputAmount'> | undefined | null,
+): Price<Currency, Currency> | undefined {
+  if (!trade) {
     return undefined
   }
 
-  const { inputAmount, outputAmount } = params
+  const { inputAmount, outputAmount } = trade
 
   if (!inputAmount || !outputAmount) {
     return undefined
@@ -19,6 +18,5 @@ export function getExecutionPrice(params?: GetExecutionPriceParams): Price<Curre
   if (inputAmount.quotient === ZERO || outputAmount.quotient === ZERO) {
     return undefined
   }
-
   return new Price(inputAmount.currency, outputAmount.currency, inputAmount.quotient, outputAmount.quotient)
 }

--- a/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
+++ b/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
@@ -1,16 +1,12 @@
-import { Currency, Price, TradeType, ZERO } from '@pancakeswap/sdk'
+import { Currency, Price, UnifiedCurrencyAmount, ZERO } from '@pancakeswap/sdk'
 
-import { SmartRouterTrade } from '../types'
-
-export function getExecutionPrice(
-  trade: Pick<SmartRouterTrade<TradeType>, 'inputAmount' | 'outputAmount'> | undefined | null,
-): Price<Currency, Currency> | undefined {
-  if (!trade) {
-    return undefined
-  }
-
-  const { inputAmount, outputAmount } = trade
-
+export function getExecutionPrice({
+  inputAmount,
+  outputAmount,
+}: {
+  inputAmount?: UnifiedCurrencyAmount<Currency>
+  outputAmount?: UnifiedCurrencyAmount<Currency>
+}): Price<Currency, Currency> | undefined {
   if (!inputAmount || !outputAmount) {
     return undefined
   }
@@ -18,5 +14,6 @@ export function getExecutionPrice(
   if (inputAmount.quotient === ZERO || outputAmount.quotient === ZERO) {
     return undefined
   }
+
   return new Price(inputAmount.currency, outputAmount.currency, inputAmount.quotient, outputAmount.quotient)
 }

--- a/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
+++ b/packages/smart-router/evm/v3-router/utils/getExecutionPrice.ts
@@ -1,12 +1,17 @@
 import { Currency, Price, UnifiedCurrencyAmount, ZERO } from '@pancakeswap/sdk'
 
-export function getExecutionPrice({
-  inputAmount,
-  outputAmount,
-}: {
+interface GetExecutionPriceParams {
   inputAmount?: UnifiedCurrencyAmount<Currency>
   outputAmount?: UnifiedCurrencyAmount<Currency>
-}): Price<Currency, Currency> | undefined {
+}
+
+export function getExecutionPrice(params?: GetExecutionPriceParams): Price<Currency, Currency> | undefined {
+  if (!params) {
+    return undefined
+  }
+
+  const { inputAmount, outputAmount } = params
+
   if (!inputAmount || !outputAmount) {
     return undefined
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `SwapModalFooterV2` component by modifying how the execution price is calculated, transitioning to use `UnifiedCurrencyAmount` for better consistency and future-proofing.

### Detailed summary
- Added `UnifiedCurrencyAmount` import to the file.
- Changed the execution price calculation to use `SmartRouter.getExecutionPrice` with `inputAmount` and `outputAmount` cast as `CurrencyAmount<Currency>`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->