### PR TITLE
fix: sync switcher state

### DIFF
--- a/apps/web/src/wallet/atoms/switchChainRequestAtom.ts
+++ b/apps/web/src/wallet/atoms/switchChainRequestAtom.ts
@@ -7,7 +7,7 @@ export interface SwitchChainRequest {
   replaceUrl: boolean // Replace url with chainId if succ
   wagmiConnector?: Connector // Connector used to switch chain
   evmAddress?: `0x${string}` // EVM address used to check session sync
-  from: 'wagmi' | 'url' | 'switch'
+  from: 'wagmi' | 'url' | 'switch' | 'connect'
   path: string
 }
 

--- a/apps/web/src/wallet/hook/useSwitchNetworkV2.ts
+++ b/apps/web/src/wallet/hook/useSwitchNetworkV2.ts
@@ -10,9 +10,10 @@ import { accountActiveChainAtom } from 'wallet/atoms/accountStateAtoms'
 import { SwitchChainRequest, switchChainUpdatingAtom } from 'wallet/atoms/switchChainRequestAtom'
 import { SOLANA_SUPPORTED_PATH } from 'wallet/network.switch.config'
 
+type SwitchFrom = 'wagmi' | 'url' | 'switch' | 'connect'
 export interface SwitchChainOption {
   replaceUrl?: boolean
-  from: 'wagmi' | 'url' | 'switch'
+  from: SwitchFrom
 }
 export const useSwitchNetworkV2 = () => {
   const { isConnected } = useAccount()
@@ -173,10 +174,7 @@ const useProcessSwitchChainRequest = () => {
       const { from, chainId: requestChainId } = request
       const activeChainId = activeChainIdRef.current
 
-      // Check request chain ID && active Chain ID
-      // For url type, wagmi state may not sync with the active chain ID
-      if (requestChainId === activeChainId && from !== 'url') {
-        // No need to switch
+      if (requestChainId === activeChainId && !['url', 'connect'].includes(from)) {
         return false
       }
 

--- a/apps/web/src/wallet/hook/useSyncWagmiState.ts
+++ b/apps/web/src/wallet/hook/useSyncWagmiState.ts
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useRef } from 'react'
 
 import { getQueryChainId } from 'wallet/util/getQueryChainId'
@@ -9,7 +9,7 @@ import { wagmiConfigAtom } from './useWagmiConfig'
 
 export function useSyncWagmiState() {
   const { chainId: wagmiChainId, address: evmAccount, connector } = useAccount()
-  const [{ isWrongNetwork }, updAccountState] = useAtom(accountActiveChainAtom)
+  const updAccountState = useSetAtom(accountActiveChainAtom)
   const { switchNetwork } = useSwitchNetworkV2()
 
   const oldWagmiChainId = useRef(wagmiChainId)
@@ -17,6 +17,13 @@ export function useSyncWagmiState() {
 
   useEffect(() => {
     const verifyWalletChainId = async () => {
+      if (!oldWagmiChainId.current && wagmiChainId) {
+        const urlChain = getQueryChainId()
+        switchNetwork(urlChain || wagmiChainId, {
+          from: 'connect',
+          replaceUrl: true,
+        })
+      }
       if (wagmiChainId && oldWagmiChainId.current && oldWagmiChainId.current !== wagmiChainId) {
         switchNetwork(wagmiChainId, {
           replaceUrl: true,
@@ -27,29 +34,6 @@ export function useSyncWagmiState() {
     verifyWalletChainId()
     oldWagmiChainId.current = wagmiChainId
   }, [wagmiChainId])
-
-  useAccountEffect({
-    config: wagmiConfig,
-    onConnect: (data) => {
-      const { chainId, isReconnected } = data
-
-      if (!isReconnected) {
-        switchNetwork(chainId, {
-          from: 'wagmi',
-          replaceUrl: true,
-        })
-      } else {
-        const urlChain = getQueryChainId()
-        // if wrongnetwork, keep in current state
-        if (urlChain && urlChain !== chainId && !isWrongNetwork) {
-          switchNetwork(urlChain, {
-            from: 'url',
-            replaceUrl: true,
-          })
-        }
-      }
-    },
-  })
 
   useEffect(() => {
     updAccountState((prev) => ({


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `switchChainRequestAtom` and `useSwitchNetworkV2` functionalities by introducing a new option for the `from` property and refining the logic for network switching. It also improves the `useSyncWagmiState` to better handle network changes.

### Detailed summary
- Added `connect` as a new option to the `from` property in `switchChainRequestAtom` and `SwitchChainOption`.
- Changed the type of `from` in `SwitchChainOption` to `SwitchFrom`.
- Updated logic in `useProcessSwitchChainRequest` to allow for `connect` in network switching checks.
- Enhanced `useSyncWagmiState` to initiate switching from `connect` when the wallet chain ID changes. 
- Removed obsolete code related to `useAccountEffect`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->