### PR TITLE
fix: PAN 7499

### DIFF
--- a/apps/web/src/hooks/useAddressBalance.ts
+++ b/apps/web/src/hooks/useAddressBalance.ts
@@ -56,8 +56,12 @@ export const useAddressBalance = (address?: string, options: UseAddressBalanceOp
   const list = useCombinedActiveList()
 
   const isListedToken = useCallback(
-    (chainId: ChainId, tokenAddress: string): boolean => {
-      return isNative(tokenAddress) || Boolean(list[chainId]?.[safeGetAddress(tokenAddress) ?? ''])
+    (chainId: ChainId | NonEVMChainId, tokenAddress: string): boolean => {
+      return (
+        chainId === NonEVMChainId.SOLANA ||
+        isNative(tokenAddress) ||
+        Boolean(list[chainId]?.[safeGetAddress(tokenAddress) ?? ''])
+      )
     },
     [list],
   )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `isListedToken` function in the `useAddressBalance.ts` file to support an additional `NonEVMChainId` for `SOLANA`, improving its ability to determine if a token is listed across different blockchain types.

### Detailed summary
- Modified the parameter type of `chainId` from `ChainId` to `ChainId | NonEVMChainId`.
- Added a condition to check if `chainId` is equal to `NonEVMChainId.SOLANA`.
- Wrapped the return statement in parentheses for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->