### PR TITLE
fix: PAN 7703

### DIFF
--- a/apps/web/src/state/swap/hooks.test.ts
+++ b/apps/web/src/state/swap/hooks.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable vars-on-top */
 import { parse } from 'querystring'
 import { Mock, vi } from 'vitest'
+import { NonEVMChainId } from '@pancakeswap/chains'
 import { Field } from './actions'
 import { queryParametersToSwapState } from './hooks'
 
@@ -87,6 +88,19 @@ describe('hooks', () => {
         pairDataById: {},
         derivedPairDataById: {},
         recipient: '0x0fF2D1eFd7A57B7562b2bf27F3f37899dB27F4a5',
+      })
+    })
+
+    test('handle Solana chain with token address', () => {
+      const outputCurrency = '4qQeZ5LwSz6HuupUu8jCtgXyW1mYQcNbFAW1sWZp89HL'
+      expect(queryParametersToSwapState(parse(`chain=solana&outputCurrency=${outputCurrency}`))).toEqual({
+        [Field.INPUT]: { currencyId: 'SOL', chainId: NonEVMChainId.SOLANA },
+        [Field.OUTPUT]: { currencyId: outputCurrency, chainId: NonEVMChainId.SOLANA },
+        typedValue: '',
+        independentField: Field.INPUT,
+        pairDataById: {},
+        derivedPairDataById: {},
+        recipient: null,
       })
     })
   })

--- a/apps/web/src/state/swap/hooks.ts
+++ b/apps/web/src/state/swap/hooks.ts
@@ -78,7 +78,8 @@ export function queryParametersToSwapState(
 ): SwapState {
   // Parse chains
   const inputChain = parsedQs.chain
-  const outputChain = parsedQs.chainOut
+  // NOTE: if chainOut is not provided, means user want to swap on the same chain
+  const outputChain = parsedQs.chainOut || inputChain
 
   const inputChainId = typeof inputChain === 'string' ? getChainId(inputChain) : undefined
   const outputChainId = typeof outputChain === 'string' ? getChainId(outputChain) : undefined


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the handling of chain outputs in the `hooks.ts` file and adding a test case for the Solana chain in `hooks.test.ts`.

### Detailed summary
- In `hooks.ts`, updated `outputChain` to default to `inputChain` if `chainOut` is not provided.
- In `hooks.test.ts`, added a test case for handling the Solana chain with a specific token address, verifying the expected output structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->