### PR TITLE
fix: check privy ready state before async wallet state

### DIFF
--- a/apps/web/src/wallet/hook/useSyncWagmiState.ts
+++ b/apps/web/src/wallet/hook/useSyncWagmiState.ts
@@ -1,15 +1,19 @@
+import { usePrivy } from '@privy-io/react-auth'
 import { useSetAtom } from 'jotai'
 import { useEffect, useRef } from 'react'
 
 import { getQueryChainId } from 'wallet/util/getQueryChainId'
 import { accountActiveChainAtom } from 'wallet/atoms/accountStateAtoms'
 import { useAccount } from 'wagmi'
+import { usePrivyWalletAddress } from 'wallet/Privy/hooks'
 import { useSwitchNetworkV2 } from './useSwitchNetworkV2'
 
 export function useSyncWagmiState() {
   const { chainId: wagmiChainId, address: evmAccount, connector } = useAccount()
   const updAccountState = useSetAtom(accountActiveChainAtom)
   const { switchNetwork } = useSwitchNetworkV2()
+  const { ready, authenticated, user } = usePrivy()
+  const { address: privyAddress, isLoading: isPrivyAddressLoading } = usePrivyWalletAddress()
 
   const oldWagmiChainId = useRef(wagmiChainId)
 
@@ -37,9 +41,26 @@ export function useSyncWagmiState() {
   }, [wagmiChainId, switchNetwork])
 
   useEffect(() => {
+    if (!ready) {
+      return
+    }
+
+    if (authenticated) {
+      if (isPrivyAddressLoading) {
+        return
+      }
+
+      updAccountState((prev) => ({
+        ...prev,
+        account: privyAddress,
+      }))
+
+      return
+    }
+
     updAccountState((prev) => ({
       ...prev,
       account: evmAccount,
     }))
-  }, [evmAccount, connector, updAccountState])
+  }, [ready, authenticated, user, privyAddress, isPrivyAddressLoading, evmAccount, connector, updAccountState])
 }

--- a/apps/web/src/wallet/hook/useSyncWagmiState.ts
+++ b/apps/web/src/wallet/hook/useSyncWagmiState.ts
@@ -12,7 +12,7 @@ export function useSyncWagmiState() {
   const { chainId: wagmiChainId, address: evmAccount, connector } = useAccount()
   const updAccountState = useSetAtom(accountActiveChainAtom)
   const { switchNetwork } = useSwitchNetworkV2()
-  const { ready, authenticated, user } = usePrivy()
+  const { ready, authenticated } = usePrivy()
   const { address: privyAddress, isLoading: isPrivyAddressLoading } = usePrivyWalletAddress()
 
   const oldWagmiChainId = useRef(wagmiChainId)
@@ -62,5 +62,5 @@ export function useSyncWagmiState() {
       ...prev,
       account: evmAccount,
     }))
-  }, [ready, authenticated, user, privyAddress, isPrivyAddressLoading, evmAccount, connector, updAccountState])
+  }, [ready, authenticated, privyAddress, isPrivyAddressLoading, evmAccount, connector, updAccountState])
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `useSyncWagmiState` hook by integrating Privy wallet address handling. It updates the account state based on the readiness and authentication status of the Privy wallet, ensuring that the correct address is used.

### Detailed summary
- Added `usePrivyWalletAddress` hook to retrieve Privy wallet address.
- Introduced checks for `ready` and `authenticated` states of the Privy wallet.
- Updated account state with `privyAddress` when authenticated and not loading.
- Adjusted dependencies in the `useEffect` hook to include new variables.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->