### PR TITLE
fix: create dyn-infi-pool

### DIFF
--- a/apps/web/src/views/CreateLiquidityPool/Infinity/CreateLiquidityInfinityForm.tsx
+++ b/apps/web/src/views/CreateLiquidityPool/Infinity/CreateLiquidityInfinityForm.tsx
@@ -28,7 +28,7 @@ import { FieldSlippageTolerance } from '../components/FieldSlippageTolerance'
 export const CreateLiquidityInfinityForm = () => {
   const { chainId } = useSelectIdRouteParams()
 
-  const { isBin, isCl, startPrice, feeLevel } = useInfinityCreateFormQueryState()
+  const { isBin, isCl, startPrice, feeLevel, isDynamic } = useInfinityCreateFormQueryState()
 
   const { lowerBinId, upperBinId } = useInfinityBinQueryState()
   const { lowerTick, upperTick } = useInfinityCLQueryState()
@@ -71,7 +71,7 @@ export const CreateLiquidityInfinityForm = () => {
       </Card>
       <Card>
         <CardBody>
-          <DynamicSection disabled={poolInitialized || isUndefinedOrNull(feeLevel)}>
+          <DynamicSection disabled={poolInitialized || (!isDynamic && isUndefinedOrNull(feeLevel))}>
             <AutoColumn gap={['16px', null, null, '24px']}>
               <FieldStartingPrice />
               <DynamicSection disabled={!startPrice}>


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `CreateLiquidityInfinityForm` component to include a new state variable `isDynamic` from `useInfinityCreateFormQueryState`. This change alters the logic for the `DynamicSection` component's `disabled` prop, enhancing the form's behavior based on the dynamic state.

### Detailed summary
- Added `isDynamic` to destructuring from `useInfinityCreateFormQueryState`.
- Updated `disabled` prop of `DynamicSection` to check for `isDynamic` alongside `isUndefinedOrNull(feeLevel)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `isDynamic` to form state and adjusts `DynamicSection` disablement to depend on `isDynamic` and `feeLevel`.
> 
> - **Infinity Create Form (`CreateLiquidityInfinityForm.tsx`)**:
>   - Extend query state to include `isDynamic` from `useInfinityCreateFormQueryState`.
>   - Update `DynamicSection` `disabled` logic to `poolInitialized || (!isDynamic && isUndefinedOrNull(feeLevel))`, allowing the section when `isDynamic` is true regardless of `feeLevel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea895297d9f70acbc298aae2248945ae37cf7259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->