### PR TITLE
fix: Town token decimal

### DIFF
--- a/apps/web/src/config/constants/warningTokens/bscWarningTokens.ts
+++ b/apps/web/src/config/constants/warningTokens/bscWarningTokens.ts
@@ -61,5 +61,5 @@ export const bscWarningTokens = {
   ),
   nmt: new ERC20Token(ChainId.BSC, '0x03AA6298F1370642642415EDC0db8b957783e8D6', 18, 'NMT', 'NetMind Token'),
   uniBTC: new ERC20Token(ChainId.BSC, '0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a', 8, 'uniBTC', 'uniBTC'),
-  town: new ERC20Token(ChainId.BSC, '0x973253D0C12366e0fA5AFb9F9E2e9486ECA69c01', 8, 'TOWN', 'Alt.town'),
+  town: new ERC20Token(ChainId.BSC, '0x973253D0C12366e0fA5AFb9F9E2e9486ECA69c01', 18, 'TOWN', 'Alt.town'),
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the token configuration for the `TOWN` token in the `bscWarningTokens.ts` file by changing its decimal precision from `8` to `18`.

### Detailed summary
- Changed the decimal precision of the `TOWN` token from `8` to `18` in the `bscWarningTokens.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update BSC `TOWN` token decimals from 8 to 18 in `bscWarningTokens` config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7705e383fce28521f318ec35ef82b94cad70f591. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->