### PR TITLE
fix: rsc replace

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -123,10 +123,14 @@ const config = {
           source: '/.well-known/vercel/flags',
           destination: '/api/vercel/flags',
         },
-        // {
-        //   source: '/perp/:path*',
-        //   destination: 'https://perp.pancakeswap.finance/perp/:path*',
-        // },
+        {
+          source: '/perp/v2/:symbol.rsc',
+          destination: 'https://perp.pancakeswap.finance/perp/v2/:symbol',
+        },
+        {
+          source: '/perp/:path*',
+          destination: 'https://perp.pancakeswap.finance/perp/:path*',
+        },
       ],
     }
   },

--- a/apps/web/src/utils/getPerpetualUrl.ts
+++ b/apps/web/src/utils/getPerpetualUrl.ts
@@ -25,16 +25,12 @@ const mapPerpChain = (chainId: ChainId): string => {
 
 const supportV1Chains: ChainId[] = [ChainId.ETHEREUM]
 
-const host = 'https://perp.pancakeswap.finance'
-
 export const getPerpetualUrl = ({ chainId, languageCode, isDark }: GetPerpetualUrlProps) => {
   if (!chainId || !languageCode) {
-    return `${host}/perp/en/futures/v2/BTCUSD`
+    return '/perp/en/futures/v2/BTCUSD'
   }
 
   const perpChain = mapPerpChain(chainId)
   const version = supportV1Chains.includes(chainId) ? '' : 'v2/'
-  return `${host}/perp/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(
-    isDark,
-  )}&chain=${perpChain}`
+  return `/perp/${perpLangMap(languageCode)}/futures/${version}BTCUSD?theme=${perpTheme(isDark)}&chain=${perpChain}`
 }


### PR DESCRIPTION
<!--
Before opening a pull request, please read the [contributing guidelines](https://github.com/pancakeswap/pancake-frontend/blob/develop/CONTRIBUTING.md) first
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the routing configuration in `next.config.mjs` for the `/perp` API and modifying the URL generation logic in `getPerpetualUrl.ts` to remove a hardcoded host.

### Detailed summary
- In `next.config.mjs`, added a new route for `/perp/v2/:symbol.rsc` pointing to `https://perp.pancakeswap.finance/perp/v2/:symbol`.
- Retained the existing route for `/perp/:path*`.
- In `getPerpetualUrl.ts`, removed the hardcoded `host` variable and adjusted URL returns to be relative paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->