### PR TITLE
fix: PAN 7342

### DIFF
--- a/apps/web/src/components/SearchModal/SolanaManageList.tsx
+++ b/apps/web/src/components/SearchModal/SolanaManageList.tsx
@@ -25,7 +25,7 @@ const SolanaListRow = memo(function SolanaListRow({
   const [listSettings, setListSettings] = useAtom(solanaListSettingsAtom)
   const { tokenCountsByList } = useSolanaTokenList()
 
-  const isActive = listSettings[listKey]
+  const isActive = listKey === TokenListKey.PANCAKESWAP ? true : listSettings[listKey]
 
   // Count tokens from this specific list (simplified - in reality you'd need to track per list)
   const tokenCount = tokenCountsByList[listKey]
@@ -47,7 +47,7 @@ const SolanaListRow = memo(function SolanaListRow({
           </Text>
         </RowFixed>
       </Column>
-      <Toggle checked={isActive} onChange={handleToggle} />
+      {listKey !== TokenListKey.PANCAKESWAP && <Toggle checked={isActive} onChange={handleToggle} />}
     </RowWrapper>
   )
 })

--- a/apps/web/src/config/solana-list.ts
+++ b/apps/web/src/config/solana-list.ts
@@ -96,4 +96,4 @@ export const SOLANA_LISTS_CONFIG: Record<TokenListKey, SolanaTokenListConfig> = 
 }
 
 // Filter out PancakeSwap list since it's always enabled
-export const SOLANA_LISTS = Object.values(SOLANA_LISTS_CONFIG).filter((list) => list.key !== TokenListKey.PANCAKESWAP)
+export const SOLANA_LISTS = Object.values(SOLANA_LISTS_CONFIG)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR modifies the handling of the PancakeSwap token list within the Solana configuration and UI components, ensuring that it is always active and visible in the user interface.

### Detailed summary
- In `solana-list.ts`, the `SOLANA_LISTS` now includes all lists without filtering out PancakeSwap.
- In `SolanaManageList.tsx`, `isActive` is set to `true` for `TokenListKey.PANCAKESWAP`, regardless of `listSettings`.
- The toggle for PancakeSwap is conditionally rendered, ensuring it is always displayed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->