### PR TITLE
fix: broken bug bounty link on home page

### DIFF
--- a/packages/uikit/src/widgets/Menu/components/footerConfig.ts
+++ b/packages/uikit/src/widgets/Menu/components/footerConfig.ts
@@ -61,7 +61,7 @@ export const footerLinks: (t: ContextApi["t"]) => FooterLinkType[] = (t) => [
       },
       {
         label: t("Bug Bounty"),
-        href: "https://docs.pancakeswap.finance/developers/bug-bounty",
+        href: "https://developer.pancakeswap.finance/bug-bounty#bug-bounty",
       },
     ],
   },


### PR DESCRIPTION
Fix: Broken Bug Bounty link (PAN-8300)

This PR resolves PAN-8300 by updating the "Bug Bounty" link in the footer. The previous link was broken, and this change directs users to the correct developer documentation page.

---
Linear Issue: [PAN-8300](https://linear.app/pancakeswap/issue/PAN-8300/home-page-bug-bounty-link-broken)

<a href="https://cursor.com/background-agent?bcId=bc-8567f15e-c605-4ce3-bae6-1e848ba40471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8567f15e-c605-4ce3-bae6-1e848ba40471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `href` URL for the "Bug Bounty" label in the `footerConfig.ts` file to point to a new documentation link.

### Detailed summary
- Changed the `href` for the "Bug Bounty" label from `https://docs.pancakeswap.finance/developers/bug-bounty` to `https://developer.pancakeswap.finance/bug-bounty#bug-bounty`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->