### PR TITLE
feat: Candlestick Price Charts for Add Liquidity

### DIFF
--- a/apps/web/src/components/AdPanel/DesktopCard.tsx
+++ b/apps/web/src/components/AdPanel/DesktopCard.tsx
@@ -27,7 +27,6 @@ export const DesktopCard = ({
 
   // Apply left class when chart is displayed and swap details are open
   const shouldApplyLeftClass = isChartDisplayed && isSwapDetailsOpen
-  console.log('shouldApplyLeftClass', { isChartDisplayed, isSwapDetailsOpen, shouldApplyLeftClass })
 
   return shouldRender && isDesktop && show ? (
     <FloatingContainer className={shouldApplyLeftClass ? 'left' : ''}>

--- a/apps/web/src/components/Liquidity/Form/FieldLiquidityShape.tsx
+++ b/apps/web/src/components/Liquidity/Form/FieldLiquidityShape.tsx
@@ -18,6 +18,7 @@ export const FieldLiquidityShape: React.FC<FieldLiquidityShapeProps> = ({ ...box
           href="https://docs.pancakeswap.finance/trade/pancakeswap-infinity/pool-types"
           fontSize="12px"
           textTransform="uppercase"
+          color="primary60"
         >
           {t('Learn More')}
         </ScanLink>

--- a/apps/web/src/components/PoolInfoHeader/index.tsx
+++ b/apps/web/src/components/PoolInfoHeader/index.tsx
@@ -7,7 +7,6 @@ import {
   Box,
   BscScanIcon,
   Card,
-  CardBody,
   CopyButton,
   Flex,
   FlexGap,
@@ -260,8 +259,12 @@ export const PoolInfoHeader = ({
             </FlexGap>
           </FlexGap>
           {poolInfo && (
-            <FlexGap gap="16px" flexDirection={['column', null, 'row']}>
-              <Box p="8px 16px" width="100%">
+            <FlexGap
+              gap={isMobile ? '20px' : '16px'}
+              flexDirection={isMobile ? 'row-reverse' : 'row'}
+              alignItems="center"
+            >
+              <Box py="8px" width="100%">
                 <FlexGap gap="2px" alignItems="center">
                   <Text
                     fontSize={12}
@@ -277,7 +280,7 @@ export const PoolInfoHeader = ({
                 </FlexGap>
                 <FlexGap gap="8px" alignItems="center" width="100%">
                   {poolInfo && (
-                    <Text fontSize={24} bold width="max-content">
+                    <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
                       {formatNumber(Number(isInverted ? poolInfo.token0Price : poolInfo.token1Price), {
                         maximumSignificantDigits: 6,
                         maxDecimalDisplayDigits: 6,
@@ -301,7 +304,7 @@ export const PoolInfoHeader = ({
                   </Text>
                 </FlexGap>
               </Box>
-              <Box padding="8px 16px">
+              <Box py="8px">
                 <AutoColumn rowGap="2px">
                   <FlexGap>
                     <Text fontSize={12} bold color="textSubtle" textTransform="uppercase" width="max-content">
@@ -313,7 +316,7 @@ export const PoolInfoHeader = ({
                         showApyText={false}
                         color="text"
                         aprInfo={getFarmAprInfo(poolInfo.farm)}
-                        fontSize="24px"
+                        fontSize={isMobile ? '20px' : '24px'}
                       />
                     )}
                   </FlexGap>
@@ -323,7 +326,7 @@ export const PoolInfoHeader = ({
                       showApyButton={false}
                       color="text"
                       aprInfo={getFarmAprInfo(poolInfo.farm)}
-                      fontSize="24px"
+                      fontSize={isMobile ? '20px' : '24px'}
                     />
                   )}
                 </AutoColumn>

--- a/apps/web/src/hooks/v3/usePoolTickData.ts
+++ b/apps/web/src/hooks/v3/usePoolTickData.ts
@@ -89,6 +89,7 @@ export function usePoolActiveLiquidity(
     pool,
     ticks,
   })
+
   return useMemo(() => {
     if (
       !currencyA ||
@@ -133,7 +134,7 @@ export function useActiveLiquidityByPool({
 } {
   const activeTick = useMemo(() => getActiveTick(pool?.tickCurrent, tickSpacing), [pool, tickSpacing])
   return useMemo(() => {
-    if (!currencyA || !currencyB || !ticks || !activeTick) {
+    if (!currencyA || !currencyB || !ticks || activeTick === undefined) {
       return {
         data: undefined,
         activeTick,

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -145,6 +145,12 @@ export const CLPriceRangePanel = () => {
               {t('Position Range')}
             </Text>
           </FlexGap>
+          <FlexGap gap="8px" alignItems="center">
+            <Dot color="input" show />
+            <Text color="textSubtle" small>
+              {t('Liquidity Depth')}
+            </Text>
+          </FlexGap>
         </FlexGap>
       </FlexGap>
       <Box mt="22px" border="1px solid" borderColor="cardBorder" borderRadius="24px" p="8px 8px 2px">

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -147,7 +147,7 @@ export const CLPriceRangePanel = () => {
           </FlexGap>
         </FlexGap>
       </FlexGap>
-      <Box mt="22px" border="1px solid" borderColor="cardBorder" borderRadius="24px" p="8px">
+      <Box mt="22px" border="1px solid" borderColor="cardBorder" borderRadius="24px" p="8px 8px 2px">
         <FlexGap
           flexDirection={isMobile ? 'column' : 'row'}
           justifyContent={isMobile ? 'flex-start' : 'space-between'}

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -12,8 +12,6 @@ import { useCLPriceRangeCallback } from 'hooks/infinity/useCLPriceRangeCallback'
 import { useCurrencyByPoolId } from 'hooks/infinity/useCurrencyByPoolId'
 import { useCallback, useMemo, useState } from 'react'
 import { useInverted } from 'state/infinity/shared'
-
-import { getTokenSymbolAlias } from 'utils/getTokenAlias'
 import { useCLDensityChartData } from '../hooks/useDensityChartData'
 import { usePool } from '../hooks/usePool'
 import { useTicksAtLimit } from '../hooks/useTicksAtLimit'
@@ -117,8 +115,10 @@ export const CLPriceRangePanel = () => {
     if (ticksAtLimit[Bound.UPPER]) {
       return defaultZoom
     }
+
     const min = Number(lowerPrice?.divide(rawPrice ?? 1).toSignificant(6) ?? 1)
     const max = Number(upperPrice?.divide(rawPrice ?? 1).toSignificant(6) ?? 1)
+
     return {
       ...defaultZoom,
       initialMin: min * defaultZoom.initialMin,
@@ -127,18 +127,10 @@ export const CLPriceRangePanel = () => {
   }, [ticksAtLimit, quickAction, pool?.tickSpacing, lowerPrice, rawPrice, upperPrice])
 
   const axisTicks = useMemo(() => getAxisTicks(pricePeriod.value, isMobile), [pricePeriod.value, isMobile])
-  const symbol0 = useMemo(
-    () => getTokenSymbolAlias(currency0?.wrapped?.address, currency0?.chainId, currency0?.symbol),
-    [currency0],
-  )
-  const symbol1 = useMemo(
-    () => getTokenSymbolAlias(currency1?.wrapped?.address, currency1?.chainId, currency1?.symbol),
-    [currency1],
-  )
 
   return (
     <>
-      <FlexGap gap="8px" justifyContent="space-between" alignItems="center">
+      <FlexGap gap="8px" justifyContent="space-between" alignItems="center" flexWrap="wrap">
         <PreTitle>{t('Set position range')}</PreTitle>
         <FlexGap gap="8px" alignItems="center">
           <FlexGap gap="8px" alignItems="center">

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -1,8 +1,9 @@
 import { Protocol } from '@pancakeswap/farms'
 import { useTranslation } from '@pancakeswap/localization'
-import { Box, FlexGap, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Dot } from 'views/Notifications/styles'
+import { Box, FlexGap, PreTitle, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { getPriceOfCurrency } from '@pancakeswap/v3-sdk'
-import { Liquidity, PricePeriodRangeChart } from '@pancakeswap/widgets-internal'
+import { Card, Liquidity, PricePeriodRangeChart } from '@pancakeswap/widgets-internal'
 import { CLRangeSelector } from 'components/Liquidity/Form/CLRangeSelector'
 import { Bound } from 'config/constants/types'
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
@@ -137,52 +138,62 @@ export const CLPriceRangePanel = () => {
 
   return (
     <>
-      <FlexGap
-        flexDirection={isMobile ? 'column' : 'row'}
-        justifyContent={isMobile ? 'flex-start' : 'space-between'}
-        gap="16px"
-      >
-        <Liquidity.PriceRangeDatePicker onChange={setPricePeriod} value={pricePeriod} />
-        <Liquidity.RateToggle
-          currencyA={inverted ? currency1 : currency0}
-          handleRateToggle={() => {
-            setIsInverted(!inverted)
-          }}
-          showReset={false}
-        />
+      <FlexGap gap="8px" justifyContent="space-between" alignItems="center">
+        <PreTitle>{t('Set position range')}</PreTitle>
+        <FlexGap gap="8px" alignItems="center">
+          <FlexGap gap="8px" alignItems="center">
+            <Dot color="primary" show />
+            <Text color="textSubtle" small>
+              {t('Current Price')}
+            </Text>
+          </FlexGap>
+          <FlexGap gap="8px" alignItems="center">
+            <Dot color="secondary" show />
+            <Text color="textSubtle" small>
+              {t('Position Range')}
+            </Text>
+          </FlexGap>
+        </FlexGap>
       </FlexGap>
-      <FlexGap gap="2px" mt="8px" mb="-16px">
-        <Text color="textSubtle" small>
-          {t('Current Price')}: {price}
-        </Text>
-        <Text color="textSubtle" small>
-          {t('%assetA% per %assetB%', {
-            assetA: inverted ? symbol0 : symbol1,
-            assetB: inverted ? symbol1 : symbol0,
-          })}
-        </Text>
-      </FlexGap>
-      <Box mb="8px">
-        <PricePeriodRangeChart
-          isLoading={isChartDataLoading}
-          key={currency0?.wrapped.address}
-          zoomLevel={zoom}
-          baseCurrency={baseCurrency}
-          quoteCurrency={quoteCurrency}
-          ticksAtLimit={ticksAtLimit}
-          price={price}
-          priceLower={lowerPrice}
-          priceUpper={upperPrice}
-          onBothRangeInput={onChangeBothPrice}
-          onMinPriceInput={onChangeMinPrice}
-          onMaxPriceInput={onChangeMaxPrice}
-          formattedData={formattedData}
-          priceHistoryData={rateData}
-          axisTicks={axisTicks}
-          interactive
-        />
+      <Box mt="22px" border="1px solid" borderColor="cardBorder" borderRadius="24px" p="8px">
+        <FlexGap
+          flexDirection={isMobile ? 'column' : 'row'}
+          justifyContent={isMobile ? 'flex-start' : 'space-between'}
+          gap="16px"
+        >
+          <Liquidity.PriceRangeDatePicker onChange={setPricePeriod} value={pricePeriod} />
+          <Liquidity.RateToggle
+            currencyA={inverted ? currency1 : currency0}
+            handleRateToggle={() => {
+              setIsInverted(!inverted)
+            }}
+            showReset={false}
+          />
+        </FlexGap>
+
+        <Box mt="16px">
+          <PricePeriodRangeChart
+            isLoading={isChartDataLoading}
+            key={currency0?.wrapped.address}
+            zoomLevel={zoom}
+            baseCurrency={baseCurrency}
+            quoteCurrency={quoteCurrency}
+            ticksAtLimit={ticksAtLimit}
+            price={price}
+            priceLower={lowerPrice}
+            priceUpper={upperPrice}
+            onBothRangeInput={onChangeBothPrice}
+            onMinPriceInput={onChangeMinPrice}
+            onMaxPriceInput={onChangeMaxPrice}
+            formattedData={formattedData}
+            priceHistoryData={rateData}
+            axisTicks={axisTicks}
+            interactive
+          />
+        </Box>
       </Box>
-      <Box mb="8px">
+
+      <Box mt="22px" mb="8px">
         <CLRangeSelector
           currentPrice={rawPrice}
           baseCurrency={baseCurrency}

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -132,7 +132,7 @@ export const CLPriceRangePanel = () => {
     <>
       <FlexGap gap="8px" justifyContent="space-between" alignItems="center" flexWrap="wrap">
         <PreTitle>{t('Set position range')}</PreTitle>
-        <FlexGap gap="8px" alignItems="center">
+        <FlexGap gap="8px" alignItems="center" flexWrap="wrap">
           <FlexGap gap="8px" alignItems="center">
             <Dot color="primary" show />
             <Text color="textSubtle" small>

--- a/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/CLPriceRangePanel.tsx
@@ -24,7 +24,7 @@ export const CLPriceRangePanel = () => {
   const { poolId, chainId } = useInfinityPoolIdRouteParams()
   const { currency0, currency1, baseCurrency, quoteCurrency } = useCurrencyByPoolId({ poolId, chainId })
   const pool = usePool<'CL'>()
-  const [inverted, setIsInverted] = useInverted()
+  const [inverted] = useInverted()
   const [pricePeriod, setPricePeriod] = useState<Liquidity.PresetRangeItem>(Liquidity.PRESET_RANGE_ITEMS[0])
   const { lowerPrice, upperPrice } = useCLPriceRange(currency0, currency1, pool?.tickSpacing ?? undefined)
 
@@ -160,13 +160,6 @@ export const CLPriceRangePanel = () => {
           gap="16px"
         >
           <Liquidity.PriceRangeDatePicker onChange={setPricePeriod} value={pricePeriod} />
-          <Liquidity.RateToggle
-            currencyA={inverted ? currency1 : currency0}
-            handleRateToggle={() => {
-              setIsInverted(!inverted)
-            }}
-            showReset={false}
-          />
         </FlexGap>
 
         <Box mt="16px">

--- a/apps/web/src/views/AddLiquidityInfinity/components/InfinityPoolInfoHeader.tsx
+++ b/apps/web/src/views/AddLiquidityInfinity/components/InfinityPoolInfoHeader.tsx
@@ -1,4 +1,5 @@
 import { Protocol } from '@pancakeswap/farms'
+import { useMatchBreakpoints } from '@pancakeswap/uikit'
 import { PoolInfoHeader } from 'components/PoolInfoHeader'
 import { useInfinityPoolIdRouteParams } from 'hooks/dynamicRoute/usePoolIdRoute'
 import { useCurrencyByPoolId } from 'hooks/infinity/useCurrencyByPoolId'
@@ -14,7 +15,7 @@ import {
 
 export const InfinityPoolInfoHeader = () => {
   const { chainId, poolId } = useInfinityPoolIdRouteParams()
-
+  const { isMobile } = useMatchBreakpoints()
   const poolInfo = usePoolInfo({ poolAddress: poolId, chainId })
   const hookData = useHookByPoolId(chainId, poolId)
   const { currency0, currency1 } = useCurrencyByPoolId({ chainId, poolId })
@@ -46,9 +47,9 @@ export const InfinityPoolInfoHeader = () => {
       overrideAprDisplay={{
         aprDisplay: poolInfo ? (
           poolInfo.protocol === Protocol.InfinityCLAMM ? (
-            <InfinityCLPoolDerivedAprButton pool={poolInfo} fontSize="24px" />
+            <InfinityCLPoolDerivedAprButton pool={poolInfo} fontSize={isMobile ? '20px' : '24px'} />
           ) : poolInfo.protocol === Protocol.InfinityBIN ? (
-            <InfinityBinPoolDerivedAprButton pool={poolInfo} fontSize="24px" />
+            <InfinityBinPoolDerivedAprButton pool={poolInfo} fontSize={isMobile ? '20px' : '24px'} />
           ) : (
             '-'
           )

--- a/apps/web/src/views/AddLiquidityInfinity/components/useTokenToTokenRateData.ts
+++ b/apps/web/src/views/AddLiquidityInfinity/components/useTokenToTokenRateData.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@pancakeswap/farms'
 import { Currency, isCurrencySorted } from '@pancakeswap/swap-sdk-core'
 import { useQuery } from '@tanstack/react-query'
 import { QUERY_SETTINGS_IMMUTABLE, QUERY_SETTINGS_WITHOUT_INTERVAL_REFETCH } from 'config/constants'
@@ -13,7 +14,7 @@ import type { Address } from 'viem/accounts'
 interface IRateDataProps {
   period: APISchema['schemas']['ChartPeriod']
   poolId?: Address
-  protocol: InfinityProtocol
+  protocol: InfinityProtocol | Protocol.V3
   chainId?: number
 }
 
@@ -80,6 +81,7 @@ const generateDateSequence = (period: APISchema['schemas']['ChartPeriod']) => {
   }))
 }
 
+// Token Rate Data for Infinity and V3
 export const useTokenRateData = ({
   chainId,
   poolId,

--- a/apps/web/src/views/AddLiquidityInfinity/components/useTokenToTokenRateData.ts
+++ b/apps/web/src/views/AddLiquidityInfinity/components/useTokenToTokenRateData.ts
@@ -91,6 +91,7 @@ export const useTokenRateData = ({
   quoteCurrency,
 }: ITokenRateProps) => {
   const { data: rateData, isLoading } = usePoolRateData({ chainId, poolId, protocol, period })
+
   const isSorted = useMemo(
     () => baseCurrency && quoteCurrency && isCurrencySorted(baseCurrency, quoteCurrency),
     [baseCurrency, quoteCurrency],
@@ -158,41 +159,61 @@ const usePoolRateData = ({ chainId, poolId, protocol, period }: IRateDataProps) 
       high: Number(d.high),
       low: Number(d.low),
     }))
-    return generateDateSequence(period).map((seqPoint) => {
-      const before = resp?.findLast((d) => +d.time <= +seqPoint.time)
-      const after = resp?.find((d) => +d.time > +seqPoint.time)
 
-      if (before && +before.time === +seqPoint.time) {
+    if (!resp || resp.length === 0) {
+      return generateDateSequence(period)
+    }
+
+    // Actual data range from API
+    const firstDataTime = Math.min(...resp.map((d) => +d.time))
+    const lastDataTime = Math.max(...resp.map((d) => +d.time))
+
+    return generateDateSequence(period).map((seqPoint) => {
+      const seqTime = +seqPoint.time
+
+      // If sequence point is outside API data range, return zero values
+      if (seqTime < firstDataTime || seqTime > lastDataTime) {
+        return seqPoint
+      }
+
+      const before = resp?.findLast((d) => +d.time <= seqTime)
+      const after = resp?.find((d) => +d.time > seqTime)
+
+      // Exact match
+      if (before && +before.time === seqTime) {
         return {
           ...before,
           time: seqPoint.time,
         }
       }
+
+      // In case no data available
       if (!before && !after) {
         return seqPoint
       }
-      if (!after) {
+
+      // Only delve between actual data points
+      if (before && after) {
+        const totalTimeDiff = +after.time - +before.time
+        const pointTimeDiff = seqTime - +before.time
+        const ratio = pointTimeDiff / totalTimeDiff
         return {
-          ...before,
           time: seqPoint.time,
+          open: before.open + (after.open - before.open) * ratio,
+          close: before.close + (after.close - before.close) * ratio,
+          high: before.high + (after.high - before.high) * ratio,
+          low: before.low + (after.low - before.low) * ratio,
         }
       }
-      if (!before) {
-        return {
-          ...after,
-          time: seqPoint.time,
-        }
-      }
-      const totalTimeDiff = +after.time - +before.time
-      const pointTimeDiff = +seqPoint.time - +before.time
-      const ratio = pointTimeDiff / totalTimeDiff
-      return {
-        time: seqPoint.time,
-        open: before.open + (after.open - before.open) * ratio,
-        close: before.close + (after.close - before.close) * ratio,
-        high: before.high + (after.high - before.high) * ratio,
-        low: before.low + (after.low - before.low) * ratio,
-      }
+
+      // Edge case: use closest available value
+      const closestPoint = before || after
+      return closestPoint
+        ? {
+            ...closestPoint,
+            time: seqPoint.time,
+          }
+        : seqPoint
     })
   }, [period, rateDataFromAPI?.data])
 

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/V3RangeSelector.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/components/V3RangeSelector.tsx
@@ -234,7 +234,7 @@ export default function V3RangeSelector({
 
   return (
     <AutoColumn gap="8px">
-      <FlexGap gap="16px" width="100%">
+      <FlexGap gap="8px" width="100%" flexDirection={['column', null, null, 'row']}>
         <StepCounter
           value={leftValue}
           onUserInput={onLeftRangeInput}

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -1,4 +1,7 @@
+import { Protocol } from '@pancakeswap/farms'
+import { useTranslation } from '@pancakeswap/localization'
 import { Currency, CurrencyAmount, Percent } from '@pancakeswap/sdk'
+import { Price } from '@pancakeswap/swap-sdk-core'
 import {
   AutoColumn,
   AutoRow,
@@ -8,78 +11,81 @@ import {
   CardBody,
   Column,
   DynamicSection,
+  FlexGap,
   Message,
   MessageText,
   PreTitle,
   RowBetween,
   Text,
   Toggle,
+  useMatchBreakpoints,
   useModal,
 } from '@pancakeswap/uikit'
+import { useIsExpertMode, useUserSlippage } from '@pancakeswap/utils/user'
+import { FeeAmount, NonfungiblePositionManager, Pool } from '@pancakeswap/v3-sdk'
 import {
   ConfirmationModalContent,
   Liquidity,
-  LiquidityChartRangeInput,
   NumericalInput,
+  PricePeriodRangeChart,
   ZOOM_LEVELS,
   ZoomLevels,
 } from '@pancakeswap/widgets-internal'
-import { tryParsePrice } from 'hooks/v3/utils'
-import { useCurrencyInversionEvent } from 'views/AddLiquidityV3/hooks/useHeaderInvertCurrencies'
+import BigNumber from 'bignumber.js'
+import CurrencyInputPanelSimplify from 'components/CurrencyInputPanelSimplify'
+import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
+import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
+import { Bound } from 'config/constants/types'
+import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
+import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
+import useAccountActiveChain from 'hooks/useAccountActiveChain'
+import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
+import { useV3NFTPositionManagerContract } from 'hooks/useContract'
 import useNativeCurrency from 'hooks/useNativeCurrency'
+import { usePoolMarketPriceSlippage } from 'hooks/usePoolMarketPriceSlippage'
+import { useTransactionDeadline } from 'hooks/useTransactionDeadline'
+import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
+import { tryParsePrice } from 'hooks/v3/utils'
+import { useRouter } from 'next/router'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTransactionAdder } from 'state/transactions/hooks'
+import { styled } from 'styled-components'
+import { calculateGasMargin } from 'utils'
 import {
   logGTMAddLiquidityTxSentEvent,
   logGTMClickAddLiquidityConfirmEvent,
   logGTMClickAddLiquidityEvent,
 } from 'utils/customGTMEventTracking'
-import { formatDollarAmount } from 'views/V3Info/utils/numbers'
-import { useNativeCurrencyInstead } from 'views/AddLiquidityV3/hooks/useNativeCurrencyInstead'
-import { useIsExpertMode, useUserSlippage } from '@pancakeswap/utils/user'
-import { FeeAmount, NonfungiblePositionManager, Pool } from '@pancakeswap/v3-sdk'
-import { useTransactionDeadline } from 'hooks/useTransactionDeadline'
-import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { SlippageButton } from 'views/Swap/components/SlippageButton'
-import { ApprovalState, useApproveCallback } from 'hooks/useApproveCallback'
 import { basisPointsToPercent } from 'utils/exchange'
-import { maxAmountSpend } from 'utils/maxAmountSpend'
-import { CurrencyField as Field } from 'utils/types'
-import { useTranslation } from '@pancakeswap/localization'
-import TransactionConfirmationModal from 'components/TransactionConfirmationModal'
-import { Bound } from 'config/constants/types'
-import { useIsTransactionUnsupported, useIsTransactionWarning } from 'hooks/Trades'
-import { useV3NFTPositionManagerContract } from 'hooks/useContract'
-import { useRouter } from 'next/router'
-import { useTransactionAdder } from 'state/transactions/hooks'
-import { styled } from 'styled-components'
-import { calculateGasMargin } from 'utils'
 import { formatCurrencyAmount, formatRawAmount } from 'utils/formatCurrencyAmount'
+import { maxAmountSpend } from 'utils/maxAmountSpend'
 import { isUserRejected } from 'utils/sentry'
+import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
+import { CurrencyField as Field } from 'utils/types'
 import { getViemClients } from 'utils/viem'
 import { hexToBigInt } from 'viem'
+import { useTokenRateData } from 'views/AddLiquidityInfinity/components/useTokenToTokenRateData'
+import { getAxisTicks } from 'views/AddLiquidityInfinity/utils'
 import { V3SubmitButton } from 'views/AddLiquidityV3/components/V3SubmitButton'
-import { HandleFeePoolSelectFn, QUICK_ACTION_CONFIGS } from 'views/AddLiquidityV3/types'
-import { useSendTransaction, useWalletClient } from 'wagmi'
-import { Price } from '@pancakeswap/swap-sdk-core'
-import BigNumber from 'bignumber.js'
-import { ZapLiquidityWidget } from 'components/ZapLiquidityWidget'
-import { ZAP_V3_POOL_ADDRESSES } from 'config/constants/zapV3'
-import CurrencyInputPanelSimplify from 'components/CurrencyInputPanelSimplify'
-import useAccountActiveChain from 'hooks/useAccountActiveChain'
-import { usePoolMarketPriceSlippage } from 'hooks/usePoolMarketPriceSlippage'
-import { transactionErrorToUserReadableMessage } from 'utils/transactionErrorToUserReadableMessage'
 import { useDensityChartData } from 'views/AddLiquidityV3/hooks/useDensityChartData'
+import { useCurrencyInversionEvent } from 'views/AddLiquidityV3/hooks/useHeaderInvertCurrencies'
+import { useNativeCurrencyInstead } from 'views/AddLiquidityV3/hooks/useNativeCurrencyInstead'
+import { HandleFeePoolSelectFn, QUICK_ACTION_CONFIGS } from 'views/AddLiquidityV3/types'
 import { MarketPriceSlippageWarning } from 'views/CreateLiquidityPool/components/SubmitCreateButton'
 import { MevProtectToggle } from 'views/Mev/MevProtectToggle'
+import { Dot } from 'views/Notifications/styles'
+import { SlippageButton } from 'views/Swap/components/SlippageButton'
+import { formatDollarAmount } from 'views/V3Info/utils/numbers'
+import { useSendTransaction, useWalletClient } from 'wagmi'
+import { useTotalUsdValue } from '../../../AddLiquidity/hooks/useTotalUsdValue'
+import FeeSelector from './components/FeeSelector'
+import LockedDeposit from './components/LockedDeposit'
+import { PositionPreview } from './components/PositionPreview'
 import V3RangeSelector from './components/V3RangeSelector'
 import { useInitialRange } from './form/hooks/useInitialRange'
 import { useRangeHopCallbacks } from './form/hooks/useRangeHopCallbacks'
 import { useV3MintActionHandlers } from './form/hooks/useV3MintActionHandlers'
 import { useV3FormAddLiquidityCallback, useV3FormState } from './form/reducer'
-import FeeSelector from './components/FeeSelector'
-import LockedDeposit from './components/LockedDeposit'
-import { PositionPreview } from './components/PositionPreview'
-import { useTotalUsdValue } from '../../../AddLiquidity/hooks/useTotalUsdValue'
 
 const StyledInput = styled(NumericalInput)`
   background-color: ${({ theme }) => theme.colors.input};
@@ -113,6 +119,7 @@ export default function V3FormView({
   currencyIdB,
 }: V3FormViewPropsType) {
   const router = useRouter()
+  const { isMobile } = useMatchBreakpoints()
   const { data: signer } = useWalletClient()
   const { sendTransactionAsync } = useSendTransaction()
   const native = useNativeCurrency()
@@ -135,6 +142,9 @@ export default function V3FormView({
   const positionManager = useV3NFTPositionManagerContract()
   const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const addTransaction = useTransactionAdder()
+
+  const [pricePeriod, setPricePeriod] = useState<Liquidity.PresetRangeItem>(Liquidity.PRESET_RANGE_ITEMS[0])
+  const axisTicks = useMemo(() => getAxisTicks(pricePeriod.value, isMobile), [pricePeriod.value, isMobile])
 
   // mint state
   const formState = useV3FormState()
@@ -623,6 +633,26 @@ export default function V3FormView({
     formattedAmounts,
   ])
 
+  const handleRateToggle = useCallback(() => {
+    if (!router.isReady || !currencyIdA || !currencyIdB) return
+
+    invertRange()
+
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: {
+          ...router.query,
+          currency: [currencyIdB!, currencyIdA!, feeAmount ? feeAmount.toString() : ''],
+        },
+      },
+      undefined,
+      {
+        shallow: true,
+      },
+    )
+  }, [invertRange, currencyIdA, currencyIdB, feeAmount, router, invertPrice, priceLower, priceUpper])
+
   const inversionEvent = useCurrencyInversionEvent()
 
   useEffect(() => {
@@ -642,6 +672,16 @@ export default function V3FormView({
     currencyA: baseCurrency ?? undefined,
     currencyB: quoteCurrency ?? undefined,
     feeAmount,
+  })
+
+  // Price Rate Data
+  const { data: rateData } = useTokenRateData({
+    period: pricePeriod.value,
+    protocol: Protocol.V3,
+    baseCurrency: baseCurrency ?? undefined,
+    quoteCurrency: quoteCurrency ?? undefined,
+    chainId: baseCurrency?.chainId,
+    poolId: pool ? Pool.getAddress(pool.token0, pool.token1, pool.fee) : undefined,
   })
 
   return (
@@ -681,81 +721,64 @@ export default function V3FormView({
                 </Box>
               )}
               <DynamicSection disabled={!feeAmount || invalidPool}>
-                <RowBetween mb="8px">
-                  <PreTitle>{t('Set Price Range')}</PreTitle>
-                  <Liquidity.RateToggle
-                    currencyA={baseCurrency}
-                    handleRateToggle={() => {
-                      invertRange()
+                <FlexGap gap="8px" justifyContent="space-between" alignItems="center">
+                  <PreTitle>{t('Set position range')}</PreTitle>
+                  <FlexGap gap="8px" alignItems="center">
+                    <FlexGap gap="8px" alignItems="center">
+                      <Dot color="primary" show />
+                      <Text color="textSubtle" small>
+                        {t('Current Price')}
+                      </Text>
+                    </FlexGap>
+                    <FlexGap gap="8px" alignItems="center">
+                      <Dot color="secondary" show />
+                      <Text color="textSubtle" small>
+                        {t('Position Range')}
+                      </Text>
+                    </FlexGap>
+                  </FlexGap>
+                </FlexGap>
 
-                      router.replace(
-                        {
-                          pathname: router.pathname,
-                          query: {
-                            ...router.query,
-                            currency: [currencyIdB!, currencyIdA!, feeAmount ? feeAmount.toString() : ''],
-                          },
-                        },
-                        undefined,
-                        {
-                          shallow: true,
-                        },
-                      )
-                    }}
-                  />
-                </RowBetween>
+                <Box mt="22px" border="1px solid" borderColor="cardBorder" borderRadius="24px" p="8px">
+                  <FlexGap
+                    flexDirection={isMobile ? 'column' : 'row'}
+                    justifyContent={isMobile ? 'flex-start' : 'space-between'}
+                    gap="16px"
+                    mb="24px"
+                  >
+                    <Liquidity.PriceRangeDatePicker onChange={setPricePeriod} value={pricePeriod} />
+                    <Liquidity.RateToggle currencyA={baseCurrency} handleRateToggle={handleRateToggle} />
+                  </FlexGap>
 
-                {!noLiquidity && (
-                  <>
-                    {price && baseCurrency && quoteCurrency && !noLiquidity && (
-                      <AutoRow
-                        gap="4px"
-                        marginBottom={['24px', '0px']}
-                        justifyContent="center"
-                        style={{ marginTop: '0.5rem' }}
-                      >
-                        <Text fontWeight={500} textAlign="center" fontSize={12} color="text1">
-                          {t('Current Price')}:
-                        </Text>
-                        <Text fontWeight={500} textAlign="center" fontSize={12} color="text1">
-                          {invertPrice ? price.invert().toSignificant(6) : price.toSignificant(6)}
-                        </Text>
-                        <Text color="text2" fontSize={12}>
-                          {t('%assetA% per %assetB%', {
-                            assetA: quoteCurrency?.symbol ?? '',
-                            assetB: baseCurrency.symbol ?? '',
-                          })}
-                        </Text>
-                      </AutoRow>
-                    )}
-                    <LiquidityChartRangeInput
-                      zoomLevel={
-                        customZoomLevel ||
-                        (activeQuickAction && feeAmount
-                          ? QUICK_ACTION_CONFIGS?.[feeAmount]?.[activeQuickAction]
-                          : undefined)
-                      }
-                      key={baseCurrency?.wrapped?.address}
-                      currencyA={baseCurrency ?? undefined}
-                      currencyB={quoteCurrency ?? undefined}
-                      feeAmount={feeAmount}
-                      ticksAtLimit={ticksAtLimit}
-                      tickUpper={tickUpper}
-                      tickLower={tickLower}
-                      tickCurrent={pool?.tickCurrent}
-                      price={price ? parseFloat((invertPrice ? price.invert() : price).toSignificant(8)) : undefined}
-                      priceLower={priceLower}
-                      priceUpper={priceUpper}
-                      onBothRangeInput={onBothRangePriceInput}
-                      onLeftRangeInput={onLeftRangePriceInput}
-                      onRightRangeInput={onRightRangePriceInput}
-                      formattedData={formattedData}
-                      isLoading={isChartDataLoading}
-                      error={chartDataError}
-                      interactive
-                    />
-                  </>
-                )}
+                  {!noLiquidity && (
+                    <>
+                      <PricePeriodRangeChart
+                        isLoading={isChartDataLoading}
+                        key={baseCurrency?.wrapped.address}
+                        zoomLevel={
+                          customZoomLevel ||
+                          (activeQuickAction && feeAmount
+                            ? QUICK_ACTION_CONFIGS?.[feeAmount]?.[activeQuickAction]
+                            : undefined)
+                        }
+                        baseCurrency={baseCurrency}
+                        quoteCurrency={quoteCurrency}
+                        ticksAtLimit={ticksAtLimit}
+                        price={price ? parseFloat((invertPrice ? price.invert() : price).toSignificant(8)) : undefined}
+                        priceLower={priceLower}
+                        priceUpper={priceUpper}
+                        onBothRangeInput={onBothRangePriceInput}
+                        onMinPriceInput={onLeftRangePriceInput}
+                        onMaxPriceInput={onRightRangePriceInput}
+                        formattedData={formattedData}
+                        priceHistoryData={rateData}
+                        axisTicks={axisTicks}
+                        error={chartDataError}
+                        interactive
+                      />
+                    </>
+                  )}
+                </Box>
               </DynamicSection>
 
               <DynamicSection disabled={!feeAmount || invalidPool || (noLiquidity && !startPriceTypedValue)} gap="16px">

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -736,6 +736,12 @@ export default function V3FormView({
                         {t('Position Range')}
                       </Text>
                     </FlexGap>
+                    <FlexGap gap="8px" alignItems="center">
+                      <Dot color="input" show />
+                      <Text color="textSubtle" small>
+                        {t('Liquidity Depth')}
+                      </Text>
+                    </FlexGap>
                   </FlexGap>
                 </FlexGap>
 

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -721,7 +721,7 @@ export default function V3FormView({
                 </Box>
               )}
               <DynamicSection disabled={!feeAmount || invalidPool}>
-                <FlexGap gap="8px" justifyContent="space-between" alignItems="center">
+                <FlexGap gap="8px" justifyContent="space-between" alignItems="center" flexWrap="wrap">
                   <PreTitle>{t('Set position range')}</PreTitle>
                   <FlexGap gap="8px" alignItems="center">
                     <FlexGap gap="8px" alignItems="center">

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -641,26 +641,6 @@ export default function V3FormView({
     formattedAmounts,
   ])
 
-  const handleRateToggle = useCallback(() => {
-    if (!router.isReady || !currencyIdA || !currencyIdB) return
-
-    invertRange()
-
-    router.replace(
-      {
-        pathname: router.pathname,
-        query: {
-          ...router.query,
-          currency: [currencyIdB!, currencyIdA!, feeAmount ? feeAmount.toString() : ''],
-        },
-      },
-      undefined,
-      {
-        shallow: true,
-      },
-    )
-  }, [invertRange, currencyIdA, currencyIdB, feeAmount, router, invertPrice, priceLower, priceUpper])
-
   const inversionEvent = useCurrencyInversionEvent()
 
   useEffect(() => {
@@ -761,7 +741,6 @@ export default function V3FormView({
                     mb="24px"
                   >
                     <Liquidity.PriceRangeDatePicker onChange={setPricePeriod} value={pricePeriod} />
-                    <Liquidity.RateToggle currencyA={baseCurrency} handleRateToggle={handleRateToggle} />
                   </FlexGap>
 
                   {!noLiquidity && (

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -665,10 +665,10 @@ export default function V3FormView({
   // Price Rate Data
   const { data: rateData } = useTokenRateData({
     period: pricePeriod.value,
-    protocol: Protocol.V3,
     baseCurrency: baseCurrencyWithoutNative ?? undefined,
     quoteCurrency: quoteCurrencyWithoutNative ?? undefined,
     chainId: baseCurrency?.chainId,
+    protocol: Protocol.V3,
     poolId: pool ? Pool.getAddress(pool.token0, pool.token1, pool.fee) : undefined,
   })
 

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -711,7 +711,7 @@ export default function V3FormView({
               <DynamicSection disabled={!feeAmount || invalidPool}>
                 <FlexGap gap="8px" justifyContent="space-between" alignItems="center" flexWrap="wrap">
                   <PreTitle>{t('Set position range')}</PreTitle>
-                  <FlexGap gap="8px" alignItems="center">
+                  <FlexGap gap="8px" alignItems="center" flexWrap="wrap">
                     <FlexGap gap="8px" alignItems="center">
                       <Dot color="primary" show />
                       <Text color="textSubtle" small>

--- a/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx
@@ -139,6 +139,14 @@ export default function V3FormView({
     feeAmount,
   })
 
+  // Negate the effect of useNativeCurrencyInstead when we need actual WNATIVE currency
+  const baseCurrencyWithoutNative = useMemo(() => {
+    return baseCurrency?.isNative ? (baseCurrency.wrapped as Currency) : baseCurrency
+  }, [baseCurrency])
+  const quoteCurrencyWithoutNative = useMemo(() => {
+    return quoteCurrency?.isNative ? (quoteCurrency.wrapped as Currency) : quoteCurrency
+  }, [quoteCurrency])
+
   const positionManager = useV3NFTPositionManagerContract()
   const { account, chainId, isWrongNetwork } = useAccountActiveChain()
   const addTransaction = useTransactionAdder()
@@ -678,8 +686,8 @@ export default function V3FormView({
   const { data: rateData } = useTokenRateData({
     period: pricePeriod.value,
     protocol: Protocol.V3,
-    baseCurrency: baseCurrency ?? undefined,
-    quoteCurrency: quoteCurrency ?? undefined,
+    baseCurrency: baseCurrencyWithoutNative ?? undefined,
+    quoteCurrency: quoteCurrencyWithoutNative ?? undefined,
     chainId: baseCurrency?.chainId,
     poolId: pool ? Pool.getAddress(pool.token0, pool.token1, pool.fee) : undefined,
   })
@@ -767,8 +775,8 @@ export default function V3FormView({
                             ? QUICK_ACTION_CONFIGS?.[feeAmount]?.[activeQuickAction]
                             : undefined)
                         }
-                        baseCurrency={baseCurrency}
-                        quoteCurrency={quoteCurrency}
+                        baseCurrency={baseCurrencyWithoutNative}
+                        quoteCurrency={quoteCurrencyWithoutNative}
                         ticksAtLimit={ticksAtLimit}
                         price={price ? parseFloat((invertPrice ? price.invert() : price).toSignificant(8)) : undefined}
                         priceLower={priceLower}

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -1,20 +1,20 @@
-import { Pair } from '@pancakeswap/sdk'
 import { Box, Breadcrumbs, Container, FlexGap, Text } from '@pancakeswap/uikit'
 
+import { Pair } from '@pancakeswap/sdk'
 import { FeeAmount, Pool } from '@pancakeswap/v3-sdk'
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
-import { useRouter } from 'next/router'
 import { useV3FarmAPI } from 'hooks/useV3FarmAPI'
+import { useRouter } from 'next/router'
 
 import { atom, useAtom } from 'jotai'
 import { styled } from 'styled-components'
 
-import { useFeeTierDistribution } from 'hooks/v3/useFeeTierDistribution'
-import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import { useTranslation } from '@pancakeswap/localization'
-import { getPoolDetailPageLink } from 'utils/getPoolLink'
+import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import { useQuery } from '@tanstack/react-query'
+import { useFeeTierDistribution } from 'hooks/v3/useFeeTierDistribution'
+import { getPoolDetailPageLink } from 'utils/getPoolLink'
 
 import { usePreviousValue } from '@pancakeswap/hooks'
 import { useCurrency } from 'hooks/Tokens'
@@ -23,11 +23,11 @@ import AddStableLiquidity from 'views/AddLiquidity/AddStableLiquidity'
 import useWarningLiquidity from 'views/AddLiquidity/hooks/useWarningLiquidity'
 import useStableConfig, { StableConfigContext } from 'views/Swap/hooks/useStableConfig'
 
+import { PoolInfoHeader } from 'components/PoolInfoHeader'
 import { useActiveChainId } from 'hooks/useActiveChainId'
 import { usePoolInfo } from 'state/farmsV4/state/extendPools/hooks'
 import { resetMintState } from 'state/mint/actions'
 import { useAddLiquidityV2FormDispatch } from 'state/mint/reducer'
-import { PoolInfoHeader } from 'components/PoolInfoHeader'
 
 import StableFormView from './formViews/StableFormView'
 import V2FormView from './formViews/V2FormView'
@@ -175,7 +175,6 @@ export function UniversalAddLiquidity({
 export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation()
   const { chainId } = useActiveChainId()
-  const router = useRouter()
 
   const [selectType] = useAtom(selectTypeAtom)
   const { currencyIdA, currencyIdB, feeAmount } = useCurrencyParams()

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Breadcrumbs, Container, FlexGap, Text } from '@pancakeswap/uikit'
+import { Box, Breadcrumbs, Container, FlexGap, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 
 import { Pair } from '@pancakeswap/sdk'
 import { FeeAmount, Pool } from '@pancakeswap/v3-sdk'
@@ -175,6 +175,7 @@ export function UniversalAddLiquidity({
 export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }) {
   const { t } = useTranslation()
   const { chainId } = useActiveChainId()
+  const { isMobile } = useMatchBreakpoints()
 
   const [selectType] = useAtom(selectTypeAtom)
   const { currencyIdA, currencyIdB, feeAmount } = useCurrencyParams()
@@ -292,7 +293,7 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
                     showTitle={false}
                     derived
                     showApyButton={false}
-                    fontSize="24px"
+                    fontSize={isMobile ? '20px' : '24px'}
                   />
                 ),
                 roiCalculator: (
@@ -302,7 +303,7 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
                     showTitle={false}
                     derived
                     showApyText={false}
-                    fontSize="24px"
+                    fontSize={isMobile ? '20px' : '24px'}
                   />
                 ),
               }

--- a/apps/web/src/views/AddLiquidityV3/types.ts
+++ b/apps/web/src/views/AddLiquidityV3/types.ts
@@ -66,7 +66,12 @@ export const QUICK_ACTION_CONFIGS: Record<FeeAmount, { [percentage: number]: Zoo
       min: 0.00001,
       max: 20,
     },
-    50: ZOOM_LEVELS[FeeAmount.MEDIUM],
+    50: {
+      initialMin: 0.5,
+      initialMax: 1.5,
+      min: 0.00001,
+      max: 20,
+    },
   },
   [FeeAmount.HIGH]: {
     10: {
@@ -81,7 +86,12 @@ export const QUICK_ACTION_CONFIGS: Record<FeeAmount, { [percentage: number]: Zoo
       min: 0.00001,
       max: 20,
     },
-    50: ZOOM_LEVELS[FeeAmount.HIGH],
+    50: {
+      initialMin: 0.5,
+      initialMax: 1.5,
+      min: 0.00001,
+      max: 20,
+    },
   },
 }
 

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -4366,5 +4366,6 @@
   "Position Range": "Position Range",
   "Price Range": "Price Range",
   "price range": "price range",
-  "Price range": "Price range"
+  "Price range": "Price range",
+  "Liquidity Depth": "Liquidity Depth"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -1888,7 +1888,6 @@
   "Current Price": "Current Price",
   "Min Price": "Min Price",
   "Max Price": "Max Price",
-  "Price Range": "Price Range",
   "Invalid range selected. The min price must be lower than the max price.": "Invalid range selected. The min price must be lower than the max price.",
   "Invalid range selected.": "Invalid range selected.",
   "Invalid range selected. The min price must be lower than the max price. And price should around the start price: %minPrice% - %maxPrice%": "Invalid range selected. The min price must be lower than the max price. And price should around the start price: %minPrice% - %maxPrice%",
@@ -3071,7 +3070,6 @@
   "View on": "View on",
   "NUM BIN": "NUM BIN",
   "reset": "reset",
-  "PRICE RANGE": "PRICE RANGE",
   "Zap in for %lpSymbol%": "Zap in for %lpSymbol%",
   "Service Unavailable in Your Region": "Service Unavailable in Your Region",
   "Due to regional regulatory requirements. We are unable to provide service for your region.": "Due to regional regulatory requirements. We are unable to provide service for your region.",
@@ -3268,7 +3266,6 @@
   "Audit info": "Audit info",
   "Audit Outcome": "Audit Outcome",
   "Hook Creator": "Hook Creator",
-  "price range": "price range",
   "The price range is outside current pool price": "The price range is outside current pool price",
   "Set price range first": "Set price range first",
   "No hooks available with the selected filters": "No hooks available with the selected filters",
@@ -3842,7 +3839,6 @@
   "Quote token": "Quote token",
   "Base token": "Base token",
   "Initial price": "Initial price",
-  "Price range": "Price range",
   "Price Setting": "Price Setting",
   "%subject% price": "%subject% price",
   "This is the current price of an existing pool on PancakeSwap. You can still enter a different initial price but be aware this may lead to arbitrage if the price difference is large.": "This is the current price of an existing pool on PancakeSwap. You can still enter a different initial price but be aware this may lead to arbitrage if the price difference is large.",
@@ -4367,5 +4363,8 @@
   "Try Zap": "Try Zap",
   "to automatically balance and provide V3 liquidity in one click.": "to automatically balance and provide V3 liquidity in one click.",
   "Set position range": "Set position range",
-  "Position Range": "Position Range"
+  "Position Range": "Position Range",
+  "Price Range": "Price Range",
+  "price range": "price range",
+  "Price range": "Price range"
 }

--- a/packages/localization/src/config/translations.json
+++ b/packages/localization/src/config/translations.json
@@ -4365,5 +4365,7 @@
   "Liquidity Slippage": "Liquidity Slippage",
   "Loading more pools...": "Loading more pools...",
   "Try Zap": "Try Zap",
-  "to automatically balance and provide V3 liquidity in one click.": "to automatically balance and provide V3 liquidity in one click."
+  "to automatically balance and provide V3 liquidity in one click.": "to automatically balance and provide V3 liquidity in one click.",
+  "Set position range": "Set position range",
+  "Position Range": "Position Range"
 }

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisBottom.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisBottom.tsx
@@ -66,7 +66,7 @@ export const AxisBottom = <T extends ScaleTime<number, number>>({
   }, [xScale, ticks, tickFormat]);
 
   return (
-    <StyledGroup $isMobile={isMobile} transform={`translate(0, ${innerHeight + offset})`}>
+    <StyledGroup $isMobile={isMobile} transform={`translate(0, ${innerHeight + offset + (isMobile ? 5 : 0)})`}>
       <Axis axisGenerator={axisGenerator} />
     </StyledGroup>
   );

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -86,6 +86,7 @@ export const AxisRight = ({
   ticks = 6,
   highlightValue,
   highlightSecondaryValues,
+  onAxisMount,
 }: {
   highlightValue?: number;
   highlightSecondaryValues?: number[];
@@ -93,6 +94,7 @@ export const AxisRight = ({
   innerWidth: number;
   offset?: number;
   ticks?: number;
+  onAxisMount?: (element: SVGGElement | null) => void;
 }) => {
   const defaultTicks = yScale.ticks(ticks);
   const { isMobile } = useMatchBreakpoints();
@@ -125,7 +127,12 @@ export const AxisRight = ({
   }
 
   return (
-    <StyledGroup $isMobile={isMobile} transform={`translate(${innerWidth + offset})`}>
+    <StyledGroup
+      id="price-range-chart-axis-right"
+      $isMobile={isMobile}
+      transform={`translate(${innerWidth + offset})`}
+      ref={onAxisMount}
+    >
       <Axis
         axisGenerator={axisLeft(yScale).tickValues(finalTicks).tickSize(0)}
         highlightValue={highlightValue}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -14,7 +14,15 @@ const StyledGroup = styled.g<{ $isMobile: boolean }>`
   }
 `;
 
-const Axis = ({ axisGenerator, highlightValue }: { axisGenerator: d3Axis<NumberValue>; highlightValue?: number }) => {
+const Axis = ({
+  axisGenerator,
+  highlightValue,
+  highlightSecondaryValues,
+}: {
+  axisGenerator: d3Axis<NumberValue>;
+  highlightValue?: number;
+  highlightSecondaryValues?: number[];
+}) => {
   const { theme } = useTheme();
   const axisRef = (axis: SVGGElement) => {
     if (!axis) return;
@@ -42,6 +50,26 @@ const Axis = ({ axisGenerator, highlightValue }: { axisGenerator: d3Axis<NumberV
             .attr("rx", 4)
             .attr("fill", theme.colors.primary);
         });
+
+      if (highlightSecondaryValues) {
+        axisGroup
+          .selectAll(".tick")
+          .filter((d) => highlightSecondaryValues.includes(d as number))
+          .select("text")
+          .style("fill", theme.colors.v2Default)
+          .attr("transform", "translate(-2, 0)")
+          .each(function iter() {
+            const bbox = (this as SVGTextElement).getBBox();
+            select((this as SVGTextElement).parentElement)
+              .insert("rect", "text")
+              .attr("x", bbox.x - 4)
+              .attr("y", bbox.y)
+              .attr("width", bbox.width + 4)
+              .attr("height", bbox.height)
+              .attr("rx", 4)
+              .attr("fill", theme.colors.secondary);
+          });
+      }
     }
   };
 
@@ -54,8 +82,10 @@ export const AxisRight = ({
   offset = 0,
   ticks = 6,
   highlightValue,
+  highlightSecondaryValues,
 }: {
   highlightValue?: number;
+  highlightSecondaryValues?: number[];
   yScale: ScaleLinear<number, number>;
   innerWidth: number;
   offset?: number;
@@ -72,9 +102,31 @@ export const AxisRight = ({
     );
     finalTicks = defaultTicks.map((tick) => (tick === closestTick ? highlightValue : tick));
   }
+
+  // If highlightSecondaryValues array is defined, replace the closest ticks with highlightSecondaryValues
+  if (highlightSecondaryValues) {
+    const closestTicks = highlightSecondaryValues.map((value) => {
+      const closestTick = finalTicks.reduce((prev, curr) =>
+        Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
+      );
+      return closestTick;
+    });
+    finalTicks = finalTicks.map((tick) => {
+      const closestTickIndex = closestTicks.indexOf(tick);
+      if (closestTickIndex !== -1) {
+        return highlightSecondaryValues[closestTickIndex];
+      }
+      return tick;
+    });
+  }
+
   return (
     <StyledGroup $isMobile={isMobile} transform={`translate(${innerWidth + offset})`}>
-      <Axis axisGenerator={axisLeft(yScale).tickValues(finalTicks).tickSize(0)} highlightValue={highlightValue} />
+      <Axis
+        axisGenerator={axisLeft(yScale).tickValues(finalTicks).tickSize(0)}
+        highlightValue={highlightValue}
+        highlightSecondaryValues={highlightSecondaryValues}
+      />
     </StyledGroup>
   );
 };

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -1,9 +1,11 @@
 import { useTheme } from "@pancakeswap/hooks";
 import { useMatchBreakpoints } from "@pancakeswap/uikit";
-import { Axis as d3Axis, NumberValue, ScaleLinear, select, axisLeft } from "d3";
+import { axisLeft, Axis as d3Axis, NumberValue, ScaleLinear, select } from "d3";
 import { styled } from "styled-components";
 
 const StyledGroup = styled.g<{ $isMobile: boolean }>`
+  z-index: 10;
+
   line {
     display: none;
   }
@@ -57,6 +59,7 @@ const Axis = ({
           .filter((d) => highlightSecondaryValues.includes(d as number))
           .select("text")
           .style("fill", theme.colors.v2Default)
+          .style("z-index", 10)
           .attr("transform", "translate(-2, 0)")
           .each(function iter() {
             const bbox = (this as SVGTextElement).getBBox();

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -4,7 +4,7 @@ import { axisLeft, Axis as d3Axis, NumberValue, ScaleLinear, select } from "d3";
 import { styled } from "styled-components";
 
 const StyledGroup = styled.g<{ $isMobile: boolean }>`
-  z-index: 10;
+  z-index: 2;
 
   line {
     display: none;
@@ -99,11 +99,12 @@ export const AxisRight = ({
 
   // If current is defined, replace the closest tick with current
   let finalTicks = defaultTicks;
+
   if (highlightValue !== undefined) {
-    const closestTick = defaultTicks.reduce((prev, curr) =>
+    const closestTick = finalTicks.reduce((prev, curr) =>
       Math.abs(curr - highlightValue) < Math.abs(prev - highlightValue) ? curr : prev
     );
-    finalTicks = defaultTicks.map((tick) => (tick === closestTick ? highlightValue : tick));
+    finalTicks = finalTicks.map((tick) => (tick === closestTick ? highlightValue : tick));
   }
 
   // If highlightSecondaryValues array is defined, replace the closest ticks with highlightSecondaryValues

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -40,7 +40,7 @@ const Axis = ({ axisGenerator, highlightValue }: { axisGenerator: d3Axis<NumberV
             .attr("width", bbox.width + 4)
             .attr("height", bbox.height)
             .attr("rx", 4)
-            .attr("fill", theme.colors.secondary);
+            .attr("fill", theme.colors.primary);
         });
     }
   };

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/AxisRight.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@pancakeswap/hooks";
 import { useMatchBreakpoints } from "@pancakeswap/uikit";
 import { axisLeft, Axis as d3Axis, NumberValue, ScaleLinear, select } from "d3";
+import { useCallback } from "react";
 import { styled } from "styled-components";
 
 const StyledGroup = styled.g<{ $isMobile: boolean }>`
@@ -19,18 +20,30 @@ const StyledGroup = styled.g<{ $isMobile: boolean }>`
 const Axis = ({
   axisGenerator,
   highlightValue,
-  highlightSecondaryValues,
+  selectedMin,
+  selectedMax,
+  yScale,
 }: {
   axisGenerator: d3Axis<NumberValue>;
   highlightValue?: number;
-  highlightSecondaryValues?: number[];
+  selectedMin?: number;
+  selectedMax?: number;
+  yScale: ScaleLinear<number, number>;
 }) => {
   const { theme } = useTheme();
+
+  const min = yScale.domain()[0];
+  const max = yScale.domain()[1];
+
   const axisRef = (axis: SVGGElement) => {
     if (!axis) return;
     const axisGroup = select(axis);
 
     axisGroup.call(axisGenerator).call((g) => g.select(".domain").remove());
+
+    const isValueNearEdge = (value: number) => {
+      return value < min + (max - min) * 0.05 || value > max - (max - min) * 0.05;
+    };
 
     // Highlight current value if provided
     if (highlightValue !== undefined) {
@@ -46,27 +59,50 @@ const Axis = ({
           select((this as SVGTextElement).parentElement)
             .insert("rect", "text")
             .attr("x", bbox.x - 4)
-            .attr("y", bbox.y)
+            .attr("y", isValueNearEdge(highlightValue) ? bbox.y - 4 : bbox.y)
             .attr("width", bbox.width + 4)
             .attr("height", bbox.height)
             .attr("rx", 4)
             .attr("fill", theme.colors.primary);
         });
 
-      if (highlightSecondaryValues) {
+      // Highlight selectedMax if provided
+      if (selectedMax !== undefined) {
         axisGroup
           .selectAll(".tick")
-          .filter((d) => highlightSecondaryValues.includes(d as number))
+          .filter((d) => d === selectedMax)
           .select("text")
           .style("fill", theme.colors.v2Default)
           .style("z-index", 10)
-          .attr("transform", "translate(-2, 0)")
+          .attr("transform", isValueNearEdge(selectedMax) ? "translate(-2, 8)" : "translate(-2, 0)")
           .each(function iter() {
             const bbox = (this as SVGTextElement).getBBox();
             select((this as SVGTextElement).parentElement)
               .insert("rect", "text")
               .attr("x", bbox.x - 4)
-              .attr("y", bbox.y)
+              .attr("y", isValueNearEdge(selectedMax) ? bbox.y + 8 : bbox.y)
+              .attr("width", bbox.width + 4)
+              .attr("height", bbox.height)
+              .attr("rx", 4)
+              .attr("fill", theme.colors.secondary);
+          });
+      }
+
+      // Highlight selectedMin if provided
+      if (selectedMin !== undefined) {
+        axisGroup
+          .selectAll(".tick")
+          .filter((d) => d === selectedMin)
+          .select("text")
+          .style("fill", theme.colors.v2Default)
+          .style("z-index", 10)
+          .attr("transform", isValueNearEdge(selectedMin) ? "translate(-2, -8)" : "translate(-2, 0)")
+          .each(function iter() {
+            const bbox = (this as SVGTextElement).getBBox();
+            select((this as SVGTextElement).parentElement)
+              .insert("rect", "text")
+              .attr("x", bbox.x - 4)
+              .attr("y", isValueNearEdge(selectedMin) ? bbox.y - 8 : bbox.y)
               .attr("width", bbox.width + 4)
               .attr("height", bbox.height)
               .attr("rx", 4)
@@ -85,11 +121,13 @@ export const AxisRight = ({
   offset = 0,
   ticks = 6,
   highlightValue,
-  highlightSecondaryValues,
+  selectedMin,
+  selectedMax,
   onAxisMount,
 }: {
   highlightValue?: number;
-  highlightSecondaryValues?: number[];
+  selectedMin?: number;
+  selectedMax?: number;
   yScale: ScaleLinear<number, number>;
   innerWidth: number;
   offset?: number;
@@ -109,21 +147,20 @@ export const AxisRight = ({
     finalTicks = finalTicks.map((tick) => (tick === closestTick ? highlightValue : tick));
   }
 
-  // If highlightSecondaryValues array is defined, replace the closest ticks with highlightSecondaryValues
-  if (highlightSecondaryValues) {
-    const closestTicks = highlightSecondaryValues.map((value) => {
-      const closestTick = finalTicks.reduce((prev, curr) =>
-        Math.abs(curr - value) < Math.abs(prev - value) ? curr : prev
-      );
-      return closestTick;
-    });
-    finalTicks = finalTicks.map((tick) => {
-      const closestTickIndex = closestTicks.indexOf(tick);
-      if (closestTickIndex !== -1) {
-        return highlightSecondaryValues[closestTickIndex];
-      }
-      return tick;
-    });
+  // If selectedMin is defined, replace the closest tick with selectedMin
+  if (selectedMin !== undefined) {
+    const closestTick = finalTicks.reduce((prev, curr) =>
+      Math.abs(curr - selectedMin) < Math.abs(prev - selectedMin) ? curr : prev
+    );
+    finalTicks = finalTicks.map((tick) => (tick === closestTick ? selectedMin : tick));
+  }
+
+  // If selectedMax is defined, replace the closest tick with selectedMax
+  if (selectedMax !== undefined) {
+    const closestTick = finalTicks.reduce((prev, curr) =>
+      Math.abs(curr - selectedMax) < Math.abs(prev - selectedMax) ? curr : prev
+    );
+    finalTicks = finalTicks.map((tick) => (tick === closestTick ? selectedMax : tick));
   }
 
   return (
@@ -136,7 +173,9 @@ export const AxisRight = ({
       <Axis
         axisGenerator={axisLeft(yScale).tickValues(finalTicks).tickSize(0)}
         highlightValue={highlightValue}
-        highlightSecondaryValues={highlightSecondaryValues}
+        selectedMin={selectedMin}
+        selectedMax={selectedMax}
+        yScale={yScale}
       />
     </StyledGroup>
   );

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
@@ -201,8 +201,8 @@ export const Brush = ({
           <linearGradient id={`${id}-gradient-handle`} x1="0%" y1="0%" x2="100%" y2="0%">
             <stop offset="0%" style={{ stopColor: theme.colors.secondary, stopOpacity: 1 }} />
             <stop offset="68%" style={{ stopColor: theme.colors.secondary, stopOpacity: 1 }} />
-            <stop offset="71.8%" style={{ stopColor: theme.colors.secondary, stopOpacity: 0.4 }} />
-            <stop offset="81.7%" style={{ stopColor: theme.colors.secondary, stopOpacity: 0 }} />
+            <stop offset="71.8%" style={{ stopColor: theme.colors.secondary, stopOpacity: 1 }} />
+            <stop offset="81.7%" style={{ stopColor: theme.colors.secondary, stopOpacity: 1 }} />
           </linearGradient>
         </defs>
 
@@ -214,25 +214,9 @@ export const Brush = ({
           onMouseLeave={() => setHovering(false)}
         />
         {/* Top dashed line */}
-        <line
-          x1="0"
-          y1={scale(max)}
-          x2={innerWidth}
-          y2={scale(max)}
-          stroke={maxHandleColor}
-          strokeWidth="1"
-          strokeDasharray="1,3"
-        />
+        <line x1="0" y1={scale(max)} x2={innerWidth} y2={scale(max)} stroke={maxHandleColor} strokeWidth="1" />
         {/* bottom dashed line */}
-        <line
-          x1="0"
-          y1={scale(min)}
-          x2={innerWidth}
-          y2={scale(min)}
-          stroke={minHandleColor}
-          strokeWidth="1"
-          strokeDasharray="1,3"
-        />
+        <line x1="0" y1={scale(min)} x2={innerWidth} y2={scale(min)} stroke={minHandleColor} strokeWidth="1" />
 
         {localBrushExtent && (
           <>

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
@@ -12,7 +12,7 @@ const Handle = styled.path<{ color: string; id: string }>`
   pointer-events: none;
 
   stroke-width: 1;
-  stroke: url(#${({ id }) => id});
+  stroke: transparent;
   fill: ${({ color }) => color};
 
   z-index: 1;
@@ -22,7 +22,7 @@ const HandleAccent = styled.path`
   cursor: ew-resize;
   pointer-events: none;
 
-  stroke-width: 1.5;
+  stroke-width: 0.5;
   stroke: ${({ theme }) => theme.colors.background};
   opacity: ${({ theme }) => theme.colors.background};
 
@@ -53,6 +53,7 @@ export const Brush = ({
   brushLabelValue,
   brushExtent,
   setBrushExtent,
+  setLocalBrushExtent: setLocalBrushExtentPropCallback,
   innerWidth,
   innerHeight,
   minHandleColor,
@@ -66,6 +67,7 @@ export const Brush = ({
   brushLabelValue: (d: "n" | "s", x: number) => string;
   brushExtent: BrushDomainType;
   setBrushExtent: (extent: BrushDomainType, mode: string | undefined) => void;
+  setLocalBrushExtent: (extent: BrushDomainType | null) => void;
   innerWidth: number;
   width: number;
   innerHeight: number;
@@ -83,6 +85,10 @@ export const Brush = ({
   const [hovering, setHovering] = useState(false);
 
   const previousBrushExtent = usePreviousValue(brushExtent);
+
+  useEffect(() => {
+    setLocalBrushExtentPropCallback?.(localBrushExtent);
+  }, [localBrushExtent, setLocalBrushExtentPropCallback]);
 
   const brushed = useCallback(
     (event: D3BrushEvent<unknown>) => {

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { styled } from "styled-components";
 
 import { brushHandleAccentPath, brushHandlePath, OffScreenHandle } from "./svg";
-import { BrushDomainType } from "./types";
 import { ToolTip } from "./ToolTip";
+import { BrushDomainType } from "./types";
 
 const Handle = styled.path<{ color: string; id: string }>`
   cursor: ew-resize;
@@ -14,6 +14,8 @@ const Handle = styled.path<{ color: string; id: string }>`
   stroke-width: 1;
   stroke: url(#${({ id }) => id});
   fill: ${({ color }) => color};
+
+  z-index: 1;
 `;
 
 const HandleAccent = styled.path`
@@ -23,6 +25,8 @@ const HandleAccent = styled.path`
   stroke-width: 1.5;
   stroke: ${({ theme }) => theme.colors.background};
   opacity: ${({ theme }) => theme.colors.background};
+
+  z-index: 1;
 `;
 
 // flips the handles draggers when close to the container edges

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Brush.tsx
@@ -2,8 +2,15 @@ import { usePreviousValue, useTheme } from "@pancakeswap/hooks";
 import { BrushBehavior, brushY, D3BrushEvent, ScaleLinear, select } from "d3";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { styled } from "styled-components";
+import { useMatchBreakpoints } from "@pancakeswap/uikit";
 
-import { brushHandleAccentPath, brushHandlePath, OffScreenHandle } from "./svg";
+import {
+  brushHandleAccentPath,
+  brushHandleAccentPathMobile,
+  brushHandlePath,
+  brushHandlePathMobile,
+  OffScreenHandle,
+} from "./svg";
 import { ToolTip } from "./ToolTip";
 import { BrushDomainType } from "./types";
 
@@ -76,9 +83,10 @@ export const Brush = ({
   current: number;
 }) => {
   const { theme } = useTheme();
+  const { isMobile } = useMatchBreakpoints();
+
   const brushRef = useRef<SVGGElement | null>(null);
   const brushBehavior = useRef<BrushBehavior<SVGGElement> | null>(null);
-
   // only used to drag the handles on brush for performance
   const [localBrushExtent, setLocalBrushExtent] = useState<BrushDomainType | null>(brushExtent);
   const [showLabels, setShowLabels] = useState(false);
@@ -145,7 +153,7 @@ export const Brush = ({
       .attr("stroke", "none")
       .attr("fill-opacity", "0.05")
       .attr("fill", `url(#${id}-gradient-selection)`);
-  }, [brushExtent, brushed, id, innerHeight, innerWidth, interactive, previousBrushExtent, scale]);
+  }, [brushExtent, brushed, id, innerHeight, innerWidth, interactive, previousBrushExtent, scale, isMobile]);
 
   // respond to xScale changes only
   useEffect(() => {
@@ -237,8 +245,12 @@ export const Brush = ({
                 })`}
               >
                 <g>
-                  <Handle color={theme.colors.secondary} d={brushHandlePath(width)} id={`${id}-gradient-handle`} />
-                  <HandleAccent d={brushHandleAccentPath()} />
+                  <Handle
+                    color={theme.colors.secondary}
+                    d={isMobile ? brushHandlePathMobile(width) : brushHandlePath(width)}
+                    id={`${id}-gradient-handle`}
+                  />
+                  <HandleAccent d={isMobile ? brushHandleAccentPathMobile() : brushHandleAccentPath()} />
                 </g>
                 <ToolTip
                   width={toolTipWidth}
@@ -246,6 +258,7 @@ export const Brush = ({
                   flip={!flipMaxHandle}
                   text={brushLabelValue("n", localBrushExtent.max)}
                   visible={showLabels || hovering}
+                  isMobile={isMobile}
                 />
               </g>
             ) : null}
@@ -257,8 +270,12 @@ export const Brush = ({
                 })`}
               >
                 <g>
-                  <Handle color={theme.colors.secondary} d={brushHandlePath(width)} id={`${id}-gradient-handle`} />
-                  <HandleAccent d={brushHandleAccentPath()} />
+                  <Handle
+                    color={theme.colors.secondary}
+                    d={isMobile ? brushHandlePathMobile(width) : brushHandlePath(width)}
+                    id={`${id}-gradient-handle`}
+                  />
+                  <HandleAccent d={isMobile ? brushHandleAccentPathMobile() : brushHandleAccentPath()} />
                 </g>
 
                 <ToolTip
@@ -267,6 +284,7 @@ export const Brush = ({
                   flip={!flipMinHandle}
                   text={brushLabelValue("s", localBrushExtent.min)}
                   visible={showLabels || hovering}
+                  isMobile={isMobile}
                 />
               </g>
             ) : null}
@@ -309,6 +327,7 @@ export const Brush = ({
       minHandleInView,
       scale,
       width,
+      isMobile,
     ]
   );
 };

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/CandleChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/CandleChart.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { ScaleLinear, ScaleTime } from "d3";
+import { useTheme } from "@pancakeswap/hooks";
+import { useTranslation } from "@pancakeswap/localization";
+import { PriceChartEntry } from "./types";
+
+export const CandleChart = ({
+  series,
+  xScale,
+  yScale,
+  xValue,
+  yValue,
+  color,
+}: {
+  series: PriceChartEntry[];
+  xScale: ScaleTime<number, number>;
+  yScale: ScaleLinear<number, number>;
+  xValue: (d: PriceChartEntry) => Date;
+  yValue: (d: PriceChartEntry) => number;
+  color: string;
+}) => {
+  const { theme } = useTheme();
+  const { t } = useTranslation();
+
+  // Calculate bandwidth for candlestick width
+  const candleWidth = useMemo(() => {
+    if (series.length < 2) return 10;
+    const firstX = xScale(xValue(series[0]));
+    const secondX = xScale(xValue(series[1]));
+    return Math.abs(secondX - firstX) * 0.3; // 30% of available space
+  }, [series, xScale, xValue]);
+
+  // Colors for bullish and bearish candles
+  const bullishColor = theme.colors.success || "#00d4aa";
+  const bearishColor = theme.colors.failure || "#ed4b9e";
+
+  if (series.every((i) => i.close <= 0)) {
+    return (
+      <text
+        transform="scale(1)"
+        x={0}
+        y="50%"
+        dominantBaseline="middle"
+        fill={theme.colors.textSubtle}
+        fontSize="9px"
+        style={{ userSelect: "none" }}
+      >
+        {t("Insufficient data for historical price chart.")}
+      </text>
+    );
+  }
+
+  return (
+    <g>
+      {series.map((entry, index) => {
+        const x = xScale(xValue(entry));
+        const yHigh = yScale(entry.high);
+        const yLow = yScale(entry.low);
+        const yOpen = yScale(entry.open);
+        const yClose = yScale(entry.close);
+
+        const isBullish = entry.close > entry.open;
+        const candleColor = isBullish ? bullishColor : bearishColor;
+
+        return (
+          <g key={index} transform={`translate(${x}, 0)`}>
+            {/* High-Low line (wick) */}
+            <line x1={0} y1={yLow} x2={0} y2={yHigh} stroke={candleColor} strokeWidth={1} strokeLinecap="round" />
+
+            {/* Open-Close body */}
+            <line
+              x1={0}
+              y1={yOpen}
+              x2={0}
+              y2={yClose}
+              stroke={candleColor}
+              strokeWidth={candleWidth}
+              strokeLinecap="round"
+            />
+          </g>
+        );
+      })}
+    </g>
+  );
+};

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -9,7 +9,7 @@ import { AxisRight } from "./AxisRight";
 import { Brush } from "./Brush";
 import { CandleChart } from "./CandleChart";
 import { HorizontalLine } from "./Line";
-import { ChartProps, LiquidityChartEntry, PriceChartEntry } from "./types";
+import { BrushDomainType, ChartProps, LiquidityChartEntry, PriceChartEntry } from "./types";
 import { Area } from "./VerticalArea";
 import Zoom, { ZoomOverlay } from "./Zoom";
 
@@ -114,6 +114,9 @@ export function Chart({
     [priceScale]
   );
 
+  // Only used for tracking the brush extent when dragging the handles
+  const [localBrushExtent, setLocalBrushExtent] = useState<BrushDomainType | null>(brushDomain ?? defaultBrushExtent);
+
   const handleResetBrush = useCallback(() => {
     onBrushDomainChange({ min: current * zoomLevels.initialMin, max: current * zoomLevels.initialMax }, "reset");
   }, [current, onBrushDomainChange, zoomLevels.initialMax, zoomLevels.initialMin]);
@@ -216,16 +219,18 @@ export function Chart({
           />
 
           <ZoomOverlay width={innerWidth} height={height} ref={zoomRef} />
+
           <Brush
             id={id}
             scale={priceScale}
             interactive={interactive}
             brushLabelValue={brushLabels}
             brushExtent={brushDomain ?? defaultBrushExtent}
-            width={innerWidth / 2 - margins.right - paddingRight}
+            width={innerWidth / 2 - margins.right - paddingRight * 2}
             innerWidth={innerWidth}
             innerHeight={innerHeight}
             setBrushExtent={onBrushDomainChange}
+            setLocalBrushExtent={setLocalBrushExtent}
             minHandleColor={minHandleColor}
             maxHandleColor={maxHandleColor}
             current={current}
@@ -235,7 +240,9 @@ export function Chart({
             innerWidth={width}
             highlightValue={current}
             highlightSecondaryValues={
-              brushDomain ? [Number(brushDomain.min.toPrecision(6)), Number(brushDomain.max.toPrecision(6))] : undefined
+              localBrushExtent
+                ? [Number(localBrushExtent.min.toFixed(12)), Number(localBrushExtent.max.toFixed(12))]
+                : undefined
             }
             ticks={isMobile ? 4 : 6}
             offset={1}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -214,7 +214,16 @@ export function Chart({
             color={theme.colors.primary}
             strokeWidth={0.5}
           />
-          <AxisRight yScale={priceScale} innerWidth={width} highlightValue={current} ticks={isMobile ? 4 : 6} />
+          <AxisRight
+            yScale={priceScale}
+            innerWidth={width}
+            highlightValue={current}
+            highlightSecondaryValues={
+              brushDomain ? [Number(brushDomain.min.toPrecision(6)), Number(brushDomain.max.toPrecision(6))] : undefined
+            }
+            ticks={isMobile ? 4 : 6}
+            offset={1}
+          />
           <ZoomOverlay width={innerWidth} height={height} ref={zoomRef} />
           <Brush
             id={id}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -41,22 +41,57 @@ export function Chart({
 
   const [zoom, setZoom] = useState<ZoomTransform | null>(null);
 
+  // Calculate domain from the price history candlestick chart
+  const calculatePriceHistoryDomain = useCallback(() => {
+    const priceValues: number[] = [];
+    priceHistory.forEach((entry) => {
+      if (entry.open > 0) priceValues.push(entry.open);
+      if (entry.close > 0) priceValues.push(entry.close);
+      if (entry.high > 0) priceValues.push(entry.high);
+      if (entry.low > 0) priceValues.push(entry.low);
+    });
+
+    // Fallback to current-price based domain if no valid price data
+    if (priceValues.length === 0) {
+      return {
+        min: current * zoomLevels.initialMin,
+        max: current * zoomLevels.initialMax,
+      };
+    }
+
+    const minPrice = Math.min(...priceValues);
+    const maxPrice = Math.max(...priceValues);
+
+    // Apply +/-10% padding to keep the price chart always in view
+    const priceRange = maxPrice - minPrice;
+
+    // If all prices are the same, use a percentage of the price as padding
+    const padding = priceRange > 0 ? priceRange * 0.1 : maxPrice * 0.1;
+    const domainMin = minPrice - padding;
+    const domainMax = maxPrice + padding;
+
+    return { min: domainMin, max: domainMax };
+  }, [priceHistory, current, zoomLevels.initialMin, zoomLevels.initialMax]);
+
   const [innerHeight, innerWidth] = useMemo(
     () => [height - margins.top - margins.bottom, width - margins.left - margins.right],
     [width, height, margins]
   );
 
   const { liquidityScale, priceScale, periodScale } = useMemo(() => {
+    const priceDomain = calculatePriceHistoryDomain();
+
     const scales = {
       liquidityScale: scaleLinear()
         .domain([0, max(liquiditySeries, liquidityAccessor)] as number[])
         .range([innerWidth, innerWidth * 0.5]),
       priceScale: scaleLinear()
-        .domain([current * zoomLevels.initialMin, current * zoomLevels.initialMax] as number[])
+        // Keep the candlestick chart in view by default instead of user's selected range
+        .domain([priceDomain.min, priceDomain.max] as number[])
         .range([innerHeight, 0]),
       periodScale: scaleTime()
         .domain(extent(priceHistory, periodAccessor) as [Date, Date])
-        .range([0, innerWidth * 0.95]),
+        .range([0, innerWidth * 0.93]),
     };
 
     if (zoom) {
@@ -65,16 +100,7 @@ export function Chart({
     }
 
     return scales;
-  }, [
-    priceHistory,
-    current,
-    zoomLevels.initialMin,
-    zoomLevels.initialMax,
-    innerWidth,
-    liquiditySeries,
-    innerHeight,
-    zoom,
-  ]);
+  }, [calculatePriceHistoryDomain, innerWidth, liquiditySeries, innerHeight, zoom, priceHistory]);
 
   useEffect(() => {
     if (!brushDomain) {
@@ -133,8 +159,8 @@ export function Chart({
           width={innerWidth}
           height={height}
           resetBrush={handleResetBrush}
-          showResetButton={false}
           zoomLevels={zoomLevels}
+          showResetButton={false}
         />
       )}
       <svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`} style={{ overflow: "hidden" }}>

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -56,7 +56,7 @@ export function Chart({
         .range([innerHeight, 0]),
       periodScale: scaleTime()
         .domain(extent(priceHistory, periodAccessor) as [Date, Date])
-        .range([0, innerWidth * 0.75]),
+        .range([0, innerWidth * 0.95]),
     };
 
     if (zoom) {

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -8,6 +8,7 @@ import { AxisBottom } from "./AxisBottom";
 import { AxisRight } from "./AxisRight";
 import { Brush } from "./Brush";
 import { CandleChart } from "./CandleChart";
+import { GridLines } from "./GridLines";
 import { HorizontalLine } from "./Line";
 import { BrushDomainType, ChartProps, LiquidityChartEntry, PriceChartEntry } from "./types";
 import { Area } from "./VerticalArea";
@@ -32,6 +33,7 @@ export function Chart({
   zoomLevels,
   showZoomButtons = true,
   axisTicks,
+  showGridLines = true,
 }: ChartProps) {
   const zoomRef = useRef<SVGRectElement | null>(null);
   const { theme } = useTheme();
@@ -107,7 +109,7 @@ export function Chart({
     // const isHighToLow = liquiditySeries[0]?.price0 > liquiditySeries[liquiditySeries.length - 1]?.price0;
     // return isHighToLow ? [theme.colors.success, theme.colors.failure] : [theme.colors.failure, theme.colors.success];
     return [theme.colors.secondary, theme.colors.secondary];
-  }, [liquiditySeries, theme.colors.failure, theme.colors.success]);
+  }, [liquiditySeries, theme.colors.secondary]);
 
   const defaultBrushExtent = useMemo(
     () => ({ min: priceScale.domain()[1], max: priceScale.domain()[0] }),
@@ -173,6 +175,20 @@ export function Chart({
           </clipPath>
         </defs>
 
+        {/* Grid lines rendered first so they appear behind chart data */}
+        {showGridLines && (
+          <g clipPath={`url(#${id}-chart-clip)`}>
+            <GridLines
+              priceScale={priceScale}
+              periodScale={periodScale}
+              innerWidth={innerWidth}
+              innerHeight={innerHeight}
+              horizontalTicks={6}
+              verticalTicks={4}
+            />
+          </g>
+        )}
+
         <g>
           <g clipPath={`url(#${id}-chart-clip)`}>
             <Area
@@ -212,7 +228,7 @@ export function Chart({
           <HorizontalLine
             value={current}
             yScale={priceScale}
-            x1={innerWidth * 0.6}
+            x1={0}
             x2={innerWidth}
             color={theme.colors.primary}
             strokeWidth={0.5}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -11,7 +11,7 @@ import { HorizontalLine } from "./Line";
 import { LiquidityChartEntry, PriceChartEntry, ChartProps } from "./types";
 import Zoom, { ZoomOverlay } from "./Zoom";
 import { AxisBottom } from "./AxisBottom";
-import { LineChart } from "./LineChart";
+import { CandleChart } from "./CandleChart";
 
 const priceAccessor = (d: LiquidityChartEntry) => d.price0;
 const liquidityAccessor = (d: LiquidityChartEntry) => d.activeLiquidity;
@@ -104,8 +104,9 @@ export function Chart({
   }, [current, liquiditySeries]);
 
   const [minHandleColor, maxHandleColor] = useMemo(() => {
-    const isHighToLow = liquiditySeries[0]?.price0 > liquiditySeries[liquiditySeries.length - 1]?.price0;
-    return isHighToLow ? [theme.colors.success, theme.colors.failure] : [theme.colors.failure, theme.colors.success];
+    // const isHighToLow = liquiditySeries[0]?.price0 > liquiditySeries[liquiditySeries.length - 1]?.price0;
+    // return isHighToLow ? [theme.colors.success, theme.colors.failure] : [theme.colors.failure, theme.colors.success];
+    return [theme.colors.secondary, theme.colors.secondary];
   }, [liquiditySeries, theme.colors.failure, theme.colors.success]);
 
   const defaultBrushExtent = useMemo(
@@ -134,12 +135,10 @@ export function Chart({
       <svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`} style={{ overflow: "hidden" }}>
         <defs>
           <linearGradient id="green-gradient" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="5%" stopColor={theme.colors.success} stopOpacity={1} />
-            <stop offset="100%" stopColor={theme.colors.success} stopOpacity={0.05} />
+            <stop offset="5%" stopColor={theme.colors.input} stopOpacity={1} />
           </linearGradient>
           <linearGradient id="red-gradient" x1="0" y1="0" x2="1" y2="0">
-            <stop offset="5%" stopColor={theme.colors.failure} stopOpacity={1} />
-            <stop offset="100%" stopColor={theme.colors.failure} stopOpacity={0.05} />
+            <stop offset="5%" stopColor={theme.colors.input} stopOpacity={1} />
           </linearGradient>
         </defs>
         <defs>
@@ -151,7 +150,7 @@ export function Chart({
             // mask to highlight selected area
             <mask id={`${id}-chart-area-mask`}>
               <rect
-                fill="white"
+                fill={theme.colors.secondary}
                 y={liquidityScale(brushDomain.min)}
                 x="0"
                 width={innerWidth}
@@ -195,7 +194,7 @@ export function Chart({
         </g>
         <g>
           <g clipPath={`url(#${id}-line-chart-clip)`}>
-            <LineChart
+            <CandleChart
               series={priceHistory}
               xScale={periodScale}
               yScale={priceScale}
@@ -212,7 +211,7 @@ export function Chart({
             yScale={priceScale}
             x1={innerWidth * 0.6}
             x2={innerWidth}
-            color={theme.colors.secondary}
+            color={theme.colors.primary}
             strokeWidth={0.5}
           />
           <AxisRight yScale={priceScale} innerWidth={width} highlightValue={current} ticks={isMobile ? 4 : 6} />

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -36,10 +36,23 @@ export function Chart({
   showGridLines = true,
 }: ChartProps) {
   const zoomRef = useRef<SVGRectElement | null>(null);
+
   const { theme } = useTheme();
   const { isMobile } = useMatchBreakpoints();
 
   const [zoom, setZoom] = useState<ZoomTransform | null>(null);
+  const [axisRightWidth, setAxisRightWidth] = useState<number>(0);
+
+  // Handle axis mount and measure its width
+  const handleAxisMount = useCallback((element: SVGGElement | null) => {
+    if (element) {
+      // Use a small delay to ensure the axis is fully rendered
+      setTimeout(() => {
+        const width = element.getBoundingClientRect().width;
+        setAxisRightWidth(width);
+      }, 0);
+    }
+  }, []);
 
   // Calculate domain from the price history candlestick chart
   const calculatePriceHistoryDomain = useCallback(() => {
@@ -81,6 +94,9 @@ export function Chart({
   const { liquidityScale, priceScale, periodScale } = useMemo(() => {
     const priceDomain = calculatePriceHistoryDomain();
 
+    // Subtract right axis width using state
+    const priceScaleRange = axisRightWidth > 0 ? innerWidth - axisRightWidth : innerWidth * 0.93;
+
     const scales = {
       liquidityScale: scaleLinear()
         .domain([0, max(liquiditySeries, liquidityAccessor)] as number[])
@@ -91,7 +107,7 @@ export function Chart({
         .range([innerHeight, 0]),
       periodScale: scaleTime()
         .domain(extent(priceHistory, periodAccessor) as [Date, Date])
-        .range([0, innerWidth * 0.93]),
+        .range([0, priceScaleRange]),
     };
 
     if (zoom) {
@@ -100,7 +116,7 @@ export function Chart({
     }
 
     return scales;
-  }, [calculatePriceHistoryDomain, innerWidth, liquiditySeries, innerHeight, zoom, priceHistory]);
+  }, [calculatePriceHistoryDomain, innerWidth, liquiditySeries, innerHeight, zoom, priceHistory, axisRightWidth]);
 
   useEffect(() => {
     if (!brushDomain) {
@@ -288,6 +304,7 @@ export function Chart({
             }
             ticks={isMobile ? 4 : 6}
             offset={1}
+            onAxisMount={handleAxisMount}
           />
         </g>
         <AxisBottom

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -1,17 +1,17 @@
 import { useTheme } from "@pancakeswap/hooks";
-import { max, extent, scaleLinear, ZoomTransform, scaleTime } from "d3";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import partition from "lodash/partition";
 import { useMatchBreakpoints } from "@pancakeswap/uikit";
+import { extent, max, scaleLinear, scaleTime, ZoomTransform } from "d3";
+import partition from "lodash/partition";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Area } from "./VerticalArea";
+import { AxisBottom } from "./AxisBottom";
 import { AxisRight } from "./AxisRight";
 import { Brush } from "./Brush";
-import { HorizontalLine } from "./Line";
-import { LiquidityChartEntry, PriceChartEntry, ChartProps } from "./types";
-import Zoom, { ZoomOverlay } from "./Zoom";
-import { AxisBottom } from "./AxisBottom";
 import { CandleChart } from "./CandleChart";
+import { HorizontalLine } from "./Line";
+import { ChartProps, LiquidityChartEntry, PriceChartEntry } from "./types";
+import { Area } from "./VerticalArea";
+import Zoom, { ZoomOverlay } from "./Zoom";
 
 const priceAccessor = (d: LiquidityChartEntry) => d.price0;
 const liquidityAccessor = (d: LiquidityChartEntry) => d.activeLiquidity;
@@ -214,16 +214,7 @@ export function Chart({
             color={theme.colors.primary}
             strokeWidth={0.5}
           />
-          <AxisRight
-            yScale={priceScale}
-            innerWidth={width}
-            highlightValue={current}
-            highlightSecondaryValues={
-              brushDomain ? [Number(brushDomain.min.toPrecision(6)), Number(brushDomain.max.toPrecision(6))] : undefined
-            }
-            ticks={isMobile ? 4 : 6}
-            offset={1}
-          />
+
           <ZoomOverlay width={innerWidth} height={height} ref={zoomRef} />
           <Brush
             id={id}
@@ -238,6 +229,16 @@ export function Chart({
             minHandleColor={minHandleColor}
             maxHandleColor={maxHandleColor}
             current={current}
+          />
+          <AxisRight
+            yScale={priceScale}
+            innerWidth={width}
+            highlightValue={current}
+            highlightSecondaryValues={
+              brushDomain ? [Number(brushDomain.min.toPrecision(6)), Number(brushDomain.max.toPrecision(6))] : undefined
+            }
+            ticks={isMobile ? 4 : 6}
+            offset={1}
           />
         </g>
         <AxisBottom

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -297,11 +297,8 @@ export function Chart({
             yScale={priceScale}
             innerWidth={width}
             highlightValue={current}
-            highlightSecondaryValues={
-              localBrushExtent
-                ? [Number(localBrushExtent.min.toFixed(12)), Number(localBrushExtent.max.toFixed(12))]
-                : undefined
-            }
+            selectedMin={localBrushExtent ? Number(localBrushExtent.min.toFixed(12)) : undefined}
+            selectedMax={localBrushExtent ? Number(localBrushExtent.max.toFixed(12)) : undefined}
             ticks={isMobile ? 4 : 6}
             offset={1}
             onAxisMount={handleAxisMount}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Chart.tsx
@@ -43,7 +43,7 @@ export function Chart({
   const [zoom, setZoom] = useState<ZoomTransform | null>(null);
   const [axisRightWidth, setAxisRightWidth] = useState<number>(0);
 
-  // Handle axis mount and measure its width
+  // Need axis width to calculate price scale range (width of candlestick chart)
   const handleAxisMount = useCallback((element: SVGGElement | null) => {
     if (element) {
       // Use a small delay to ensure the axis is fully rendered

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/GridLines.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/GridLines.tsx
@@ -1,0 +1,89 @@
+import { ScaleLinear, ScaleTime, axisLeft, axisBottom, select } from "d3";
+import { useTheme } from "@pancakeswap/hooks";
+import { useEffect, useRef } from "react";
+import { styled } from "styled-components";
+
+interface GridLinesProps {
+  priceScale: ScaleLinear<number, number>;
+  periodScale: ScaleTime<number, number>;
+  innerWidth: number;
+  innerHeight: number;
+  showHorizontal?: boolean;
+  showVertical?: boolean;
+  horizontalTicks?: number;
+  verticalTicks?: number;
+}
+
+const StyledGridGroup = styled.g<{ $stroke: string }>`
+  .grid line {
+    stroke: ${({ $stroke }) => $stroke};
+    stroke-width: 0.5;
+    stroke-opacity: 0.3;
+    shape-rendering: crispEdges;
+  }
+
+  .grid path {
+    stroke-width: 0;
+  }
+
+  .grid text {
+    display: none;
+  }
+`;
+
+export const GridLines = ({
+  priceScale,
+  periodScale,
+  innerWidth,
+  innerHeight,
+  showHorizontal = true,
+  showVertical = true,
+  horizontalTicks = 6,
+  verticalTicks = 6,
+}: GridLinesProps) => {
+  const { theme } = useTheme();
+  const horizontalGridRef = useRef<SVGGElement>(null);
+  const verticalGridRef = useRef<SVGGElement>(null);
+
+  const gridColor = theme.colors.cardBorder;
+
+  useEffect(() => {
+    if (showHorizontal && horizontalGridRef.current) {
+      const horizontalGrid = axisLeft(priceScale)
+        .ticks(horizontalTicks)
+        .tickSize(-innerWidth)
+        .tickFormat(() => "");
+
+      select(horizontalGridRef.current).call(horizontalGrid);
+    }
+
+    if (showVertical && verticalGridRef.current) {
+      const verticalGrid = axisBottom(periodScale)
+        .ticks(verticalTicks)
+        .tickSize(-innerHeight)
+        .tickFormat(() => "");
+
+      select(verticalGridRef.current).call(verticalGrid);
+    }
+  }, [
+    priceScale,
+    periodScale,
+    innerWidth,
+    innerHeight,
+    horizontalTicks,
+    verticalTicks,
+    showHorizontal,
+    showVertical,
+    gridColor,
+  ]);
+
+  return (
+    <StyledGridGroup $stroke={gridColor}>
+      {showHorizontal && <g ref={horizontalGridRef} className="grid horizontal-grid" />}
+
+      {showVertical && (
+        <g ref={verticalGridRef} className="grid vertical-grid" transform={`translate(0, ${innerHeight})`} />
+      )}
+    </StyledGridGroup>
+  );
+};

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -38,6 +38,7 @@ export interface PricePeriodRangeChartProps {
   formattedData: LiquidityChartEntry[] | undefined;
   priceHistoryData?: PriceChartEntry[];
   axisTicks?: ChartProps["axisTicks"];
+  showGridLines?: boolean;
 }
 
 export function PricePeriodRangeChart({
@@ -57,6 +58,7 @@ export function PricePeriodRangeChart({
   formattedData,
   priceHistoryData,
   axisTicks,
+  showGridLines = true,
 }: PricePeriodRangeChartProps) {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -165,6 +167,7 @@ export function PricePeriodRangeChart({
             zoomLevels={zoomLevel ?? ZOOM_LEVELS[TICK_SPACING_LEVEL.MEDIUM]}
             ticksAtLimit={ticksAtLimit}
             axisTicks={axisTicks}
+            showGridLines={showGridLines}
           />
         </ChartWrapper>
       )}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -149,7 +149,7 @@ export function PricePeriodRangeChart({
             dimensions={{ width: 400, height: 200 }}
             margins={{
               top: 10,
-              right: 2,
+              right: 4,
               bottom: 20,
               left: 0,
             }}

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -147,7 +147,12 @@ export function PricePeriodRangeChart({
             key={baseCurrency.wrapped.address}
             data={{ liquiditySeries: formattedData, current: price, priceHistory: priceHistoryData }}
             dimensions={{ width: 400, height: 200 }}
-            margins={{ top: 10, right: 18, bottom: 20, left: 0 }}
+            margins={{
+              top: 10,
+              right: 2,
+              bottom: 20,
+              left: 0,
+            }}
             styles={{
               area: {
                 selection: theme.colors.text,

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -147,7 +147,7 @@ export function PricePeriodRangeChart({
             key={baseCurrency.wrapped.address}
             data={{ liquiditySeries: formattedData, current: price, priceHistory: priceHistoryData }}
             dimensions={{ width: 400, height: 200 }}
-            margins={{ top: 10, right: 2, bottom: 20, left: 0 }}
+            margins={{ top: 10, right: 18, bottom: 20, left: 0 }}
             styles={{
               area: {
                 selection: theme.colors.text,

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -82,6 +82,12 @@ export function PricePeriodRangeChart({
 
   const onBrushDomainChangeEnded = useCallback(
     (domain: BrushDomainType, mode: string | undefined) => {
+      // Don't trigger parent callbacks for automatic domain changes (when mode is undefined)
+      // This prevents double inversion when currencies change due to route updates
+      if (mode === undefined) {
+        return;
+      }
+
       const { min, max } = brushDomain || {};
       const newMinPrice = domain.min <= 0 ? 1 / 10 ** 6 : domain.min;
       const newMaxPrice = domain.max;

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -82,7 +82,7 @@ export function PricePeriodRangeChart({
 
   const onBrushDomainChangeEnded = useCallback(
     (domain: BrushDomainType, mode: string | undefined) => {
-      // This prevents double inversion when currencies change due to route updates,
+      // This prevents double inversion in V3's Add Liquidity when currencies change due to route updates,
       // while still allowing to set the initial domain on load
       if (mode === undefined && brushDomain) {
         return;

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/PricePeriodRangeChart.tsx
@@ -82,9 +82,9 @@ export function PricePeriodRangeChart({
 
   const onBrushDomainChangeEnded = useCallback(
     (domain: BrushDomainType, mode: string | undefined) => {
-      // Don't trigger parent callbacks for automatic domain changes (when mode is undefined)
-      // This prevents double inversion when currencies change due to route updates
-      if (mode === undefined) {
+      // This prevents double inversion when currencies change due to route updates,
+      // while still allowing to set the initial domain on load
+      if (mode === undefined && brushDomain) {
         return;
       }
 

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/ToolTip.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/ToolTip.tsx
@@ -35,7 +35,7 @@ export const ToolTip = ({ visible = false, flip = false, text = "", textRef, wid
       })`}
       visible={visible}
     >
-      <TooltipBackground y="0" x="0" height={LABEL_HEIGHT} width={boxWidth} rx="8" />
+      <TooltipBackground y="0" x="0" height={LABEL_HEIGHT} width={boxWidth} rx="4" />
       <TooltipText y={LABEL_HEIGHT / 2 + 1} x={boxWidth / 2} dominantBaseline="middle" ref={textRef}>
         {text}
       </TooltipText>

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/ToolTip.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/ToolTip.tsx
@@ -20,23 +20,45 @@ export interface ToolTipProps {
   text: string;
   textRef: React.Ref<SVGTextElement>;
   width?: number;
+  isMobile?: boolean;
 }
 
 const LABEL_WIDTH = 37;
 const LABEL_HEIGHT = 20;
 const PADDING_RIGHT = 4;
 
-export const ToolTip = ({ visible = false, flip = false, text = "", textRef, width = LABEL_WIDTH }: ToolTipProps) => {
-  const boxWidth = Math.ceil(width + PADDING_RIGHT * 2);
+const MOBILE_LABEL_WIDTH = 45;
+const MOBILE_LABEL_HEIGHT = 24;
+const MOBILE_PADDING_RIGHT = 5;
+
+export const ToolTip = ({
+  visible = false,
+  flip = false,
+  text = "",
+  textRef,
+  width,
+  isMobile = false,
+}: ToolTipProps) => {
+  const labelWidth = isMobile ? MOBILE_LABEL_WIDTH : LABEL_WIDTH;
+  const labelHeight = isMobile ? MOBILE_LABEL_HEIGHT : LABEL_HEIGHT;
+  const paddingRight = isMobile ? MOBILE_PADDING_RIGHT : PADDING_RIGHT;
+  const defaultWidth = width ?? labelWidth;
+  const boxWidth = Math.ceil(defaultWidth + paddingRight * 2);
   return (
     <LabelGroup
-      transform={`translate(-${boxWidth + 6}, ${LABEL_HEIGHT * (flip ? 0.5 : -0.5) + 7}), scale(1, ${
-        flip ? "-1" : "1"
-      })`}
+      transform={`translate(-${boxWidth + (isMobile ? 8 : 6)}, ${
+        labelHeight * (flip ? 0.5 : -0.5) + (isMobile ? 9 : 7)
+      }), scale(1, ${flip ? "-1" : "1"})`}
       visible={visible}
     >
-      <TooltipBackground y="0" x="0" height={LABEL_HEIGHT} width={boxWidth} rx="4" />
-      <TooltipText y={LABEL_HEIGHT / 2 + 1} x={boxWidth / 2} dominantBaseline="middle" ref={textRef}>
+      <TooltipBackground y="0" x="0" height={labelHeight} width={boxWidth} rx={isMobile ? 5 : 4} />
+      <TooltipText
+        y={labelHeight / 2 + 1}
+        x={boxWidth / 2}
+        dominantBaseline="middle"
+        ref={textRef}
+        style={{ fontSize: isMobile ? "12px" : "10px" }}
+      >
         {text}
       </TooltipText>
     </LabelGroup>

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
@@ -9,8 +9,6 @@ const Wrapper = styled.div<{ $count: number; $isMobile?: boolean }>`
   grid-template-columns: repeat(${({ $count }) => $count.toString()}, 1fr);
   grid-gap: 6px;
 
-  margin-left: auto;
-
   position: absolute;
   top: ${({ $isMobile }) => ($isMobile ? `-5px` : `-26px`)};
   right: ${({ $isMobile }) => ($isMobile ? `auto` : `0`)};
@@ -22,8 +20,6 @@ export const ZoomOverlay = styled.rect`
   cursor: grab;
 
   z-index: 3;
-
-  border: 1px solid red;
 
   &:active {
     cursor: grabbing;

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
@@ -9,6 +9,8 @@ const Wrapper = styled.div<{ $count: number; $isMobile?: boolean }>`
   grid-template-columns: repeat(${({ $count }) => $count.toString()}, 1fr);
   grid-gap: 6px;
 
+  margin-left: auto;
+
   position: absolute;
   top: ${({ $isMobile }) => ($isMobile ? `-5px` : `-26px`)};
   right: ${({ $isMobile }) => ($isMobile ? `auto` : `0`)};
@@ -18,6 +20,10 @@ const Wrapper = styled.div<{ $count: number; $isMobile?: boolean }>`
 export const ZoomOverlay = styled.rect`
   fill: transparent;
   cursor: grab;
+
+  z-index: 3;
+
+  border: 1px solid red;
 
   &:active {
     cursor: grabbing;

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/Zoom.tsx
@@ -48,7 +48,7 @@ export default function Zoom({
   const zoomBehavior = useRef<ZoomBehavior<Element, unknown>>();
   const { isMobile } = useMatchBreakpoints();
 
-  const [zoomIn, zoomOut, zoomInitial, zoomReset] = useMemo(
+  const [zoomIn, zoomOut, _zoomInitial, zoomReset] = useMemo(
     () => [
       () =>
         svg &&
@@ -92,11 +92,6 @@ export default function Zoom({
       select(svg as Element).call(zoomBehavior.current);
     }
   }, [height, width, setZoom, svg, xScale, zoomBehavior, zoomLevels, zoomLevels.max, zoomLevels.min]);
-
-  useEffect(() => {
-    // reset zoom to initial on zoomLevel change
-    zoomInitial();
-  }, [zoomInitial, zoomLevels]);
 
   return (
     <Wrapper $count={showResetButton ? 3 : 2} $isMobile={isMobile}>

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/svg.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/svg.tsx
@@ -1,28 +1,30 @@
+export const brushHandlePath = (width: number) =>
+  `M 3 0 h ${width} m 0 1 H 0 M 0 0 L 0 0 h 17 v 7 q 0 4 -4 4 h -9 q -4 0 -4 -4 z`;
 /*
  * https://medium.com/@dennismphil/one-side-rounded-rectangle-using-svg-fb31cf318d90
  */
-export const brushHandlePath = (width: number) =>
-  [
-    // handle
-    "M 3 0", // move to origin
-    `h ${width}`, // horizontal line
-    "m 0 1", // move 1px to the top
-    "H 0", // second horizontal line
-    "M 3 0", // move to origin
+// export const brushHandlePath = (width: number) =>
+//   [
+//     // handle
+//     "M 3 0", // move to origin
+//     `h ${width}`, // horizontal line
+//     "m 0 1", // move 1px to the top
+//     "H 0", // second horizontal line
+//     "M 3 0", // move to origin
 
-    // head
-    "M 0 4", // move to left side, 4px down
-    "q 0 -4 4 -4", // top-left corner radius
-    "h 16", // horizontal line
-    "q 4 0 4 4", // top-right corner radius
-    "v 7", // vertical line
-    "q 0 4 -4 4", // bottom-right corner radius
-    "h -16", // horizontal line
-    "q -4 0 -4 -4", // bottom-left corner radius
-    "z", // close path
-  ].join(" ");
+//     // head
+//     "M 0 4", // move to left side, 4px down
+//     "q 0 -4 4 -4", // top-left corner radius
+//     "h 16", // horizontal line
+//     "q 4 0 4 4", // top-right corner radius
+//     "v 7", // vertical line
+//     "q 0 4 -4 4", // bottom-right corner radius
+//     "h -16", // horizontal line
+//     "q -4 0 -4 0", // bottom-left corner radius
+//     "z", // close path
+//   ].join(" ");
 
-export const brushHandleAccentPath = () => "m 5 9 h 14 M 0 0 m 5 5 h 14 z";
+export const brushHandleAccentPath = () => "m 5 7 h 7 M 0 0 m 5 4 h 7 z";
 // export const brushHandleAccentPath = () =>
 // "M 4 0 h 16 a 4 4 0 0 1 4 4 v 7 a 4 4 0 0 1 -4 4 h -16 a 4 4 0 0 1 -4 -4 v -7 a 4 4 0 0 1 4 -4";
 

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/svg.tsx
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/svg.tsx
@@ -1,5 +1,8 @@
 export const brushHandlePath = (width: number) =>
   `M 3 0 h ${width} m 0 1 H 0 M 0 0 L 0 0 h 17 v 7 q 0 4 -4 4 h -9 q -4 0 -4 -4 z`;
+
+export const brushHandlePathMobile = (width: number) =>
+  `M 3.5 0 h ${width} m 0 1.2 H 0 M 0 0 L 0 0 h 23 v 9 q 0 5 -5 5 h -13 q -5 0 -5 -5 z`;
 /*
  * https://medium.com/@dennismphil/one-side-rounded-rectangle-using-svg-fb31cf318d90
  */
@@ -25,6 +28,8 @@ export const brushHandlePath = (width: number) =>
 //   ].join(" ");
 
 export const brushHandleAccentPath = () => "m 5 7 h 7 M 0 0 m 5 4 h 7 z";
+
+export const brushHandleAccentPathMobile = () => "m 6.5 9 h 10 M 0 0 m 6.5 5.5 h 10 z";
 // export const brushHandleAccentPath = () =>
 // "M 4 0 h 16 a 4 4 0 0 1 4 4 v 7 a 4 4 0 0 1 -4 4 h -16 a 4 4 0 0 1 -4 -4 v -7 a 4 4 0 0 1 4 -4";
 

--- a/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/types.ts
+++ b/packages/widgets-internal/components/PriceRangeChartWithPeriodAndLiquidity/types.ts
@@ -61,6 +61,7 @@ export interface ChartProps {
   zoomLevels: ZoomLevels;
   showZoomButtons?: boolean;
   axisTicks?: { bottomTicks?: TicksType; bottomFormat?: TickFormat };
+  showGridLines?: boolean;
 }
 
 export enum Bound {

--- a/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
+++ b/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
@@ -14,16 +14,16 @@ const StyledButton = styled(Button)<{ $isActive: boolean }>`
 
 export const PRESET_RANGE_ITEMS = [
   {
-    label: "1D",
-    value: "1D",
+    label: "1M",
+    value: "1M",
   },
   {
     label: "7D",
     value: "1W",
   },
   {
-    label: "1M",
-    value: "1M",
+    label: "1D",
+    value: "1D",
   },
 ] as const;
 

--- a/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
+++ b/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
@@ -3,10 +3,10 @@ import { ButtonMenu, ButtonMenuItem, FlexGap, Text } from "@pancakeswap/uikit";
 import { useCallback, useMemo } from "react";
 
 export const PRESET_RANGE_ITEMS = [
-  {
-    label: "1H",
-    value: "1H",
-  },
+  // {
+  //   label: "1H",
+  //   value: "1H",
+  // },
   {
     label: "1D",
     value: "1D",

--- a/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
+++ b/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
@@ -1,12 +1,18 @@
 import { useTranslation } from "@pancakeswap/localization";
-import { ButtonMenu, ButtonMenuItem, FlexGap, Text } from "@pancakeswap/uikit";
+import { Button, ButtonMenuItem, FlexGap, Text } from "@pancakeswap/uikit";
 import { useCallback, useMemo } from "react";
+import styled from "styled-components";
+
+const ButtonGroup = styled(FlexGap)``;
+
+const StyledButton = styled(Button)<{ $isActive: boolean }>`
+  color: ${({ $isActive, theme }) => ($isActive ? theme.colors.primary60 : theme.colors.textSubtle)};
+  font-weight: ${({ $isActive }) => ($isActive ? "600" : "400")};
+  padding: 0 14px;
+  transition: all 0.2s ease-out;
+`;
 
 export const PRESET_RANGE_ITEMS = [
-  // {
-  //   label: "1H",
-  //   value: "1H",
-  // },
   {
     label: "1D",
     value: "1D",
@@ -46,16 +52,20 @@ export const PriceRangeDatePicker = ({
   );
   return (
     <FlexGap columnGap="12px" gap="12px" alignItems="center">
-      <Text color="secondary" small bold>
-        {t("PRICE RANGE")}
-      </Text>
-      <ButtonMenu variant="subtle" style={{ borderRadius: 30 }} activeIndex={activeIndex} onItemClick={onItemSelect}>
-        {PRESET_RANGE_ITEMS.map((item) => (
-          <ButtonMenuItem height={height || "36px"} px="16px" style={{ borderRadius: 30 }} key={item.value}>
+      <ButtonGroup>
+        {PRESET_RANGE_ITEMS.map((item, index) => (
+          <StyledButton
+            variant="text"
+            scale="xs"
+            height={height || "24px"}
+            key={item.value}
+            onClick={() => onItemSelect(index)}
+            $isActive={activeIndex === index}
+          >
             {item.label}
-          </ButtonMenuItem>
+          </StyledButton>
         ))}
-      </ButtonMenu>
+      </ButtonGroup>
     </FlexGap>
   );
 };

--- a/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
+++ b/packages/widgets-internal/liquidity/infinity/PriceRangeDatePicker.tsx
@@ -1,5 +1,4 @@
-import { useTranslation } from "@pancakeswap/localization";
-import { Button, ButtonMenuItem, FlexGap, Text } from "@pancakeswap/uikit";
+import { Button, ButtonMenu, ButtonMenuItem, FlexGap, Text, useMatchBreakpoints } from "@pancakeswap/uikit";
 import { useCallback, useMemo } from "react";
 import styled from "styled-components";
 
@@ -40,7 +39,7 @@ export const PriceRangeDatePicker = ({
   height,
   onChange,
 }: PriceRangeDatePickerProps) => {
-  const { t } = useTranslation();
+  const { isMobile } = useMatchBreakpoints();
 
   const activeIndex = useMemo(() => PRESET_RANGE_ITEMS.findIndex((item) => item.value === value.value), [value]);
 
@@ -52,20 +51,35 @@ export const PriceRangeDatePicker = ({
   );
   return (
     <FlexGap columnGap="12px" gap="12px" alignItems="center">
-      <ButtonGroup>
-        {PRESET_RANGE_ITEMS.map((item, index) => (
-          <StyledButton
-            variant="text"
-            scale="xs"
-            height={height || "24px"}
-            key={item.value}
-            onClick={() => onItemSelect(index)}
-            $isActive={activeIndex === index}
-          >
-            {item.label}
-          </StyledButton>
-        ))}
-      </ButtonGroup>
+      {isMobile ? (
+        <ButtonMenu
+          variant="subtle"
+          style={{ borderRadius: 30, width: "100%" }}
+          activeIndex={activeIndex}
+          onItemClick={onItemSelect}
+        >
+          {PRESET_RANGE_ITEMS.map((item) => (
+            <ButtonMenuItem key={item.value} height={height || "36px"} px="16px" style={{ borderRadius: 30 }}>
+              {item.label}
+            </ButtonMenuItem>
+          ))}
+        </ButtonMenu>
+      ) : (
+        <ButtonGroup>
+          {PRESET_RANGE_ITEMS.map((item, index) => (
+            <StyledButton
+              variant="text"
+              scale="xs"
+              height={height || "24px"}
+              key={item.value}
+              onClick={() => onItemSelect(index)}
+              $isActive={activeIndex === index}
+            >
+              {item.label}
+            </StyledButton>
+          ))}
+        </ButtonGroup>
+      )}
     </FlexGap>
   );
 };

--- a/packages/widgets-internal/liquidity/infinity/constants.ts
+++ b/packages/widgets-internal/liquidity/infinity/constants.ts
@@ -73,19 +73,19 @@ export const QUICK_ACTION_CONFIGS: Record<TICK_SPACING_LEVEL, { [percentage: num
   [TICK_SPACING_LEVEL.FINE]: {
     5: {
       initialMin: 0.95,
-      initialMax: 1.054,
+      initialMax: 1.05,
       min: 0.00001,
       max: 1.5,
     },
     10: {
       initialMin: 0.9,
-      initialMax: 1.11,
+      initialMax: 1.1,
       min: 0.00001,
       max: 1.5,
     },
     20: {
       initialMin: 0.8,
-      initialMax: 1.25,
+      initialMax: 1.2,
       min: 0.00001,
       max: 1.5,
     },
@@ -93,17 +93,22 @@ export const QUICK_ACTION_CONFIGS: Record<TICK_SPACING_LEVEL, { [percentage: num
   [TICK_SPACING_LEVEL.MEDIUM]: {
     10: {
       initialMin: 0.9,
-      initialMax: 1.11,
+      initialMax: 1.1,
       min: 0.00001,
       max: 20,
     },
     20: {
       initialMin: 0.8,
-      initialMax: 1.25,
+      initialMax: 1.2,
       min: 0.00001,
       max: 20,
     },
-    50: ZOOM_LEVELS[TICK_SPACING_LEVEL.MEDIUM],
+    50: {
+      initialMin: 0.5,
+      initialMax: 1.5,
+      min: 0.00001,
+      max: 20,
+    },
   },
   [TICK_SPACING_LEVEL.COARSE]: {
     10: {
@@ -114,10 +119,15 @@ export const QUICK_ACTION_CONFIGS: Record<TICK_SPACING_LEVEL, { [percentage: num
     },
     20: {
       initialMin: 0.8,
-      initialMax: 1.25,
+      initialMax: 1.2,
       min: 0.00001,
       max: 20,
     },
-    50: ZOOM_LEVELS[TICK_SPACING_LEVEL.COARSE],
+    50: {
+      initialMin: 0.5,
+      initialMax: 1.5,
+      min: 0.00001,
+      max: 20,
+    },
   },
 };


### PR DESCRIPTION
Adds candlestick price selector charts to **Infinity** and **V3** Add Liquidity Pages
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the user interface and functionality of liquidity-related components in a web application, particularly improving responsiveness and introducing new features like grid lines in charts and better handling of price ranges.

### Detailed summary
- Added `color="primary60"` to `ScanLink`.
- Introduced `showGridLines` option in `PriceRangeChartWithPeriodAndLiquidity`.
- Improved layout responsiveness using `isMobile` checks.
- Enhanced `Brush` and `GridLines` components for better chart interaction.
- Updated `ToolTip` for mobile compatibility.
- Refined price range handling in liquidity forms.
- Adjusted font sizes and spacing for better UI consistency.

> The following files were skipped due to too many changes: `apps/web/src/views/AddLiquidityV3/formViews/V3FormView/index.tsx`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->