### PR TITLE
chore: Allow ci checks for i18n branch

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   code:
+    if: github.head_ref != l10n_develop
     runs-on: ubuntu-latest
     timeout-minutes: 6
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   code:
-    if: github.head_ref != l10n_develop
+    if: github.head_ref != 'l10n_develop'
     runs-on: ubuntu-latest
     timeout-minutes: 6
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   eslint:
+    if: github.head_ref != l10n_develop
     runs-on: ubuntu-latest
     timeout-minutes: 4
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   eslint:
-    if: github.head_ref != l10n_develop
+    if: github.head_ref != 'l10n_develop'
     runs-on: ubuntu-latest
     timeout-minutes: 4
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   unit-tests:
+    if: github.head_ref != l10n_develop
     runs-on: ubuntu-latest
     timeout-minutes: 8
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    if: github.head_ref != l10n_develop
+    if: github.head_ref != 'l10n_develop'
     runs-on: ubuntu-latest
     timeout-minutes: 8
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,4 +2,3 @@ files:
   - source: /packages/localization/src/config/translations.json
     translation: /locales/%locale%.json
 pull_request_title: 'chore: New Crowdin updates'
-commit_message: '[ci skip]'


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces conditional execution for workflows based on the branch name, specifically excluding the `l10n_develop` branch. It also updates the `crowdin.yml` configuration by removing the `commit_message` field.

### Detailed summary
- Added condition `if: github.head_ref != 'l10n_develop'` to:
  - `.github/workflows/format.yml`
  - `.github/workflows/lint.yml`
  - `.github/workflows/unitTests.yml`
- Removed `commit_message: '[ci skip]'` from `crowdin.yml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->