### PR TITLE
fix: Wallet exist popup initially on trust wallet and add wallet not working

### DIFF
--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -11,7 +11,17 @@ export const checkWalletCanRegisterToken = async (connector: Connector) => {
       typeof provider.request === 'function' &&
       // Some providers throw if they don’t support it
       (await provider
-        .request({ method: 'wallet_watchAsset', params: { type: 'ERC20', options: {} } })
+        .request({
+          method: 'wallet_watchAsset',
+          params: {
+            type: 'ERC20',
+            options: {
+              address: '0x0000000000000000000000000000000000000000',
+              symbol: 'DUMM',
+              decimals: 18,
+            },
+          },
+        })
         .then(() => true)
         .catch(() => true)) // they support the method even if the dummy call fails
     )

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -16,7 +16,7 @@ export const checkWalletCanRegisterToken = async (connector: Connector) => {
           params: {
             type: 'ERC20',
             options: {
-              address: '0x0000000000000000000000000000000000000000',
+              address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
               symbol: 'DUMM',
               decimals: 18,
             },

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -1,31 +1,35 @@
+import { memoizeAsync } from '@pancakeswap/utils/memoize'
 import { Connector } from 'wagmi'
 
-export const checkWalletCanRegisterToken = async (connector: Connector) => {
-  try {
-    if (typeof connector.getProvider !== 'function') return false
+export const checkWalletCanRegisterToken = memoizeAsync(
+  async (connector: Connector) => {
+    try {
+      if (typeof connector.getProvider !== 'function') return false
 
-    const provider = (await connector.getProvider()) as any
+      const provider = (await connector.getProvider()) as any
 
-    return (
-      !!provider?.request &&
-      typeof provider.request === 'function' &&
-      // Some providers throw if they don’t support it
-      (await provider
-        .request({ method: 'wallet_watchAsset', params: {} })
-        .then(() => true)
-        .catch((err: any) => {
-          if (err?.code === -32601 || err?.code === -32004) {
-            throw err
-          }
-          return true // they support the method even if the dummy call fails
-        }))
-    )
-  } catch (error: any) {
-    // If the provider rejects "unknown method", it doesn’t support asset registration
-    if (error?.code === -32601 || error?.code === -32004) {
+      return (
+        !!provider?.request &&
+        typeof provider.request === 'function' &&
+        // Some providers throw if they don’t support it
+        (await provider
+          .request({ method: 'wallet_watchAsset', params: {} })
+          .then(() => true)
+          .catch((err: any) => {
+            if (err?.code === -32601 || err?.code === -32004) {
+              throw err
+            }
+            return true // they support the method even if the dummy call fails
+          }))
+      )
+    } catch (error: any) {
+      // If the provider rejects "unknown method", it doesn’t support asset registration
+      if (error?.code === -32601 || error?.code === -32004) {
+        return false
+      }
+      console.error(error, 'Error while checking wallet token registration support')
       return false
     }
-    console.error(error, 'Error while checking wallet token registration support')
-    return false
-  }
-}
+  },
+  { resolver: (connector) => connector?.id },
+)

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -11,17 +11,7 @@ export const checkWalletCanRegisterToken = async (connector: Connector) => {
       typeof provider.request === 'function' &&
       // Some providers throw if they don’t support it
       (await provider
-        .request({
-          method: 'wallet_watchAsset',
-          params: {
-            type: 'ERC20',
-            options: {
-              address: '0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF',
-              symbol: 'DUMM',
-              decimals: 18,
-            },
-          },
-        })
+        .request({ method: 'wallet_watchAsset', params: {} })
         .then(() => true)
         .catch(() => true)) // they support the method even if the dummy call fails
     )

--- a/apps/web/src/utils/wallet.ts
+++ b/apps/web/src/utils/wallet.ts
@@ -13,11 +13,18 @@ export const checkWalletCanRegisterToken = async (connector: Connector) => {
       (await provider
         .request({ method: 'wallet_watchAsset', params: {} })
         .then(() => true)
-        .catch(() => true)) // they support the method even if the dummy call fails
+        .catch((err: any) => {
+          if (err?.code === -32601 || err?.code === -32004) {
+            throw err
+          }
+          return true // they support the method even if the dummy call fails
+        }))
     )
   } catch (error: any) {
     // If the provider rejects "unknown method", it doesn’t support asset registration
-    if (error?.code === -32601) return false
+    if (error?.code === -32601 || error?.code === -32004) {
+      return false
+    }
     console.error(error, 'Error while checking wallet token registration support')
     return false
   }


### PR DESCRIPTION
To reproduce: 

Go to swap 
Connect wallet
Open the currency search modal 
Wallet exist popup appears

Any component that constains addwalletbutton component can cause this issue currently
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `checkWalletCanRegisterToken` function in `wallet.ts` to use `memoizeAsync`, enhancing its efficiency. It also improves error handling by checking for additional error codes and modifies the parameters for the `wallet_watchAsset` request.

### Detailed summary
- Refactored `checkWalletCanRegisterToken` to use `memoizeAsync`.
- Changed the `params` in the `wallet_watchAsset` request to an empty object.
- Enhanced error handling to check for error codes `-32601` and `-32004`.
- Adjusted the catch block to throw errors for specific cases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->