### PR TITLE
fix: add debridge api token

### DIFF
--- a/apps/web/src/views/BridgeView.tsx
+++ b/apps/web/src/views/BridgeView.tsx
@@ -109,7 +109,7 @@ export const BridgeView = () => {
             supportedChainIds={[...CHAIN_IDS, 7565164]}
             rpcConfig={PUBLIC_NODES}
             disabledToChains={DISABLED_TO_CHAINS}
-            deBridgeAccessToken={process.env.NEXT_PUBLIC_DEBRIDGE_ACCESS_TOEKN}
+            deBridgeAccessToken={process.env.NEXT_PUBLIC_DEBRIDGE_ACCESS_TOKEN}
           />
         </Suspense>
       </Flex>

--- a/apps/web/src/views/BridgeView.tsx
+++ b/apps/web/src/views/BridgeView.tsx
@@ -109,6 +109,7 @@ export const BridgeView = () => {
             supportedChainIds={[...CHAIN_IDS, 7565164]}
             rpcConfig={PUBLIC_NODES}
             disabledToChains={DISABLED_TO_CHAINS}
+            deBridgeAccessToken={process.env.NEXT_PUBLIC_DEBRIDGE_ACCESS_TOEKN}
           />
         </Suspense>
       </Flex>

--- a/packages/canonical-bridge/src/views/index.tsx
+++ b/packages/canonical-bridge/src/views/index.tsx
@@ -39,12 +39,13 @@ export interface CanonicalBridgeProps {
   supportedChainIds: number[]
   rpcConfig: Record<number, readonly string[]>
   disabledToChains?: number[]
+  deBridgeAccessToken?: string
 }
 
 const gtmListener = createGTMEventListener()
 
 export const CanonicalBridge = (props: CanonicalBridgeProps) => {
-  const { connectWalletButtons, supportedChainIds, disabledToChains, rpcConfig } = props
+  const { connectWalletButtons, supportedChainIds, disabledToChains, rpcConfig, deBridgeAccessToken } = props
   useDisableToChains(disabledToChains)
 
   const { currentLanguage, t } = useTranslation()
@@ -96,6 +97,7 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
         apiTimeOut: 30 * 1000,
         serverEndpoint: env.SERVER_ENDPOINT,
         deBridgeReferralCode: '31958',
+        deBridgeAccessToken,
       },
       transfer: transferConfig,
       components: {
@@ -144,6 +146,7 @@ export const CanonicalBridge = (props: CanonicalBridgeProps) => {
       fromChain,
       toChain,
       connectWalletButtons,
+      deBridgeAccessToken,
     ],
   )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `deBridgeAccessToken` property to the `BridgeView` and `CanonicalBridge` components, enabling the use of a deBridge access token in the application.

### Detailed summary
- Added `deBridgeAccessToken` prop to `BridgeView` component.
- Updated `CanonicalBridgeProps` interface to include optional `deBridgeAccessToken`.
- Modified `CanonicalBridge` component to destructure `deBridgeAccessToken` from props.
- Passed `deBridgeAccessToken` to the configuration object in `CanonicalBridge`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->