### PR TITLE
fix: add network switch guard

### DIFF
--- a/apps/web/src/wallet/atoms/switchChainRequestAtom.ts
+++ b/apps/web/src/wallet/atoms/switchChainRequestAtom.ts
@@ -9,6 +9,7 @@ export interface SwitchChainRequest {
   evmAddress?: `0x${string}` // EVM address used to check session sync
   from: 'wagmi' | 'url' | 'switch' | 'connect'
   path: string
+  pathname: string
   force?: boolean
 }
 

--- a/apps/web/src/wallet/hook/useSwitchNetworkV2.ts
+++ b/apps/web/src/wallet/hook/useSwitchNetworkV2.ts
@@ -4,7 +4,7 @@ import { useActiveChainIdRef } from 'hooks/useAccountActiveChain'
 import useAuth from 'hooks/useAuth'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { useRouter } from 'next/router'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Connector, useAccount, useSwitchChain } from 'wagmi'
 import { accountActiveChainAtom } from 'wallet/atoms/accountStateAtoms'
 import { SwitchChainRequest, switchChainUpdatingAtom } from 'wallet/atoms/switchChainRequestAtom'
@@ -15,6 +15,11 @@ export interface SwitchChainOption {
   replaceUrl?: boolean
   from: SwitchFrom
   force?: boolean
+}
+
+type ReplaceGuardState = {
+  cancelled: boolean
+  requestId: number
 }
 export const useSwitchNetworkV2 = () => {
   const { isConnected } = useAccount()
@@ -42,6 +47,7 @@ export const useSwitchNetworkV2 = () => {
         evmAddress,
         wagmiConnector,
         path: window.location.pathname,
+        pathname: router.pathname,
         from,
         persistChain: Boolean(query.persistChain),
         force,
@@ -111,14 +117,39 @@ const useProcessSwitchChainRequest = () => {
   const setSwitching = useSetAtom(switchChainUpdatingAtom)
   const lock = useRef(false)
   const router = useRouter()
+  const replaceGuardRef = useRef<ReplaceGuardState>({ cancelled: false, requestId: 0 })
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      replaceGuardRef.current.cancelled = true
+    }
+
+    router.events.on('routeChangeStart', handleRouteChangeStart)
+
+    return () => {
+      replaceGuardRef.current.cancelled = true
+      router.events.off('routeChangeStart', handleRouteChangeStart)
+    }
+  }, [router])
 
   const activeChainIdRef = useActiveChainIdRef()
   const processSwitching = useCallback(
     async (request: SwitchChainRequest) => {
-      const { from, wagmiConnector, evmAddress, replaceUrl, chainId: requestChainId, path, persistChain } = request
+      const {
+        from,
+        wagmiConnector,
+        evmAddress,
+        replaceUrl,
+        chainId: requestChainId,
+        path,
+        pathname,
+        persistChain,
+      } = request
       if (lock.current) {
         return false
       }
+      const currentRequestId = replaceGuardRef.current.requestId + 1
+      replaceGuardRef.current = { cancelled: false, requestId: currentRequestId }
       console.log(`[wallet] process switch`, request)
       // Need to switch
       lock.current = true
@@ -141,10 +172,19 @@ const useProcessSwitchChainRequest = () => {
             isNotMatched: isWrongNetwork,
           }))
           if (replaceUrl && !persistChain) {
-            const chain = getChainName(requestChainId)
-            router.replace({ pathname: path, query: { ...router.query, chain } }, undefined, {
-              shallow: true,
-            })
+            const guardState = replaceGuardRef.current
+            const isLatestRequest = guardState.requestId === currentRequestId
+            const hasBeenCancelled = guardState.cancelled || !isLatestRequest
+            const matchesCurrentPathname = router.pathname === pathname
+            const matchesCurrentPath =
+              typeof window !== 'undefined' ? window.location.pathname === path : matchesCurrentPathname
+
+            if (!hasBeenCancelled && matchesCurrentPathname && matchesCurrentPath) {
+              const chain = getChainName(requestChainId)
+              router.replace({ pathname: path, query: { ...router.query, chain } }, undefined, {
+                shallow: true,
+              })
+            }
           }
 
           if (wagmiConnector && (await requireLogout(wagmiConnector, requestChainId, evmAddress))) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `useSwitchNetworkV2` hook by adding a pathname property to the switch chain request and implementing a route change guard to handle network switch requests more reliably.

### Detailed summary
- Added `pathname` property to `SwitchChainRequest`.
- Introduced `ReplaceGuardState` type for managing request state.
- Implemented a route change guard using `useEffect` to track request cancellations.
- Updated `processSwitching` to handle request state and check for cancellations before proceeding with URL replacement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->