### PR TITLE
chore: add mev toggle in create pool pages

### DIFF
--- a/apps/web/src/views/CreateLiquidityPool/Infinity/CreateLiquidityInfinityForm.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/Infinity/CreateLiquidityInfinityForm.tsx
@@ -8,6 +8,7 @@ import { FieldClTickSpacing } from 'views/CreateLiquidityPool/components/FieldCl
 import { FieldFeeLevel } from 'views/CreateLiquidityPool/components/FieldFeeLevel'
 import { FieldHookSettings } from 'views/CreateLiquidityPool/components/FieldHookSettings'
 import { FieldSelectCurrencies } from 'views/CreateLiquidityPool/components/FieldSelectCurrencies'
+import { MevProtectToggle } from 'views/Mev/MevProtectToggle'
 import { FieldStartingPrice } from 'views/CreateLiquidityPool/components/FieldStartingPrice'
 import { FieldCreateDepositAmount } from '../components/FieldCreateDepositAmount'
 import { FieldPoolType } from '../components/FieldPoolType'
@@ -83,6 +84,7 @@ export const CreateLiquidityInfinityForm = () => {
                 <AutoColumn gap={['16px', null, null, '24px']}>
                   <FieldCreateDepositAmount />
                   <FieldSlippageTolerance />
+                  <MevProtectToggle />
                   <SubmitCreateButton />
                 </AutoColumn>
               </DynamicSection>

--- a/apps/web/src/views/CreateLiquidityPool/V2/CreateLiquidityV2Form.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/V2/CreateLiquidityV2Form.tsx
@@ -4,6 +4,7 @@ import { AutoColumn, Box, Card, CardBody, DynamicSection, FlexGap, PreTitle, Tex
 import { Protocol } from '@pancakeswap/farms'
 import { useStartingPriceQueryState } from 'state/infinity/create'
 import { CurrencyField as Field } from 'utils/types'
+import { MevProtectToggle } from 'views/Mev/MevProtectToggle'
 import { useDebounce } from '@pancakeswap/hooks'
 import { FieldStartingPrice } from '../components/V3/FieldStartingPrice'
 import { FieldCreateDepositAmount } from '../components/V3/FieldCreateDepositAmount'
@@ -81,6 +82,7 @@ export const CreateLiquidityV2Form = () => {
 
             <DynamicSection disabled={poolExists || !currenciesExist || !startPriceTypedValue}>
               <FieldSlippageTolerance />
+              <MevProtectToggle />
             </DynamicSection>
 
             <DynamicSection disabled={poolExists || !currenciesExist || !startPriceTypedValue}>

--- a/apps/web/src/views/CreateLiquidityPool/V3/CreateLiquidityV3Form.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/V3/CreateLiquidityV3Form.tsx
@@ -3,6 +3,7 @@ import { Protocol } from '@pancakeswap/farms'
 import { useFeeLevelQueryState } from 'state/infinity/create'
 import { useDebounce } from '@pancakeswap/hooks'
 import { CurrencyField as Field } from 'utils/types'
+import { MevProtectToggle } from 'views/Mev/MevProtectToggle'
 import { FieldSelectCurrencies } from '../components/FieldSelectCurrencies'
 import { FieldStartingPrice } from '../components/V3/FieldStartingPrice'
 import { FieldCreateDepositAmount } from '../components/V3/FieldCreateDepositAmount'
@@ -99,6 +100,7 @@ export const CreateLiquidityV3Form = () => {
               }
             >
               <FieldSlippageTolerance />
+              <MevProtectToggle />
             </DynamicSection>
 
             <DynamicSection


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `MevProtectToggle` component to three liquidity pool forms, enhancing user control over MEV protection during liquidity creation.

### Detailed summary
- Added `MevProtectToggle` to `CreateLiquidityV3Form`.
- Added `MevProtectToggle` to `CreateLiquidityV2Form`.
- Added `MevProtectToggle` to `CreateLiquidityInfinityForm`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->