### PR TITLE
fix: remove filter by evm

### DIFF
--- a/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
+++ b/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
@@ -58,7 +58,7 @@ function getPoolId(farm: UniversalFarmConfig) {
 export type ChainNameKebab = (typeof chainNamesInKebabCase)[keyof typeof chainNamesInKebabCase]
 
 async function fetchExplorerFarmPools(protocols: Protocol[], chainIds: FarmV4SupportedChainId[]) {
-  const chains = chainIds.filter((id) => isEvm(id)).map((chainId) => getEdgeChainName(chainId as ChainId))
+  const chains = chainIds.map((chainId) => getEdgeChainName(chainId as ChainId))
   const resp = await explorerApiClient.GET('/cached/pools/farming', {
     params: {
       query: {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying the logic in the `fetchExplorerFarmPools` function by removing a filtering step for `chainIds`, potentially improving performance and clarity.

### Detailed summary
- Removed the filtering of `chainIds` based on the `isEvm` condition.
- Directly maps all `chainIds` to their corresponding edge chain names using `getEdgeChainName`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->