### PR TITLE
fix: Wallet sync switch

### DIFF
--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -96,7 +96,9 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
         await withRetry(
           async () => {
             const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
-            if (value !== chainId) throw new Error('User rejected switch after adding network.')
+            if (value !== chainId) {
+              throw new Error(`ChainId mismatch after network switch. Expected: ${chainId}, got: ${value}`)
+            }
             return value
           },
           {
@@ -108,7 +110,7 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
       async function sendAndWaitForChangeEvent(chainId: number) {
         await new Promise<void>((resolve) => {
           const listener = ((data) => {
-            if ('chainId' in data && data.chainId === chainId) {
+            if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
               config.emitter.off('change', listener)
               resolve()
             }

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -34,13 +34,21 @@ const waitForChainIdToSync = async (provider: any, chainId: number): Promise<num
 }
 
 const sendAndWaitForChangeEvent = async (config: CreateConnectorConfig, chainId: number): Promise<void> => {
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>
+
     const listener = ((data) => {
       if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
+        clearTimeout(timer)
         config.emitter.off('change', listener)
         resolve()
       }
     }) satisfies Parameters<typeof config.emitter.on>[1]
+
+    timer = setTimeout(() => {
+      config.emitter.off('change', listener)
+      reject(new Error(`Timeout waiting for chainId ${chainId} change event`))
+    }, 5000)
 
     config.emitter.on('change', listener)
     config.emitter.emit('change', { chainId })

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -5,6 +5,8 @@ import { EIP6963Detail } from './WalletProvider'
 
 const cache = new Map<string, any>()
 
+type CreateConnectorConfig = Parameters<typeof createConnector>[0] extends (arg: infer C) => any ? C : never
+
 const normalizeChainId = (chainId: unknown): number => {
   if (typeof chainId === 'number') {
     return chainId
@@ -13,6 +15,36 @@ const normalizeChainId = (chainId: unknown): number => {
     return chainId.startsWith('0x') ? parseInt(chainId, 16) : parseInt(chainId, 10)
   }
   throw new Error(`Invalid chainId: ${chainId}`)
+}
+
+const waitForChainIdToSync = async (provider: any, chainId: number): Promise<number> => {
+  return withRetry(
+    async () => {
+      const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
+      if (value !== chainId) {
+        throw new Error(`ChainId mismatch after network switch. Expected: ${chainId}, got: ${value}`)
+      }
+      return value
+    },
+    {
+      delay: 50,
+      retryCount: 20,
+    },
+  )
+}
+
+const sendAndWaitForChangeEvent = async (config: CreateConnectorConfig, chainId: number): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    const listener = ((data) => {
+      if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
+        config.emitter.off('change', listener)
+        resolve()
+      }
+    }) satisfies Parameters<typeof config.emitter.on>[1]
+
+    config.emitter.on('change', listener)
+    config.emitter.emit('change', { chainId })
+  })
 }
 
 export const createEip6963Connector = (detail: EIP6963Detail) => {
@@ -86,39 +118,11 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
         params: [{ chainId: `0x${chainId.toString(16)}` }],
       })
 
-      await waitForChainIdToSync()
-      await sendAndWaitForChangeEvent(chainId)
+      await waitForChainIdToSync(provider, chainId)
+      await sendAndWaitForChangeEvent(config, chainId)
 
       const chain = chains.find((x) => x.id === chainId)!
       return chain
-
-      async function waitForChainIdToSync() {
-        await withRetry(
-          async () => {
-            const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
-            if (value !== chainId) {
-              throw new Error(`ChainId mismatch after network switch. Expected: ${chainId}, got: ${value}`)
-            }
-            return value
-          },
-          {
-            delay: 50,
-            retryCount: 20,
-          },
-        )
-      }
-      async function sendAndWaitForChangeEvent(chainId: number) {
-        await new Promise<void>((resolve) => {
-          const listener = ((data) => {
-            if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
-              config.emitter.off('change', listener)
-              resolve()
-            }
-          }) satisfies Parameters<typeof config.emitter.on>[1]
-          config.emitter.on('change', listener)
-          config.emitter.emit('change', { chainId })
-        })
-      }
     },
   }))
   cache.set(info.uuid, connector)

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -22,7 +22,7 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
 
   const { provider, info } = detail
 
