### PR TITLE
fix: show BNB token in Gas Fee Claim Gift

### DIFF
--- a/apps/web/src/views/Gift/components/CreateGiftView.tsx
+++ b/apps/web/src/views/Gift/components/CreateGiftView.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@pancakeswap/localization'
-import { CurrencyAmount, NativeCurrency, Token } from '@pancakeswap/sdk'
+import { ChainId, CurrencyAmount, NativeCurrency, Token } from '@pancakeswap/sdk'
 import {
   Box,
   ButtonMenu,
@@ -63,7 +63,7 @@ export const CreateGiftView = ({ tokenAmount }: { tokenAmount?: CurrencyAmount<T
     </Box>
   )
 
-  const { gasPayment, gasPaymentUsd } = useReadGasPaymentAmount()
+  const { gasPayment, gasPaymentUsd } = useReadGasPaymentAmount(tokenAmount?.currency.chainId as ChainId)
 
   const totalUsd = useCalculateTotalCostCreateGift({ tokenAmount, nativeAmount })
 

--- a/apps/web/src/views/Gift/components/CreateGiftView.tsx
+++ b/apps/web/src/views/Gift/components/CreateGiftView.tsx
@@ -63,7 +63,7 @@ export const CreateGiftView = ({ tokenAmount }: { tokenAmount?: CurrencyAmount<T
     </Box>
   )
 
-  const { gasPayment, gasPaymentUsd } = useReadGasPaymentAmount(tokenAmount?.currency.chainId as ChainId)
+  const { gasPayment, gasPaymentUsd } = useReadGasPaymentAmount(tokenAmount?.currency?.chainId)
 
   const totalUsd = useCalculateTotalCostCreateGift({ tokenAmount, nativeAmount })
 

--- a/apps/web/src/views/Gift/hooks/useReadGasPayment.tsx
+++ b/apps/web/src/views/Gift/hooks/useReadGasPayment.tsx
@@ -21,8 +21,8 @@ export const useReadGasPayment = () => {
   return gasPayment as bigint | undefined
 }
 
-export const useReadGasPaymentAmount = () => {
-  const nativeCurrency = useNativeCurrency(ChainId.BSC)
+export const useReadGasPaymentAmount = (chainId?: ChainId) => {
+  const nativeCurrency = useNativeCurrency(chainId ?? ChainId.BSC)
   const gasPayment = useReadGasPayment()
   const stableNativePrice = useStablecoinPrice(nativeCurrency)
 

--- a/apps/web/src/views/Gift/hooks/useReadGasPayment.tsx
+++ b/apps/web/src/views/Gift/hooks/useReadGasPayment.tsx
@@ -22,7 +22,7 @@ export const useReadGasPayment = () => {
 }
 
 export const useReadGasPaymentAmount = () => {
-  const nativeCurrency = useNativeCurrency()
+  const nativeCurrency = useNativeCurrency(ChainId.BSC)
   const gasPayment = useReadGasPayment()
   const stableNativePrice = useStablecoinPrice(nativeCurrency)
 


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->
Fixes #PAN-7910

### What
Updated the `useReadGasPaymentAmount` hook to explicitly use `ChainId.BSC` when determining the native currency for the gift claim gas fee display.

### Why
The "Gift Claim Gas Fee (Fixed)" was incorrectly showing ETH instead of BNB when a user was on a different chain (e.g., Base) but creating a gift on the BNB chain. This was because the `useNativeCurrency` hook was defaulting to the user's active chain ID. Since gifts are always processed on the BNB chain, explicitly passing `ChainId.BSC` ensures the correct native currency symbol (BNB) is displayed for the gas fee, regardless of the user's connected chain.

---
Linear Issue: [PAN-7910](https://linear.app/pancakeswap/issue/PAN-7910/prod-gift-gift-claim-gas-fee-showing-eth-instead-of-bnb)

<a href="https://cursor.com/background-agent?bcId=bc-cb3d6312-aba7-4777-abf4-0f129aa6d4d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb3d6312-aba7-4777-abf4-0f129aa6d4d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces an enhancement to the `useReadGasPaymentAmount` hook by allowing it to accept an optional `chainId` parameter. This change improves its flexibility in determining the native currency based on the specified chain.

### Detailed summary
- Modified `useReadGasPaymentAmount` to accept an optional `chainId` parameter.
- Updated the call to `useNativeCurrency` within `useReadGasPaymentAmount` to use the provided `chainId` or default to `ChainId.BSC`.
- Adjusted `CreateGiftView` to pass the `chainId` from `tokenAmount?.currency` to `useReadGasPaymentAmount`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->