### PR TITLE
fix: home page remove testnet farm call

### DIFF
--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -46,11 +46,13 @@ export const fetchExplorerFarmPools = async (
       params: {
         query: {
           protocols: args.protocols ?? DEFAULT_PROTOCOLS,
-          chains: chains.reduce((acc, cur) => {
-            if (cur) {
-              acc.push(getMainnetChainNameInKebabCase(cur))
+          chains: chains.reduce((requestChainIds, currentChainId) => {
+            const chainName = currentChainId ? getMainnetChainNameInKebabCase(currentChainId) : undefined
+            if (chainName) {
+              requestChainIds.push(chainName)
             }
-            return acc
+
+            return requestChainIds
           }, [] as any[]),
         },
       },

--- a/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
+++ b/apps/web/src/state/farmsV4/state/farmPools/fetcher.ts
@@ -1,4 +1,4 @@
-import { ChainId, getChainNameInKebabCase, isEvm } from '@pancakeswap/chains'
+import { getMainnetChainNameInKebabCase } from '@pancakeswap/chains'
 import {
   FarmV4SupportedChainId,
   Protocol,
@@ -48,7 +48,7 @@ export const fetchExplorerFarmPools = async (
           protocols: args.protocols ?? DEFAULT_PROTOCOLS,
           chains: chains.reduce((acc, cur) => {
             if (cur) {
-              acc.push(getChainNameInKebabCase(cur as ChainId))
+              acc.push(getMainnetChainNameInKebabCase(cur))
             }
             return acc
           }, [] as any[]),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the handling of chain names in the `fetchExplorerFarmPools` function by replacing the previous method of obtaining chain names with a new utility function.

### Detailed summary
- Updated the chain name retrieval in `fetchExplorerFarmPools`.
- Replaced `getChainNameInKebabCase` with `getMainnetChainNameInKebabCase`.
- Changed variable names from `acc` and `cur` to `requestChainIds` and `currentChainId` for clarity.
- Ensured that only valid chain names are pushed to the array.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->