### PR TITLE
fix: only eth cake proposal

### DIFF
--- a/apps/web/src/state/voting/helpers.ts
+++ b/apps/web/src/state/voting/helpers.ts
@@ -63,7 +63,13 @@ export const getProposal = async (id: string): Promise<Proposal> => {
     { id },
   )
 
-  return response.proposal
+  const proposal = response.proposal
+  // IMPORTANT: guard against proposals from unofficial Snapshot spaces. Never remove this check.
+  if (proposal?.space?.id !== 'cakevote.eth') {
+    throw new Error('Untrusted proposal space')
+  }
+
+  return proposal
 }
 
 export const getVotes = async (first: number, skip: number, where: VoteWhere): Promise<Vote[]> => {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the security of the proposal retrieval process by adding a check to ensure that proposals originate from a trusted source, specifically the `cakevote.eth` space.

### Detailed summary
- Changed the return statement of `response.proposal` to a constant `proposal`.
- Added a guard clause to verify that `proposal?.space?.id` equals `cakevote.eth`.
- Introduced an error throw if the proposal is from an untrusted space.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->