### PR TITLE
fix: PAN 7368

### DIFF
--- a/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
+++ b/apps/web/src/views/Swap/V3Swap/components/RouteDisplayModal.tsx
@@ -60,8 +60,18 @@ interface RouteDisplayProps {
   route: RouteDisplayEssentials
 }
 
-function RouteDisplayView({ inputCurrency, outputCurrency, pairNodes, percent }) {
-  const { targetRef, tooltip, tooltipVisible } = useTooltip(<Text>{inputCurrency.symbol}</Text>, {
+function RouteDisplayView({
+  inputCurrency,
+  outputCurrency,
+  pairNodes,
+  percent,
+}: {
+  inputCurrency: UnifiedCurrency | null | undefined
+  outputCurrency: UnifiedCurrency | null | undefined
+  pairNodes: React.ReactNode
+  percent: number
+}) {
+  const { targetRef, tooltip, tooltipVisible } = useTooltip(<Text>{inputCurrency?.symbol ?? ''}</Text>, {
     placement: 'right',
   })
 
@@ -69,9 +79,13 @@ function RouteDisplayView({ inputCurrency, outputCurrency, pairNodes, percent })
     targetRef: outputTargetRef,
     tooltip: outputTooltip,
     tooltipVisible: outputTooltipVisible,
-  } = useTooltip(<Text>{outputCurrency.symbol}</Text>, {
+  } = useTooltip(<Text>{outputCurrency?.symbol ?? ''}</Text>, {
     placement: 'right',
   })
+
+  if (!inputCurrency || !outputCurrency) {
+    return null
+  }
 
   return (
     <AutoColumn gap="24px">


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `RouteDisplayView` component in `RouteDisplayModal.tsx` by improving type definitions and adding null checks for `inputCurrency` and `outputCurrency`. This ensures better type safety and prevents potential runtime errors when these values are not provided.

### Detailed summary
- Updated the function signature of `RouteDisplayView` to include TypeScript types for its parameters.
- Changed `inputCurrency.symbol` and `outputCurrency.symbol` to use optional chaining and default to an empty string if undefined.
- Added a check to return `null` if either `inputCurrency` or `outputCurrency` is not provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->