### PR TITLE
fix: sol fix farming api

### DIFF
--- a/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
+++ b/apps/web/src/state/farmsV4/search/edgeFarmQueries.ts
@@ -62,7 +62,7 @@ export type ChainNameKebab = (typeof chainNamesInKebabCase)[keyof typeof chainNa
 async function fetchExplorerFarmPools(query: FarmQuery) {
   const { protocols, chains } = query
   const chainIds = chains.length > 0 ? chains : supportedChainIdV4
-  const chainNames = chainIds.map((chainId) => getEdgeChainName(chainId)).filter((x) => x !== 'sol')
+  const chainNames = chainIds.map((chainId) => getEdgeChainName(chainId))
   const resp = await explorerApiClient.GET('/cached/pools/farming', {
     params: {
       query: {


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR modifies the handling of `chainNames` in the `edgeFarmQueries.ts` file by removing a filter that excluded the string 'sol', allowing all chain names to be included in the resulting array.

### Detailed summary
- Removed the filter that excluded 'sol' from `chainNames`.
- `chainNames` now includes all names returned by `getEdgeChainName(chainId)`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->