### PR TITLE
fix: translations fallback to english

### DIFF
--- a/.changeset/sixty-geese-rhyme.md
+++ b/.changeset/sixty-geese-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@pancakeswap/localization': minor
+---
+
+Default to English if no translations available

--- a/packages/localization/src/Provider.tsx
+++ b/packages/localization/src/Provider.tsx
@@ -32,7 +32,7 @@ export const LanguageProvider: React.FC<React.PropsWithChildren> = ({ children }
         return cache.get(cacheKey) || ''
       }
       function getTranslationValue() {
-        return bundle[key] || ''
+        return bundle[key] || key
       }
 
       const value = getTranslationValue()

--- a/packages/localization/src/Provider.tsx
+++ b/packages/localization/src/Provider.tsx
@@ -31,11 +31,8 @@ export const LanguageProvider: React.FC<React.PropsWithChildren> = ({ children }
       if (cache.has(cacheKey)) {
         return cache.get(cacheKey) || ''
       }
-      function getTranslationValue() {
-        return bundle[key] || key
-      }
 
-      const value = getTranslationValue()
+      const value = bundle[key] || key
 
       const interpolated = value.replace(/%([a-zA-Z0-9-_]+)%/g, (match, p1) => {
         const replacement = data?.[p1] || ''


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the localization feature by ensuring that if no translations are available, the default language is set to English. It also simplifies the retrieval of translation values.

### Detailed summary
- Updated `@pancakeswap/localization` to minor version.
- Added a note to default to English if no translations are available.
- Modified `getTranslationValue` function to directly access `bundle[key]` or fallback to `key` instead of returning an empty string.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->