### PR TITLE
fix: ToReversed crash on some mobile browsers

### DIFF
--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -8,9 +8,6 @@ import { NetworkModal } from 'components/NetworkModal'
 import { FixedSubgraphHealthIndicator } from 'components/SubgraphHealthIndicator/FixedSubgraphHealthIndicator'
 import TransactionsDetailModal from 'components/TransactionDetailModal'
 import { VercelToolbar } from 'components/VercelToolbar'
-import 'core-js/features/array/to-sorted'
-import 'core-js/features/array/find-last'
-import 'core-js/features/string/replace-all'
 import { useAccountEventListener } from 'hooks/useAccountEventListener'
 import useEagerConnect from 'hooks/useEagerConnect'
 import useLockedEndNotification from 'hooks/useLockedEndNotification'
@@ -24,7 +21,6 @@ import Head from 'next/head'
 import Script from 'next/script'
 import { Fragment, Suspense } from 'react'
 import { PersistGate } from 'redux-persist/integration/react'
-import 'utils/abortcontroller-polyfill'
 
 import { DesktopCard } from 'components/AdPanel/DesktopCard'
 import { MobileCard } from 'components/AdPanel/MobileCard'
@@ -52,6 +48,13 @@ import Providers from '../Providers'
 import Menu, { SharedComponentWithOutMenu } from '../components/Menu'
 import GlobalStyle from '../style/Global'
 import { NextPageWithLayout } from '../utils/page.types'
+
+// polyfills
+import 'core-js/features/array/to-sorted'
+import 'core-js/features/array/to-reversed'
+import 'core-js/features/array/find-last'
+import 'core-js/features/string/replace-all'
+import 'utils/abortcontroller-polyfill'
 
 const EasterEgg = dynamic(() => import('components/EasterEgg'), { ssr: false })
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on reorganizing polyfills in the `apps/web/src/pages/_app.tsx` file, removing some imports and adding them back in a different order for better structure.

### Detailed summary
- Removed the imports for `core-js/features/array/to-sorted`, `core-js/features/array/find-last`, `core-js/features/string/replace-all`, and `utils/abortcontroller-polyfill`.
- Added back the imports for `core-js/features/array/to-sorted`, `core-js/features/array/to-reversed`, `core-js/features/array/find-last`, `core-js/features/string/replace-all`, and `utils/abortcontroller-polyfill` in a new section labeled as "polyfills".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->