### PR TITLE
fix: PAN 7370

### DIFF
--- a/apps/web/src/quoter/utils/__test__/parseSVMTradeIntoSVMOrder.test.ts
+++ b/apps/web/src/quoter/utils/__test__/parseSVMTradeIntoSVMOrder.test.ts
@@ -1,10 +1,12 @@
 import { OrderType } from '@pancakeswap/price-api-sdk'
 import { PoolType, SVMPool } from '@pancakeswap/smart-router'
-import type { SolRouterTrade } from '@pancakeswap/solana-router-sdk'
+import { SOL } from '@pancakeswap/sdk'
 import { SPLToken, TradeType, UnifiedCurrencyAmount } from '@pancakeswap/swap-sdk-core'
 import { PublicKey } from '@solana/web3.js'
 import type { SVMQuoteQuery } from '../../quoter.types'
 import { parseRoutePlansToRoutes, parseSVMTradeIntoSVMOrder } from '../svm-utils/parseSVMTradeIntoSVMOrder'
+
+const NATIVE_SOL = SOL
 
 // Mock tokens
 const MOCK_SOL = new SPLToken({
@@ -50,7 +52,7 @@ const MOCK_TOKEN_2 = new SPLToken({
 describe('parseSVMTradeIntoSVMOrder', () => {
   it('should convert SolRouterTrade to SVMOrder correctly with single-route and single-hop', () => {
     // Mock SolRouterTrade
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       inputAmount: UnifiedCurrencyAmount.fromRawAmount(MOCK_SOL, '1000000000'), // 1 SOL
@@ -139,7 +141,7 @@ describe('single-route', () => {
   // NOTE: no need to test single-hop only because it's already tested in the main test
 
   it('should work with multi-hop', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       otherAmountThreshold: '99000000', // 99 USDC minimum out
@@ -210,7 +212,7 @@ describe('single-route', () => {
 
 describe('split-routes', () => {
   it('should work with single-hop only', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       inputAmount: UnifiedCurrencyAmount.fromRawAmount(MOCK_SOL, '1000000000'), // 1 SOL
@@ -269,7 +271,7 @@ describe('split-routes', () => {
   })
 
   it('should work with multi-hop in first', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       otherAmountThreshold: '16780', // 99 USDC minimum out
@@ -363,7 +365,7 @@ describe('split-routes', () => {
   })
 
   it('should work with multi-hop in middle', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       otherAmountThreshold: '16780', // 99 USDC minimum out
@@ -481,7 +483,7 @@ describe('split-routes', () => {
   })
 
   it('should work with multi-hop in last', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       otherAmountThreshold: '99000000', // 99 USDC minimum out
@@ -559,7 +561,7 @@ describe('split-routes', () => {
   })
 
   it('should work with all multi-hop', () => {
-    const mockSolRouterTrade: SolRouterTrade = {
+    const mockSolRouterTrade = {
       requestId: 'mock_request_id',
       tradeType: TradeType.EXACT_INPUT,
       otherAmountThreshold: '99000000', // 99 USDC minimum out
@@ -648,6 +650,101 @@ describe('split-routes', () => {
     expect(route2.path.length).toBe(3)
     expect(route2.path[0]).toBe(MOCK_SOL)
     expect(route2.path[1].wrapped.address).toBe(MOCK_TOKEN_2.address)
+    expect(route2.path[2]).toBe(MOCK_USDC)
+  })
+
+  it('should work with native solana', () => {
+    const mockSolRouterTrade = {
+      requestId: 'mock_request_id',
+      tradeType: TradeType.EXACT_INPUT,
+      otherAmountThreshold: '99000000', // 99 USDC minimum out
+      priceImpactPct: '0.0002', // 0.15%
+      slippageBps: 50,
+      transaction: 'mock_transaction_string',
+      inputAmount: UnifiedCurrencyAmount.fromRawAmount(NATIVE_SOL as unknown as SPLToken, '1000000'),
+      outputAmount: UnifiedCurrencyAmount.fromRawAmount(MOCK_USDC, '289245979504'),
+      routes: [
+        {
+          swapInfo: {
+            ammKey: new PublicKey('GtpsrTHYnfFVm3qkPJtyKVwQLpXT7p2MRy9bp5hYeJnQ'),
+            label: 'PancakeSwap',
+            inputMint: 'So11111111111111111111111111111111111111112',
+            outputMint: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+            inAmount: '53000000',
+            outAmount: '36501273675',
+            feeAmount: '9576',
+            feeMint: new PublicKey('So11111111111111111111111111111111111111112'),
+          },
+          percent: 53,
+          bps: 5300,
+        },
+        {
+          swapInfo: {
+            ammKey: new PublicKey('8B8KYcFPMjZyDtJ1BENsqhW3fEmMrB4ekoEQJiM6z3SC'),
+            label: 'TesseraV',
+            inputMint: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+            outputMint: MOCK_USDC.address,
+            inAmount: '36501273675',
+            outAmount: '8864881',
+            feeAmount: '0',
+            feeMint: new PublicKey('11111111111111111111111111111111'),
+          },
+          percent: 100,
+          bps: 10000,
+        },
+        {
+          swapInfo: {
+            ammKey: new PublicKey('FLckHLGMJy5gEoXWwcE68Nprde1D4araK4TGLw4pQq2n'),
+            label: 'TesseraV',
+            inputMint: 'So11111111111111111111111111111111111111112',
+            outputMint: '674PmuiDtgKx3uKuJ1B16f9m5L84eFvNwj3xDMvHcbo7',
+            inAmount: '47000000',
+            outAmount: '7861054',
+            feeAmount: '0',
+            feeMint: new PublicKey('11111111111111111111111111111111'),
+          },
+          percent: 47,
+          bps: 4700,
+        },
+        {
+          swapInfo: {
+            ammKey: new PublicKey('F4i12x6vu71dhHpWBrpRjPYGnNFqH4emVPrsPZydB5c9'),
+            label: 'Raydium',
+            inputMint: '674PmuiDtgKx3uKuJ1B16f9m5L84eFvNwj3xDMvHcbo7',
+            outputMint: MOCK_USDC.address,
+            inAmount: '16725935',
+            outAmount: '28213897225637',
+            feeAmount: '15890',
+            feeMint: new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+          },
+          percent: 100,
+          bps: 10000,
+        },
+      ],
+    }
+
+    expect(mockSolRouterTrade.inputAmount.currency.isNative).toBe(true)
+
+    const routes = parseRoutePlansToRoutes(mockSolRouterTrade)
+
+    expect(routes).toHaveLength(2)
+
+    const [route1, route2] = routes
+
+    expect(route1.pools).toHaveLength(2)
+    expect(route1.percent).toBe(53)
+
+    expect(route1.path.length).toBe(3)
+    expect(route1.path[0]).toBe(NATIVE_SOL)
+    expect(route1.path[1].wrapped.address).toBe('DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263')
+    expect(route1.path[2]).toBe(MOCK_USDC)
+
+    expect(route2.pools).toHaveLength(2)
+    expect(route2.percent).toBe(47)
+
+    expect(route2.path.length).toBe(3)
+    expect(route2.path[0]).toBe(NATIVE_SOL)
+    expect(route2.path[1].wrapped.address).toBe('674PmuiDtgKx3uKuJ1B16f9m5L84eFvNwj3xDMvHcbo7')
     expect(route2.path[2]).toBe(MOCK_USDC)
   })
 })

--- a/apps/web/src/quoter/utils/svm-utils/parseSVMTradeIntoSVMOrder.ts
+++ b/apps/web/src/quoter/utils/svm-utils/parseSVMTradeIntoSVMOrder.ts
@@ -1,6 +1,6 @@
 import { type SVMOrder, OrderType, SVMTrade } from '@pancakeswap/price-api-sdk'
 import { PoolType, Route, RouteType, SVMPool } from '@pancakeswap/smart-router'
-import { SolRouterTrade } from '@pancakeswap/solana-router-sdk'
+import type { SolRouterTrade } from '@pancakeswap/solana-router-sdk'
 import {
   Currency,
   CurrencyAmount,
@@ -8,11 +8,17 @@ import {
   TradeType,
   UnifiedCurrencyAmount,
   SPLToken,
+  SPLNativeCurrency,
 } from '@pancakeswap/swap-sdk-core'
-import { SOLANA_NATIVE_TOKEN_ADDRESS } from 'quoter/consts'
 import { SVMQuoteQuery } from 'quoter/quoter.types'
 
-export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
+// Extended type to support both SPLToken and SPLNative currencies
+type ExtendedSolRouterTrade = Omit<SolRouterTrade, 'inputAmount' | 'outputAmount'> & {
+  inputAmount: UnifiedCurrencyAmount<SPLToken>
+  outputAmount: UnifiedCurrencyAmount<SPLToken>
+}
+
+export function parseRoutePlansToRoutes(svmTrade: ExtendedSolRouterTrade): Route[] {
   const routes: Route[] = []
   let currentGroup: typeof svmTrade.routes = []
 
@@ -20,14 +26,21 @@ export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
     const routerPlan = svmTrade.routes[i]
     currentGroup.push(routerPlan)
 
-    // Check if this RouterPlan's outputMint matches the final outputAmount address
-    // or if this is the last plan in the array
-    const isEndOfRoute =
-      routerPlan.swapInfo.outputMint === svmTrade.outputAmount.currency.wrapped.address ||
-      i === svmTrade.routes.length - 1
+    // Group based on percentage inheritance:
+    // - percent < 100: Start of new route (new split)
+    // - percent = 100: Continue current route (next hop)
+    // - Last plan always ends a route
+    const isLastPlan = i === svmTrade.routes.length - 1
+    const nextPlan = isLastPlan ? null : svmTrade.routes[i + 1]
+
+    // End route if:
+    // 1. This is the last plan, OR
+    // 2. Next plan has percent < 100 (starts new split)
+    const isEndOfRoute = isLastPlan || (nextPlan && nextPlan.percent < 100)
 
     if (isEndOfRoute) {
       // Process the current group into a single Route
+      // TODO: need to update feeAmount. It's not correct.
       const pools = currentGroup.map((plan) => {
         const feeAmount = UnifiedCurrencyAmount.fromRawAmount(svmTrade.inputAmount.currency, plan.swapInfo.feeAmount)
 
@@ -35,7 +48,7 @@ export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
           type: PoolType.SVM,
           id: plan.swapInfo.ammKey.toString(),
           fee: plan.bps,
-          feeAmount,
+          feeAmount: feeAmount as UnifiedCurrencyAmount<SPLToken>,
         }
 
         return pool
@@ -55,7 +68,7 @@ export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
         const outputMintAddress = plan.swapInfo.outputMint
 
         // Find the currency for this outputMint
-        let intermediateCurrency: SPLToken
+        let intermediateCurrency: SPLToken | SPLNativeCurrency
         if (outputMintAddress === svmTrade.inputAmount.currency.wrapped.address) {
           intermediateCurrency = svmTrade.inputAmount.currency
         } else if (outputMintAddress === svmTrade.outputAmount.currency.wrapped.address) {
@@ -81,20 +94,36 @@ export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
         path.push(intermediateCurrency as Currency)
       }
 
-      // Add the final output currency
-      path.push(svmTrade.outputAmount.currency as Currency)
-
-      // Use amounts from first and last plans in the group
+      // Determine final output currency based on last plan in group
       const lastPlan = currentGroup[currentGroup.length - 1]
+      const finalOutputMintAddress = lastPlan.swapInfo.outputMint
+
+      let finalOutputCurrency: Currency
+      if (finalOutputMintAddress === svmTrade.inputAmount.currency.wrapped.address) {
+        finalOutputCurrency = svmTrade.inputAmount.currency as Currency
+      } else if (finalOutputMintAddress === svmTrade.outputAmount.currency.wrapped.address) {
+        finalOutputCurrency = svmTrade.outputAmount.currency as Currency
+      } else {
+        // Create currency for final output token
+        finalOutputCurrency = new SPLToken({
+          address: finalOutputMintAddress,
+          chainId: svmTrade.inputAmount.currency.chainId,
+          programId: svmTrade.inputAmount.currency.programId,
+          decimals: svmTrade.inputAmount.currency.decimals,
+          symbol: svmTrade.inputAmount.currency.symbol,
+          name: svmTrade.inputAmount.currency.name,
+          logoURI: '',
+        }) as Currency
+      }
+
+      // Add the final output currency
+      path.push(finalOutputCurrency)
 
       const inputAmount = UnifiedCurrencyAmount.fromRawAmount(
         svmTrade.inputAmount.currency as Currency,
         firstPlan.swapInfo.inAmount,
       )
-      const outputAmount = UnifiedCurrencyAmount.fromRawAmount(
-        svmTrade.outputAmount.currency as Currency,
-        lastPlan.swapInfo.outAmount,
-      )
+      const outputAmount = UnifiedCurrencyAmount.fromRawAmount(finalOutputCurrency, lastPlan.swapInfo.outAmount)
 
       routes.push({
         type: RouteType.SVM,
@@ -135,7 +164,7 @@ export function parseRoutePlansToRoutes(svmTrade: SolRouterTrade): Route[] {
  * ├── minimumAmountOut → minimumAmountOut ✓ (direct copy)
  * └── + quoteQueryHash (from query.hash)
  */
-export function parseSVMTradeIntoSVMOrder(svmTrade: SolRouterTrade, query: SVMQuoteQuery): SVMOrder<TradeType> {
+export function parseSVMTradeIntoSVMOrder(svmTrade: ExtendedSolRouterTrade, query: SVMQuoteQuery): SVMOrder<TradeType> {
   // Convert RouterPlan[] to Route[] with grouping logic
   const routes: Route[] = parseRoutePlansToRoutes(svmTrade)
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the `parseSVMTradeIntoSVMOrder` function to support both `SPLToken` and `SPLNativeCurrency`, enhancing the handling of Solana trades. It introduces an extended type for `SolRouterTrade` to accommodate this change and updates related logic in the parsing functions.

### Detailed summary
- Changed `SolRouterTrade` to `ExtendedSolRouterTrade` to include `inputAmount` and `outputAmount` as `UnifiedCurrencyAmount<SPLToken>`.
- Updated `parseRoutePlansToRoutes` function to handle new currency types.
- Enhanced route processing logic to determine end of routes based on percentage.
- Adjusted currency determination for final output based on last plan in the group.
- Updated tests to mock `SolRouterTrade` with native Solana currency support.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->