### PR TITLE
chore(PAN-7556): add fallback for v3 pools current price when no trades

### DIFF
--- a/apps/web/src/components/PoolInfoHeader/index.tsx
+++ b/apps/web/src/components/PoolInfoHeader/index.tsx
@@ -45,9 +45,6 @@ interface PoolInfoHeaderProps {
   linkType?: LinkType
   onInvertPrices?: () => void
 
-  /** Override current price. Useful if poolInfo does not have token prices */
-  overridePrice?: Price<Currency, Currency>
-
   /** Optional override for currency0.symbol */
   symbol0?: string
   /** Optional override for currency1.symbol */
@@ -65,7 +62,6 @@ export const PoolInfoHeader = ({
   isInverted,
   onInvertPrices,
   overrideAprDisplay,
-  overridePrice,
   linkType,
 }: PoolInfoHeaderProps) => {
   const { t } = useTranslation()
@@ -283,18 +279,18 @@ export const PoolInfoHeader = ({
                   <SwapHorizIcon color="primary60" onClick={onInvertPrices} style={{ cursor: 'pointer' }} />
                 </FlexGap>
                 <FlexGap gap="8px" alignItems="center" width="100%">
-                  {overridePrice ? (
-                    <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
-                      {isInverted ? overridePrice.invert().toSignificant(6) : overridePrice.toSignificant(6)}
-                    </Text>
-                  ) : poolInfo && poolInfo.token0Price && poolInfo.token1Price ? (
+                  {poolInfo && poolInfo.token0Price && poolInfo.token1Price ? (
                     <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
                       {formatNumber(Number(isInverted ? poolInfo.token0Price : poolInfo.token1Price), {
                         maximumSignificantDigits: 6,
                         maxDecimalDisplayDigits: 6,
                       })}
                     </Text>
-                  ) : null}
+                  ) : (
+                    <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
+                      -
+                    </Text>
+                  )}
                   <Text fontSize={10} color="textSubtle" textTransform="uppercase" width="max-content">
                     {t(
                       '%symbol0% per %symbol1%',

--- a/apps/web/src/components/PoolInfoHeader/index.tsx
+++ b/apps/web/src/components/PoolInfoHeader/index.tsx
@@ -1,7 +1,7 @@
 import { Protocol } from '@pancakeswap/farms'
 import { HookData } from '@pancakeswap/infinity-sdk'
 import { useTranslation } from '@pancakeswap/localization'
-import { Currency, Percent } from '@pancakeswap/sdk'
+import { Currency, Percent, Price } from '@pancakeswap/sdk'
 import {
   AutoColumn,
   Box,
@@ -45,6 +45,9 @@ interface PoolInfoHeaderProps {
   linkType?: LinkType
   onInvertPrices?: () => void
 
+  /** Override current price. Useful if poolInfo does not have token prices */
+  overridePrice?: Price<Currency, Currency>
+
   /** Optional override for currency0.symbol */
   symbol0?: string
   /** Optional override for currency1.symbol */
@@ -62,6 +65,7 @@ export const PoolInfoHeader = ({
   isInverted,
   onInvertPrices,
   overrideAprDisplay,
+  overridePrice,
   linkType,
 }: PoolInfoHeaderProps) => {
   const { t } = useTranslation()
@@ -279,15 +283,18 @@ export const PoolInfoHeader = ({
                   <SwapHorizIcon color="primary60" onClick={onInvertPrices} style={{ cursor: 'pointer' }} />
                 </FlexGap>
                 <FlexGap gap="8px" alignItems="center" width="100%">
-                  {poolInfo && (
+                  {overridePrice ? (
+                    <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
+                      {isInverted ? overridePrice.invert().toSignificant(6) : overridePrice.toSignificant(6)}
+                    </Text>
+                  ) : poolInfo && poolInfo.token0Price && poolInfo.token1Price ? (
                     <Text fontSize={isMobile ? 20 : 24} bold width="max-content">
                       {formatNumber(Number(isInverted ? poolInfo.token0Price : poolInfo.token1Price), {
                         maximumSignificantDigits: 6,
                         maxDecimalDisplayDigits: 6,
                       })}
                     </Text>
-                  )}
-
+                  ) : null}
                   <Text fontSize={10} color="textSubtle" textTransform="uppercase" width="max-content">
                     {t(
                       '%symbol0% per %symbol1%',

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -22,6 +22,7 @@ import AddLiquidity from 'views/AddLiquidity'
 import AddStableLiquidity from 'views/AddLiquidity/AddStableLiquidity'
 import useWarningLiquidity from 'views/AddLiquidity/hooks/useWarningLiquidity'
 import useStableConfig, { StableConfigContext } from 'views/Swap/hooks/useStableConfig'
+import { PoolInfo } from 'state/farmsV4/state/type'
 import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
 
 import { PoolInfoHeader } from 'components/PoolInfoHeader'
@@ -274,6 +275,17 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
     baseCurrency ?? undefined,
   )
 
+  const poolInfo: PoolInfo | null = useMemo(() => {
+    if (!pool) return null
+    return {
+      ...pool,
+      ...(!isTokenPriceAvailable && {
+        token0Price: v3Price?.invert().toSignificant(6) as `${number}`,
+        token1Price: v3Price?.toSignificant(6) as `${number}`,
+      }),
+    }
+  }, [pool, isTokenPriceAvailable, v3Price])
+
   return (
     <Container mx="auto" my="24px" maxWidth="1200px">
       <Box mb="24px">
@@ -293,14 +305,13 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
       </Box>
       <PoolInfoHeader
         linkType="addLiquidity"
-        poolInfo={pool}
+        poolInfo={poolInfo}
         chainId={chainId}
         currency0={currencyA}
         currency1={currencyB}
         isInverted={inverted}
         onInvertPrices={handleInvertCurrencies}
         poolId={poolAddress}
-        overridePrice={!isTokenPriceAvailable ? v3Price : undefined}
         overrideAprDisplay={
           selectType === SELECTOR_TYPE.V3
             ? {

--- a/apps/web/src/views/AddLiquidityV3/index.tsx
+++ b/apps/web/src/views/AddLiquidityV3/index.tsx
@@ -22,6 +22,7 @@ import AddLiquidity from 'views/AddLiquidity'
 import AddStableLiquidity from 'views/AddLiquidity/AddStableLiquidity'
 import useWarningLiquidity from 'views/AddLiquidity/hooks/useWarningLiquidity'
 import useStableConfig, { StableConfigContext } from 'views/Swap/hooks/useStableConfig'
+import useV3DerivedInfo from 'hooks/v3/useV3DerivedInfo'
 
 import { PoolInfoHeader } from 'components/PoolInfoHeader'
 import { useActiveChainId } from 'hooks/useActiveChainId'
@@ -257,6 +258,22 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
     enabled: !!chainId && !!pool,
   })
 
+  const currencyA = pool?.token0 ?? baseCurrency ?? undefined
+  const currencyB = pool?.token1 ?? quoteCurrency ?? undefined
+
+  // Fallback for fetching pool price in new V3 pools with no trades.
+  // With no trades, BE doesn't index the pool so we do not get token0Price and token1Price in the pool object.
+  const isTokenPriceAvailable = useMemo(
+    () => Number(pool?.token0Price) && Number(pool?.token1Price),
+    [pool?.token0Price, pool?.token1Price],
+  )
+  const { price: v3Price } = useV3DerivedInfo(
+    !isTokenPriceAvailable ? currencyA : undefined,
+    !isTokenPriceAvailable ? currencyB : undefined,
+    feeAmount,
+    baseCurrency ?? undefined,
+  )
+
   return (
     <Container mx="auto" my="24px" maxWidth="1200px">
       <Box mb="24px">
@@ -278,11 +295,12 @@ export function AddLiquidityV3Layout({ children }: { children: React.ReactNode }
         linkType="addLiquidity"
         poolInfo={pool}
         chainId={chainId}
-        currency0={pool?.token0 ?? baseCurrency ?? undefined}
-        currency1={pool?.token1 ?? quoteCurrency ?? undefined}
+        currency0={currencyA}
+        currency1={currencyB}
         isInverted={inverted}
         onInvertPrices={handleInvertCurrencies}
         poolId={poolAddress}
+        overridePrice={!isTokenPriceAvailable ? v3Price : undefined}
         overrideAprDisplay={
           selectType === SELECTOR_TYPE.V3
             ? {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `PoolInfoHeader` and `AddLiquidityV3Layout` components to improve the handling of pool prices, particularly for new V3 pools without trades. It introduces a fallback mechanism to fetch prices and updates the props passed to `PoolInfoHeader`.

### Detailed summary
- Added `Price` to imports from `@pancakeswap/sdk`.
- Modified price display logic in `PoolInfoHeader` to handle cases where `token0Price` and `token1Price` are unavailable.
- Introduced `isTokenPriceAvailable` to determine price availability in `AddLiquidityV3Layout`.
- Updated `poolInfo` to include fallback prices using `useV3DerivedInfo`.
- Changed the `poolInfo` prop passed to `PoolInfoHeader` to use the new `poolInfo` derived from the V3 logic.
- Updated currency props in `PoolInfoHeader` to use `currencyA` and `currencyB`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->