### PR TITLE
chore: New Crowdin updates

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -3125,7 +3125,7 @@
   "Token Launches": "代币发布",
   "Get Help": "获取帮助",
   "Audits": "审计",
-  "Perps": "Perp",
+  "Perps": "永续合约",
   "Farm / Liquidity": "农场/流动性",
   "Play": "参与",
   "Legacy products": "传统产品",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -3125,7 +3125,7 @@
   "Token Launches": "代幣發行",
   "Get Help": "取得說明",
   "Audits": "稽核",
-  "Perps": "Perp",
+  "Perps": "永續合約",
   "Farm / Liquidity": "農場 / 流動性",
   "Play": "參與",
   "Legacy products": "傳統產品",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the Chinese translations for the term "Perps" in the `locales/zh-CN.json` and `locales/zh-TW.json` files, changing it from "Perp" to "永续合约" and "永續合約" respectively.

### Detailed summary
- In `locales/zh-CN.json`, changed:
  - `"Perps": "Perp"` to `"Perps": "永续合约"`
  
- In `locales/zh-TW.json`, changed:
  - `"Perps": "Perp"` to `"Perps": "永續合約"`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->