### PR TITLE
fix: replaced the slippage‑inflated r.maxOutput with the exact r.output

### DIFF
--- a/apps/solana/src/features/Liquidity/Increase/Add/index.tsx
+++ b/apps/solana/src/features/Liquidity/Increase/Add/index.tsx
@@ -95,7 +95,7 @@ export default function AddLiquidity({
       quoteReserve: rpcData?.quoteReserve || new BN(new Decimal(pool.mintAmountB).mul(10 ** pool.mintB.decimals).toString()),
       baseIn: isBase
     }).then((r) => {
-      computeAmountRef.current[updateSide] = new Decimal(r.maxOutput).toFixed()
+      computeAmountRef.current[updateSide] = new Decimal(r.output).toFixed()
       computeAmountRef.current.minAnother = new Decimal(r.minOutput).toFixed()
       computedLpRef.current = new Decimal(r.liquidity.toString())
       setPairAmount((prev) => ({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the calculation logic for the amount being computed in the `Add` component of the liquidity feature in the Solana application. It changes the source of the computed amount from `r.maxOutput` to `r.output`.

### Detailed summary
- Changed the assignment of `computeAmountRef.current[updateSide]` from `new Decimal(r.maxOutput).toFixed()` to `new Decimal(r.output).toFixed()`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->