-  const connector = createConnector(() => ({
+  const connector = createConnector((config) => ({
     id: 'injected',
     name: info.name,
     type: 'injected',
@@ -87,6 +87,7 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
       })
 
       await waitForChainIdToSync()
+      await sendAndWaitForChangeEvent(chainId)
 
       const chain = chains.find((x) => x.id === chainId)!
       return chain
@@ -103,6 +104,18 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
             retryCount: 20,
           },
         )
+      }
+      async function sendAndWaitForChangeEvent(chainId: number) {
+        await new Promise<void>((resolve) => {
+          const listener = ((data) => {
+            if ('chainId' in data && data.chainId === chainId) {
+              config.emitter.off('change', listener)
+              resolve()
+            }
+          }) satisfies Parameters<typeof config.emitter.on>[1]
+          config.emitter.on('change', listener)
+          config.emitter.emit('change', { chainId })
+        })
       }
     },
   }))

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -15,29 +15,6 @@ const normalizeChainId = (chainId: unknown): number => {
   throw new Error(`Invalid chainId: ${chainId}`)
 }
 
-// Helper function to wait for chain ID to sync with retry logic
-const waitForChainIdSync = async (provider: any, expectedChainId: number, timeout = 5000) => {
-  const startTime = Date.now()
-  
-  return withRetry(
-    async () => {
-      if (Date.now() - startTime > timeout) {
-        throw new Error(`Chain sync timeout after ${timeout}ms`)
-      }
-      
-      const currentChainId = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
-      if (currentChainId !== expectedChainId) {
-        throw new Error(`ChainId mismatch. Expected: ${expectedChainId}, got: ${currentChainId}`)
-      }
-      return currentChainId
-    },
-    {
-      delay: 100,
-      retryCount: Math.floor(timeout / 100),
-    },
-  )
-}
-
 export const createEip6963Connector = (detail: EIP6963Detail) => {
   if (cache.has(detail.info.uuid)) {
     return cache.get(detail.info.uuid)
@@ -104,29 +81,43 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
     },
 
     async switchChain({ chainId }) {
-      try {
-        // Request the chain switch from the wallet
-        await provider.request({
-          method: 'wallet_switchEthereumChain',
-          params: [{ chainId: `0x${chainId.toString(16)}` }],
+      await provider.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: `0x${chainId.toString(16)}` }],
+      })
+
+      await waitForChainIdToSync()
+      await sendAndWaitForChangeEvent(chainId)
+
+      const chain = chains.find((x) => x.id === chainId)!
+      return chain
+
+      async function waitForChainIdToSync() {
+        await withRetry(
+          async () => {
+            const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
+            if (value !== chainId) {
+              throw new Error(`ChainId mismatch after network switch. Expected: ${chainId}, got: ${value}`)
+            }
+            return value
+          },
+          {
+            delay: 50,
+            retryCount: 20,
+          },
+        )
+      }
+      async function sendAndWaitForChangeEvent(chainId: number) {
+        await new Promise<void>((resolve) => {
+          const listener = ((data) => {
+            if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
+              config.emitter.off('change', listener)
+              resolve()
+            }
+          }) satisfies Parameters<typeof config.emitter.on>[1]
+          config.emitter.on('change', listener)
+          config.emitter.emit('change', { chainId })
         })
-
-        // Wait for the chain ID to sync with a timeout
-        await waitForChainIdSync(provider, chainId)
-
-        // Emit the change event to sync with wagmi config
-        config.emitter.emit('change', { chainId })
-
-        const chain = chains.find((x) => x.id === chainId)!
-        return chain
-      } catch (error) {
-        // If the chain switch fails, still try to return the current chain
-        const currentChainId = await this.getChainId()
-        const currentChain = chains.find((x) => x.id === currentChainId)
-        if (currentChain) {
-          return currentChain
-        }
-        throw error
       }
     },
   }))

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -15,6 +15,29 @@ const normalizeChainId = (chainId: unknown): number => {
   throw new Error(`Invalid chainId: ${chainId}`)
 }
 
