### PR TITLE
fix: PAN 7563

### DIFF
--- a/apps/web/src/quoter/utils/svm-utils/parseSVMTradeIntoSVMOrder.ts
+++ b/apps/web/src/quoter/utils/svm-utils/parseSVMTradeIntoSVMOrder.ts
@@ -81,14 +81,29 @@ export function parseRoutePlansToRoutes(svmTrade: ExtendedSolRouterTrade): Route
   return routes
 }
 
+const FEE_PRECISION = 1_000_000n
+
+function trimPercentage(fee: number) {
+  // Round to 5 decimal places to remove floating point precision errors
+  // This handles cases like 0.00120000000002 becoming 0.0012
+  return Math.round(fee * 100000) / 100000
+}
+
 function createRoute(currentGroup: RouterPlan[], svmTrade: ExtendedSolRouterTrade): Route {
   // Process the current group into a single Route
-  // TODO: need to update feeAmount. It's not correct.
   const pools = currentGroup.map((plan) => {
+    const inAmountNumber = BigInt(plan.swapInfo.inAmount)
+    const feeAmountNumber = BigInt(plan.swapInfo.feeAmount)
+
+    // In case inAmountNumber is 0 or NaN
+    const feeAmount = inAmountNumber > 0 ? (feeAmountNumber * FEE_PRECISION) / inAmountNumber : 0n
+
+    const fee = (Number(feeAmount) / Number(FEE_PRECISION)) * 100
+
     const pool: SVMPool = {
       type: PoolType.SVM,
       id: plan.swapInfo.ammKey.toString(),
-      fee: plan.bps,
+      fee: trimPercentage(fee),
       feeAmount: plan.swapInfo.feeAmount,
       feeMintAddress: plan.swapInfo.feeMint.toString(),
     }

--- a/apps/web/src/views/Swap/V3Swap/components/RouteDisplay/JupPairNodes.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RouteDisplay/JupPairNodes.tsx
@@ -1,25 +1,23 @@
 import { Currency, SPLToken } from '@pancakeswap/sdk'
 import React, { useMemo } from 'react'
 import { useUnifiedCurrency } from 'hooks/Tokens'
+import { SVMPool } from '@pancakeswap/smart-router'
 import { PairNode } from '../PairNode'
 
 export type Pair = [Currency, Currency]
 
 export interface PairNodeProps {
   pair: Pair
-  text: string | React.ReactNode
   className: string
-  tooltipText: string
+  poolFee?: number
 }
-
-export type PairNodeComponent = React.ComponentType<PairNodeProps>
 
 interface Params {
   pairs: Pair[]
-  pools: any[]
+  pools: SVMPool[]
 }
 
-function SolanaPairNode({ pair, className }: Omit<PairNodeProps, 'text' | 'tooltipText'>) {
+function SolanaPairNode({ pair, className, poolFee }: PairNodeProps) {
   const [input, output] = pair as [SPLToken, SPLToken]
 
   // why need to use useUnifiedCurrency here?
@@ -30,7 +28,7 @@ function SolanaPairNode({ pair, className }: Omit<PairNodeProps, 'text' | 'toolt
   const inputCurrency = useUnifiedCurrency(input.address, input.chainId)
   const outputCurrency = useUnifiedCurrency(output.address, output.chainId)
 
-  const tooltipText = `${inputCurrency?.symbol}/${outputCurrency?.symbol}`
+  const tooltipText = `${inputCurrency?.symbol}/${outputCurrency?.symbol} ${poolFee ? `(${poolFee}%)` : ''}`
 
   const slpTokenPair: Pair | undefined = useMemo(() => {
     if (!inputCurrency || !outputCurrency) {
@@ -46,10 +44,19 @@ function SolanaPairNode({ pair, className }: Omit<PairNodeProps, 'text' | 'toolt
   return <PairNode pair={slpTokenPair} text={tooltipText} className={className} tooltipText={tooltipText} />
 }
 
-export function JupPairNodes({ pairs }: Params): React.ReactNode[] | null {
+export function JupPairNodes({ pairs, pools }: Params): React.ReactNode[] | null {
+  const isMatchLength = pairs?.length === pools?.length
+
   return pairs.length > 0
     ? pairs.map((p, index) => {
-        return <SolanaPairNode pair={p} className="highlight" key={index} />
+        return (
+          <SolanaPairNode
+            pair={p}
+            poolFee={isMatchLength ? pools[0].fee : undefined}
+            className="highlight"
+            key={index}
+          />
+        )
       })
     : null
 }

--- a/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { Route, RouteType } from '@pancakeswap/smart-router'
+import { Route, RouteType, SVMPool } from '@pancakeswap/smart-router'
 import { AutoColumn, Flex, Modal, ModalV2, QuestionHelper, Text, UseModalV2Props, useTooltip } from '@pancakeswap/uikit'
 import { CurrencyLogo } from '@pancakeswap/widgets-internal'
 import { memo, useMemo } from 'react'
@@ -164,7 +164,7 @@ function SolanaRouteDisplayContainer({ route }: RouteDisplayProps) {
       percent={route.percent}
       inputCurrency={inputCurrency}
       outputCurrency={outputCurrency}
-      pairNodes={<JupPairNodes pairs={pairs} pools={pools} />}
+      pairNodes={<JupPairNodes pairs={pairs} pools={pools as SVMPool[]} />}
     />
   )
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the handling of `SVMPool` data within the `RouteDisplayModal` and `JupPairNodes` components, improving fee calculations and displaying pool fees in the UI.

### Detailed summary
- Added `SVMPool` import in `RouteDisplayModal.tsx`.
- Updated `pairNodes` prop to cast `pools` as `SVMPool[]`.
- Introduced `FEE_PRECISION` in `parseSVMTradeIntoSVMOrder.ts` and created `trimPercentage` function for fee rounding.
- Modified fee calculation in `createRoute` function to use `trimPercentage`.
- Updated `PairNodeProps` to include optional `poolFee`.
- Adjusted `SolanaPairNode` to display `poolFee` in the tooltip.
- Enhanced `JupPairNodes` to receive `pools` prop and pass `poolFee` to `SolanaPairNode`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->