### PR TITLE
fix: update transaction list based on phase 3

### DIFF
--- a/apps/web/src/state/transactions/hooks.tsx
+++ b/apps/web/src/state/transactions/hooks.tsx
@@ -52,6 +52,7 @@ export function useTransactionAdder(overrideChainId?: number): (
     expectedCurrencyOwed0?: string
     expectedCurrencyOwed1?: string
     receipt?: SerializableTransactionReceipt
+    overrideAccount?: string
   },
 ) => void {
   const { account, chainId: activeChainId } = useAccountActiveChain()
@@ -72,6 +73,7 @@ export function useTransactionAdder(overrideChainId?: number): (
         order,
         crossChainFarm,
         receipt,
+        overrideAccount,
       }: {
         summary?: string
         translatableSummary?: { text: string; data?: Record<string, string | number | undefined> }
@@ -81,9 +83,10 @@ export function useTransactionAdder(overrideChainId?: number): (
         order?: Order
         crossChainFarm?: CrossChainFarmTransactionType
         receipt?: SerializableTransactionReceipt
+        overrideAccount?: string
       } = {},
     ) => {
-      if (!account) return
+      if (!account && !overrideAccount) return
       if (!chainId) return
 
       let hash: Hash | string | undefined
@@ -108,7 +111,7 @@ export function useTransactionAdder(overrideChainId?: number): (
       dispatch(
         addTransaction({
           hash,
-          from: account,
+          from: overrideAccount || account || '',
           chainId,
           approval,
           summary,
@@ -127,7 +130,7 @@ export function useTransactionAdder(overrideChainId?: number): (
 
 // returns all the transactions
 export function useAllTransactions(): { [chainId: number]: { [txHash: string]: TransactionDetails } } {
-  const { unifiedAccount } = useAccountActiveChain()
+  const { account, solanaAccount } = useAccountActiveChain()
 
   const state: {
     [chainId: number]: {
@@ -139,10 +142,12 @@ export function useAllTransactions(): { [chainId: number]: { [txHash: string]: T
     return mapValues(state, (transactions) =>
       pickBy(
         transactions,
-        (transactionDetails) => transactionDetails.from.toLowerCase() === unifiedAccount?.toLowerCase(),
+        (transactionDetails) =>
+          transactionDetails.from.toLowerCase() === account?.toLowerCase() ||
+          transactionDetails.from.toLowerCase() === solanaAccount?.toLowerCase(),
       ),
     )
-  }, [unifiedAccount, state])
+  }, [account, solanaAccount, state])
 }
 
 export function useAllSortedRecentTransactions(): { [chainId: number]: { [txHash: string]: TransactionDetails } } {
@@ -173,19 +178,23 @@ export function useAllActiveChainTransactions(overrideChainId?: number): { [txHa
 }
 
 export function useAllChainTransactions(chainId?: number): { [txHash: string]: TransactionDetails } {
-  const { address: account } = useAccount()
+  const { account, solanaAccount } = useAccountActiveChain()
 
   const state = useSelector<AppState, AppState['transactions']>((s) => s.transactions)
 
-  return useMemo(() => {
+  const list = useMemo(() => {
     if (chainId && state[chainId]) {
       return pickBy(
         state[chainId],
-        (transactionDetails) => transactionDetails.from.toLowerCase() === account?.toLowerCase(),
+        (transactionDetails) =>
+          transactionDetails.from.toLowerCase() === account?.toLowerCase() ||
+          transactionDetails.from.toLowerCase() === solanaAccount?.toLowerCase(),
       )
     }
     return {}
-  }, [account, chainId, state])
+  }, [account, solanaAccount, chainId, state])
+  console.log(`[tx]`, state, chainId, list)
+  return list
 }
 
 export function useIsTransactionPending(transactionHash?: string): boolean {

--- a/apps/web/src/state/transactions/hooks.tsx
+++ b/apps/web/src/state/transactions/hooks.tsx
@@ -193,7 +193,6 @@ export function useAllChainTransactions(chainId?: number): { [txHash: string]: T
     }
     return {}
   }, [account, solanaAccount, chainId, state])
-  console.log(`[tx]`, state, chainId, list)
   return list
 }
 

--- a/apps/web/src/views/Swap/V3Swap/hooks/useSwapRecordTransaction.ts
+++ b/apps/web/src/views/Swap/V3Swap/hooks/useSwapRecordTransaction.ts
@@ -97,6 +97,7 @@ export default function useSwapRecordTransaction(chainId?: number, account?: str
           },
           type: 'swap',
           receipt,
+          overrideAccount: account,
         },
       )
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `overrideAccount` feature to enhance transaction handling in the `useTransactionAdder` and related hooks, allowing for more flexible account management in transaction records.

### Detailed summary
- Added `overrideAccount` parameter to transaction-related functions.
- Updated checks to allow transactions without a default account if `overrideAccount` is provided.
- Modified transaction filtering logic to include `solanaAccount`.
- Adjusted dependencies in `useMemo` hooks to reflect new account structure.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->