### PR TITLE
fix(MEV): get correct provider from privy's connector

### DIFF
--- a/apps/web/src/views/Mev/hooks/index.ts
+++ b/apps/web/src/views/Mev/hooks/index.ts
@@ -187,7 +187,12 @@ export const useAddMevRpc = (onSuccess?: () => void, onBeforeStart?: () => void,
 
 export async function getWalletType(connector?: Connector, mevParam?: string | null): Promise<WalletType> {
   if (!connector || typeof connector.getProvider !== 'function') return WalletType.mevNotSupported
-  const provider = (await connector.getProvider()) as any
+  let provider = (await connector.getProvider()) as any
+
+  // If Privy's Smart Account connector is used, we need the inside walletProvider
+  if (provider && provider?.walletProvider) {
+    provider = provider.walletProvider
+  }
 
   // check WalletConnect + supported wallets
   if (provider.isWalletConnect) {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the `getWalletType` function to handle cases where the `provider` might be a Smart Account connector. It updates the way the `provider` is assigned and checks for the existence of a `walletProvider`.

### Detailed summary
- Changed `const provider` to `let provider` for reassignment.
- Added a conditional check for `provider?.walletProvider`.
- If `walletProvider` exists, it assigns `provider` to `provider.walletProvider`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->