### PR TITLE
Fix broken get link in web app

### DIFF
--- a/apps/web/src/config/constants/index.ts
+++ b/apps/web/src/config/constants/index.ts
@@ -17,7 +17,7 @@ export const PREDICTION_TOOLTIP_DISMISS_KEY = 'prediction-switcher-dismiss-toolt
 // Gelato uses this address to define a native currency in all chains
 export const GELATO_NATIVE = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 
-export const EXCHANGE_HELP_URLS = 'https://docs.pancakeswap.finance/help'
+export const EXCHANGE_HELP_URLS = 'https://docs.pancakeswap.finance/welcome-to-pancakeswap/contact-us/social-accounts'
 
 export const QUERY_SETTINGS_IMMUTABLE = {
   refetchOnReconnect: false,


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->
**Description:**

This PR resolves Linear issue PAN-8309 by updating the `EXCHANGE_HELP_URLS` constant.

**Why this change?**

The previous "Get Link" was broken, leading users to an outdated or non-existent help page. This change directs users to the correct documentation page for social accounts and contact information, improving user experience and ensuring accurate navigation.

---
Linear Issue: [PAN-8309](https://linear.app/pancakeswap/issue/PAN-8309/home-prod-get-link-broken-link)

<a href="https://cursor.com/background-agent?bcId=bc-b24d6bf9-7632-42e7-a56e-fd27912a3c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b24d6bf9-7632-42e7-a56e-fd27912a3c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

