### PR TITLE
fix: quote shadow result restore

### DIFF
--- a/apps/web/src/quoter/atom/bestSameChainAtom.ts
+++ b/apps/web/src/quoter/atom/bestSameChainAtom.ts
@@ -75,7 +75,7 @@ export const bestSameChainWithoutPlaceHolderAtom = atomFamily((_option: QuoteQue
             }
           }
           return {
-            quote: Loadable.Pending<InterfaceOrder>(),
+            quote: Loadable.Pending<InterfaceOrder>(bestQuote),
             anyShadowFail,
             anyTimeout,
           }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `quote` property in the return object of a function within the `bestSameChainAtom.ts` file to initialize it with `bestQuote`, enhancing its functionality.

### Detailed summary
- Changed the initialization of `quote` from `Loadable.Pending<InterfaceOrder>()` to `Loadable.Pending<InterfaceOrder>(bestQuote)` in the return object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->