### PR TITLE
fix: PAN 7383

### DIFF
--- a/apps/web/src/hooks/useAccountActiveChain.ts
+++ b/apps/web/src/hooks/useAccountActiveChain.ts
@@ -37,7 +37,7 @@ export const useActiveChainId = (checkChainId?: number) => {
   return {
     chainId,
     isNotMatched,
-    isWrongNetwork: isWrongNetwork ? Boolean(checkChainId && checkChainId !== chainId) : false,
+    isWrongNetwork: checkChainId ? isWrongNetwork && checkChainId !== chainId : isWrongNetwork,
   }
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the logic for the `isWrongNetwork` property in the `useAccountActiveChain` hook to improve clarity and functionality when determining if the current network is incorrect based on the `checkChainId`.

### Detailed summary
- Modified the calculation of `isWrongNetwork`:
  - Changed from a ternary operation to a more straightforward conditional check.
  - Now checks if `checkChainId` exists, and if so, verifies both `isWrongNetwork` and whether `checkChainId` differs from `chainId`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->