### PR TITLE
fix: PAN 7538

### DIFF
--- a/apps/web/src/components/SearchModal/CurrencyList.tsx
+++ b/apps/web/src/components/SearchModal/CurrencyList.tsx
@@ -114,21 +114,23 @@ function ComplementSection({
             ml="8px"
             tooltipPlacement="top"
           />
-          <AddToWalletButton
-            data-dd-action-name="Add to wallet"
-            variant="text"
-            p="0"
-            ml="12px"
-            height="auto"
-            width="fit-content"
-            tokenAddress={selectedCurrency.wrapped.address}
-            tokenSymbol={selectedCurrency.symbol}
-            tokenDecimals={selectedCurrency.decimals}
-            tokenLogo={
-              selectedCurrency.wrapped instanceof WrappedTokenInfo ? selectedCurrency.wrapped.logoURI : undefined
-            }
-            tooltipPlacement="top"
-          />
+          {selectedCurrency.chainId === NonEVMChainId.SOLANA ? null : (
+            <AddToWalletButton
+              data-dd-action-name="Add to wallet"
+              variant="text"
+              p="0"
+              ml="12px"
+              height="auto"
+              width="fit-content"
+              tokenAddress={selectedCurrency.wrapped.address}
+              tokenSymbol={selectedCurrency.symbol}
+              tokenDecimals={selectedCurrency.decimals}
+              tokenLogo={
+                selectedCurrency.wrapped instanceof WrappedTokenInfo ? selectedCurrency.wrapped.logoURI : undefined
+              }
+              tooltipPlacement="top"
+            />
+          )}
         </>
       ) : (
         showActions && (

--- a/apps/web/src/components/ViewOnExplorerButton/index.tsx
+++ b/apps/web/src/components/ViewOnExplorerButton/index.tsx
@@ -1,5 +1,8 @@
 import { useTranslation } from '@pancakeswap/localization'
 import { Box, BoxProps, BscScanIcon, LinkExternal, TooltipOptions, useTooltip } from '@pancakeswap/uikit'
+import { useAtom } from 'jotai'
+import { solanaExplorerAtom } from '@pancakeswap/utils/user'
+import { NonEVMChainId } from '@pancakeswap/chains'
 import { getBlockExploreLink } from '../../utils'
 
 interface ViewOnExplorerButtonProps extends BoxProps {
@@ -20,6 +23,7 @@ export const ViewOnExplorerButton = ({
   ...props
 }: ViewOnExplorerButtonProps) => {
   const { t } = useTranslation()
+  const [currentExplorer] = useAtom(solanaExplorerAtom)
 
   const { targetRef, tooltipVisible, tooltip } = useTooltip(t('Open on Explorer'), {
     placement: tooltipPlacement,
@@ -29,7 +33,11 @@ export const ViewOnExplorerButton = ({
     <>
       <Box ref={targetRef} {...props}>
         <LinkExternal
-          href={getBlockExploreLink(address, type, chainId)}
+          href={
+            chainId === NonEVMChainId.SOLANA
+              ? `${currentExplorer.host}/token/${address}`
+              : getBlockExploreLink(address, type, chainId)
+          }
           target="_blank"
           rel="noopener noreferrer"
           title={t('Open on Explorer')}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on modifying the behavior of the `AddToWalletButton` and the `ViewOnExplorerButton` components to accommodate the Solana blockchain. It introduces conditional rendering and updates the explorer link generation based on the selected chain.

### Detailed summary
- In `CurrencyList.tsx`, the `AddToWalletButton` is conditionally rendered based on `selectedCurrency.chainId`.
- In `ViewOnExplorerButton`, a new atom `solanaExplorerAtom` is used to get the current explorer.
- The explorer link is updated to use Solana's explorer format when the chain is Solana.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->