### PR TITLE
chore: update abitier hook

### DIFF
--- a/packages/infinity-sdk/src/constants/hooksList/bsc.ts
+++ b/packages/infinity-sdk/src/constants/hooksList/bsc.ts
@@ -211,7 +211,7 @@ export const bscHooksList: HookData[] = [
   },
   {
     poolType: POOL_TYPE.CLAMM,
-    address: '0x544Ec7F1bA881ff150331e7557b40945e2FC0f3C',
+    address: '0xD7059ABd653e87cb124690E2eba175391AC52243',
     name: 'Arbiter MEV Capture',
     description: `Arbiter hook allows LPs to capture significant part of MEV extracted from pool. This is achieved by introducing auction for MEV actors. Winner can control the pool’s fee, outperform competitors and optimize routing traffic - increasing their and LPs profits as proceeds from auction go to LPs.`,
     github: 'https://github.com/ArbiterFinance/arbiter-contracts/blob/main/src/ArbiterAmAmmPoolCurrencyHook.sol',


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `address` for a specific liquidity pool in the `bsc.ts` file, changing it from one Ethereum address to another. This change is likely aimed at reflecting a new contract or deployment for the `Arbiter MEV Capture` hook.

### Detailed summary
- Updated `address` from `0x544Ec7F1bA881ff150331e7557b40945e2FC0f3C` to `0xD7059ABd653e87cb124690E2eba175391AC52243` for the `Arbiter MEV Capture` hook.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->