### PR TITLE
chore: support twap translations bypass test

### DIFF
--- a/apps/web/src/__tests__/translations.test.ts
+++ b/apps/web/src/__tests__/translations.test.ts
@@ -219,7 +219,7 @@ describe('Check translations available', () => {
   })
 
   it('should use all translation key in translation.json', () => {
-    const ignoreReg = new RegExp(/^twap:/)
+    const ignoreReg = new RegExp(/^twap\\./)
     const leftKeys = [...translationKeys]
     leftKeys.forEach((key) => {
       if (ignoreReg.test(key)) {

--- a/apps/web/src/__tests__/translations.test.ts
+++ b/apps/web/src/__tests__/translations.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 // FIXME: should move this test file inside localization pkg
 import { translations } from '@pancakeswap/localization'
+import { Scope } from '@sentry/nextjs'
 
 const allTranslationKeys = Object.keys(translations)
 
@@ -219,6 +220,13 @@ describe('Check translations available', () => {
   })
 
   it('should use all translation key in translation.json', () => {
+    const ignoreReg = new RegExp(/^twap:/)
+    const leftKeys = [...translationKeys]
+    leftKeys.forEach((key) => {
+      if (ignoreReg.test(key)) {
+        translationKeys.delete(key)
+      }
+    })
     expect(
       translationKeys.size,
       `Found unused ${translationKeys.size} key(s) ${JSON.stringify(

--- a/apps/web/src/__tests__/translations.test.ts
+++ b/apps/web/src/__tests__/translations.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from 'vitest'
 
 // FIXME: should move this test file inside localization pkg
 import { translations } from '@pancakeswap/localization'
-import { Scope } from '@sentry/nextjs'
 
 const allTranslationKeys = Object.keys(translations)
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a feature to a test that ensures all translation keys in `translation.json` are used. It introduces logic to ignore specific keys that start with `twap.` when checking for unused translation keys.

### Detailed summary
- Introduced a regular expression `ignoreReg` to match keys starting with `twap.`
- Created a copy of `translationKeys` in `leftKeys`
- Added a loop to remove ignored keys from `translationKeys`
- Updated the expectation to check the size of `translationKeys`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->