### PR TITLE
chore: show global settings in slippage button, remove history tab

### DIFF
--- a/apps/web/src/views/Swap/components/SlippageButton.tsx
+++ b/apps/web/src/views/Swap/components/SlippageButton.tsx
@@ -20,7 +20,9 @@ import {
 } from '@pancakeswap/uikit'
 import { useUserSlippage } from '@pancakeswap/utils/user'
 import { VerticalDivider } from '@pancakeswap/widgets-internal'
+import GlobalSettings from 'components/Menu/GlobalSettings'
 import { DEFAULT_SLIPPAGE_TOLERANCE, SlippageError } from 'components/Menu/GlobalSettings/TransactionSettings'
+import { SettingsMode } from 'components/Menu/GlobalSettings/types'
 
 import { useAutoSlippageEnabled, useAutoSlippageWithFallback } from 'hooks/useAutoSlippageWithFallback'
 import { useCallback, useState } from 'react'
@@ -94,32 +96,49 @@ export const SlippageButton = ({ enableAutoSlippage = false }: SlippageButtonPro
     ? theme.colors.yellow
     : theme.colors.primary60
 
+  const button = (onClick) => (
+    <div style={{ textAlign: 'center' }}>
+      <div ref={!isMobile ? targetRef : undefined}>
+        <TertiaryButton
+          $color={color}
+          startIcon={
+            isRiskyVeryHigh ? (
+              <RiskAlertIcon color={color} width={16} />
+            ) : isRiskyLow || isRiskyHigh ? (
+              <WarningIcon color={color} width={16} />
+            ) : undefined
+          }
+          endIcon={<PencilIcon color={color} width={12} />}
+          onClick={onClick}
+        >
+          {enableAutoSlippage && isAuto && tolerance
+            ? `${t('Auto')}: ${basisPointsToPercent(tolerance).toFixed(2)}%`
+            : typeof tolerance === 'number'
+            ? `${basisPointsToPercent(tolerance).toFixed(2)}%`
+            : tolerance}
+        </TertiaryButton>
+      </div>
+
+      {(isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
+    </div>
+  )
+
+  if (enableAutoSlippage) {
+    return (
+      <>
+        <GlobalSettings
+          id="slippage_btn_global_settings"
+          key="slippage_btn_global_settings"
+          mode={SettingsMode.SWAP_LIQUIDITY}
+          overrideButton={button}
+        />
+      </>
+    )
+  }
+
   return (
     <>
-      <div style={{ textAlign: 'center' }}>
-        <div ref={!isMobile ? targetRef : undefined}>
-          <TertiaryButton
-            $color={color}
-            startIcon={
-              isRiskyVeryHigh ? (
-                <RiskAlertIcon color={color} width={16} />
-              ) : isRiskyLow || isRiskyHigh ? (
-                <WarningIcon color={color} width={16} />
-              ) : undefined
-            }
-            endIcon={<PencilIcon color={color} width={12} />}
-            onClick={onOpen}
-          >
-            {enableAutoSlippage && isAuto && tolerance
-              ? `${t('Auto')}: ${basisPointsToPercent(tolerance).toFixed(2)}%`
-              : typeof tolerance === 'number'
-              ? `${basisPointsToPercent(tolerance).toFixed(2)}%`
-              : tolerance}
-          </TertiaryButton>
-        </div>
-
-        {(isRiskyLow || isRiskyHigh) && tooltipVisible && tooltip}
-      </div>
+      {button(onOpen)}
       <SlippageSettingsModal isOpen={isOpen} onDismiss={onDismiss} enableAutoSlippage={enableAutoSlippage} />
     </>
   )

--- a/apps/web/src/views/universalFarms/UniversalFarms.tsx
+++ b/apps/web/src/views/universalFarms/UniversalFarms.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Button, Card, FlexGap, Tab, TabMenu, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
+import { Button, FlexGap, Tab, TabMenu, Text, useMatchBreakpoints } from '@pancakeswap/uikit'
 import { NextLinkFromReactRouter } from '@pancakeswap/widgets-internal'
 import Page_ from 'components/Layout/Page'
 import { useRouter } from 'next/router'
@@ -30,7 +30,6 @@ const ButtonContainer = styled.div`
 const PAGES_LINK = {
   POOLS: '/liquidity/pools',
   POSITIONS: '/liquidity/positions',
-  HISTORY: '/farms/history',
 }
 
 const usePageInfo = () => {
@@ -102,14 +101,6 @@ export const UniversalFarms: React.FC<PropsWithChildren> = () => {
           </StyledTab>
         ),
         page: () => <PositionPage />,
-      },
-      2: {
-        menu: () => (
-          <StyledTab key="history">
-            <NextLinkFromReactRouter to={PAGES_LINK.HISTORY}>{t('History')}</NextLinkFromReactRouter>
-          </StyledTab>
-        ),
-        page: () => <Card>History</Card>,
       },
     }
   }, [t])


### PR DESCRIPTION
1. PAN-7523
2. PAN-7528

<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on the `UniversalFarms` and `SlippageButton` components. It removes the `HISTORY` tab from `UniversalFarms` and enhances the `SlippageButton` by integrating `GlobalSettings` and restructuring the button rendering logic.

### Detailed summary
- Removed `HISTORY` tab from `UniversalFarms`.
- Updated `SlippageButton` to include `GlobalSettings`.
- Refactored button rendering logic in `SlippageButton` for better clarity and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->