+// Helper function to wait for chain ID to sync with retry logic
+const waitForChainIdSync = async (provider: any, expectedChainId: number, timeout = 5000) => {
+  const startTime = Date.now()
+  
+  return withRetry(
+    async () => {
+      if (Date.now() - startTime > timeout) {
+        throw new Error(`Chain sync timeout after ${timeout}ms`)
+      }
+      
+      const currentChainId = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
+      if (currentChainId !== expectedChainId) {
+        throw new Error(`ChainId mismatch. Expected: ${expectedChainId}, got: ${currentChainId}`)
+      }
+      return currentChainId
+    },
+    {
+      delay: 100,
+      retryCount: Math.floor(timeout / 100),
+    },
+  )
+}
+
 export const createEip6963Connector = (detail: EIP6963Detail) => {
   if (cache.has(detail.info.uuid)) {
     return cache.get(detail.info.uuid)
@@ -81,43 +104,29 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
     },
 
     async switchChain({ chainId }) {
-      await provider.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: `0x${chainId.toString(16)}` }],
-      })
-
-      await waitForChainIdToSync()
-      await sendAndWaitForChangeEvent(chainId)
-
-      const chain = chains.find((x) => x.id === chainId)!
-      return chain
-
-      async function waitForChainIdToSync() {
-        await withRetry(
-          async () => {
-            const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
-            if (value !== chainId) {
-              throw new Error(`ChainId mismatch after network switch. Expected: ${chainId}, got: ${value}`)
-            }
-            return value
-          },
-          {
-            delay: 50,
-            retryCount: 20,
-          },
-        )
-      }
-      async function sendAndWaitForChangeEvent(chainId: number) {
-        await new Promise<void>((resolve) => {
-          const listener = ((data) => {
-            if (data && typeof data === 'object' && 'chainId' in data && data.chainId === chainId) {
-              config.emitter.off('change', listener)
-              resolve()
-            }
-          }) satisfies Parameters<typeof config.emitter.on>[1]
-          config.emitter.on('change', listener)
-          config.emitter.emit('change', { chainId })
+      try {
+        // Request the chain switch from the wallet
+        await provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: `0x${chainId.toString(16)}` }],
         })
+
+        // Wait for the chain ID to sync with a timeout
+        await waitForChainIdSync(provider, chainId)
+
+        // Emit the change event to sync with wagmi config
+        config.emitter.emit('change', { chainId })
+
+        const chain = chains.find((x) => x.id === chainId)!
+        return chain
+      } catch (error) {
+        // If the chain switch fails, still try to return the current chain
+        const currentChainId = await this.getChainId()
+        const currentChain = chains.find((x) => x.id === currentChainId)
+        if (currentChain) {
+          return currentChain
+        }
+        throw error
       }
     },
   }))

--- a/apps/web/src/wallet/eip6963Connector.ts
+++ b/apps/web/src/wallet/eip6963Connector.ts
@@ -1,6 +1,6 @@
 import { chains } from 'utils/wagmi'
 import { createConnector } from 'wagmi'
-import { UserRejectedRequestError } from 'viem'
+import { UserRejectedRequestError, withRetry } from 'viem'
 import { EIP6963Detail } from './WalletProvider'
 
 const cache = new Map<string, any>()
@@ -30,7 +30,7 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
 
     async connect({ chainId } = {}) {
       const accounts = await provider.request({ method: 'eth_requestAccounts' })
-      let currentChainId = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
+      let currentChainId = await this.getChainId()
 
       if (chainId && currentChainId !== chainId) {
         const chain = await this.switchChain!({ chainId }).catch((error) => {
@@ -86,8 +86,24 @@ export const createEip6963Connector = (detail: EIP6963Detail) => {
         params: [{ chainId: `0x${chainId.toString(16)}` }],
       })
 
+      await waitForChainIdToSync()
+
       const chain = chains.find((x) => x.id === chainId)!
       return chain
+
+      async function waitForChainIdToSync() {
+        await withRetry(
+          async () => {
+            const value = normalizeChainId(await provider.request({ method: 'eth_chainId' }))
+            if (value !== chainId) throw new Error('User rejected switch after adding network.')
+            return value
+          },
+          {
+            delay: 50,
+            retryCount: 20,
+          },
+        )
+      }
     },
   }))
   cache.set(info.uuid, connector)


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `eip6963Connector` by adding retry logic for chain ID synchronization and a mechanism to wait for change events. It improves the connection handling process, ensuring that the connector accurately reflects the current chain ID after switching networks.

### Detailed summary
- Added `withRetry` import from `viem`.
- Introduced `waitForChainIdToSync` function to retry fetching the chain ID.
- Added `sendAndWaitForChangeEvent` function to wait for a change event with a timeout.
- Updated `createConnector` to use the new `config` parameter.
- Replaced direct chain ID retrieval with `this.getChainId()`.
- Integrated `waitForChainIdToSync` and `sendAndWaitForChangeEvent` into the connection process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->