### PR TITLE
Fix broken get link in web app

### DIFF
--- a/apps/web/src/components/Menu/config/config.ts
+++ b/apps/web/src/components/Menu/config/config.ts
@@ -223,7 +223,7 @@ const config: (
         },
         {
           label: t('Docs'),
-          href: 'https://docs.pancakeswap.finance',
+          href: 'https://docs.pancakeswap.finance/welcome-to-pancakeswap/contact-us/social-accounts',
           type: DropdownMenuItemType.EXTERNAL_LINK,
         },
       ].map((item) => addMenuItemSupported(item, chainId)),


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->
Fixes [PAN-8309](https://linear.app/pancakeswap/issue/PAN-8309).

Updates the "Docs" link in the main navigation menu (`apps/web/src/components/Menu/config/config.ts`) to point to the correct social accounts page: `https://docs.pancakeswap.finance/welcome-to-pancakeswap/contact-us/social-accounts`. This resolves the broken "Get Link" issue, ensuring users are directed to the intended contact information.

---
Linear Issue: [PAN-8309](https://linear.app/pancakeswap/issue/PAN-8309/home-prod-get-link-broken-link)

<a href="https://cursor.com/background-agent?bcId=bc-c289ff0c-d756-4a9f-959d-628311e84ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c289ff0c-d756-4a9f-959d-628311e84ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

